### PR TITLE
`Hyperion`: Change workflows

### DIFF
--- a/.github/workflows/hyperion_build-and-push-docker.yml
+++ b/.github/workflows/hyperion_build-and-push-docker.yml
@@ -1,7 +1,15 @@
 name: Hyperion - Build Docker Images
 
 on:
+  pull_request:
+    paths:
+      - 'hyperion/**'
+      - '.github/workflows/hyperion_build-and-push-docker.yml'
+    paths-ignore:
+      - 'hyperion/README.md'
   push:
+    branches:
+      - main
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_build-and-push-docker.yml'

--- a/.github/workflows/hyperion_build-and-push-docker.yml
+++ b/.github/workflows/hyperion_build-and-push-docker.yml
@@ -15,6 +15,7 @@ on:
     types:
       - created
 
+
 jobs:
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/hyperion_build-and-push-docker.yml
+++ b/.github/workflows/hyperion_build-and-push-docker.yml
@@ -1,13 +1,7 @@
 name: Hyperion - Build Docker Images
 
 on:
-  pull_request:
-    paths:
-      - 'hyperion/**'
-      - '.github/workflows/hyperion_build-and-push-docker.yml'
   push:
-    branches:
-      - main
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_build-and-push-docker.yml'

--- a/.github/workflows/hyperion_build-and-push-docker.yml
+++ b/.github/workflows/hyperion_build-and-push-docker.yml
@@ -5,16 +5,12 @@ on:
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_build-and-push-docker.yml'
-    paths-ignore:
-      - 'hyperion/README.md'
   push:
     branches:
       - main
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_build-and-push-docker.yml'
-    paths-ignore:
-      - 'hyperion/README.md'
   release:
     types:
       - created

--- a/.github/workflows/hyperion_build-and-push-docker.yml
+++ b/.github/workflows/hyperion_build-and-push-docker.yml
@@ -1,16 +1,7 @@
 name: Hyperion - Build Docker Images
 
 on:
-  pull_request:
-    paths:
-      - 'hyperion/**'
-      - '.github/workflows/hyperion_build-and-push-docker.yml'
-    paths-ignore:
-      - 'hyperion/README.md'
   push:
-    branches:
-      - main
-      - release/*
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_build-and-push-docker.yml'

--- a/.github/workflows/hyperion_check-openapi.yml
+++ b/.github/workflows/hyperion_check-openapi.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-api-client:
-    name: Verify API Specs (add autocommit-openapi label to PR to auto-commit changes)
+    name: Verify API Specs (add hyperion:autocommit-openapi label to PR to auto-commit changes)
     runs-on: ubuntu-latest
 
     steps:
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Commit files
-        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'hyperion:autocommit-openapi') }}
         run: |
           echo "Committing and pushing changes..."
           git config --local user.name "github-actions[bot]"
@@ -78,15 +78,15 @@ jobs:
           git commit -a -m "chore: update API specs and client"
 
       - name: Push changes
-        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'hyperion:autocommit-openapi') }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GH_PAT }}
           branch: ${{ github.event.pull_request.head.ref  }}
 
-      - name: Remove autocommit-openapi label
-        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+      - name: Remove hyperion:autocommit-openapi label
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'hyperion:autocommit-openapi') }}
         run: |
-          echo "Removing the autocommit-openapi label..."
+          echo "Removing the hyperion:autocommit-openapi label..."
           curl --silent --fail-with-body -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/hyperion:autocommit-openapi

--- a/.github/workflows/hyperion_check-openapi.yml
+++ b/.github/workflows/hyperion_check-openapi.yml
@@ -2,19 +2,19 @@ name: Hyperion - OpenAPI
 
 on:
   pull_request:
+    types: [ opened, synchronize, labeled, reopened ]
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
     paths-ignore:
       - 'hyperion/README.md'
   push:
-    branches:
-      - main
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
     paths-ignore:
       - 'hyperion/README.md'
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hyperion_check-openapi.yml
+++ b/.github/workflows/hyperion_check-openapi.yml
@@ -2,7 +2,6 @@ name: Hyperion - OpenAPI
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, reopened]
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
@@ -10,7 +9,6 @@ on:
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hyperion_check-openapi.yml
+++ b/.github/workflows/hyperion_check-openapi.yml
@@ -5,10 +5,16 @@ on:
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
+    paths-ignore:
+      - 'hyperion/README.md'
   push:
+    branches:
+      - main
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
+    paths-ignore:
+      - 'hyperion/README.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hyperion_check-openapi.yml
+++ b/.github/workflows/hyperion_check-openapi.yml
@@ -2,19 +2,15 @@ name: Hyperion - OpenAPI
 
 on:
   pull_request:
-    types: [ opened, synchronize, labeled, reopened ]
+    types: [opened, synchronize, labeled, reopened]
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
-    paths-ignore:
-      - 'hyperion/README.md'
   push:
     paths:
       - 'hyperion/**'
       - '.github/workflows/hyperion_check-openapi.yml'
-    paths-ignore:
-      - 'hyperion/README.md'
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for the Hyperion project. The changes focus on modifying the trigger conditions and updating label names for consistency.

Trigger condition updates:

* [`.github/workflows/hyperion_build-and-push-docker.yml`](diffhunk://#diff-b97d8553561566d593f98a84e08662328ffd2e2ea86a84cd8c3478086954974bL4-R12): Removed the `pull_request` trigger and its associated paths and paths-ignore settings. The `push` trigger now only includes paths settings.

Label name updates:

* [`.github/workflows/hyperion_check-openapi.yml`](diffhunk://#diff-5de9e2c05d2ca25d650e820aadb8cf50dcb76677933cfb56b2b53d799dd2cd40L18-R18): Updated the label name from `autocommit-openapi` to `hyperion:autocommit-openapi` in the `generate-api-client` job name and in the conditions for committing, pushing changes, and removing the label. [[1]](diffhunk://#diff-5de9e2c05d2ca25d650e820aadb8cf50dcb76677933cfb56b2b53d799dd2cd40L18-R18) [[2]](diffhunk://#diff-5de9e2c05d2ca25d650e820aadb8cf50dcb76677933cfb56b2b53d799dd2cd40L73-R92)