### PR TITLE
`Development`: Fix pull request labeler

### DIFF
--- a/.github/pullrequest-labeler.yml
+++ b/.github/pullrequest-labeler.yml
@@ -4,16 +4,16 @@ github:
 
 athena:
   - changed-files:
-      - any-glob-to-any-file: .athena/**/*
+      - any-glob-to-any-file: athena/**/*
 
 atlas:
   - changed-files:
-      - any-glob-to-any-file: .atlas/**/*
+      - any-glob-to-any-file: atlas/**/*
 
 hyperion:
   - changed-files:
-      - any-glob-to-any-file: .hyperion/**/*
+      - any-glob-to-any-file: hyperion/**/*
 
 iris:
   - changed-files:
-      - any-glob-to-any-file: .iris/**/*
+      - any-glob-to-any-file: iris/**/*


### PR DESCRIPTION
This pull request includes changes to the `.github/pullrequest-labeler.yml` file to correct the glob patterns for file paths associated with different teams. The changes ensure that the file paths do not start with a dot, which aligns with the correct directory structure.

Changes to file path glob patterns:

* [`.github/pullrequest-labeler.yml`](diffhunk://#diff-0b5caae487a3392730cd95acfcf49943fa1f81f7b0cdfa219b4edea57c8132ddL7-R19): Updated the glob patterns for `athena`, `atlas`, `hyperion`, and `iris` to remove the leading dot in the file paths.