### PR TITLE
`Development`: Add workflow to automate adding issues to project

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -12,20 +12,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Add issues/PRs labeled with 'hyperion' to the Hyperion project board
-      - name: Assign Hyperion Project
+      # Add issues/PRs labeled with 'athena' to the Athena project board
+      - name: Assign Athena Project
         if: >
           (github.event_name == 'issues' &&
-            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'hyperion')) ||
-             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
+            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'athena')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
           ) ||
           (github.event_name == 'pull_request' &&
-            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'hyperion')) ||
-             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
+            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'athena')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
           )
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/orgs/ls1intum/projects/97
+          project-url: https://github.com/orgs/ls1intum/projects/93
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
       # Add issues/PRs labeled with 'atlas' to the Atlas project board
@@ -44,18 +44,18 @@ jobs:
           project-url: https://github.com/orgs/ls1intum/projects/38
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
-      # Add issues/PRs labeled with 'athena' to the Athena project board
-      - name: Assign Athena Project
+      # Add issues/PRs labeled with 'hyperion' to the Hyperion project board
+      - name: Assign Hyperion Project
         if: >
           (github.event_name == 'issues' &&
-            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'athena')) ||
-             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
+            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'hyperion')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
           ) ||
           (github.event_name == 'pull_request' &&
-            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'athena')) ||
-             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
+            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'hyperion')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
           )
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/orgs/ls1intum/projects/93
+          project-url: https://github.com/orgs/ls1intum/projects/97
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,61 @@
+name: Assign Issue/PR to Project
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  assign_project:
+    name: Assign Issue/PR to Project Board
+    runs-on: ubuntu-latest
+
+    steps:
+      # Add issues/PRs labeled with 'hyperion' to the Hyperion project board
+      - name: Assign Hyperion Project
+        if: >
+          (github.event_name == 'issues' &&
+            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'hyperion')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
+          ) ||
+          (github.event_name == 'pull_request' &&
+            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'hyperion')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'hyperion'))
+          )
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/ls1intum/projects/97
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+      # Add issues/PRs labeled with 'atlas' to the Atlas project board
+      - name: Assign Atlas Project
+        if: >
+          (github.event_name == 'issues' &&
+            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'atlas')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'atlas'))
+          ) ||
+          (github.event_name == 'pull_request' &&
+            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'atlas')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'atlas'))
+          )
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/ls1intum/projects/38
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+      # Add issues/PRs labeled with 'athena' to the Athena project board
+      - name: Assign Athena Project
+        if: >
+          (github.event_name == 'issues' &&
+            ((github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'athena')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
+          ) ||
+          (github.event_name == 'pull_request' &&
+            ((github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'athena')) ||
+             (github.event.action == 'labeled' && github.event.label.name == 'athena'))
+          )
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/ls1intum/projects/93
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically assign issues and pull requests to specific project boards based on their labels. This helps streamline project management by ensuring that issues and PRs are properly categorized and tracked.

New GitHub Actions workflow:

* [`.github/workflows/add-issue-to-project.yml`](diffhunk://#diff-9ecaed921dc3fdb1c79d3c91eaae02eb8da09cdbb8c452e16a37e7848611e121R1-R61): Added a workflow that triggers on issues and pull requests being opened or labeled. It assigns items labeled with 'hyperion', 'atlas', or 'athena' to their respective project boards using the `actions/add-to-project@v1.0.2` action.

#### Open Issues

- [x] Accept PAT request
- [x] Add PAT to `ADD_TO_PROJECT_PAT` as GitHub repository secret
- [ ] Link `Iris` project board