### PR TITLE
`Hyperion`: Fix docker compose path in deploy workflows

### DIFF
--- a/.github/workflows/hyperion_deploy-test.yml
+++ b/.github/workflows/hyperion_deploy-test.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Hyperion - Test 1"
-      docker-compose-file: "./docker/compose.hyperion.yaml"
+      docker-compose-file: "./hyperion/docker/compose.hyperion.yaml"
       main-image-name: ls1intum/edutelligence/hyperion
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: "/opt/hyperion"
@@ -32,7 +32,7 @@ jobs:
     uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: hyperion-test1
-      docker-compose-file: "./docker/compose.proxy.yaml"
+      docker-compose-file: "./hyperion/docker/compose.proxy.yaml"
       # We just keep the main-image-name and image-tag as placeholders
       main-image-name: ls1intum/edutelligence/hyperion
       image-tag: ${{ inputs.image-tag }}

--- a/.github/workflows/hyperion_deploy-with-helios.yml
+++ b/.github/workflows/hyperion_deploy-with-helios.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: ${{ inputs.environment_name }}
-      docker-compose-file: "./docker/compose.hyperion.yaml"
+      docker-compose-file: "./hyperion/docker/compose.hyperion.yaml"
       main-image-name: ls1intum/edutelligence/hyperion
       image-tag: ${{ inputs.commit_sha }}
       deployment-base-path: "/opt/hyperion"


### PR DESCRIPTION
This pull request includes changes to the `docker-compose-file` paths in several GitHub workflow files to reflect a new directory structure. The most important changes are as follows:

Workflow file updates:
* [`.github/workflows/hyperion_deploy-test.yml`](diffhunk://#diff-796343012c3bb3a3ec4e52177d37aaca56785e36ece3732e52a5463610d7f06cL24-R24): Updated `docker-compose-file` path to `./hyperion/docker/compose.hyperion.yaml` for the "Hyperion - Test 1" environment.
* [`.github/workflows/hyperion_deploy-test.yml`](diffhunk://#diff-796343012c3bb3a3ec4e52177d37aaca56785e36ece3732e52a5463610d7f06cL35-R35): Updated `docker-compose-file` path to `./hyperion/docker/compose.proxy.yaml` for the `hyperion-test1` environment.
* [`.github/workflows/hyperion_deploy-with-helios.yml`](diffhunk://#diff-8a969e6ba7d9dfb3a6d12de524efeb0b107f12481b99a0dfe6de01fb00f0de22L27-R27): Updated `docker-compose-file` path to `./hyperion/docker/compose.hyperion.yaml` for the specified environment.