### PR TITLE
Consistency check should use o3-mini

### DIFF
--- a/iris/app/llm/external/openai_chat.py
+++ b/iris/app/llm/external/openai_chat.py
@@ -227,10 +227,14 @@ class OpenAIChatModel(ChatModel):
             try:
                 params = {
                     "model": self.model,
-                    "messages": messages,
-                    "temperature": arguments.temperature,
-                    "max_tokens": arguments.max_tokens,
+                    "messages": messages
                 }
+
+                if arguments.temperature is not None:
+                    params["temperature"] = arguments.temperature
+
+                if arguments.max_tokens is not None:
+                    params["max_tokens"] = arguments.max_tokens
 
                 if arguments.response_format == "JSON":
                     params["response_format"] = ResponseFormatJSONObject(

--- a/iris/app/pipeline/inconsistency_check_pipeline.py
+++ b/iris/app/pipeline/inconsistency_check_pipeline.py
@@ -30,12 +30,12 @@ class InconsistencyCheckPipeline(Pipeline):
 
     def __init__(self, callback: Optional[InconsistencyCheckCallback] = None):
         super().__init__(implementation_id="inconsistency_check_pipeline")
-        completion_args = CompletionArguments(temperature=0, max_tokens=2000)
+        completion_args = CompletionArguments()
 
         self.llm = IrisLangchainChatModel(
             request_handler=CapabilityRequestHandler(
                 requirements=RequirementList(
-                    gpt_version_equivalent=4.5,
+                    gpt_version_equivalent=5.5,
                     context_length=16385,
                 )
             ),


### PR DESCRIPTION
Configuration of o3-mini in PROD llm_config.yml should look like the following:

> - api_key: "xxx"
>   api_version: 2024-12-01-preview
>   azure_deployment: o3-mini
>   capabilities:
>     context_length: 128000
>     gpt_version_equivalent: 5.5
>     image_recognition: false
>     input_cost: 1.05
>     json_mode: true
>     output_cost: 15
>     privacy_compliance: true
>     self_hosted: false
>     vendor: OpenAI
>   description: GPT o3 Mini on Azure
>   endpoint: 'https://ase-se01.openai.azure.com/openai/deployments/o3-mini/chat/completions?api-version=2024-12-01-preview'
>   id: o3-mini
>   model: o3-mini
>   name: GPT o3 mini
>   type: azure_chat

Cost calculation is not working (yet), but that's fine.