### PR TITLE
`Atlas`: Bump jinja to 3.1.6

### DIFF
--- a/atlas/docs/requirements.txt
+++ b/atlas/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==1.0.0
 docutils==0.21.2
-Jinja2==3.1.5
+Jinja2==3.1.6
 requests==2.32.3
 Sphinx==8.1.3
 sphinx-rtd-theme==3.0.2


### PR DESCRIPTION
This pull request includes a small change to the `atlas/docs/requirements.txt` file. The change updates the version of the `Jinja2` package from `3.1.5` to `3.1.6`.