### PR TITLE
`Hyperion`: Add option to disable auth for testing

### DIFF
--- a/hyperion/.env.example
+++ b/hyperion/.env.example
@@ -1,6 +1,5 @@
 # API Authentication
 API_KEY=<YOUR_API_KEY_HERE>
-API_KEY_HEADER=X-API-Key
 DISABLE_AUTH=false
 
 # Playground Authentication (Leave empty for no authentication)

--- a/hyperion/app/main.py
+++ b/hyperion/app/main.py
@@ -5,6 +5,7 @@ from shared.security import AuthMiddleware, add_security_schema_to_app
 from shared.health import create_health_router
 
 from app.models import get_model
+from app.logger import logger
 from app.settings import settings
 from app.project_meta import project_meta
 
@@ -15,16 +16,22 @@ app = FastAPI(
     contact=project_meta.contact,
 )
 
-exclude_paths = ["/playground"]
-app.add_middleware(
-    AuthMiddleware,
-    api_key=settings.API_KEY,
-    header_name=settings.API_KEY_HEADER,
-    exclude_paths=exclude_paths,
-)
-add_security_schema_to_app(
-    app, header_name=settings.API_KEY_HEADER, exclude_paths=exclude_paths
-)
+# Add security schema to the app, can be disabled for development
+if not settings.DISABLE_AUTH:
+    logger.warning(
+        "API authentication is disabled. This is not recommended for production."
+    )
+
+    exclude_paths = ["/playground"]
+    app.add_middleware(
+        AuthMiddleware,
+        api_key=settings.API_KEY,
+        header_name="X-API-Key",
+        exclude_paths=exclude_paths,
+    )
+    add_security_schema_to_app(
+        app, header_name="X-API-Key", exclude_paths=exclude_paths
+    )
 
 # Add routers
 app.include_router(create_health_router(app.version))

--- a/hyperion/app/openapi.py
+++ b/hyperion/app/openapi.py
@@ -14,7 +14,7 @@ def get_openapi_specs():
         routes=app.routes,
     )
     openapi_json = add_security_schema_to_openapi(
-        openapi_json, header_name=settings.API_KEY_HEADER, exclude_paths=["/playground"]
+        openapi_json, header_name="X-API-Key", exclude_paths=["/playground"]
     )
     openapi_yaml = yaml.dump(openapi_json, allow_unicode=True)
     return openapi_yaml

--- a/hyperion/app/openapi.py
+++ b/hyperion/app/openapi.py
@@ -2,7 +2,6 @@ import yaml
 from fastapi.openapi.utils import get_openapi
 from shared.security import add_security_schema_to_openapi
 from app.main import app
-from app.settings import settings
 
 
 def get_openapi_specs():

--- a/hyperion/app/settings.py
+++ b/hyperion/app/settings.py
@@ -13,7 +13,6 @@ class Settings(BaseSettings):
 
     # API Security
     API_KEY: str = ""
-    API_KEY_HEADER: str = "X-API-Key"
     DISABLE_AUTH: bool = False
 
     # Playground Security


### PR DESCRIPTION
This pull request includes changes to the authentication setup and logging in the `hyperion` project. The most important changes include the removal of the `API_KEY_HEADER` setting, the addition of a logger for warning messages, and updates to the middleware configuration to use a hardcoded header name.

Authentication setup changes:

* [`hyperion/.env.example`](diffhunk://#diff-15cda091cfd87a787a20115a460783422823967494e528f3bd99a87adc382f84L3): Removed the `API_KEY_HEADER` setting from the example environment file.
* [`hyperion/app/settings.py`](diffhunk://#diff-81db3d32788cb6262570accf2dea38bc5b33e79ff2b6900136d9d861939b261fL16): Removed the `API_KEY_HEADER` attribute from the `Settings` class.

Logging and middleware configuration:

* [`hyperion/app/main.py`](diffhunk://#diff-16e120900d2ad11b2ba9ebf64d8662b56e9d56aaafbdbd16eb33d649d3992813R8): Added a logger to the main application file and included a warning message if authentication is disabled. [[1]](diffhunk://#diff-16e120900d2ad11b2ba9ebf64d8662b56e9d56aaafbdbd16eb33d649d3992813R8) [[2]](diffhunk://#diff-16e120900d2ad11b2ba9ebf64d8662b56e9d56aaafbdbd16eb33d649d3992813R19-R33)
* [`hyperion/app/main.py`](diffhunk://#diff-16e120900d2ad11b2ba9ebf64d8662b56e9d56aaafbdbd16eb33d649d3992813R19-R33): Updated the middleware configuration to use the hardcoded header name `"X-API-Key"` instead of the removed `API_KEY_HEADER` setting.