### PR TITLE
`Athena`: Add a llm as profiler approach for text exercise feedback generation

### DIFF
--- a/athena/modules/text/module_text_llm/module_text_llm/config.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/config.py
@@ -6,8 +6,9 @@ from athena import config_schema_provider
 from module_text_llm.chain_of_thought_approach import ChainOfThoughtConfig
 from module_text_llm.basic_approach import BasicApproachConfig
 from module_text_llm.divide_and_conquer import DivideAndConquerConfig
+from module_text_llm.llm_as_profiler import LLMAsProfilerConfig
 
-ApproachConfigUnion = Union[BasicApproachConfig, ChainOfThoughtConfig, DivideAndConquerConfig, SelfConsistencyConfig]
+ApproachConfigUnion = Union[BasicApproachConfig, ChainOfThoughtConfig, DivideAndConquerConfig, SelfConsistencyConfig, LLMAsProfilerConfig]
 
 @config_schema_provider
 class Configuration(BaseModel):

--- a/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/__init__.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/__init__.py
@@ -1,0 +1,18 @@
+from pydantic import Field
+from typing import Literal
+
+from athena.text import Exercise, Submission
+from module_text_llm.approach_config import ApproachConfig
+from module_text_llm.llm_as_profiler.prompt_generate_feedback import GenerateSuggestionsPrompt
+from module_text_llm.llm_as_profiler.prompt_profiler import ProfilerPrompt
+from module_text_llm.llm_as_profiler.generate_suggestions import generate_suggestions
+
+
+class LLMAsProfilerConfig(ApproachConfig):
+    type: Literal['llm_as_profiler'] = 'llm_as_profiler'
+    profiler_prompt: ProfilerPrompt = Field(default=ProfilerPrompt())
+    generate_suggestions_prompt: GenerateSuggestionsPrompt = Field(default=GenerateSuggestionsPrompt())
+
+    async def generate_suggestions(self, exercise: Exercise, submission: Submission, config, *, debug: bool,
+                                   is_graded: bool):
+        return await generate_suggestions(exercise, submission, config, debug=debug, is_graded=is_graded)

--- a/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/generate_suggestions.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/generate_suggestions.py
@@ -1,0 +1,129 @@
+from typing import List
+
+from athena import emit_meta
+from athena.text import Exercise, Submission, Feedback
+from athena.logger import logger
+from llm_core.utils.llm_utils import (
+    get_chat_prompt_with_formatting_instructions,
+    check_prompt_length_and_omit_features_if_necessary,
+    num_tokens_from_prompt,
+)
+from llm_core.utils.predict_and_parse import predict_and_parse
+from module_text_llm.approach_config import ApproachConfig
+from module_text_llm.helpers.utils import add_sentence_numbers, get_index_range_from_line_range, \
+    format_grading_instructions
+from module_text_llm.llm_as_profiler.prompt_profiler import ProfileModel
+from module_text_llm.llm_as_profiler.prompt_generate_feedback import AssessmentModel
+
+async def generate_suggestions(exercise: Exercise, submission: Submission, config: ApproachConfig, debug: bool,
+                               is_graded: bool) -> List[Feedback]:
+    model = config.model.get_model()  # type: ignore[attr-defined]
+
+    # Inject student preferences into the prompt
+    prompt_input = {
+        "grading_instructions": format_grading_instructions(exercise.grading_instructions, exercise.grading_criteria),
+        "problem_statement": exercise.problem_statement or "No problem statement.",
+        "example_solution": exercise.example_solution,
+        "submission": add_sentence_numbers(submission.text)
+    }
+
+    chat_prompt = get_chat_prompt_with_formatting_instructions(
+        model=model,
+        system_message=config.profiler_prompt.system_message,
+        human_message=config.profiler_prompt.human_message,
+        pydantic_object=ProfileModel
+    )
+
+    # Check if the prompt is too long and omit features if necessary (in order of importance)
+    omittable_features = ["example_solution", "problem_statement", "grading_instructions"]
+    prompt_input, should_run = check_prompt_length_and_omit_features_if_necessary(
+        prompt=chat_prompt,
+        prompt_input=prompt_input,
+        max_input_tokens=config.max_input_tokens,
+        omittable_features=omittable_features,
+        debug=debug
+    )
+
+    # Skip if the prompt is too long
+    if not should_run:
+        logger.warning("Input too long. Skipping.")
+        if debug:
+            emit_meta("prompt", chat_prompt.format(**prompt_input))
+            emit_meta("error",
+                      f"Input too long {num_tokens_from_prompt(chat_prompt, prompt_input)} > {config.max_input_tokens}")
+        return []
+
+    initial_result = await predict_and_parse(
+        model=model,
+        chat_prompt=chat_prompt,
+        prompt_input=prompt_input,
+        pydantic_object=ProfileModel,
+        tags=[
+            f"exercise-{exercise.id}",
+            f"submission-{submission.id}",
+        ],
+        use_function_calling=True
+    )
+
+    second_prompt_input = {
+        "max_points": exercise.max_points,
+        "student_assessment": initial_result.dict(),
+        "submission": add_sentence_numbers(submission.text),
+        "grading_instructions": format_grading_instructions(exercise.grading_instructions, exercise.grading_criteria),
+        "problem_statement": exercise.problem_statement or "No problem statement.",
+        "example_solution": exercise.example_solution
+    }
+
+
+    second_chat_prompt = get_chat_prompt_with_formatting_instructions(
+        model=model,
+        system_message=config.generate_suggestions_prompt.second_system_message,
+        human_message=config.generate_suggestions_prompt.answer_message,
+        pydantic_object=AssessmentModel)
+
+    result = await predict_and_parse(
+        model=model,
+        chat_prompt=second_chat_prompt,
+        prompt_input=second_prompt_input,
+        pydantic_object=AssessmentModel,
+        tags=[
+            f"exercise-{exercise.id}",
+            f"submission-{submission.id}",
+        ],
+        use_function_calling=True
+    )
+
+    if debug:
+        emit_meta("generate_suggestions", {
+            "prompt": chat_prompt.format(**prompt_input),
+            "result": result.dict() if result is not None else None
+        })
+
+    if result is None:
+        return []
+
+    grading_instruction_ids = set(
+        grading_instruction.id
+        for criterion in exercise.grading_criteria or []
+        for grading_instruction in criterion.structured_grading_instructions
+    )
+
+    feedbacks = []
+    for feedback in result.feedbacks:
+        index_start, index_end = get_index_range_from_line_range(feedback.line_start, feedback.line_end,
+                                                                 submission.text)
+        grading_instruction_id = feedback.grading_instruction_id if feedback.grading_instruction_id in grading_instruction_ids else None
+        feedbacks.append(Feedback(
+            exercise_id=exercise.id,
+            submission_id=submission.id,
+            title=feedback.title,
+            description=feedback.description,
+            index_start=index_start,
+            index_end=index_end,
+            credits=feedback.credits,
+            is_graded=is_graded,
+            structured_grading_instruction_id=grading_instruction_id,
+            meta={}
+        ))
+
+    return feedbacks

--- a/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/prompt_generate_feedback.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/prompt_generate_feedback.py
@@ -1,0 +1,82 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+system_message = """
+You are a grading assistant at a prestigious university tasked with grading student submissions for text exercises.
+
+Your goal is to be as helpful as possible to the student while providing constructive feedback without revealing the solution. You should also personalize the feedback based on the student's individual learning profile and preferences.
+
+To successfully complete this task, follow the steps below:
+
+1. Start by carefully reading the problem statement to identify what exactly is being asked. This is what the grading will be based on.
+2. If a sample solution is provided, analyze it to understand the logic and approach used to solve the problem. Use this to deduce the grading criteria and what a successful answer should contain.
+3. Carefully review the grading instructions. Determine how they align with the sample solution. Think through what kind of submissions would receive full, partial, or no credit.
+4. Read the student's submission and compare it to the sample solution and grading instructions. Grade the submission using the given criteria.
+5. Provide feedback in two parts:
+   - Referenced Feedback: List specific comments for any lines that contain mistakes, issues, or notable points. Refer to the line number line_start and line_end.
+   - General Feedback: Summarize the student's performance, comment on their strengths and challenges, and suggest improvements without referring to line numbers.
+6. Provide constructive, supportive suggestions on what the student could have done better to receive full credit or to improve their understanding. Avoid giving away the actual solution.
+7. Personalize your feedback based on the learner profile provided below. Consider the student's demonstrated competencies, learning challenges, cognitive level (based on Bloom's Taxonomy), and preferred feedback style. Adapt the tone, level of detail, and type of guidance accordingly.
+
+Below is the student's learner profile:
+{student_assessment}
+
+You are tasked with grading the following exercise. Remember: you are responding directly to the student, so your feedback should be addressed to them using a clear, respectful, and supportive tone.
+
+The maximum score for this exercise is {max_points} points. Your total score may not exceed this value.
+
+# Problem Statement
+{problem_statement}
+
+# Sample Solution
+{example_solution}
+
+# Grading Instructions
+{grading_instructions}
+
+Instructions:
+- Provide a score out of {max_points}.
+- Write personalized, actionable feedback using the style and cognitive insights from the learner profile.
+- Do not reveal the correct solution directly.
+- Return only the score and feedback. Do not include any extra commentary or metadata.
+
+"""
+
+
+human_message = """\
+Student\'s submission to grade (with sentence numbers <number>: <sentence>):
+\"\"\"
+{submission}
+\"\"\"\
+"""
+
+
+# Input Prompt
+
+class GenerateSuggestionsPrompt(BaseModel):
+    """\
+Features cit available: **{initial_feedback}**, **{max_points}**, **{student_grade}**, **{learner_profile}**
+
+"""
+    second_system_message: str = Field(default=system_message,
+                                       description="Message for priming AI behavior and instructing it what to do.")
+    answer_message: str = Field(default=human_message,
+                                description="Message from a human. The input on which the AI is supposed to act.")
+
+# Output Object
+
+class FeedbackModel(BaseModel):
+    title: str = Field(description="Very short title, i.e. feedback category or similar", example="Logic Error")
+    description: str = Field(description="Feedback description")
+    line_start: Optional[int] = Field(description="Referenced line number start, or empty if unreferenced")
+    line_end: Optional[int] = Field(description="Referenced line number end, or empty if unreferenced")
+    credits: float = Field(0.0, description="Number of points received/deducted")
+    grading_instruction_id: Optional[int] = Field(
+        description="ID of the grading instruction that was used to generate this feedback, or empty if no grading instruction was used"
+    )
+
+
+class AssessmentModel(BaseModel):
+    """Collection of feedbacks making up an assessment"""
+
+    feedbacks: List[FeedbackModel] = Field(description="Assessment feedbacks")

--- a/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/prompt_profiler.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/llm_as_profiler/prompt_profiler.py
@@ -1,0 +1,110 @@
+from typing import List, Optional
+from enum import Enum
+from pydantic import BaseModel, Field
+
+
+system_message = """
+You are an educational analyst tasked with evaluating a student's answer to a text-based exercise.
+
+Your goal is to:
+1. Identify the student's demonstrated competencies (what they understand or do well).
+2. Identify the student's challenges (mistakes, misconceptions, or difficulties).
+3. Estimate the current cognitive level the student demonstrates using Bloom's Taxonomy.
+4. Suggest the next cognitive level the student should aim for (target level).
+5. Include the student's known feedback style preference (brief/detailed, practical/theoretical).
+
+You will be given:
+- The student's submission
+- The correct solution or expected answer
+- Grading instructions or rubric (if available)
+- The student's feedback style preference
+
+Problem Statement:
+{problem_statement}
+
+Example Solution:
+{example_solution}
+
+Grading Instructions:
+{grading_instructions}
+
+Instructions:
+- Be specific in describing competencies and challenges.
+- Include Bloom level tags only if reasonably clear.
+- Provide suggestions only when helpful.
+- Return only valid JSON. Do not add any comments or explanations outside the JSON block.
+
+"""
+
+
+human_message = """\
+Student\'s submission to grade (with sentence numbers <number>: <sentence>):
+\"\"\"
+{submission}
+\"\"\"\
+"""
+
+
+# Input Prompt
+class ProfilerPrompt(BaseModel):
+    """\
+Features available: **{problem_statement}**, **{example_solution}**, **{grading_instructions}**, **{max_points}**, **{bonus_points}**, **{submission}**, **{practical_theoretical}**, **{creative_guidance}**, **{followup_summary}**, **{brief_detailed}**
+
+_Note: **{problem_statement}**, **{example_solution}**, or **{grading_instructions}** might be omitted if the input is too long._\
+"""
+    system_message: str = Field(default=system_message,
+                                description="Message for priming AI behavior and instructing it what to do.")
+    human_message: str = Field(default=human_message,
+                               description="Message from a human. The input on which the AI is supposed to act.")
+
+
+# Output Object
+
+class BloomLevel(str, Enum):
+    REMEMBER = "Remember"
+    UNDERSTAND = "Understand"
+    APPLY = "Apply"
+    ANALYZE = "Analyze"
+    EVALUATE = "Evaluate"
+    CREATE = "Create"
+
+
+class Competency(BaseModel):
+    description: str = Field(
+        description="A description of what the student demonstrated successfully."
+    )
+    bloom_level: Optional[BloomLevel] = Field(
+        default=None,
+        description="The Bloom's Taxonomy level corresponding to this competency."
+    )
+
+
+class Challenge(BaseModel):
+    description: str = Field(
+        description="A description of a learning challenge, misconception, or error identified in the student's response."
+    )
+    bloom_level: Optional[BloomLevel] = Field(
+        default=None,
+        description="The Bloom's level that this challenge relates to."
+    )
+    suggestion: Optional[str] = Field(
+        default=None,
+        description="An optional suggestion or tip to help the student overcome this challenge."
+    )
+
+
+class ProfileModel(BaseModel):
+    competencies: List[Competency] = Field(
+        description="A list of competencies the student has demonstrated in their submission."
+    )
+    challenges: List[Challenge] = Field(
+        description="A list of learning challenges or misconceptions detected in the student's response."
+    )
+    current_level: Optional[BloomLevel] = Field(
+        default=None,
+        description="The highest Bloom's level the student demonstrated in this exercise."
+    )
+    target_level: Optional[BloomLevel] = Field(
+        default=None,
+        description="The next Bloom's level the student should aim to reach."
+    )


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As we want to generate more personalized feedback, we want to introduce an approach that would make use of the LLM to profile the student.

### Description
<!-- Describe your changes in detail -->
- Add a new feedback generation approach, which in the first iteration profiles the student. Then uses that profile to generate personalized feedback.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
