### PR TITLE
`Iris`: Update DTO to use artifact instead of suggestion

### DIFF
--- a/iris/src/iris/domain/communication/communication_tutor_suggestion_status_update_dto.py
+++ b/iris/src/iris/domain/communication/communication_tutor_suggestion_status_update_dto.py
@@ -7,9 +7,9 @@ class TutorSuggestionStatusUpdateDTO(StatusUpdateDTO):
     """
     This class is used to update the status of a tutor suggestion.
     It inherits from StatusUpdateDTO and adds two optional fields:
-    - suggestion: The suggestion generated.
+    - artifact: The suggestion generated.
     - result: Generated chat answer.
     """
 
-    suggestion: Optional[str] = None
+    artifact: Optional[str] = None
     result: Optional[str] = None

--- a/iris/src/iris/pipeline/tutor_suggestion_pipeline.py
+++ b/iris/src/iris/pipeline/tutor_suggestion_pipeline.py
@@ -98,7 +98,7 @@ class TutorSuggestionPipeline(Pipeline):
             post_summary = None
         self.callback.done(
             "Generated tutor suggestions",
-            tutor_suggestion=post_summary,
+            artifact=post_summary,
             tokens=self.tokens,
         )
 

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -434,7 +434,7 @@ class TutorSuggestionCallback(StatusCallback):
         tokens: Optional[List[TokenUsageDTO]] = None,
         next_stage_message: Optional[str] = None,
         start_next_stage: bool = True,
-        tutor_suggestion: Optional[str] = None,
+        artifact: Optional[str] = None,
     ):
-        self.status.suggestion = tutor_suggestion
+        self.status.artifact = artifact
         super().done(message=message, final_result=final_result, tokens=tokens)


### PR DESCRIPTION
This PR updates the DTO to use `artifact` instead of `suggestion` as the DTO already has `suggestions`.