### PR TITLE
`Iris`: Adjust course chat prompt to reflect transcript availability per course

### DIFF
--- a/iris/src/iris/pipeline/prompts/iris_course_chat_prompts.py
+++ b/iris/src/iris/pipeline/prompts/iris_course_chat_prompts.py
@@ -59,7 +59,15 @@ You have access to each exercise's title, start/due date, and the student's subm
 You can request the problem statement of an exercise. Use this if you think understanding the problem statement will make your response more relevant or if the student asks about it.
 """
 
-iris_lecture_block = """
+iris_lecture_slides_only_block = """
+You can retrieve lecture content, including slides and summarized segments.
+• Use lecture retrieval to answer questions about lecture material, concepts, or to help the student connect content with their learning strategies.
+• Only reference lecture content if it's directly relevant to the student's question or reflection.
+• Reference lecture material using descriptive markdown links where appropriate.
+• There are NO transcripts for this course. Never mention transcripts. Like really never.
+"""
+
+iris_lecture_with_transcriptions_block = """
 You can retrieve lecture content, including slides, transcripts, and summarized segments.
 • Use lecture retrieval to answer questions about lecture material, concepts, or to help the student connect content with their learning strategies.
 • Only reference lecture content if it's directly relevant to the student's question or reflection.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for incorporating lecture transcriptions, when available, into course chat responses.
  - Chat responses now adapt to include either both slides and transcriptions, or slides only, based on course content availability.

- **Improvements**
  - Enhanced prompts to clearly distinguish between courses with and without lecture transcriptions, ensuring more accurate and context-aware chat guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->