### PR TITLE
`Athena`: Sort Evaluation Configs in Evaluation Config Selector

### DIFF
--- a/athena/playground/src/components/selectors/evaluation_config_selector.tsx
+++ b/athena/playground/src/components/selectors/evaluation_config_selector.tsx
@@ -18,11 +18,14 @@ export default function EvaluationConfigSelector(evaluationConfigSelectorProps: 
         onChange={(e) => setSelectedConfigId(e.target.value)}
       >
         <option value="new">New Evaluation</option>
-        {expertEvaluationConfigs.map((config) => (
-          <option key={config.id} value={config.id}>
-            {config.name}: {config.creationDate?.toString() ?? ""}
-          </option>
-        ))}
+        {expertEvaluationConfigs
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((config) => (
+            <option key={config.id} value={config.id}>
+              {config.name}: {config.creationDate?.toString() ?? ""}
+            </option>
+          ))}
       </select>
     </section>
   );


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sort evaluation configs in the selector.
We need a lot more evaluation configs than anticipated and it is getting unübersichtlich.

### Description
<!-- Describe your changes in detail -->
Implemented sorting for the evaluation config selector

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Open playground, upload multiple evaluation configs. View the evaluation config selector. The evaluation configs should be sorted by name.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

Without sorting:
<img width="599" alt="Bildschirmfoto 2025-06-30 um 12 10 13" src="https://github.com/user-attachments/assets/bb2d97a8-da8c-45c5-88ed-a3572910933a" />

With sorting:
<img width="599" alt="Bildschirmfoto 2025-06-30 um 12 09 33" src="https://github.com/user-attachments/assets/1075a591-094b-4ba3-81c7-777b890f05bb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the evaluation configuration dropdown to display options sorted alphabetically by name for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->