### PR TITLE
`Athena`: Add release tag to docker images for releases

### DIFF
--- a/.github/workflows/athena_build-and-push-docker.yml
+++ b/.github/workflows/athena_build-and-push-docker.yml
@@ -97,6 +97,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.ref == 'refs/heads/main' && 'main' || github.sha }}
             type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
+            type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/athena_build-and-push-docker.yml
+++ b/.github/workflows/athena_build-and-push-docker.yml
@@ -96,8 +96,8 @@ jobs:
             ls1tum/athena_${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ github.ref == 'refs/heads/main' && 'main' || github.sha }}
-            type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
-            type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name }}
+            type=ref,event=pull_request
+            type=ref,event=tag
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/athena_build-and-push-docker.yml
+++ b/.github/workflows/athena_build-and-push-docker.yml
@@ -96,7 +96,7 @@ jobs:
             ls1tum/athena_${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ github.ref == 'refs/heads/main' && 'main' || github.sha }}
-            type=ref,event=pull_request
+            type=ref,event=pr
             type=ref,event=tag
 
       - name: Build and push Docker image


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging in the build and push workflow to include the release tag name when triggered by a release event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->