### PR TITLE
`Athena`: Update link in playground footer to link to the new edutelligence repo

### DIFF
--- a/athena/playground/src/pages/_app.tsx
+++ b/athena/playground/src/pages/_app.tsx
@@ -30,16 +30,16 @@ export default function App({ Component, pageProps }: AppProps) {
         {
           process.env.NEXT_PUBLIC_ATHENA_IS_DEVELOP === 'true' ? <>
             <span>develop</span>&nbsp;-&nbsp;
-            <a href={`https://github.com/ls1intum/Athena/commit/${process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
+            <a href={`https://github.com/ls1intum/edutelligence/commit/${process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
               Commit:&nbsp;{(process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA ?? '').slice(0, 7)}
             </a>&nbsp;-&nbsp;
             </> : (
             process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA ? <>
-              <a href={`https://github.com/ls1intum/Athena/pull/${process.env.NEXT_PUBLIC_ATHENA_PR_NUMBER}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
+              <a href={`https://github.com/ls1intum/edutelligence/pull/${process.env.NEXT_PUBLIC_ATHENA_PR_NUMBER}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
                 PR&nbsp;#{process.env.NEXT_PUBLIC_ATHENA_PR_NUMBER}:&nbsp;
                 {process.env.NEXT_PUBLIC_ATHENA_PR_TITLE}
               </a>&nbsp;-&nbsp;
-              <a href={`https://github.com/ls1intum/Athena/pull/${process.env.NEXT_PUBLIC_ATHENA_PR_NUMBER}/commits/${process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
+              <a href={`https://github.com/ls1intum/edutelligence/pull/${process.env.NEXT_PUBLIC_ATHENA_PR_NUMBER}/commits/${process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA}`} target="_blank" className="text-primary-500 hover:text-primary-400 hover:underline">
                 Commit:&nbsp;{(process.env.NEXT_PUBLIC_ATHENA_COMMIT_SHA ?? '').slice(0, 7)}
               </a>&nbsp;-&nbsp;
               <span>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub links in the application footer to point to the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->