### PR TITLE
`Hyperion`: Fix sync proto artemis path

### DIFF
--- a/hyperion/app/scripts/sync_proto_artemis.py
+++ b/hyperion/app/scripts/sync_proto_artemis.py
@@ -192,13 +192,6 @@ Examples:
         artemis_path
         / "src"
         / "main"
-        / "java"
-        / "de"
-        / "tum"
-        / "cit"
-        / "aet"
-        / "artemis"
-        / "hyperion"
         / "proto"
         / "hyperion.proto"
     )


### PR DESCRIPTION
This pull request simplifies the file path construction in the `sync_proto_artemis.py` script by removing unnecessary directory components.

Path simplification:

* [`hyperion/app/scripts/sync_proto_artemis.py`](diffhunk://#diff-be4cf35edeb000e7879aaf425e64c7b9e35b09238d95d1639b086e01ecbb609aL195-L201): Removed redundant directory components (`java`, `de`, `tum`, `cit`, `aet`, `artemis`, `hyperion`) from the `artemis_path` definition in the `main()` function to streamline the file path construction.