### PR TITLE
`Hyperion`: Fix OpenAPI spec path to sync to Artemis

### DIFF
--- a/hyperion/app/scripts/sync_openapi_artemis.py
+++ b/hyperion/app/scripts/sync_openapi_artemis.py
@@ -183,16 +183,12 @@ Examples:
     config = load_config()
 
     # Get source openapi file (we know where this is)
-    source_openapi = Path(__file__).parent.parent / "openapi.yaml"
+    source_openapi = Path(__file__).parent.parent.parent / "openapi.yaml"
 
     # Get Artemis path
     artemis_path = get_artemis_path(config, args.artemis_path)
     target_openapi = (
         artemis_path
-        / "src"
-        / "main"
-        / "resources"
-        / "static"
         / "openapi"
         / "hyperion.yaml"
     )


### PR DESCRIPTION
This pull request includes a minor change to the `sync_openapi_artemis.py` script to fix the path to the source OpenAPI file.

Path correction:

* [`hyperion/app/scripts/sync_openapi_artemis.py`](diffhunk://#diff-2c9732d6fb47c32309860336317d1651b8c9ee0202d6a9015998ad45eeafb5f8L186-L195): Updated the `source_openapi` path to correctly navigate three parent directories instead of two, ensuring the script locates the `openapi.yaml` file in the intended location.