### PR TITLE
`Hyperion`: Add OpenRouter support for consistency check

### DIFF
--- a/hyperion/app/creation_steps/step8_review_and_refine/consistency_check/handler.py
+++ b/hyperion/app/creation_steps/step8_review_and_refine/consistency_check/handler.py
@@ -4,6 +4,8 @@ from langchain.chat_models import init_chat_model
 from langchain_core.runnables import RunnableParallel, RunnableLambda
 from langfuse.callback import CallbackHandler
 
+from app.models.openrouter import ChatOpenRouter
+
 from .models import (
     Metadata,
     ConsistencyCheckRequest,
@@ -20,7 +22,12 @@ langfuse_handler = CallbackHandler()
 class ConsistencyCheck:
 
     def __init__(self, model_name: str):
-        self.model = init_chat_model(model_name)
+        if model_name.startswith("openrouter:"):
+            self.model = ChatOpenRouter(
+                model_name=model_name.replace("openrouter:", ""),
+            )
+        else:
+            self.model = init_chat_model(model_name)
 
     def check(self, request: ConsistencyCheckRequest) -> ConsistencyCheckResponse:
         trace_id = uuid4()

--- a/hyperion/app/models/openrouter.py
+++ b/hyperion/app/models/openrouter.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from langchain_core.utils.utils import secret_from_env
+from langchain_openai import ChatOpenAI
+from pydantic import Field, SecretStr
+from app.settings import settings
+
+
+class ChatOpenRouter(ChatOpenAI):
+    openai_api_key: Optional[SecretStr] = Field(
+        alias="api_key",
+        default_factory=secret_from_env(settings.OPENROUTER_API_KEY, default=None),
+    )
+
+    @property
+    def lc_secrets(self) -> dict[str, str]:
+        return {"openai_api_key": "OPENROUTER_API_KEY"}
+
+    def __init__(self, openai_api_key: Optional[str] = None, **kwargs):
+        openai_api_key = openai_api_key or settings.OPENROUTER_API_KEY
+        super().__init__(
+            base_url="https://openrouter.ai/api/v1",
+            openai_api_key=openai_api_key,
+            **kwargs
+        )

--- a/hyperion/app/settings.py
+++ b/hyperion/app/settings.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     OLLAMA_BASIC_AUTH_PASSWORD: str = ""
     OLLAMA_HOST: str = ""
 
+    # OpenRouter
+    OPENROUTER_API_KEY: str = ""
+
     LANGFUSE_PUBLIC_KEY: str = ""
     LANGFUSE_SECRET_KEY: str = ""
     LANGFUSE_HOST: str = ""


### PR DESCRIPTION
This pull request introduces support for the OpenRouter API in the consistency check functionality. The key changes include the addition of a new `ChatOpenRouter` class, integration of OpenRouter-specific logic into the `ConsistencyCheck` class, and updates to the application settings to include an OpenRouter API key.

### OpenRouter API Integration:

* **New `ChatOpenRouter` class**: Added a new class in `hyperion/app/models/openrouter.py` that extends `ChatOpenAI` to support OpenRouter-specific configurations, including the API key and base URL. (`[hyperion/app/models/openrouter.pyR1-R25](diffhunk://#diff-a5ec6d7de993d7501090166e2220beaf9cf4023e3744098fdeda82dd975906c3R1-R25)`)

* **Integration in `ConsistencyCheck`**: Updated the `ConsistencyCheck` class in `hyperion/app/creation_steps/step8_review_and_refine/consistency_check/handler.py` to initialize the `ChatOpenRouter` model when the `model_name` starts with the `openrouter:` prefix. (`[hyperion/app/creation_steps/step8_review_and_refine/consistency_check/handler.pyR25-R29](diffhunk://#diff-46df47cdc996bbadfd2306d3a2ccb5bc6d0b9107f745a777b1e5cab390d64472R25-R29)`)

### Configuration Updates:

* **Added OpenRouter API key setting**: Introduced a new `OPENROUTER_API_KEY` field in the `Settings` class in `hyperion/app/settings.py` to store the OpenRouter API key. (`[hyperion/app/settings.pyR33-R35](diffhunk://#diff-81db3d32788cb6262570accf2dea38bc5b33e79ff2b6900136d9d861939b261fR33-R35)`)