### PR TITLE
`Atlas`: AtlasML Deployment Workflow + Documentation 

### DIFF
--- a/.github/workflows/atlas_build-and-push-docker.yml
+++ b/.github/workflows/atlas_build-and-push-docker.yml
@@ -1,196 +1,28 @@
-name: AtlasML - Build and Push Docker Image natively
+name: AtlasML - Build Docker Images
 
 on:
-  workflow_call:
-    inputs:
-        image-name:
-          type: string
-          default: ${{ github.repository }}/atlasml
-          description: "The name for the docker image (Default: Repository name)"
-        registry:
-          type: string
-          default: ghcr.io
-          description: "The registry to push the image to (Default: ghcr.io)"
-        labels:
-          type: string
-          description: "Label that should be appended to the image"
-          required: false
-        tags:
-          type: string
-          description: |
-            Tags for the image. Supports flexible formats:
-            - Comma-separated simple tags (e.g., "v1.0,latest,stable")
-            - Full docker/metadata-action tag configuration (e.g., "type=semver,pattern={{version}}")
-            - Mixed format with multiple lines (e.g., "v1.0,stable" on one line and "type=semver,pattern={{version}}" on another)
-          required: false
-    outputs:
-      image_tag: 
-        description: "The tag of the image that was built"
-        value: ${{ jobs.merge.outputs.image_tag }}
-    secrets:
-      registry-user:
-        required: false
-      registry-password:
-        required: false
-
+  push:
+    paths:
+      - 'atlas/**'
+      - '.github/workflows/atlas_build-and-push-docker.yml'
+  release:
+    types:
+      - created
 
 jobs:
   build:
-    name: Build ${{ matrix.platform }} Docker Image for AtlasML
+    name: ${{ matrix.name }}
+    if: github.actor != 'dependabot[bot]'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-          # - platform: linux/arm64
-          #   runner: ubuntu-24.04-arm
-
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
-    steps:
-      # Git Checkout
-      - name: Git Checkout (specific ref)
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ inputs.registry }}/${{ inputs.image-name }}
-
-      - name: Build and push Docker Image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: ./atlas/AtlasMl
-          file: ./atlas/AtlasMl/Dockerfile
-          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
-          outputs: type=image,"name=${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          image="${{ inputs.image-name }}"
-          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"          
-  
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-  merge:
-    runs-on: ubuntu-latest
-    outputs: 
-      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
-    needs:
-      - build
-    steps:
-      - name: Prepare
-        run: |
-          image="${{ inputs.image-name }}"
-          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-${{ env.IMAGE_NAME }}-*
-          merge-multiple: true
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # Process tags input to support both simple tags and advanced configuration
-      - name: Prepare tag configuration
-        id: tag_config
-        run: |
-          # Use TAGS_CONFIG environment variable to store tags configuration
-          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
-          
-          # Default tagging configuration
-          echo "type=raw,value=latest,enable={{is_default_branch}}" >> $GITHUB_ENV
-          echo "type=ref,event=branch" >> $GITHUB_ENV
-          echo "type=ref,event=pr" >> $GITHUB_ENV
-          
-          # Check if tags input is provided
-          if [ -n "${{ inputs.tags }}" ]; then
-            # Process input line by line
-            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
-              # Trim whitespace
-              line=$(echo "$line" | xargs)
-          
-              if [ -n "$line" ]; then
-                if [[ "$line" == *"type="* ]]; then
-                  # Line contains configuration, add it directly
-                  echo "$line" >> $GITHUB_ENV
-                else
-                  # Line contains simple tags, process as comma-separated list
-                  IFS=',' read -ra TAG_ARRAY <<< "$line"
-                  for tag in "${TAG_ARRAY[@]}"; do
-                    # Trim whitespace from each tag
-                    tag=$(echo "$tag" | xargs)
-                    if [ -n "$tag" ]; then
-                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
-                    fi
-                  done
-                fi
-              fi
-            done
-          fi
-          
-          echo "EOF" >> $GITHUB_ENV
-
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ inputs.registry }}/${{ inputs.image-name }}
-          tags: |
-            ${{ env.TAGS_CONFIG }}
-          labels: |
-            ${{ inputs.labels }}        
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ inputs.registry }}/${{ inputs.image-name }}@sha256:%s ' *)          
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
-          
-      - id: output-image-tag
-        run: |
-          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+          - name: AtlasML
+            dockerfile: ./atlas/AtlasMl/Dockerfile
+            image: ghcr.io/ls1intum/edutelligence/atlasml
+            context: ./atlas/AtlasMl
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@feat/minor-build-improvements
+    with:
+      image-name: ${{ matrix.image }}
+      docker-file: ${{ matrix.dockerfile }}
+      docker-context: ${{ matrix.context }}

--- a/.github/workflows/atlas_deploy-test.yml
+++ b/.github/workflows/atlas_deploy-test.yml
@@ -42,7 +42,7 @@ jobs:
     uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: 'AtlasML - Test 1'
-      docker-compose-file: './atlas/docker/compose.atlas.yaml'
+      docker-compose-file: './atlas/compose.atlas.yaml'
       main-image-name: ls1intum/edutelligence/atlasml
       image-tag: ${{ inputs.image-tag }}
       deployment-base-path: '/opt/atlasml'

--- a/.github/workflows/atlas_deploy-test.yml
+++ b/.github/workflows/atlas_deploy-test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   provision-env:
     runs-on: ubuntu-latest
-    environment: 'AtlasML - Test 1'
+    environment: 'Atlas - Test 1'
     steps:
       - name: Write .env to remote host
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/atlas_deploy-test.yml
+++ b/.github/workflows/atlas_deploy-test.yml
@@ -1,0 +1,49 @@
+name: AtlasML - Deploy to Test 1
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        type: string
+        description: 'Image tag to deploy (default: pr-<number> if PR exists, latest for default branch)'
+      deploy-atlasml:
+        type: boolean
+        default: true
+        description: (Re-)deploys AtlasML.
+
+jobs:
+  provision-env:
+    runs-on: ubuntu-latest
+    environment: 'AtlasML - Test 1'
+    steps:
+      - name: Write .env to remote host
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            sudo mkdir -p /opt/atlasml
+            cat << EOF | sudo tee /opt/atlasml/.env > /dev/null
+            PYTHONPATH='${{ secrets.PYTHONPATH }}'
+            WEAVIATE_HOST='${{ secrets.WEAVIATE_HOST }}'
+            WEAVIATE_PORT='${{ secrets.WEAVIATE_PORT }}'
+            WEAVIATE_GRPC_PORT='${{ secrets.WEAVIATE_GRPC_PORT }}'
+            OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}'
+            OPENAI_API_URL='${{ secrets.OPENAI_API_URL }}'
+            ATLAS_API_KEYS='${{ secrets.ATLAS_API_KEYS }}'
+            SENTRY_DSN='${{ secrets.SENTRY_DSN }}'
+            ENV='${{ secrets.ENV }}'
+            EOF
+            sudo chmod 600 /opt/atlasml/.env
+  deploy-atlasml:
+    needs: provision-env
+    if: ${{ inputs.deploy-atlasml }}
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
+    with:
+      environment: 'AtlasML - Test 1'
+      docker-compose-file: './atlas/docker/compose.atlas.yaml'
+      main-image-name: ls1intum/edutelligence/atlasml
+      image-tag: ${{ inputs.image-tag }}
+      deployment-base-path: '/opt/atlasml'
+    secrets: inherit

--- a/atlas/AtlasMl/atlasml/dependencies.py
+++ b/atlas/AtlasMl/atlasml/dependencies.py
@@ -1,3 +1,15 @@
+"""
+Authentication dependencies for FastAPI routes.
+
+This module exposes reusable dependencies for header-based API key validation.
+Routers can include `Depends(TokenValidator)` (or `validate_token`) to enforce
+that incoming requests provide a valid key via the `Authorization` header.
+
+Headers:
+- Authorization: Raw API key value (no prefix). Must match one configured in
+  `ATLAS_API_KEYS`.
+"""
+
 from fastapi import Depends
 from fastapi.requests import Request
 from typing import List
@@ -14,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_api_key(request: Request) -> str:
+    """Extract the `Authorization` header value or raise for missing header."""
     authorization_header = request.headers.get("Authorization")
     logger.debug(f"Received Authorization header: {authorization_header}")
 
@@ -30,10 +43,12 @@ def get_api_keys() -> List[APIKeyConfig]:
 
 
 class TokenValidator:
+    """Callable dependency that validates API keys against configured values."""
     def __init__(self, api_keys: List[APIKeyConfig] = Depends(get_api_keys)):
         self.api_keys = api_keys
 
     async def __call__(self, api_key: str = Depends(_get_api_key)) -> APIKeyConfig:
+        """Return the matching `APIKeyConfig` if the key is valid, else raise."""
         for key in self.api_keys:
             logger.debug(f"Checking API key: {key}")
             if key.token == api_key:
@@ -47,7 +62,7 @@ def validate_token(
     api_key: str = Depends(_get_api_key),
     api_keys: List[APIKeyConfig] = Depends(get_api_keys),
 ) -> APIKeyConfig:
-    """Dependency function to validate API tokens."""
+    """Functional alternative to `TokenValidator` for validating API tokens."""
     for key in api_keys:
         logger.debug(f"Checking API key: {key}")
         if key.token == api_key:

--- a/atlas/AtlasMl/atlasml/routers/competency.py
+++ b/atlas/AtlasMl/atlasml/routers/competency.py
@@ -1,3 +1,15 @@
+"""
+Competency endpoints for AtlasML.
+
+This router exposes endpoints to:
+- Suggest competencies similar to a given description
+- Persist competencies and exercises with an operation type
+- Suggest competency relations (currently generated heuristically)
+
+All endpoints are versioned under `/api/v1/competency`.
+Request/response models are defined in `atlasml.models.competency`.
+"""
+
 import logging
 import random
 from fastapi import APIRouter, HTTPException, Depends
@@ -33,16 +45,16 @@ async def suggest_competencies(
     request: SuggestCompetencyRequest,
 ) -> SuggestCompetencyResponse:
     """
-    Suggest competencies based on similarity to the provided description.
+    Suggest competencies based on semantic similarity of the input description.
 
     Args:
-        request: Request containing description for competency suggestion
+        request: Pydantic model with `description` and `course_id`.
 
     Returns:
-        SuggestCompetencyResponse with suggested competencies
+        SuggestCompetencyResponse: A list of matching `Competency` items.
 
     Raises:
-        HTTPException: 400 for validation errors, 500 for server errors
+        HTTPException: 400 on validation errors, 500 on internal failures.
     """
     try:
         logger.info(
@@ -73,16 +85,17 @@ async def suggest_competencies(
 @router.post("/save", dependencies=[])
 async def save_competencies(request: SaveCompetencyRequest):
     """
-    Save competencies and/or exercises with the specified operation type.
+    Save competencies and/or a single exercise with an operation type.
 
     Args:
-        request: Request containing competency/exercise data and operation type
+        request: Pydantic model with optional `competencies`, optional `exercise`,
+            and an `operation_type` (UPDATE/DELETE).
 
     Returns:
-        200 OK HTTP response on successful save
+        200 OK on success with an empty body.
 
     Raises:
-        HTTPException: 400 for validation errors, 500 for server errors
+        HTTPException: 400 on validation errors, 500 on internal failures.
     """
     try:
         logger.info(
@@ -147,8 +160,10 @@ async def save_competencies(request: SaveCompetencyRequest):
 )
 async def suggest_competency_relations(course_id: int) -> CompetencyRelationSuggestionResponse:
     """
-    Suggest competency relations for a given course.
-    Currently generates random directed relations between competencies of the course.
+    Suggest directed relations between competencies for a course.
+
+    The current implementation relies on the pipeline to produce relation
+    suggestions; it may (temporarily) be heuristic.
     """
     try:
         logger.info(f"Suggesting competency relations for course_id={course_id}")

--- a/atlas/AtlasMl/atlasml/routers/health.py
+++ b/atlas/AtlasMl/atlasml/routers/health.py
@@ -1,3 +1,9 @@
+"""Health check endpoints for AtlasML.
+
+Provides a minimal liveness probe under `/api/v1/health/` returning HTTP 200.
+This router is safe to use for container orchestrator probes and uptime checks.
+"""
+
 from fastapi import APIRouter, Response, status
 
 router = APIRouter(prefix="/api/v1/health", tags=["health"])
@@ -5,6 +11,7 @@ router = APIRouter(prefix="/api/v1/health", tags=["health"])
 
 @router.get("/")
 def health():
+    """Return an empty JSON list with 200 OK as a simple liveness response."""
     return Response(
         status_code=status.HTTP_200_OK,
         content=b"[]",

--- a/atlas/compose.atlas.yaml
+++ b/atlas/compose.atlas.yaml
@@ -1,0 +1,36 @@
+services:
+  atlasml:
+    image: 'ghcr.io/ls1intum/edutelligence/atlasml:${IMAGE_TAG}'
+    env_file:
+      - .env
+    environment:
+      PYTHONPATH: ${PYTHONPATH:-/atlasml}
+      WEAVIATE_HOST: ${WEAVIATE_HOST:-http://weaviate-test.ase.cit.tum.de/}
+      WEAVIATE_PORT: ${WEAVIATE_PORT:-80}
+      WEAVIATE_GRPC_PORT: ${WEAVIATE_GRPC_PORT:-443}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_API_URL: ${OPENAI_API_URL:-https://ase-se01.openai.azure.com}
+      ATLAS_API_KEYS: ${ATLAS_API_KEYS:-["SuperSecureKey"]}
+      SENTRY_DSN: ${SENTRY_DSN:-https://8fe7eac930933ea3c83ff7a66555de18@sentry.aet.cit.tum.de/6}
+      ENV: ${ENV:-production}
+    restart: unless-stopped
+    ports:
+      - '80:8000'
+    networks:
+      - shared-network
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/v1/health']
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 5s
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '50m'
+        max-file: '5'
+
+networks:
+  shared-network:
+    name: shared-network
+    driver: bridge

--- a/atlas/docs/dev/atlasml/api.md
+++ b/atlas/docs/dev/atlasml/api.md
@@ -1,0 +1,36 @@
+---
+title: 'AtlasML API'
+---
+
+# AtlasML API
+
+The AtlasML API is a versioned REST interface exposed via FastAPI. Base paths depend on deployment configuration (e.g., service root when accessed internally). All responses use standard HTTP status codes and Pydantic-validated payloads.
+
+All endpoints are versioned and grouped by router.
+
+## Health
+
+- `GET /api/v1/health/`
+  - Returns 200 OK with an empty JSON list, serving as a minimalist liveness endpoint. Use this for container orchestrator probes and uptime monitors.
+
+## Competency
+
+Authentication: if enabled upstream, include `Authorization: <API_KEY>` with a token present in `ATLAS_API_KEYS`. Unauthorized requests will be rejected by the dependency if configured on the route.
+
+- `POST /api/v1/competency/suggest`
+
+  - Request: `SuggestCompetencyRequest`
+  - Response: `SuggestCompetencyResponse`
+  - Suggests relevant competencies for a given textual description and course context by leveraging the service’s ML pipeline and vector search. Use this to provide recommendations during content creation or tagging.
+
+- `POST /api/v1/competency/save`
+
+  - Request: `SaveCompetencyRequest`
+  - Response: 200 OK (no content)
+  - Persists competencies and/or exercises with an explicit `operation_type` (`UPDATE`/`DELETE`). Use this to upsert items or remove outdated entries, triggering downstream updates where applicable.
+
+- `GET /api/v1/competency/relations/suggest/{course_id}`
+  - Response: `CompetencyRelationSuggestionResponse`
+  - Generates candidate directed relations between competencies for the specified course. This can support graph-building tasks such as prerequisite mapping or curriculum analysis.
+
+See the models page for full schema definitions and field descriptions.

--- a/atlas/docs/dev/atlasml/models.md
+++ b/atlas/docs/dev/atlasml/models.md
@@ -1,0 +1,58 @@
+---
+title: 'AtlasML Models'
+---
+
+# AtlasML Models
+
+Module: `atlasml/models/competency.py`. These Pydantic models define the API contracts and core DTOs. They are validated automatically by FastAPI and rendered in OpenAPI, enabling type-safe client generation and consistent error handling.
+
+## Core Types
+
+- `OperationType`: `UPDATE` | `DELETE`. Indicates whether a request should upsert or remove records. Use `UPDATE` for both creating and modifying entries.
+
+- `Competency`. Represents a single competency item identified within a course. It is the core unit for suggestions, relations, and persistence.
+
+  - `id: int`
+  - `title: str`
+  - `description: Optional[str]`
+  - `course_id: int`
+
+- `ExerciseWithCompetencies`. Captures an exercise artifact and optional competency links. Useful when associating learning content with one or more competencies.
+
+  - `id: int`
+  - `title: str`
+  - `description: str`
+  - `competencies: Optional[list[int]]`
+  - `course_id: int`
+
+- `SemanticCluster`. Describes a group identifier, its course context, and a vector embedding. This can support clustering and labeling workflows.
+  - `cluster_id: str`
+  - `course_id: int`
+  - `vector_embedding: list[float]`
+
+## Request/Response DTOs
+
+- `SuggestCompetencyRequest`. Input payload for retrieving recommended competencies. Provide a natural-language `description` and the `course_id` for contextualization.
+
+  - `description: str`
+  - `course_id: int`
+
+- `SuggestCompetencyResponse`. Output with a ranked list of `Competency` objects. Consumers can display, filter, or post-process suggestions as needed.
+
+  - `competencies: list[Competency]`
+
+- `SaveCompetencyRequest`. Wrapper for saving either a list of competencies, a single exercise, or both, along with an `operation_type`. This unifies create/update/delete behaviors behind a single endpoint.
+
+  - `competencies: Optional[list[Competency]]`
+  - `exercise: Optional[ExerciseWithCompetencies]`
+  - `operation_type: OperationType`
+
+- `RelationType`: `MATCHES` | `EXTENDS` | `REQUIRES`. Encodes the semantics of edges in a competency graph (e.g., prerequisites or hierarchical relationships).
+
+- `CompetencyRelation`. Directed edge from `tail_id` to `head_id` with an associated `relation_type`. Used to represent candidate or curated links among competencies.
+
+  - `tail_id: int`
+  - `head_id: int`
+  - `relation_type: RelationType`
+
+- `CompetencyRelationSuggestionResponse`. Collection of proposed relations for a course. Downstream systems may visualize, validate, or persist these links.

--- a/atlas/docs/dev/atlasml/overview.md
+++ b/atlas/docs/dev/atlasml/overview.md
@@ -1,0 +1,32 @@
+---
+title: 'AtlasML Service Overview'
+---
+
+# AtlasML Service Overview
+
+AtlasML is a FastAPI-based microservice that exposes competency-centric ML features through a REST API. It integrates tightly with a Weaviate vector database to persist and query embeddings and domain metadata. The service is designed to be modular and observable, with configurable authentication and optional Sentry integration for production use.
+
+## Architecture
+
+- FastAPI app: `atlasml/app.py`. Creates the application, wires startup/shutdown logic, installs logging middleware, and registers routers. Centralized validation error handling provides consistent 422 responses with debugging details.
+- Routers: `atlasml/routers/`. `health.py` offers a minimal liveness check for probes. `competency.py` provides endpoints for suggesting competencies, persisting items, and proposing relations within a course context.
+- Models: `atlasml/models/competency.py`. Defines request/response Pydantic models for endpoint contracts and core domain DTOs such as `Competency` and `ExerciseWithCompetencies`.
+- Configuration: `atlasml/config.py`. Loads strongly typed settings from environment variables, including API keys, Weaviate endpoints, and optional Sentry DSN. Safe defaults are used in tests or when explicitly requested.
+- Auth dependencies: `atlasml/dependencies.py`. Supplies `TokenValidator`/`validate_token` dependencies to enforce a simple API-key based authorization using the `Authorization` header.
+- Weaviate client: `atlasml/clients/weaviate.py`. Manages a singleton Weaviate connection, bootstraps collections and properties, and exposes high-level CRUD/search helpers.
+
+## Runtime
+
+- Sentry (optional) is initialized automatically when `ENV=production` and `SENTRY_DSN` is set. This captures errors and traces with PII only when explicitly enabled.
+- Request/response logging middleware emits concise request lines, best-effort bodies for POST, response codes, and end-to-end duration. This supports rapid debugging in dev and observability in staging.
+- The Weaviate client is checked on startup for liveness and closed gracefully on shutdown, ensuring connections are released and schemas are validated before requests hit the endpoints.
+
+```{toctree}
+:maxdepth: 2
+:caption: AtlasML Details
+
+api
+models
+settings_auth
+weaviate
+```

--- a/atlas/docs/dev/atlasml/settings_auth.md
+++ b/atlas/docs/dev/atlasml/settings_auth.md
@@ -1,0 +1,30 @@
+---
+title: 'Settings and Authentication'
+---
+
+# Settings and Authentication
+
+## Settings
+
+Module: `atlasml/config.py`. Settings are strongly typed via Pydantic and loaded from environment variables. The service can operate with safe defaults in tests or when explicitly requested, while production requires explicit configuration.
+
+Environment variables:
+
+- `ATLAS_API_KEYS`: Comma-separated list of API key tokens
+- `WEAVIATE_HOST`: Weaviate host (e.g., `localhost`)
+- `WEAVIATE_PORT`: Weaviate REST port (e.g., `8080`)
+- `WEAVIATE_GRPC_PORT`: Weaviate gRPC port (e.g., `50051`)
+- `SENTRY_DSN`: Optional Sentry DSN (used when `ENV=production`)
+- `ENV`: Environment name (e.g., `dev`, `production`)
+
+Defaults are used in tests or when `get_settings(use_defaults=True)` is explicitly requested. The `ENV` variable also toggles optional production-only features like Sentry error reporting.
+
+## Authentication
+
+Module: `atlasml/dependencies.py`. Authentication uses a simple API-key strategy implemented as FastAPI dependencies. This can be attached per-route or globally depending on deployment needs.
+
+AtlasML uses a simple API key mechanism via the `Authorization` header. Keys are compared verbatim and should be rotated and stored securely via your deployment platform’s secret manager.
+
+- Header: `Authorization: <API_KEY>`
+- Keys are read from `ATLAS_API_KEYS` and compared verbatim.
+- Use `Depends(TokenValidator)` or `validate_token` on routes to enforce auth. For example, add `dependencies=[Depends(TokenValidator)]` to a router or endpoint.

--- a/atlas/docs/dev/atlasml/weaviate.md
+++ b/atlas/docs/dev/atlasml/weaviate.md
@@ -1,0 +1,37 @@
+---
+title: 'Weaviate Integration'
+---
+
+# Weaviate Integration
+
+Module: `atlasml/clients/weaviate.py`. The client wraps the official SDK with a singleton accessor, schema bootstrap, and high-level helpers. This keeps API handlers simple and centralizes error handling and connection lifecycle.
+
+AtlasML connects to Weaviate using settings from `atlasml/config.py`. On startup, the client ensures that required collections exist with the expected schema, adding missing properties when necessary to avoid manual migrations.
+
+## Collections
+
+- `Exercise`. Stores exercise metadata and optional competency associations for retrieval and analysis.
+- `Competency`. Holds core competency records used for suggestions, relations, and clustering operations.
+- `SemanticCluster`. Maintains cluster identifiers and related metadata for grouping and labeling.
+
+Properties are defined via `COLLECTION_SCHEMAS` and created/updated at runtime. This allows incremental evolution of the data model without service downtime.
+
+## Client Access
+
+```python
+from atlasml.clients.weaviate import get_weaviate_client, CollectionNames
+
+client = get_weaviate_client()
+items = client.get_all_embeddings(CollectionNames.COMPETENCY.value)
+```
+
+## Common Operations
+
+- `add_embeddings(collection, embeddings, properties)` → `uuid`. Inserts a vector and associated properties into a collection and returns the object UUID.
+- `get_all_embeddings(collection)` → list of objects with vectors. Iterates all objects for analysis, export, or debugging.
+- `get_embeddings_by_property(collection, property_name, property_value)` → filtered list. Fetches objects where a property equals a given value (e.g., `course_id`).
+- `search_by_multiple_properties(collection, property_filters)` → filtered list. Combines multiple equality filters (AND) to narrow down results.
+- `update_property_by_id(collection, id, properties, vector)` → `True`. Updates stored properties and optionally replaces the vector for a specific UUID.
+- `delete_by_property(collection, property_name, property_value)` → number deleted. Removes objects matching the equality filter and reports the count.
+
+Errors raise `WeaviateOperationError`; connectivity issues raise `WeaviateConnectionError`. Callers should translate these into appropriate HTTP responses or retries depending on context.

--- a/atlas/docs/dev/dev.md
+++ b/atlas/docs/dev/dev.md
@@ -1,7 +1,14 @@
 ---
-title: "Developer Guide"
+title: 'Developer Guide'
 ---
 
 # Developer Guide
 
-General dev guide todo
+This developer guide contains technical documentation for Atlas services and components.
+
+```{toctree}
+:maxdepth: 2
+:caption: AtlasML Service
+
+atlasml/overview
+```


### PR DESCRIPTION
<!--
  > [!CAUTION]
  > This PR does NOT contain migrations.
  > This PR does NOT introduce breaking changes.
-->

### What?

This PR adds a production-ready build-and-deploy pipeline for AtlasML:

- Standardized Docker build-and-push workflow aligned with Hyperion
- New Docker Compose for AtlasML service
- New deploy workflow that provisions runtime env vars from GitHub Environment secrets and deploys via docker compose
- Exposes AtlasML on host port 80

### Why?

We want AtlasML to follow the same CI/CD conventions as Hyperion for consistency, easier maintenance, and faster, safer deployments. Centralizing env management in GitHub Environments simplifies secret handling and avoids manual edits on servers.

### How?

- **Build and Push**

  - Replaced Atlas build workflow with the reusable workflow used by Hyperion
  - Builds `ghcr.io/ls1intum/edutelligence/atlasml` from `./atlas/AtlasMl/Dockerfile` and `./atlas/AtlasMl`
  - File: `edutelligence/.github/workflows/atlas_build-and-push-docker.yml`

- **Compose (Runtime)**

  - Added `atlas/compose.atlas.yaml` for the AtlasML service
  - Publishes container port 8000 to host port 80 (`ports: ['80:8000']`)
  - Healthcheck targets `http://localhost:8000/api/v1/health`
  - Traefik labels removed
  - Loads `.env` at runtime (see below)

- **Deploy**

  - New deploy workflow writes `/opt/atlasml/.env` on the target host based on GitHub Environment “AtlasML - Test 1” secrets, then runs the reusable compose deploy
  - Files:
    - `edutelligence/.github/workflows/atlas_deploy-test.yml`
    - `atlas/compose.atlas.yaml`

- **Required GitHub Environment secrets** (Environment: “AtlasML - Test 1”)
  - Infra: `SSH_HOST`, `SSH_USERNAME`, `SSH_PRIVATE_KEY`
  - App config: `PYTHONPATH`, `WEAVIATE_HOST`, `WEAVIATE_PORT`, `WEAVIATE_GRPC_PORT`, `OPENAI_API_KEY`, `OPENAI_API_URL`, `ATLAS_API_KEYS`, `SENTRY_DSN`, `ENV`

### Affected Issues & Feature Proposal

- Align AtlasML CI/CD with Hyperion
- Enable one-click deploys with environment-scoped secrets

### Checklist

#### General

- [x] I chose a title conforming to the naming conventions for pull requests.

#### AtlasML - Infrastructure/DevOps

- [x] Build workflow aligns with Hyperion’s reusable workflow
- [x] Deploy workflow provisions server-side `.env` from Environment secrets
- [x] Service listens on host port 80

### Testing

#### Testing Instructions

1. Build image
   - Push to a branch or trigger the Atlas build workflow; verify an image is pushed to `ghcr.io/ls1intum/edutelligence/atlasml:<tag>`.
2. Provision environment and deploy
   - Ensure Environment “AtlasML - Test 1” has the secrets listed above.
   - Trigger “AtlasML - Deploy to Test 1” with `image-tag=<tag>`.
3. Verify service
   - On the target host, confirm container is up: `docker ps`
   - Healthcheck: `curl http://localhost:80/api/v1/health` (from host)
   - Remote access: ensure firewall/security groups allow inbound port 80 if external access is needed.

#### Review Progress

##### Code Review

- [ ] Code Review 1
- [ ] Code Review 2

##### Manual Test

- [ ] Deploy succeeds with Environment-provisioned `.env`
- [ ] Health endpoint returns OK on port 80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added AtlasML service with Docker Compose (healthcheck, restart policy, port 80) and env-file support.
  - API improvements: request/response timing logs, clearer 422 validation responses, and API-key authentication dependency.
- Chores
  - Simplified CI build to use a reusable build-and-push workflow and updated triggers.
  - Added automated deploy workflow for "AtlasML - Test 1" with remote provisioning and optional deploy toggle.
- Documentation
  - New developer docs: overview, API reference, models, settings/auth, and Weaviate integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->