### PR TITLE
`Athena`: Convert repository import functions to work with file maps instead of zips

### DIFF
--- a/athena/athena/athena/helpers/programming/__init__.py
+++ b/athena/athena/athena/helpers/programming/__init__.py
@@ -1,8 +1,7 @@
-from .code_repository import get_repository_zip, get_repository
+from .code_repository import get_repository
 from .feedback import format_feedback_title
 
 __all__ = [
-    "get_repository_zip",
     "get_repository",
     "format_feedback_title",
 ]

--- a/athena/athena/athena/helpers/programming/code_repository.py
+++ b/athena/athena/athena/helpers/programming/code_repository.py
@@ -74,7 +74,10 @@ def get_repository(url: str, authorization_secret: Optional[str] = None) -> Repo
                 repo.git.add(all=True, force=True)
                 repo.git.commit('-m', 'Initial commit')
             # Atomic within the same filesystem
-            os.rename(tmp_dir, cache_dir_path)
+            try:
+                os.rename(tmp_dir, cache_dir_path)
+            except FileExistsError:
+                pass
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 

--- a/athena/athena/athena/helpers/programming/code_repository.py
+++ b/athena/athena/athena/helpers/programming/code_repository.py
@@ -1,8 +1,7 @@
 import hashlib
 import tempfile
 from pathlib import Path
-from typing import Optional, cast
-from zipfile import ZipFile
+from typing import Optional, cast, Dict, Any
 
 from athena import contextvars
 
@@ -12,28 +11,36 @@ from git.repo import Repo
 cache_dir = Path(tempfile.mkdtemp())
 
 
-def get_repository_zip(url: str, authorization_secret: Optional[str] = None) -> ZipFile:
-    """
-    Retrieve a zip file of a code repository from the given URL, either from
-    the cache or by downloading it, and return a ZipFile object.
-    Optional: Authorization secret for the API. If omitted, it will be auto-determined given the request session.
-    """
-    url_hash = hashlib.md5(url.encode("utf-8")).hexdigest()
-    file_name = url_hash + ".zip"
-    cache_file_path = cache_dir / file_name
+def _ensure_auth_secret(authorization_secret: Optional[str]) -> str:
+    if authorization_secret is None:
+        if contextvars.repository_authorization_secret_context_var_empty():
+            raise ValueError(
+                "Authorization secret for the repository API is not set. Pass authorization_secret to this function or add the X-Repository-Authorization-Secret header to the request from the assessment module manager."
+            )
+        return cast(str, contextvars.get_repository_authorization_secret_context_var())
+    return authorization_secret
 
-    if not cache_file_path.exists():
-        if authorization_secret is None:
-            if contextvars.repository_authorization_secret_context_var_empty():
-                raise ValueError("Authorization secret for the repository API is not set. Pass authorization_secret to this function or add the X-Repository-Authorization-Secret header to the request from the assessment module manager.")
-            authorization_secret = contextvars.get_repository_authorization_secret_context_var()
-        with httpx.stream("GET", url, headers={ "Authorization": cast(str, authorization_secret) }) as response:
-            response.raise_for_status()
-            with open(cache_file_path, "wb") as f:
-                for chunk in response.iter_bytes():
-                    f.write(chunk)
 
-    return ZipFile(cache_file_path)
+def get_repository_files_map(url: str, authorization_secret: Optional[str] = None) -> Dict[str, str]:
+    """
+    Fetch a repository from Artemis which responds with a JSON map of
+    { "<path>": "<content>" } and return it as a dict.
+    """
+    auth = _ensure_auth_secret(authorization_secret)
+    with httpx.Client() as client:
+        response = client.get(url, headers={"Authorization": auth})
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            raise ValueError("Expected JSON object {<path>: <content>} from repository endpoint")
+        return {str(k): str(v) for k, v in cast(Dict[str, Any], data).items()}
+
+
+def _write_files_to_directory(root: Path, files_map: Dict[str, str]) -> None:
+    for rel_path, content in files_map.items():
+        abs_path = root / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_text(content, encoding="utf-8")
 
 
 def get_repository(url: str, authorization_secret: Optional[str] = None) -> Repo:
@@ -47,8 +54,8 @@ def get_repository(url: str, authorization_secret: Optional[str] = None) -> Repo
     cache_dir_path = cache_dir / dir_name
 
     if not cache_dir_path.exists():
-        repo_zip = get_repository_zip(url, authorization_secret)
-        repo_zip.extractall(cache_dir_path)
+        files_map = get_repository_files_map(url, authorization_secret)
+        _write_files_to_directory(cache_dir_path, files_map)
         if not (cache_dir_path / ".git").exists():
             repo = Repo.init(cache_dir_path, initial_branch='main')
             # Config username and email to prevent Git errors

--- a/athena/athena/athena/helpers/programming/path_utils.py
+++ b/athena/athena/athena/helpers/programming/path_utils.py
@@ -8,7 +8,7 @@ def ensure_safe_path(root: Path, relative: Union[str, Path], ignore_git: bool = 
     directory and, optionally, does not traverse into .git internals.
 
     - Returns the resolved absolute Path if safe.
-    - Raises ValueError if the path escapes `root` or violates `forbid_git`.
+    - Raises ValueError if the path escapes `root` or violates `ignore_git`.
     """
     resolved_root = root.resolve()
     candidate = (resolved_root / Path(relative)).resolve()

--- a/athena/athena/athena/helpers/programming/path_utils.py
+++ b/athena/athena/athena/helpers/programming/path_utils.py
@@ -15,6 +15,9 @@ def ensure_safe_path(root: Path, relative: Union[str, Path], ignore_git: bool = 
 
     try:
         candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"Path escapes repository root: {relative!r}") from exc
+
     if ignore_git and any(part.lower() == ".git" for part in candidate.parts):
         raise ValueError(f"Path targets .git internals: {relative!r}")
 

--- a/athena/athena/athena/helpers/programming/path_utils.py
+++ b/athena/athena/athena/helpers/programming/path_utils.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Union
+
+
+def ensure_safe_path(root: Path, relative: Union[str, Path], ignore_git: bool = True) -> Path:
+    """
+    Resolve a candidate path under `root` and ensure it does not escape the root
+    directory and, optionally, does not traverse into .git internals.
+
+    - Returns the resolved absolute Path if safe.
+    - Raises ValueError if the path escapes `root` or violates `forbid_git`.
+    """
+    resolved_root = root.resolve()
+    candidate = (resolved_root / Path(relative)).resolve()
+
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError:
+        raise ValueError(f"Path escapes repository root: {relative!r}")
+
+    if ignore_git and ".git" in candidate.parts:
+        raise ValueError(f"Path targets .git internals: {relative!r}")
+
+    return candidate

--- a/athena/athena/athena/helpers/programming/path_utils.py
+++ b/athena/athena/athena/helpers/programming/path_utils.py
@@ -15,10 +15,7 @@ def ensure_safe_path(root: Path, relative: Union[str, Path], ignore_git: bool = 
 
     try:
         candidate.relative_to(resolved_root)
-    except ValueError:
-        raise ValueError(f"Path escapes repository root: {relative!r}")
-
-    if ignore_git and ".git" in candidate.parts:
+    if ignore_git and any(part.lower() == ".git" for part in candidate.parts):
         raise ValueError(f"Path targets .git internals: {relative!r}")
 
     return candidate

--- a/athena/athena/athena/schemas/programming_exercise.py
+++ b/athena/athena/athena/schemas/programming_exercise.py
@@ -25,12 +25,12 @@ class ProgrammingExercise(Exercise):
 
     def get_solution_repository(self) -> Repo:
         """Return the solution repository as a Repo object."""
-        return get_repository(self.solution_repository_uri)
+        return get_repository(str(self.solution_repository_uri))
 
     def get_template_repository(self) -> Repo:
         """Return the template repository as a Repo object."""
-        return get_repository(self.template_repository_uri)
+        return get_repository(str(self.template_repository_uri))
 
     def get_tests_repository(self) -> Repo:
         """Return the tests repository as a Repo object."""
-        return get_repository(self.tests_repository_uri)
+        return get_repository(str(self.tests_repository_uri))

--- a/athena/athena/athena/schemas/programming_exercise.py
+++ b/athena/athena/athena/schemas/programming_exercise.py
@@ -1,8 +1,7 @@
 from pydantic import Field, AnyUrl
-from zipfile import ZipFile
 from git.repo import Repo
 
-from athena.helpers.programming.code_repository import get_repository_zip, get_repository
+from athena.helpers.programming.code_repository import get_repository
 from .exercise_type import ExerciseType
 from .exercise import Exercise
 
@@ -24,30 +23,13 @@ class ProgrammingExercise(Exercise):
                                          example="http://localhost:3000/api/example-tests/1")
 
 
-    def get_solution_zip(self) -> ZipFile:
-        """Return the solution repository as a ZipFile object."""
-        return get_repository_zip(self.solution_repository_uri)
-
-
     def get_solution_repository(self) -> Repo:
         """Return the solution repository as a Repo object."""
         return get_repository(self.solution_repository_uri)
 
-
-    def get_template_zip(self) -> ZipFile:
-        """Return the template repository as a ZipFile object."""
-        return get_repository_zip(self.template_repository_uri)
-
-
     def get_template_repository(self) -> Repo:
         """Return the template repository as a Repo object."""
         return get_repository(self.template_repository_uri)
-
-
-    def get_tests_zip(self) -> ZipFile:
-        """Return the tests repository as a ZipFile object."""
-        return get_repository_zip(self.tests_repository_uri)
-
 
     def get_tests_repository(self) -> Repo:
         """Return the tests repository as a Repo object."""

--- a/athena/athena/athena/schemas/programming_submission.py
+++ b/athena/athena/athena/schemas/programming_submission.py
@@ -1,19 +1,13 @@
 from pydantic import Field
-from zipfile import ZipFile
 from git.repo import Repo
 
-from athena.helpers.programming.code_repository import get_repository_zip, get_repository
+from athena.helpers.programming.code_repository import get_repository
 from athena.schemas.submission import Submission
 
 
 class ProgrammingSubmission(Submission):
     """Submission on a programming exercise."""
     repository_uri: str = Field(example="https://lms.example.com/assignments/1/submissions/1/download")
-
-
-    def get_zip(self) -> ZipFile:
-        """Return the submission repository as a ZipFile object."""
-        return get_repository_zip(self.repository_uri)
 
 
     def get_repository(self) -> Repo:
@@ -23,8 +17,9 @@ class ProgrammingSubmission(Submission):
     def get_code(self, file_path: str) -> str:
         """
         Fetches the code from the submission repository.
-        Might be quite an expensive operation! If you need to fetch multiple files, consider using get_zip() instead.
+        Might be quite an expensive operation! If you need to fetch multiple files, consider using get_repository() instead.
         """
-        repo_zip = self.get_zip()
-        with repo_zip.open(file_path, "r") as f:
-            return f.read().decode("utf-8")
+        repo = self.get_repository()
+        file_on_disk = (repo.working_tree_dir or ".") + "/" + file_path
+        with open(file_on_disk, "r", encoding="utf-8") as f:
+            return f.read()

--- a/athena/modules/programming/module_example/module_example/__main__.py
+++ b/athena/modules/programming/module_example/module_example/__main__.py
@@ -22,9 +22,9 @@ def receive_submissions(exercise: Exercise, submissions: List[Submission], modul
     logger.info("receive_submissions: Received %d submissions for exercise %d", len(submissions), exercise.id)
     for submission in submissions:
         logger.info("- Submission %d", submission.id)
-        zip_content = submission.get_zip()
-        # list the files in the zip
-        for file in zip_content.namelist():
+        repo = submission.get_repository()
+        # list the files in the repository
+        for file in repo.git.ls_files().splitlines():
             logger.info("  - %s", file)
     # Do something with the submissions
     logger.info("Doing stuff")

--- a/athena/modules/programming/module_programming_apted/module_programming_apted/__main__.py
+++ b/athena/modules/programming/module_programming_apted/module_programming_apted/__main__.py
@@ -27,9 +27,9 @@ def receive_submissions(exercise: Exercise, submissions: List[Submission], modul
     logger.info("receive_submissions: Received %d submissions for exercise %d", len(submissions), exercise.id)
     for submission in submissions:
         logger.info("- Submission %d", submission.id)
-        zip_content = submission.get_zip()
-        # list the files in the zip
-        for file in zip_content.namelist():
+        repo = submission.get_repository()
+        # list the files in the repository
+        for file in repo.git.ls_files().splitlines():
             logger.info("  - %s", file)
     # Do something with the submissions
     logger.info("Doing stuff")

--- a/athena/modules/programming/module_programming_winnowing/module_programming_winnowing/__main__.py
+++ b/athena/modules/programming/module_programming_winnowing/module_programming_winnowing/__main__.py
@@ -27,9 +27,9 @@ def receive_submissions(exercise: Exercise, submissions: List[Submission], modul
     logger.info("receive_submissions: Received %d submissions for exercise %d", len(submissions), exercise.id)
     for submission in submissions:
         logger.info("- Submission %d", submission.id)
-        zip_content = submission.get_zip()
-        # list the files in the zip
-        for file in zip_content.namelist():
+        repo = submission.get_repository()
+        # list the files in the repository
+        for file in repo.git.ls_files().splitlines():
             logger.info("  - %s", file)
     # Do something with the submissions
     logger.info("Doing stuff")


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Athena and Artemis currently use zip files to transfer code repositories between them. On both sides, this introduces unnecessary overhead from repeatedly creating and extracting zip archives. The temporary files not only consume additional storage but also require periodic cleanup. Moreover, this process is more prone to I/O errors.
To address these issues, I am updating related programming exercise/submission functions to work with file maps of the repositories instead of zip files.

### Description
- Replace ZIP-based repository handling with a file-map JSON flow:
    - Add get_repository_files_map(url, authorization_secret) to fetch <path, content>
- Remove ZIP APIs:
    - Drop athena.helpers.programming.get_repository_zip.
    - Remove ProgrammingSubmission.get_zip() and migrate get_code() to read from the working tree.
- Update modules to use a repo working tree:
    - Switch file listing from zip.namelist() to repo.git.ls_files() in example modules.
- Public API exports:
    - Remove get_repository_zip from athena.helpers.programming.__all__.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
TBD

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced ZIP-based flows with repository-first retrieval across exercises, submissions, and programming modules; files are now enumerated from the repository and materialized on disk with path-safety checks.
  - Removed ZIP-returning public methods and exports; repository accessors remain.
  - Repository content is now fetched as a JSON map with tighter authorization and error handling.
- Documentation
  - Updated docstrings and comments to reflect repository-first usage and file-access guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->