### PR TITLE
`Iris`: Mark the Memiris stage as internal

### DIFF
--- a/iris/src/iris/domain/status/stage_dto.py
+++ b/iris/src/iris/domain/status/stage_dto.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from iris.domain.status.stage_state_dto import StageStateEnum
 
@@ -10,3 +10,6 @@ class StageDTO(BaseModel):
     weight: int
     state: StageStateEnum
     message: Optional[str] = None
+    internal: bool = Field(
+        default=False
+    )  # An internal stage is not shown in the UI and hidden from the user

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -253,6 +253,7 @@ class CourseChatStatusCallback(StatusCallback):
                 weight=10,
                 state=StageStateEnum.NOT_STARTED,
                 name="Extracting memories",
+                internal=True,
             ),
         ]
         status = CourseChatStatusUpdateDTO(stages=stages)


### PR DESCRIPTION
# Motivation
We want to hide the long memory creation phase from the user and allow them to chat while it is running

# Description
To achieve this I added a boolean flag to the stage that marks it as internal. Artemis will then take care of filtering it out in the UI.