### PR TITLE
`Iris`: Add read and delete endpoints for memories

### DIFF
--- a/iris/src/iris/common/memiris_setup.py
+++ b/iris/src/iris/common/memiris_setup.py
@@ -5,11 +5,14 @@ from uuid import UUID
 
 from memiris import (
     LearningService,
+    LearningDTO,
     Memory,
     MemoryConnectionService,
     MemoryCreationPipeline,
     MemoryCreationPipelineBuilder,
+    MemoryDTO,
     MemoryService,
+    MemoryWithRelationsDTO,
     OllamaService,
 )
 from memiris.service.vectorizer import Vectorizer
@@ -283,3 +286,74 @@ class MemirisWrapper:
             return memories
 
         return memiris_find_similar_memories
+
+    def get_memory_with_relations(
+        self, memory_id: UUID | str
+    ) -> MemoryWithRelationsDTO | None:
+        """
+        Fetch a memory by ID and fully populate its learnings and connections.
+
+        Returns a MemoryWithRelationsDTO or None if the memory does not exist.
+        """
+        if isinstance(memory_id, str):
+            if not is_valid_uuid(memory_id):
+                return None
+            memory_uuid: UUID = to_uuid(memory_id)  # type: ignore
+        else:
+            memory_uuid = memory_id
+
+        memory = self.memory_service.get_memory_by_id(self.tenant, memory_uuid)
+        if memory is None:
+            return None
+
+        # Fetch learnings
+        learning_ids = memory.learnings
+        learnings = (
+            self.learning_service.get_learnings_by_ids(self.tenant, learning_ids)
+            if learning_ids
+            else []
+        )
+
+        # Fetch connections and all connected memories
+        connections = (
+            self.memory_connection_service.get_memory_connections_by_ids(
+                self.tenant, memory.connections
+            )
+            if memory.connections
+            else []
+        )
+
+        connected_memory_ids: list[UUID] = []
+        for conn in connections:
+            for mid in conn.memories:
+                if mid not in connected_memory_ids:
+                    connected_memory_ids.append(mid)
+
+        connected_memories = (
+            self.memory_service.get_memories_by_ids(self.tenant, connected_memory_ids)
+            if connected_memory_ids
+            else []
+        )
+        connected_memory_map: dict[UUID, Memory] = {
+            m.id: m for m in connected_memories if m.id is not None
+        }
+
+        # Build DTOs
+        memory_dto = MemoryDTO.from_memory(memory)
+        learning_dtos = [LearningDTO.from_learning(l) for l in learnings]
+
+        # Import here to avoid circular import in type checking
+        from memiris.api.memory_connection_dto import MemoryConnectionDTO as _MCDTO
+
+        connection_dtos = []
+        for conn in connections:
+            cm = [
+                MemoryDTO.from_memory(connected_memory_map[mid])
+                for mid in conn.memories
+                if mid in connected_memory_map
+            ]
+            connection_dtos.append(_MCDTO.from_connection(conn, cm))
+
+        return MemoryWithRelationsDTO(
+            memory=memory_dto, learnings=learning_dtos, connections=connection_dtos
+        )

--- a/iris/src/iris/main.py
+++ b/iris/src/iris/main.py
@@ -12,6 +12,7 @@ from iris.web.routers.health import router as health_router
 from iris.web.routers.ingestion_status import router as ingestion_status_router
 from iris.web.routers.pipelines import router as pipelines_router
 from iris.web.routers.webhooks import router as webhooks_router
+from iris.web.routers.memiris import router as memiris_router
 
 settings.set_env_vars()
 
@@ -39,7 +40,7 @@ def custom_openapi():
     return app.openapi_schema
 
 
-app.openapi = custom_openapi
+app.openapi = custom_openapi  # type: ignore[assignment]
 
 
 @app.exception_handler(RequestValidationError)
@@ -80,6 +81,7 @@ app.include_router(health_router)
 app.include_router(pipelines_router)
 app.include_router(webhooks_router)
 app.include_router(ingestion_status_router)
+app.include_router(memiris_router)
 
 # Initialize the LLM manager
 from iris.llm.llm_manager import LlmManager  # noqa: E402

--- a/iris/src/iris/web/routers/memiris.py
+++ b/iris/src/iris/web/routers/memiris.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from memiris import Memory, MemoryWithRelationsDTO
+from memiris.api.memory_dto import MemoryDTO
+
+from iris.common.memiris_setup import MemirisWrapper, get_tenant_for_user
+from iris.dependencies import TokenValidator
+from iris.vector_database.database import VectorDatabase
+
+router = APIRouter(prefix="/api/v1/memiris", tags=["memiris"])
+
+
+@router.get(
+    "/user/{user_id}",
+    dependencies=[Depends(TokenValidator())],
+    response_model=list[MemoryDTO],
+)
+def list_memories(user_id: int) -> list[MemoryDTO]:
+    """
+    List all Memiris memories for a user.
+
+    Resolves the tenant for the given user and returns all memories owned by
+    that tenant. If the vector database client is not initialized, returns an
+    empty list.
+
+    Args:
+        user_id: The user identifier used to derive the tenant.
+
+    Returns:
+        list[Memory]: List of memories for the resolved tenant.
+    """
+    if not VectorDatabase._client_instance:
+        return []
+    tenant = get_tenant_for_user(user_id)
+    memories = MemirisWrapper(
+        VectorDatabase._client_instance, tenant
+    ).memory_service.get_all_memories(tenant)
+    return [MemoryDTO.from_memory(memory) for memory in memories]
+
+
+@router.delete(
+    "/user/{user_id}/{memory_id}",
+    dependencies=[Depends(TokenValidator())],
+)
+def delete_memory(user_id: int, memory_id: str) -> Response:
+    """
+    Delete a specific Memiris memory for a user.
+
+    Resolves the tenant for the given user, deletes the memory by its
+    identifier, and returns 204 No Content. If the vector database client is
+    not initialized, it still returns 204 No Content.
+
+    Args:
+        user_id: The user identifier used to derive the tenant.
+        memory_id: The memory identifier to delete.
+
+    Returns:
+        Response: Empty response with HTTP 204 No Content.
+    """
+    if not VectorDatabase._client_instance:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    tenant = get_tenant_for_user(user_id)
+    MemirisWrapper(
+        VectorDatabase._client_instance, tenant
+    ).memory_service.delete_memory(tenant, memory_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/user/{user_id}/{memory_id}",
+    dependencies=[Depends(TokenValidator())],
+    response_model=MemoryWithRelationsDTO,
+)
+def get_memory_with_relations(user_id: int, memory_id: str) -> MemoryWithRelationsDTO:
+    """
+    Load a memory by its ID and return it with learnings and connections fully fetched.
+    """
+    if not VectorDatabase._client_instance:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    tenant = get_tenant_for_user(user_id)
+    wrapper = MemirisWrapper(VectorDatabase._client_instance, tenant)
+    result = wrapper.get_memory_with_relations(memory_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return result

--- a/memiris/src/memiris/__init__.py
+++ b/memiris/src/memiris/__init__.py
@@ -11,6 +11,9 @@ from memiris.api.memory_creation_pipeline import (
     MemoryCreationPipelineBuilder,
 )
 from memiris.api.memory_dto import MemoryDTO
+from memiris.api.learning_dto import LearningDTO
+from memiris.api.memory_connection_dto import MemoryConnectionDTO
+from memiris.api.memory_with_relations_dto import MemoryWithRelationsDTO
 from memiris.api.memory_service import MemoryService
 from memiris.api.memory_sleep_pipeline import (
     MemorySleepPipeline,
@@ -33,6 +36,9 @@ __all__ = [
     # Domain Models
     "Memory",
     "MemoryDTO",
+    "LearningDTO",
+    "MemoryConnectionDTO",
+    "MemoryWithRelationsDTO",
     "Learning",
     "MemoryConnection",
     # API services

--- a/memiris/src/memiris/api/learning_dto.py
+++ b/memiris/src/memiris/api/learning_dto.py
@@ -1,0 +1,28 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from memiris.domain.learning import Learning
+
+
+class LearningDTO(BaseModel):
+    """
+    DTO representing a Learning without vectors.
+    """
+
+    id: Optional[str]
+    title: str
+    content: str
+    reference: str
+    memories: List[str]
+
+    @classmethod
+    def from_learning(cls, learning: Learning) -> "LearningDTO":
+        return cls(
+            id=str(learning.id) if learning.id else None,
+            title=learning.title,
+            content=learning.content,
+            reference=learning.reference,
+            memories=[str(mid) for mid in learning.memories],
+        )
+

--- a/memiris/src/memiris/api/memory_connection_dto.py
+++ b/memiris/src/memiris/api/memory_connection_dto.py
@@ -1,0 +1,35 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from memiris.api.memory_dto import MemoryDTO
+from memiris.domain.memory_connection import ConnectionType, MemoryConnection
+
+
+class MemoryConnectionDTO(BaseModel):
+    """
+    DTO for a MemoryConnection with connected memories fully populated.
+    """
+
+    id: Optional[str]
+    connection_type: ConnectionType = Field(alias="connectionType")
+    memories: List[MemoryDTO]
+    description: str = ""
+    context: Dict = {}
+    weight: float = 1.0
+
+    @classmethod
+    def from_connection(
+        cls,
+        connection: MemoryConnection,
+        connected_memories: List[MemoryDTO],
+    ) -> "MemoryConnectionDTO":
+        return cls(
+            id=str(connection.id) if connection.id else None,
+            connectionType=connection.connection_type,  # type: ignore[arg-type]
+            memories=connected_memories,
+            description=connection.description,
+            context=connection.context or {},
+            weight=connection.weight,
+        )
+

--- a/memiris/src/memiris/api/memory_with_relations_dto.py
+++ b/memiris/src/memiris/api/memory_with_relations_dto.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from memiris.api.learning_dto import LearningDTO
+from memiris.api.memory_connection_dto import MemoryConnectionDTO
+from memiris.api.memory_dto import MemoryDTO
+
+
+class MemoryWithRelationsDTO(BaseModel):
+    """
+    Combined DTO representing a Memory with its learnings and connections fully fetched.
+    """
+
+    memory: MemoryDTO
+    learnings: List[LearningDTO]
+    connections: List[MemoryConnectionDTO]
+


### PR DESCRIPTION
# Motivation
The users should be able to see and delete their memories within Artemis. For this Iris needs to expose this functionality to Artemis.

# Description
I added the endpoints for this to Iris and adjusted the Memiris API to support this use case better.