### PR TITLE
Infrastructure: Fix sub-pre-commit failure by pinning click<8.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,23 @@ repos:
         alias: iris
         name: "pre-commit for iris"
         args: ["-p", "iris"]
+        additional_dependencies: ['click<8.3.0']
         files: "^iris/.*"
       - id: sub-pre-commit
         alias: athena
         name: "pre-commit for athena"
         args: [ "-p", "athena" ]
+        additional_dependencies: ['click<8.3.0']
         files: "^athena/.*"
       - id: sub-pre-commit
         alias: nebula
         name: "pre-commit for nebula"
         args: ["-p", "nebula"]
+        additional_dependencies: ['click<8.3.0']
         files: "^nebula/.*"
       - id: sub-pre-commit
         alias: memiris
         name: "pre-commit for memiris"
         args: ["-p", "memiris"]
+        additional_dependencies: ['click<8.3.0']
         files: "^memiris/.*"


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change is required because all sub-pre-commit hooks (`iris`, `athena`, `nebula`, `memiris`) were failing after the release of `Click 8.3.0`, which introduced an incompatibility with the `typer` version used by `sub-pre-commit`.
The error caused pre-commit run to fail with a `NoneType` path error, breaking the developer workflow.

Fixes #274

### Description
<!-- Describe your changes in detail -->

- Pinned `click<8.3.0` for all sub-pre-commit hooks in .`pre-commit-config.yaml`.
- No application code was modified; only the development tooling configuration was adjusted.
- Verified that `pre-commit run --all-files` works as intended after the fix.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Checkout this branch.
2. Run `pre-commit clean` to clear cached environments.
3. Run `pre-commit install --install-hooks`.
4. Run `pre-commit run --all-files`.
5. Expected: All hooks (`iris`, `athena`, `nebula`, `memiris`) complete without the `NoneType` path error.
