### PR TITLE
`Athena`: Add backwards compatibility for Apollon v2 models

### DIFF
--- a/athena/modules/modeling/module_modeling_llm/module_modeling_llm/apollon_transformer/apollon_json_transformer.py
+++ b/athena/modules/modeling/module_modeling_llm/module_modeling_llm/apollon_transformer/apollon_json_transformer.py
@@ -6,6 +6,29 @@ from module_modeling_llm.apollon_transformer.parser.uml_parser import UMLParser
 class ApollonJSONTransformer:
 
     @staticmethod
+    def _convert_v2_to_v3(model_dict: dict) -> dict:
+        """
+        Converts an Apollon JSON model from version 2.0.0 to 3.0.0.
+        Changes 'elements' and 'relationships' from lists to dicts.
+        """
+        model_dict["version"] = "3.0.0"
+
+        model_dict["elements"] = {
+            element["id"]: element for element in model_dict.get("elements", [])
+        }
+
+        model_dict["relationships"] = {
+            rel["id"]: rel for rel in model_dict.get("relationships", [])
+        }
+
+        model_dict["interactive"] = {
+            "elements": {},
+            "relationships": {}
+        }
+
+        return model_dict
+
+    @staticmethod
     def transform_json(model: str) -> tuple[str, dict[str, str], str, dict[str, str]]:
         """
         Serialize a given Apollon diagram model to a string representation.
@@ -17,6 +40,10 @@ class ApollonJSONTransformer:
         """
 
         model_dict = json.loads(model)
+
+        # Convert legacy version 2.0.0 to version 3.0.0 if needed
+        if model_dict.get("version") == "2.0.0":
+            model_dict = ApollonJSONTransformer._convert_v2_to_v3(model_dict)
 
         parser = UMLParser(model_dict)
 
@@ -32,4 +59,3 @@ class ApollonJSONTransformer:
         id_type_mapping = parser.get_id_to_type_mapping()
 
         return apollon_representation, names, diagram_type, id_type_mapping
-    


### PR DESCRIPTION


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the module_modeling_llm can only give feedback on Apollon v3 models.
When trying to request feedback for an v2 model, an error occurs and no feedback can be generated.

### Description
<!-- Describe your changes in detail -->
This PR adds a converter to the module_modeling_llm so a v2 model can be converted to a v3 model and feedback can ge generated.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models now automatically convert to the latest format upon import, ensuring full compatibility and access to new features without manual intervention required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->