### PR TITLE
`Iris`: Migrate all status callback URLs to internal API endpoints

### DIFF
--- a/iris/src/iris/web/status/faq_ingestion_status_callback.py
+++ b/iris/src/iris/web/status/faq_ingestion_status_callback.py
@@ -23,7 +23,9 @@ class FaqIngestionStatus(StatusCallback):
         initial_stages: List[StageDTO] = None,
         faq_id: int = None,
     ):
-        url = f"{base_url}/api/iris/public/pyris/webhooks/ingestion/faqs/runs/{run_id}/status"
+        url = (
+            f"{base_url}/api/iris/internal/webhooks/ingestion/faqs/runs/{run_id}/status"
+        )
 
         current_stage_index = len(initial_stages) if initial_stages else 0
         stages = initial_stages or []

--- a/iris/src/iris/web/status/ingestion_status_callback.py
+++ b/iris/src/iris/web/status/ingestion_status_callback.py
@@ -23,9 +23,7 @@ class IngestionStatusCallback(StatusCallback):
         initial_stages: List[StageDTO] = None,
         lecture_unit_id: int = None,
     ):
-        url = (
-            f"{base_url}/api/iris/public/pyris/webhooks/ingestion/runs/{run_id}/status"
-        )
+        url = f"{base_url}/api/iris/internal/webhooks/ingestion/runs/{run_id}/status"
 
         current_stage_index = len(initial_stages) if initial_stages else 0
         stages = initial_stages or []

--- a/iris/src/iris/web/status/lecture_deletion_status_callback.py
+++ b/iris/src/iris/web/status/lecture_deletion_status_callback.py
@@ -19,9 +19,7 @@ class LecturesDeletionStatusCallback(StatusCallback):
     def __init__(
         self, run_id: str, base_url: str, initial_stages: List[StageDTO] = None
     ):
-        url = (
-            f"{base_url}/api/iris/public/pyris/webhooks/ingestion/runs/{run_id}/status"
-        )
+        url = f"{base_url}/api/iris/internal/webhooks/ingestion/runs/{run_id}/status"
 
         current_stage_index = len(initial_stages) if initial_stages else 0
         stages = initial_stages or []

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -50,7 +50,7 @@ class StatusCallback(ABC):
     stage: StageDTO
     current_stage_index: Optional[int]
 
-    api_url: str = "api/iris/public/pyris/pipelines"
+    api_url: str = "api/iris/internal/pipelines"
 
     def __init__(
         self,

--- a/iris/src/iris/web/status/transcription_ingestion_callback.py
+++ b/iris/src/iris/web/status/transcription_ingestion_callback.py
@@ -23,7 +23,7 @@ class TranscriptionIngestionStatus(StatusCallback):
         initial_stages: List[StageDTO] = None,
         lecture_unit_id: int = None,
     ):
-        url = f"{base_url}/api/iris/public/pyris/webhooks/ingestion/transcriptions/runs/{run_id}/status"
+        url = f"{base_url}/api/iris/internal/webhooks/ingestion/transcriptions/runs/{run_id}/status"
 
         current_stage_index = len(initial_stages) if initial_stages else 0
         stages = initial_stages or []


### PR DESCRIPTION
Artemis requires subservices to call it only through internal endpoints as those can be limited to certain networks. This PR migrates all callbacks to the new endpoints

> [!WARNING]
> This PR can only be tested together with the [corresponding PR on Artemis](https://github.com/ls1intum/Artemis/pull/11579).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal webhook routing infrastructure has been reorganized to improve system maintainability and architectural consistency across status update processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->