### PR TITLE
`Athena`: Change ollama authentication mechanism

### DIFF
--- a/athena/llm_core/llm_core/loaders/model_loaders/ollama_loader.py
+++ b/athena/llm_core/llm_core/loaders/model_loaders/ollama_loader.py
@@ -8,20 +8,16 @@ from athena.logger import logger
 OLLAMA_PREFIX = "ollama_"
 
 OLLAMA_BASE_URL: str = os.getenv("OLLAMA_ENDPOINT", "http://localhost:11434")
-GPU_USER = os.getenv("GPU_USER")
-GPU_PASSWORD = os.getenv("GPU_PASSWORD")
+OLLAMA_API_KEY = os.getenv("OLLAMA_API_KEY")
 
-_auth = (GPU_USER, GPU_PASSWORD) if GPU_USER and GPU_PASSWORD else None
 _headers = (
-    {"Authorization": requests.auth._basic_auth_str(GPU_USER, GPU_PASSWORD)}  # type: ignore
-    if _auth
-    else None
+    {"Authorization": "Bearer " + OLLAMA_API_KEY} if OLLAMA_API_KEY else None
 )
 
 
 def _discover_ollama_models() -> List[str]:
     try:
-        resp = requests.get(f"{OLLAMA_BASE_URL}/api/tags", auth=_auth, timeout=15)
+        resp = requests.get(f"{OLLAMA_BASE_URL}/api/tags", headers=_headers, timeout=15)
         resp.raise_for_status()
         data = resp.json()
         return [m["name"] for m in data.get("models", [])]

--- a/athena/modules/text/module_text_llm/.env.example
+++ b/athena/modules/text/module_text_llm/.env.example
@@ -40,6 +40,6 @@ OPENAI_API_VERSION="2024-06-01" # change base if needed
 # LANGCHAIN_API_KEY="XXX"
 # LANGCHAIN_PROJECT="XXX"
 
-# GPU_USER=
-# GPU_PASSWORD=
-# OLLAMA_ENDPOINT= #'https://gpu-artemis.ase.cit.tum.de/ollama'
+# Ollama (Local LLMs) [leave blank if not used]
+# OLLAMA_ENDPOINT= #'https://gpu.aet.cit.tum.de/ollama'
+# OLLAMA_API_KEY='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Ollama Authentication changed from basic_auth to bearer Authentication with an API Key

### Description
<!-- Describe your changes in detail -->
This PR adapts the Ollama Config to use Bearer Authentication.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ollama authentication mechanism updated to use bearer token authentication derived from API key instead of basic credentials
  * Request handling improved with conditional header support based on API key availability

* **Chores**
  * Environment configuration updated with new Ollama API key parameter and legacy username/password settings removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->