### PR TITLE
`Iris`: Fix ingestion failure

### DIFF
--- a/iris/src/iris/domain/data/metrics/transcription_dto.py
+++ b/iris/src/iris/domain/data/metrics/transcription_dto.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -12,7 +12,9 @@ class TranscriptionSegmentDTO(BaseModel):
 
 class TranscriptionDTO(BaseModel):
     language: str = Field(default="en", alias="language")
-    segments: List[TranscriptionSegmentDTO] = Field(..., alias="segments")
+    segments: Optional[List[TranscriptionSegmentDTO]] = Field(
+        default=None, alias="segments"
+    )
 
 
 class TranscriptionWebhookDTO(BaseModel):

--- a/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
+++ b/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
@@ -56,7 +56,10 @@ class LectureIngestionUpdatePipeline(Pipeline[LectureIngestionUpdateVariant]):
                 callback.done()
                 callback.in_progress("skipping slide ingestion")
                 callback.done()
-            if self.dto.lecture_unit.transcription is not None:
+            if (
+                self.dto.lecture_unit.transcription is not None
+                and self.dto.lecture_unit.transcription.segments is not None
+            ):
                 transcription_pipeline = TranscriptionIngestionPipeline(
                     client=client, dto=self.dto, callback=callback
                 )


### PR DESCRIPTION
### Motivation and Context
The lecture ingestion pipeline was failing when ingesting a lecture with a failed transcription job.


### Description
- Changed segments attribute in `TranscriptionDTO` to optional
- Only ingest transcription when segments are available (Not none)


### Steps for Testing
- create a new lecture unit
- add a new row to the `lecture_transcription` table
- make sure `segments` in null and the corresponding `lecture_unit_id` is correctly entered
- click send to iris
- check if ingestion is successful



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcription ingestion to handle incomplete transcription data gracefully. The system now validates required components before processing, preventing errors when transcription segments are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->