### PR TITLE
`Iris`: Fix curly brace escaping for LangChain templates

### DIFF
--- a/iris/src/iris/pipeline/prompts/lecture_unit_segment_summary_prompt.py
+++ b/iris/src/iris/pipeline/prompts/lecture_unit_segment_summary_prompt.py
@@ -1,14 +1,24 @@
+def _escape_braces(text: str) -> str:
+    """Escape curly braces for LangChain template compatibility."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
 def lecture_unit_segment_summary_prompt(
     lecture_name: str,
     course_name: str,
     transcription_content: str,
     slide_content: str,
 ):
+    # Escape content that may contain curly braces (e.g., code snippets)
+    safe_transcription = _escape_braces(transcription_content)
+    safe_slide = _escape_braces(slide_content)
+    safe_lecture = _escape_braces(lecture_name)
+    safe_course = _escape_braces(course_name)
     return f"""
         You are an excellent tutor with deep expertise in computer science and practical applications,
         teaching at the university level.
         A snippet of the spoken content and the content of the matching slide, the professor is talking about, \
-        of the lecture {lecture_name} in the course {course_name} will be given to you.
+        of the lecture {safe_lecture} in the course {safe_course} will be given to you.
         Please accurately follow the instructions below.
         1. If either slide content or transcription content is empty only summarize the content you are given.
         2.1. Otherwise combine the information of the transcription and the slide
@@ -16,7 +26,7 @@ def lecture_unit_segment_summary_prompt(
         3. Do not add additional information.
         4. Only answer in complete sentences.
         This is the content of the transcription:
-        {transcription_content}
+        {safe_transcription}
         This is the content of the slide:
-        {slide_content}
+        {safe_slide}
     """

--- a/iris/src/iris/pipeline/prompts/lecture_unit_summary_prompt.py
+++ b/iris/src/iris/pipeline/prompts/lecture_unit_summary_prompt.py
@@ -1,18 +1,27 @@
 from iris.domain.lecture.lecture_unit_dto import LectureUnitDTO
 
 
+def _escape_braces(text: str) -> str:
+    """Escape curly braces for LangChain template compatibility."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
 def lecture_unit_summary_prompt(
     lecture_unit_dto: LectureUnitDTO, lecture_unit_segment_summary: str
 ):
+    # Escape content that may contain curly braces (e.g., code snippets)
+    safe_lecture = _escape_braces(lecture_unit_dto.lecture_name)
+    safe_course = _escape_braces(lecture_unit_dto.course_name)
+    safe_summary = _escape_braces(lecture_unit_segment_summary)
     return f"""
         You are an excellent tutor with deep expertise in computer science and practical applications,
         teaching at the university level.
-        Summaries of the lecture {lecture_unit_dto.lecture_name} in the course {lecture_unit_dto.course_name} \
+        Summaries of the lecture {safe_lecture} in the course {safe_course} \
         will be given to you.
         Please accurately follow the instructions below.
         1. Summarize the combined information in a clear and accurate manner.
         2. Do not add additional information.
         3. Only answer in complete sentences.
         This is summary of the lecture:
-        {lecture_unit_segment_summary}
+        {safe_summary}
     """

--- a/iris/src/iris/pipeline/prompts/transcription_ingestion_prompts.py
+++ b/iris/src/iris/pipeline/prompts/transcription_ingestion_prompts.py
@@ -1,12 +1,20 @@
+def _escape_braces(text: str) -> str:
+    """Escape curly braces for LangChain template compatibility."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
 def transcription_summary_prompt(lecture_name: str, chunk_content: str):
+    # Escape content that may contain curly braces (e.g., code snippets)
+    safe_lecture = _escape_braces(lecture_name)
+    safe_chunk = _escape_braces(chunk_content)
     return f"""
         You are an excellent tutor with deep expertise in computer science and practical applications,
         teaching at the university level.
-        A snippet of the spoken content of one lecture of the lecture {lecture_name} will be given to you.
+        A snippet of the spoken content of one lecture of the lecture {safe_lecture} will be given to you.
         Please accurately follow the instructions below.
         1. Summarize the information in a clear and accurate manner.
         2. Do not add additional information.
         3. Only answer in complete sentences.
         This is the text you should summarize:
-        {chunk_content}
+        {safe_chunk}
     """

--- a/iris/src/iris/retrieval/basic_retrieval.py
+++ b/iris/src/iris/retrieval/basic_retrieval.py
@@ -107,9 +107,11 @@ class BaseRetrieval(SubPipeline, ABC):
             ]
         )
         prompt = _add_last_four_messages_to_prompt(prompt, chat_history)
+        # Escape curly braces in student_query for LangChain template compatibility
+        safe_query = student_query.replace("{", "{{").replace("}", "}}")
         prompt += ChatPromptTemplate.from_messages(
             [
-                ("user", student_query),
+                ("user", safe_query),
             ]
         )
         prompt += ChatPromptTemplate.from_messages(

--- a/iris/src/iris/retrieval/lecture/lecture_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_retrieval.py
@@ -561,9 +561,11 @@ class LectureRetrieval(SubPipeline):
             ]
         )
         prompt = self._add_last_four_messages_to_prompt(prompt, chat_history)
+        # Escape curly braces in student_query for LangChain template compatibility
+        safe_query = student_query.replace("{", "{{").replace("}", "}}")
         prompt += ChatPromptTemplate.from_messages(
             [
-                ("user", student_query),
+                ("user", safe_query),
             ]
         )
         prompt_val = prompt.format_messages(
@@ -619,9 +621,11 @@ class LectureRetrieval(SubPipeline):
             problem_statement=problem_statement,
         )
         prompt = ChatPromptTemplate.from_messages(prompt_val)
+        # Escape curly braces in student_query for LangChain template compatibility
+        safe_query = student_query.replace("{", "{{").replace("}", "}}")
         prompt += ChatPromptTemplate.from_messages(
             [
-                ("user", student_query),
+                ("user", safe_query),
             ]
         )
         try:


### PR DESCRIPTION
Escape curly braces in content that goes into ChatPromptTemplate tuples to prevent "unexpected '{' in field name" errors during lecture ingestion.

- lecture_unit_segment_summary_prompt.py
- transcription_ingestion_prompts.py
- lecture_unit_summary_prompt.py
- lecture_retrieval.py
- basic_retrieval.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template rendering errors that occurred when lecture content, course names, student queries, or other input containing curly braces (commonly found in code snippets, mathematical expressions, and technical documentation) were processed in AI summary generation and information retrieval workflows. Responses with special characters now display correctly and render as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->