### PR TITLE
`Logos`: Add OpenAI-compatible /v1/models endpoint

### DIFF
--- a/logos/src/logos/dbutils/dbmanager.py
+++ b/logos/src/logos/dbutils/dbmanager.py
@@ -1642,6 +1642,7 @@ class DBManager:
                 JOIN profile_model_permissions pmp ON m.id = pmp.model_id
             WHERE pmp.profile_id = :profile_id
               AND m.name = :name
+            ORDER BY m.id LIMIT 1
         """)
         row = self.session.execute(
             sql, {"profile_id": int(profile_id), "name": model_name}

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -3,10 +3,9 @@ import json
 import logging
 import time
 from contextlib import asynccontextmanager
-from typing import Any, Dict, Set, Tuple, Optional
+from typing import Any, Dict, Set, Optional
 import grpc
 
-_SERVER_START_TIME = int(time.time())
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -35,6 +34,8 @@ from logos.sdi.ollama_facade import OllamaSchedulingDataFacade
 from logos.sdi.azure_facade import AzureSchedulingDataFacade
 from logos.monitoring.ollama_monitor import OllamaProviderMonitor
 from scripts import setup_proxy
+
+_SERVER_START_TIME = int(time.time())
 
 logger = logging.getLogger("LogosLogger")
 _grpc_server = None

--- a/logos/tests/unit/main/test_v1_models.py
+++ b/logos/tests/unit/main/test_v1_models.py
@@ -17,7 +17,10 @@ import logos.main as main
 def _make_request(headers: dict | None = None):
     """Create a mock FastAPI Request with the given headers."""
     req = MagicMock()
-    req.headers = headers or {"authorization": "Bearer test-key"}
+    if headers is None:
+        req.headers = {"authorization": "Bearer test-key"}
+    else:
+        req.headers = headers
     return req
 
 
@@ -33,10 +36,10 @@ class DummyDB:
     def __exit__(self, *args):
         return False
 
-    def get_models_for_profile(self, profile_id: int):
+    def get_models_for_profile(self, _profile_id: int):
         return self._models
 
-    def get_model_for_profile(self, profile_id: int, model_name: str):
+    def get_model_for_profile(self, _profile_id: int, model_name: str):
         return next((m for m in self._models if m["name"] == model_name), None)
 
 


### PR DESCRIPTION
## Closes #420

## Summary

Adds OpenAI-compatible `/v1/models` endpoints to the Logos API gateway, allowing clients to list and retrieve available models using the same interface as the OpenAI API. Models are scoped to the authenticated user's profile via existing `profile_model_permissions`.

## Changes

### `logos/src/logos/main.py`
- Added a module-level `_SERVER_START_TIME` timestamp used as the `created` field in model responses.
- **`GET /v1/models`** — new endpoint that lists all models accessible to the authenticated user's profile, returning an OpenAI-compatible JSON list.
- **`GET /v1/models/{model_id:path}`** — new endpoint that retrieves a single model by name (supports slash-separated model IDs like `meta-llama/Llama-3-8B`). Returns `404` if the model is not found or the user lacks access.

### `logos/src/logos/dbutils/dbmanager.py`
- **`get_models_for_profile(profile_id)`** — new method that queries `models` joined with `profile_model_permissions` to return all models a profile has access to.
- **`get_model_for_profile(profile_id, model_name)`** — new method that retrieves a single model by name, scoped to the profile's permissions. Returns `None` if not found.

### `logos/tests/unit/main/test_v1_models.py` *(new file)*
- Comprehensive async test suite covering both endpoints:
  - `test_list_models_returns_openai_format` — verifies response shape and field values
  - `test_list_models_empty` — empty model list returns `{"object": "list", "data": []}`
  - `test_list_models_auth_failure` — missing/invalid auth raises `401`
  - `test_retrieve_model_success` — single model retrieval returns correct object
  - `test_retrieve_model_not_found` — nonexistent model returns `404`
  - `test_retrieve_model_no_access` — existing model not in profile returns `404`
  - `test_retrieve_model_with_slashes` — model IDs with `/` (e.g. `meta-llama/Llama-3-8B`) are handled correctly
  - `test_retrieve_model_auth_failure` — missing/invalid auth raises `401`

## New Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/v1/models` | Logos key + profile (via `authenticate_with_profile`) | List all models accessible to the user's current profile |
| `GET` | `/v1/models/{model_id}` | Logos key + profile (via `authenticate_with_profile`) | Retrieve a single model by name |

### Response format — `GET /v1/models`

```json
{
  "object": "list",
  "data": [
    {
      "id": "gpt-4o",
      "object": "model",
      "created": 1700000000,
      "owned_by": "logos"
    }
  ]
}
```

### Response format — `GET /v1/models/{model_id}`

```json
{
  "id": "gpt-4o",
  "object": "model",
  "created": 1700000000,
  "owned_by": "logos"
}
```

### Error responses

- **401 Unauthorized** — invalid or missing Logos API key
- **404 Not Found** — model does not exist or user's profile lacks access

## Testing

Run the new test suite:

```bash
cd logos && python -m pytest tests/unit/main/test_v1_models.py -v
```

All 8 tests use `monkeypatch` and `unittest.mock.patch` to stub the database layer and authentication, requiring no live database.

## OpenAI API Compliance

The response format for both endpoints matches the [OpenAI Models API specification](https://platform.openai.com/docs/api-reference/models):
- List endpoint returns `{"object": "list", "data": [...]}`
- Each model object contains `id`, `object` (`"model"`), `created` (Unix timestamp), and `owned_by`
- The `{model_id:path}` path parameter supports model names containing slashes (e.g. `meta-llama/Llama-3-8B`), matching OpenAI's behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /v1/models to list models accessible to the authenticated profile in OpenAI-compatible format
  * Added GET /v1/models/{model_id} to retrieve a specific model if the profile has access
  * Responses include standard OpenAI-style fields for seamless integration

* **Tests**
  * Added unit tests covering listing, retrieval, access control, auth failures, empty results, and edge cases (e.g., names with slashes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->