### PR TITLE
`Logos`: Remove executor HTTP timeout

### DIFF
--- a/logos/src/logos/pipeline/executor.py
+++ b/logos/src/logos/pipeline/executor.py
@@ -102,7 +102,7 @@ class Executor:
                     url,
                     headers=headers,
                     json=payload,
-                    timeout=120,  # Increased to 2 minutes for cold starts
+                    timeout=None,  # No timeout to handle long-running LLM requests and cold starts
                 )
 
             logger.debug(f"Response status: {response.status_code}, headers: {dict(response.headers)}")


### PR DESCRIPTION
## Problem
The executor's sync HTTP request has a hard-coded 120-second timeout. Long-running LLM requests and cold starts can exceed this limit, causing requests to fail with a timeout error.

## Solution
Set `timeout=None` on the `httpx.AsyncClient.post()` call in `Executor._execute_sync()`, removing the artificial time limit and allowing requests to complete regardless of duration.

## Changes
- `logos/src/logos/pipeline/executor.py` line 105: `timeout=120` → `timeout=None`