### PR TITLE
`Iris`: Fix agent pipeline crashes when memory retrieval fails

### DIFF
--- a/iris/src/iris/common/memiris_setup.py
+++ b/iris/src/iris/common/memiris_setup.py
@@ -29,12 +29,15 @@ from memiris.service.vectorizer import Vectorizer
 from memiris.util.uuid_util import is_valid_uuid, to_uuid
 from weaviate import WeaviateClient
 
+from iris.common.logging_config import get_logger
 from iris.config import settings
 from iris.llm import AzureOpenAIChatModel, OllamaModel
 from iris.llm.external.openai_chat import OpenAIChatModel
 from iris.llm.llm_manager import LlmManager
 from iris.tracing import observe
 from iris.vector_database.database import VectorDatabase
+
+logger = get_logger(__name__)
 
 _memiris_user_focus_personal_details = """
 Find personal details about the user itself.
@@ -478,10 +481,19 @@ class MemirisWrapper:
             Returns:
                 Sequence[Memory]: A list of Memory objects that most closely match the query.
             """
-            vectors = self.vectorizer.vectorize(query)
-            memories = self.memory_service.semantic_search(
-                tenant=self.tenant, vectors=vectors, limit=limit
-            )
+            try:
+                vectors = self.vectorizer.vectorize(query)
+                memories = self.memory_service.semantic_search(
+                    tenant=self.tenant, vectors=vectors, limit=limit
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to search for memories for tenant %s", self.tenant
+                )
+                return (
+                    "Memory retrieval is temporarily unavailable. "
+                    "Continue without using memory results."
+                )
             accessed_memory_storage.extend(memories)
             if len(memories) == 0:
                 return "No memories found for the given query."
@@ -520,47 +532,83 @@ class MemirisWrapper:
             else:
                 return "Invalid memory ID provided. Please provide a valid UUID."
 
-            memory = self.memory_service.get_memory_by_id(self.tenant, memory_uuid)
+            try:
+                memory = self.memory_service.get_memory_by_id(self.tenant, memory_uuid)
+            except Exception:
+                logger.exception(
+                    "Failed to fetch memory %s for tenant %s", memory_id, self.tenant
+                )
+                return (
+                    "Memory retrieval is temporarily unavailable. "
+                    "Continue without using memory results."
+                )
 
             if memory is None:
                 return f"Memory with ID {memory_uuid} not found. Please provide a valid memory ID."
 
             memories: list[Memory] = []
+            retrieval_succeeded = False
 
             if memory.connections:
-                connections = (
-                    self.memory_connection_service.get_memory_connections_by_ids(
-                        self.tenant, memory.connections
+                try:
+                    connections = (
+                        self.memory_connection_service.get_memory_connections_by_ids(
+                            self.tenant, memory.connections
+                        )
+                    )
+                    memory_ids: list[UUID] = []
+                    for connection in sorted(
+                        connections, key=lambda x: x.weight, reverse=True
+                    ):
+                        for mid in connection.memories:
+                            if mid not in memory_ids:
+                                memory_ids.append(mid)
+
+                    if len(memory_ids) > limit:
+                        memory_ids = memory_ids[:limit]
+
+                    memories.extend(
+                        self.memory_service.get_memories_by_ids(self.tenant, memory_ids)
+                    )
+                    retrieval_succeeded = True
+
+                    if len(memories) == limit:
+                        accessed_memory_storage.extend(memories)
+                        return memories
+                except Exception:
+                    logger.exception(
+                        "Failed to fetch memory connections for memory %s "
+                        "(tenant %s)",
+                        memory_id,
+                        self.tenant,
+                    )
+
+            try:
+                memories.extend(
+                    self.memory_service.semantic_search(
+                        tenant=self.tenant,
+                        vectors=memory.vectors,
+                        limit=limit - len(memories),
                     )
                 )
-                memory_ids: list[UUID] = []
-                for connection in sorted(
-                    connections, key=lambda x: x.weight, reverse=True
-                ):
-                    for mid in connection.memories:
-                        if mid not in memory_ids:
-                            memory_ids.append(mid)
-
-                if len(memory_ids) > limit:
-                    memory_ids = memory_ids[:limit]
-
-                memories.extend(
-                    self.memory_service.get_memories_by_ids(self.tenant, memory_ids)
+                retrieval_succeeded = True
+            except Exception:
+                logger.exception(
+                    "Failed semantic search for similar memories of %s " "(tenant %s)",
+                    memory_id,
+                    self.tenant,
                 )
-
-                if len(memories) == limit:
-                    accessed_memory_storage.extend(memories)
-                    return memories
-
-            memories.extend(
-                self.memory_service.semantic_search(
-                    tenant=self.tenant,
-                    vectors=memory.vectors,
-                    limit=limit - len(memories),
-                )
-            )
 
             accessed_memory_storage.extend(memories)
+
+            if not retrieval_succeeded:
+                return (
+                    "Memory retrieval is temporarily unavailable. "
+                    "Continue without using memory results."
+                )
+            if len(memories) == 0:
+                return "No similar memories found."
+
             return memories
 
         return memiris_find_similar_memories


### PR DESCRIPTION
### Motivation and Context
Memory service failures (e.g., CUDA OOM on embedding model, Weaviate errors) were causing the entire agent pipeline to crash. This happened when the LangChain agent tool `memiris_search_for_memories` or `memiris_find_similar_memories` raised an unhandled exception, terminating the agent execution.

Root cause from production logs:
- CUDA OOM on `nomic-embed-text:latest` embedding model
- `vectorize()` failed, cascading into `semantic_search()` receiving empty vectors
- Raised `WeaviateInvalidInputError` which crashed the entire CourseChatPipeline

### Description
Added resilience to memiris tool functions to gracefully handle memory service failures:

1. **`memiris_search_for_memories`**: Wrapped `vectorize()` and `semantic_search()` in try/except
2. **`memiris_find_similar_memories`**: Split into three granular error zones:
   - `get_memory_by_id` - fails fast if memory fetch fails
   - Connection lookup + retrieval - logs but continues to semantic search
   - Semantic search backfill - logs but returns partial results
3. Added `retrieval_succeeded` flag to distinguish "search worked but found nothing" from "service unavailable"
4. All exception logs include tenant and memory ID for debugging
5. Tools return graceful error messages instead of crashing, allowing agents to proceed without memories

### Steps for Testing
1. Simulate memory service failure by temporarily making Weaviate unavailable or causing embedding model OOM
2. Trigger course-chat pipeline via API
3. Verify agent continues execution and returns response, logging the memory service failure
4. Check logs contain tenant and memory ID in exception traces

Alternatively, unit test approach:
1. Mock `vectorizer.vectorize()` or `memory_service.semantic_search()` to raise exceptions
2. Verify tools return error strings instead of propagating exceptions
3. Verify partial results are preserved when possible

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

N/A - Backend-only change, no UI impact

### Screenshots
N/A - Backend resilience fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory search reliability with graceful error handling; users now receive a helpful message instead of an error when memory retrieval is temporarily unavailable.
  * Improved the display of results when no similar memories are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->