### PR TITLE
Add Prometheus metrics for logos-server and logos-workernode

### DIFF
--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -90,6 +90,14 @@ services:
       - "traefik.http.routers.logos-server-docs.service=logos-server"
       - "traefik.http.routers.logos-server-docs.priority=100"
 
+      # === Routing: /metrics (Prometheus) ===
+      - "traefik.http.routers.logos-server-metrics.rule=PathPrefix(`/metrics`)"
+      - "traefik.http.routers.logos-server-metrics.entrypoints=secure8080"
+      - "traefik.http.routers.logos-server-metrics.tls=true"
+      - "traefik.http.routers.logos-server-metrics.tls.certresolver=${LOGOS_CERT_RESOLVER:-}"
+      - "traefik.http.routers.logos-server-metrics.service=logos-server"
+      - "traefik.http.routers.logos-server-metrics.priority=100"
+
       # === Routing: /ws (WebSocket) ===
       - "traefik.http.routers.logos-server-ws.rule=PathPrefix(`/ws`)"
       - "traefik.http.routers.logos-server-ws.entrypoints=secure8080"

--- a/logos/logos-workernode/logos_worker_node/admin_api.py
+++ b/logos/logos-workernode/logos_worker_node/admin_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from starlette.responses import Response
 
 from logos_worker_node.auth import verify_api_key
 from logos_worker_node.config import save_lanes_config
@@ -17,9 +18,19 @@ from logos_worker_node.models import (
     LaneStatus,
     WorkerRuntimeStatus,
 )
+from logos_worker_node.prometheus_metrics import metrics_response as _prometheus_metrics_response
 from logos_worker_node.runtime import build_runtime_status
 
 router = APIRouter(tags=["admin"])
+
+
+@router.get("/metrics", tags=["monitoring"], summary="Prometheus metrics")
+async def prometheus_metrics(request: Request) -> Response:
+    """Prometheus metrics endpoint."""
+    from logos_worker_node.prometheus_metrics import update_from_runtime
+    await update_from_runtime(request.app)
+    body, content_type = _prometheus_metrics_response()
+    return Response(content=body, media_type=content_type)
 
 
 @router.get("/health", response_model=HealthResponse, summary="Public health check")

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -22,6 +22,7 @@ from logos_worker_node.models import (
 )
 from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.ollama_process import OllamaProcessHandle
+from logos_worker_node import prometheus_metrics as prom
 from logos_worker_node.vllm_process import VllmProcessHandle
 
 logger = logging.getLogger("logos_worker_node.lane_manager")
@@ -350,6 +351,7 @@ class LaneManager:
                     await old_handle.close()
 
             lane_statuses = await self._collect_statuses_unlocked()
+            prom.LANE_TRANSITIONS_TOTAL.labels(action="apply").inc()
 
             return LaneApplyResult(
                 success=len(errors) == 0,
@@ -379,6 +381,7 @@ class LaneManager:
             if lane_id not in self._handles:
                 raise KeyError(f"Lane '{lane_id}' not found")
             await self._remove_lane_unlocked(lane_id)
+            prom.LANE_TRANSITIONS_TOTAL.labels(action="delete").inc()
 
     async def reconfigure_lane(self, lane_id: str, updates: dict[str, Any]) -> LaneStatus:
         """Apply partial updates to an existing lane via hot-swap."""
@@ -406,6 +409,7 @@ class LaneManager:
             if _lane_needs_restart(current, new_lc):
                 old_handle = await self._hot_swap_lane_unlocked(lane_id, new_lc)
                 await old_handle.close()
+            prom.LANE_TRANSITIONS_TOTAL.labels(action="reconfigure").inc()
 
             return await self._get_status_unlocked(lane_id)
 
@@ -419,6 +423,7 @@ class LaneManager:
             if lc is None or not lc.vllm:
                 raise ValueError(f"Lane '{lane_id}' is not a vLLM lane")
             await handle.sleep(level=level, mode=mode)
+            prom.LANE_TRANSITIONS_TOTAL.labels(action="sleep").inc()
             self._record_event(
                 lane_id,
                 "sleep",
@@ -438,6 +443,7 @@ class LaneManager:
             if lc is None or not lc.vllm:
                 raise ValueError(f"Lane '{lane_id}' is not a vLLM lane")
             await handle.wake_up()
+            prom.LANE_TRANSITIONS_TOTAL.labels(action="wake").inc()
             self._record_event(
                 lane_id,
                 "wake",

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -23,6 +23,7 @@ except Exception:  # noqa: BLE001
 
 from logos_worker_node.config import save_lanes_config
 from logos_worker_node.models import LaneConfig, LogosConfig, WorkerTransportStatus
+from logos_worker_node import prometheus_metrics as prom
 from logos_worker_node.runtime import build_runtime_status
 
 logger = logging.getLogger("logos_worker_node.logos_bridge")
@@ -145,6 +146,8 @@ class LogosBridgeClient:
                 raise
             except ConnectionClosed as exc:
                 self._consecutive_failures += 1
+                prom.BRIDGE_RECONNECTS_TOTAL.inc()
+                prom.BRIDGE_ERRORS_TOTAL.inc()
                 logger.warning(
                     "%s══ BRIDGE DISCONNECTED ══%s websocket closed: %s "
                     "(consecutive_failures=%d)",
@@ -152,6 +155,8 @@ class LogosBridgeClient:
                 )
             except Exception as exc:  # noqa: BLE001
                 self._consecutive_failures += 1
+                prom.BRIDGE_RECONNECTS_TOTAL.inc()
+                prom.BRIDGE_ERRORS_TOTAL.inc()
                 logger.warning(
                     "%s══ BRIDGE ERROR ══%s %s (consecutive_failures=%d, "
                     "retrying in %ds)",
@@ -325,6 +330,7 @@ class LogosBridgeClient:
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         )
+        prom.BRIDGE_HEARTBEATS_TOTAL.inc()
 
     async def _send_json(self, ws, payload: dict[str, Any]) -> None:
         async with self._send_lock:

--- a/logos/logos-workernode/logos_worker_node/prometheus_metrics.py
+++ b/logos/logos-workernode/logos_worker_node/prometheus_metrics.py
@@ -1,0 +1,241 @@
+"""Prometheus metrics for LogosWorkerNode.
+
+Defines all custom metrics and exposes a WSGI app for the /metrics endpoint.
+"""
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    Info,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
+
+registry = CollectorRegistry()
+
+# ---------------------------------------------------------------------------
+# Service info
+# ---------------------------------------------------------------------------
+
+WORKER_INFO = Info(
+    "logos_worker",
+    "Static worker node metadata",
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# GPU telemetry (per device)
+# ---------------------------------------------------------------------------
+
+GPU_MEMORY_USED_MB = Gauge(
+    "logos_worker_gpu_memory_used_mb",
+    "GPU memory currently used (MB)",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+GPU_MEMORY_TOTAL_MB = Gauge(
+    "logos_worker_gpu_memory_total_mb",
+    "GPU total memory (MB)",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+GPU_MEMORY_FREE_MB = Gauge(
+    "logos_worker_gpu_memory_free_mb",
+    "GPU free memory (MB)",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+GPU_UTILIZATION_PERCENT = Gauge(
+    "logos_worker_gpu_utilization_percent",
+    "GPU utilization percentage",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+GPU_TEMPERATURE_CELSIUS = Gauge(
+    "logos_worker_gpu_temperature_celsius",
+    "GPU temperature in Celsius",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+GPU_POWER_DRAW_WATTS = Gauge(
+    "logos_worker_gpu_power_draw_watts",
+    "GPU power draw in Watts",
+    ["device_id", "gpu_index", "gpu_name"],
+    registry=registry,
+)
+
+# Aggregate GPU metrics
+GPU_DEVICES_TOTAL = Gauge(
+    "logos_worker_gpu_devices_total",
+    "Number of GPU devices detected",
+    registry=registry,
+)
+
+GPU_VRAM_TOTAL_MB = Gauge(
+    "logos_worker_gpu_vram_total_mb",
+    "Total VRAM across all GPUs (MB)",
+    registry=registry,
+)
+
+GPU_VRAM_USED_MB = Gauge(
+    "logos_worker_gpu_vram_used_mb",
+    "Total VRAM used across all GPUs (MB)",
+    registry=registry,
+)
+
+GPU_VRAM_FREE_MB = Gauge(
+    "logos_worker_gpu_vram_free_mb",
+    "Total VRAM free across all GPUs (MB)",
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Lane metrics
+# ---------------------------------------------------------------------------
+
+LANES_BY_STATE = Gauge(
+    "logos_worker_lanes_by_state",
+    "Number of lanes in each runtime state",
+    ["state"],  # cold, starting, loaded, running, sleeping, stopped, error
+    registry=registry,
+)
+
+LANES_TOTAL = Gauge(
+    "logos_worker_lanes_total",
+    "Total number of lanes",
+    registry=registry,
+)
+
+LANE_ACTIVE_REQUESTS = Gauge(
+    "logos_worker_lane_active_requests",
+    "Number of active (in-flight) requests per lane",
+    ["lane_id", "model"],
+    registry=registry,
+)
+
+LANE_VRAM_EFFECTIVE_MB = Gauge(
+    "logos_worker_lane_vram_effective_mb",
+    "Effective VRAM used by each lane (MB)",
+    ["lane_id", "model"],
+    registry=registry,
+)
+
+LANE_TRANSITIONS_TOTAL = Counter(
+    "logos_worker_lane_transitions_total",
+    "Total lane state transitions",
+    ["action"],  # apply, sleep, wake, delete, reconfigure, error
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Logos bridge connectivity
+# ---------------------------------------------------------------------------
+
+BRIDGE_CONNECTED = Gauge(
+    "logos_worker_bridge_connected",
+    "Whether the worker is connected to the Logos server (1=yes, 0=no)",
+    registry=registry,
+)
+
+BRIDGE_HEARTBEATS_TOTAL = Counter(
+    "logos_worker_bridge_heartbeats_total",
+    "Total heartbeats sent to Logos server",
+    registry=registry,
+)
+
+BRIDGE_RECONNECTS_TOTAL = Counter(
+    "logos_worker_bridge_reconnects_total",
+    "Total WebSocket reconnection attempts",
+    registry=registry,
+)
+
+BRIDGE_ERRORS_TOTAL = Counter(
+    "logos_worker_bridge_errors_total",
+    "Total bridge communication errors",
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Inference (per lane)
+# ---------------------------------------------------------------------------
+
+INFERENCE_REQUESTS_TOTAL = Counter(
+    "logos_worker_inference_requests_total",
+    "Total inference requests received by the worker",
+    ["lane_id", "model"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def metrics_response() -> tuple[bytes, str]:
+    """Return (body, content_type) suitable for a FastAPI Response."""
+    return generate_latest(registry), CONTENT_TYPE_LATEST
+
+
+async def update_from_runtime(app: object) -> None:
+    """Snapshot current runtime state into Prometheus gauges.
+
+    Called on each /metrics scrape so gauges are always fresh.
+    """
+    from logos_worker_node.runtime import build_runtime_status
+
+    try:
+        runtime = await build_runtime_status(app)
+    except Exception:
+        return
+
+    # Worker info
+    WORKER_INFO.info({
+        "name": runtime.worker_name or "",
+        "version": runtime.service_version or "",
+        "worker_id": runtime.worker_id or "",
+    })
+
+    # GPU devices
+    devices = runtime.devices
+    GPU_DEVICES_TOTAL.set(len(devices.devices) if devices.devices else 0)
+    GPU_VRAM_TOTAL_MB.set(devices.total_memory_mb)
+    GPU_VRAM_USED_MB.set(devices.used_memory_mb)
+    GPU_VRAM_FREE_MB.set(devices.free_memory_mb)
+
+    for device in (devices.devices or []):
+        labels = {
+            "device_id": device.device_id or "",
+            "gpu_index": str((device.extra or {}).get("index", "")),
+            "gpu_name": device.name or "",
+        }
+        GPU_MEMORY_USED_MB.labels(**labels).set(device.memory_used_mb)
+        GPU_MEMORY_TOTAL_MB.labels(**labels).set(device.memory_total_mb)
+        GPU_MEMORY_FREE_MB.labels(**labels).set(device.memory_free_mb)
+        if device.utilization_percent is not None:
+            GPU_UTILIZATION_PERCENT.labels(**labels).set(device.utilization_percent)
+        if device.temperature_celsius is not None:
+            GPU_TEMPERATURE_CELSIUS.labels(**labels).set(device.temperature_celsius)
+        if device.power_draw_watts is not None:
+            GPU_POWER_DRAW_WATTS.labels(**labels).set(device.power_draw_watts)
+
+    # Lane metrics
+    state_counts: dict[str, int] = {}
+    LANES_TOTAL.set(runtime.capacity.lane_count)
+    for lane in runtime.lanes:
+        state = lane.runtime_state or "unknown"
+        state_counts[state] = state_counts.get(state, 0) + 1
+        lane_labels = {"lane_id": lane.lane_id or "", "model": lane.model or ""}
+        LANE_ACTIVE_REQUESTS.labels(**lane_labels).set(lane.active_requests or 0)
+        LANE_VRAM_EFFECTIVE_MB.labels(**lane_labels).set(lane.effective_vram_mb or 0)
+
+    for state in ("cold", "starting", "loaded", "running", "sleeping", "stopped", "error"):
+        LANES_BY_STATE.labels(state=state).set(state_counts.get(state, 0))
+
+    # Bridge connectivity
+    BRIDGE_CONNECTED.set(1 if runtime.transport.connected else 0)

--- a/logos/logos-workernode/requirements.txt
+++ b/logos/logos-workernode/requirements.txt
@@ -4,3 +4,4 @@ httpx>=0.28.0,<1.0
 pyyaml>=6.0,<7.0
 pydantic>=2.0,<3.0
 websockets>=12.0,<15.0
+prometheus-client>=0.21.0,<1.0

--- a/logos/pyproject.toml
+++ b/logos/pyproject.toml
@@ -31,6 +31,7 @@ python-dateutil = "^2.9.0"
 sentence-transformers = "^5.0.0"
 matplotlib = "^3.9.2"
 aiohttp = "^3.9.0"
+prometheus-client = "^0.21.0"
 
 [tool.poetry]
 packages = [{ include = "logos", from = "src" }]

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -33,6 +33,7 @@ from logos.terminal_logging import (
 )
 
 from .demand_tracker import DemandTracker
+from logos.monitoring import prometheus_metrics as prom
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,16 @@ class CapacityPlanner:
 
     async def _run_cycle(self) -> None:
         """Execute one planner cycle."""
+        cycle_start = time.time()
         self._demand.decay_all()
+
+        # Update demand gauges
+        for model_name, score in self._demand.get_ranked_models():
+            prom.DEMAND_SCORE.labels(model=model_name).set(score)
+            prom.DEMAND_RAW_COUNT.labels(model=model_name).set(
+                self._demand.get_raw_count(model_name)
+            )
+
         all_actions: List[CapacityPlanAction] = []
 
         provider_ids = self._facade.provider_ids()
@@ -162,16 +172,22 @@ class CapacityPlanner:
         for action in validated:
             try:
                 await self._execute_action_with_confirmation(action)
+                prom.CAPACITY_PLANNER_ACTIONS_TOTAL.labels(action=action.action).inc()
             except Exception:
                 logger.exception(
                     "Failed to execute capacity action: %s on lane %s",
                     action.action, action.lane_id,
                 )
 
+        prom.CAPACITY_PLANNER_CYCLE_DURATION_SECONDS.observe(time.time() - cycle_start)
+
     def _log_cluster_summary(self, provider_ids: List[int]) -> None:
         """Print a colored cluster overview for the current planner cycle."""
         lines: list[str] = []
         connected = 0
+        total_used_vram = 0.0
+        total_free_vram = 0.0
+        state_counts: dict[str, int] = {}
         for pid in provider_ids:
             snap = self._registry.peek_runtime_snapshot(pid) if self._registry else None
             if snap is None:
@@ -186,6 +202,12 @@ class CapacityPlanner:
             lanes_list = rt.get("lanes") or []
             total_vram = (rt.get("devices") or {}).get("total_memory_mb", 0)
             free_vram = cap.get("free_memory_mb", 0)
+            total_used_vram += total_vram - free_vram
+            total_free_vram += free_vram
+            for lane in (lanes_list if isinstance(lanes_list, list) else []):
+                if isinstance(lane, dict):
+                    rs = str(lane.get("runtime_state") or "unknown")
+                    state_counts[rs] = state_counts.get(rs, 0) + 1
             used_pct = ((total_vram - free_vram) / total_vram * 100) if total_vram > 0 else 0
             heartbeat_age_s = self._heartbeat_age_seconds(snap.get("last_heartbeat"))
             worker_color = GREEN if heartbeat_age_s <= 15 else YELLOW if heartbeat_age_s <= 30 else RED
@@ -233,6 +255,13 @@ class CapacityPlanner:
                 accent=CYAN,
             )
         )
+
+        # Update Prometheus gauges
+        prom.WORKER_NODES_CONNECTED.set(connected)
+        prom.WORKER_VRAM_USED_MB.set(total_used_vram)
+        prom.WORKER_VRAM_FREE_MB.set(total_free_vram)
+        for state in ("cold", "starting", "loaded", "running", "sleeping", "stopped", "error"):
+            prom.WORKER_LANES_BY_STATE.labels(state=state).set(state_counts.get(state, 0))
 
     @staticmethod
     def _heartbeat_age_seconds(last_heartbeat: Any) -> float:

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -47,6 +47,7 @@ from logos.logosnode_registry import (
     LogosNodeRuntimeRegistry,
 )
 from logos.terminal_logging import MultiLineFormatter, UvicornAccessFilter, UvicornErrorFilter
+from logos.monitoring.prometheus_metrics import metrics_response as _prometheus_metrics_response
 from scripts import setup_proxy
 
 _SERVER_START_TIME = int(time.time())
@@ -979,6 +980,14 @@ async def add_star_cors_headers(request: Request, call_next):
     response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
     response.headers["Access-Control-Allow-Headers"] = "*"
     return response
+
+
+@app.get("/metrics", tags=["monitoring"])
+async def prometheus_metrics():
+    """Prometheus metrics endpoint."""
+    body, content_type = _prometheus_metrics_response()
+    from starlette.responses import Response
+    return Response(content=body, media_type=content_type)
 
 
 # ============================================================================

--- a/logos/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/src/logos/monitoring/prometheus_metrics.py
@@ -1,0 +1,155 @@
+"""Prometheus metrics for Logos server.
+
+Defines all custom metrics and exposes a WSGI app for the /metrics endpoint.
+"""
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
+
+registry = CollectorRegistry()
+
+# ---------------------------------------------------------------------------
+# Request pipeline
+# ---------------------------------------------------------------------------
+
+REQUESTS_TOTAL = Counter(
+    "logos_requests_total",
+    "Total requests entering the pipeline",
+    ["status"],  # enqueued, scheduled, completed, timeout, error
+    registry=registry,
+)
+
+REQUEST_DURATION_SECONDS = Histogram(
+    "logos_request_duration_seconds",
+    "End-to-end request duration from enqueue to completion",
+    ["model", "provider", "status"],
+    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0),
+    registry=registry,
+)
+
+REQUESTS_IN_FLIGHT = Gauge(
+    "logos_requests_in_flight",
+    "Requests currently being processed",
+    registry=registry,
+)
+
+COLD_STARTS_TOTAL = Counter(
+    "logos_cold_starts_total",
+    "Number of requests served by a cold (freshly loaded) model",
+    ["model"],
+    registry=registry,
+)
+
+QUEUE_DEPTH = Gauge(
+    "logos_queue_depth",
+    "Current total queue depth across all providers",
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+CLASSIFICATION_DURATION_SECONDS = Histogram(
+    "logos_classification_duration_seconds",
+    "Time spent in the classification stage",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+    registry=registry,
+)
+
+CLASSIFICATION_CANDIDATES = Histogram(
+    "logos_classification_candidates",
+    "Number of candidate models returned by classification",
+    buckets=(0, 1, 2, 3, 5, 10, 20),
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Scheduling
+# ---------------------------------------------------------------------------
+
+SCHEDULING_DECISIONS_TOTAL = Counter(
+    "logos_scheduling_decisions_total",
+    "Scheduling outcomes",
+    ["result"],  # scheduled, no_capacity, timeout
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Demand tracker
+# ---------------------------------------------------------------------------
+
+DEMAND_SCORE = Gauge(
+    "logos_demand_score",
+    "Current exponential-decay demand score per model",
+    ["model"],
+    registry=registry,
+)
+
+DEMAND_RAW_COUNT = Gauge(
+    "logos_demand_raw_count",
+    "Cumulative raw request count per model (non-decayed)",
+    ["model"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Capacity planner
+# ---------------------------------------------------------------------------
+
+CAPACITY_PLANNER_ACTIONS_TOTAL = Counter(
+    "logos_capacity_planner_actions_total",
+    "Actions taken by the capacity planner",
+    ["action"],  # sleep, wake, load, stop, tune_gpu
+    registry=registry,
+)
+
+CAPACITY_PLANNER_CYCLE_DURATION_SECONDS = Histogram(
+    "logos_capacity_planner_cycle_duration_seconds",
+    "Duration of one capacity planner evaluation cycle",
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Worker node connectivity (as seen from the server)
+# ---------------------------------------------------------------------------
+
+WORKER_NODES_CONNECTED = Gauge(
+    "logos_worker_nodes_connected",
+    "Number of worker nodes currently connected",
+    registry=registry,
+)
+
+WORKER_LANES_BY_STATE = Gauge(
+    "logos_worker_lanes_by_state",
+    "Number of worker lanes in each state (as reported to the server)",
+    ["state"],  # cold, starting, loaded, running, sleeping, stopped, error
+    registry=registry,
+)
+
+WORKER_VRAM_USED_MB = Gauge(
+    "logos_worker_vram_used_mb",
+    "Total effective VRAM used across all connected worker nodes (MB)",
+    registry=registry,
+)
+
+WORKER_VRAM_FREE_MB = Gauge(
+    "logos_worker_vram_free_mb",
+    "Total free VRAM across all connected worker nodes (MB)",
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def metrics_response() -> tuple[bytes, str]:
+    """Return (body, content_type) suitable for a FastAPI Response."""
+    return generate_latest(registry), CONTENT_TYPE_LATEST

--- a/logos/src/logos/monitoring/recorder.py
+++ b/logos/src/logos/monitoring/recorder.py
@@ -10,12 +10,17 @@ from __future__ import annotations
 
 import datetime
 import logging
+import time
 from typing import Callable, Optional, Dict, Any
 
 from logos.dbutils.dbmanager import DBManager
 from logos.dbutils.dbmodules import ResultStatus
+from logos.monitoring import prometheus_metrics as prom
 
 logger = logging.getLogger(__name__)
+
+# Track in-flight request start times for duration histograms
+_request_start_times: Dict[str, float] = {}
 
 
 class MonitoringRecorder:
@@ -35,6 +40,12 @@ class MonitoringRecorder:
         queue_depth: Optional[int],
         timeout_s: Optional[int] = None,
     ) -> None:
+        prom.REQUESTS_TOTAL.labels(status="enqueued").inc()
+        prom.REQUESTS_IN_FLIGHT.inc()
+        if queue_depth is not None:
+            prom.QUEUE_DEPTH.set(queue_depth)
+        _request_start_times[request_id] = time.monotonic()
+
         payload = {
             "model_id": model_id,
             "provider_id": provider_id,
@@ -64,6 +75,9 @@ class MonitoringRecorder:
             queue_depth_at_schedule: Total system queue depth at scheduling time.
             provider_metrics: Dictionary of provider-specific metrics (e.g. VRAM, rate limits).
         """
+        prom.REQUESTS_TOTAL.labels(status="scheduled").inc()
+        prom.SCHEDULING_DECISIONS_TOTAL.labels(result="scheduled").inc()
+
         payload = {
             "model_id": model_id,
             "provider_id": provider_id,
@@ -71,7 +85,7 @@ class MonitoringRecorder:
             "queue_depth_at_schedule": queue_depth_at_schedule,
             "scheduled_ts": datetime.datetime.now(datetime.timezone.utc),
         }
-        
+
         # Flatten provider metrics for DB columns
         if provider_metrics:
             for key, value in provider_metrics.items():
@@ -87,6 +101,20 @@ class MonitoringRecorder:
         error_message: Optional[str] = None,
     ) -> None:
         status_value = result_status.value if isinstance(result_status, ResultStatus) else str(result_status)
+
+        prom.REQUESTS_TOTAL.labels(status=status_value).inc()
+        prom.REQUESTS_IN_FLIGHT.dec()
+
+        start = _request_start_times.pop(request_id, None)
+        if start is not None:
+            duration = time.monotonic() - start
+            prom.REQUEST_DURATION_SECONDS.labels(
+                model="unknown", provider="unknown", status=status_value,
+            ).observe(duration)
+
+        if cold_start:
+            prom.COLD_STARTS_TOTAL.labels(model="unknown").inc()
+
         payload = {
             "request_complete_ts": datetime.datetime.now(datetime.timezone.utc),
             "result_status": status_value,

--- a/logos/src/logos/pipeline/pipeline.py
+++ b/logos/src/logos/pipeline/pipeline.py
@@ -12,6 +12,7 @@ from logos.classification.classification_manager import ClassificationManager
 from logos.classification.proxy_policy import ProxyPolicy
 from logos.dbutils.types import Deployment
 from logos.monitoring.recorder import MonitoringRecorder
+from logos.monitoring import prometheus_metrics as prom
 
 from logos.queue.models import Priority
 
@@ -167,6 +168,7 @@ class RequestPipeline:
             scheduling_result = await self._scheduler.schedule(scheduling_request)
         except QueueTimeoutError as exc:
             logger.warning("Request %s timed out waiting in queue", request_id)
+            prom.SCHEDULING_DECISIONS_TOTAL.labels(result="timeout").inc()
             self.record_completion(
                 request_id=request_id,
                 result_status="timeout",
@@ -189,6 +191,7 @@ class RequestPipeline:
 
         if not scheduling_result:
             logger.warning(f"Request {request_id} failed scheduling: All models unavailable")
+            prom.SCHEDULING_DECISIONS_TOTAL.labels(result="no_capacity").inc()
             self.record_completion(
                 request_id=request_id,
                 result_status="error",
@@ -346,7 +349,10 @@ class RequestPipeline:
         )
         
         elapsed = time.time() - start
-        
+
+        prom.CLASSIFICATION_DURATION_SECONDS.observe(elapsed)
+        prom.CLASSIFICATION_CANDIDATES.observe(len(candidates))
+
         # Build classification stats
         stats = {
             "classification_time": elapsed,


### PR DESCRIPTION
## Summary
- Adds `prometheus_client` dependency to both logos-server and logos-workernode
- Exposes `/metrics` endpoints on both services for Prometheus scraping
- Instruments the request pipeline (enqueue/schedule/complete counters, duration histograms, in-flight gauge, cold start counter)
- Instruments classification (duration histogram, candidate count histogram)
- Instruments scheduling decisions (scheduled/no_capacity/timeout counters)
- Instruments the capacity planner (action counters, cycle duration histogram, demand score gauges)
- Exports worker node connectivity and lane state gauges from the server
- Exports per-GPU telemetry (memory, utilization, temperature, power) from workernode
- Exports lane metrics (state counts, active requests, effective VRAM per lane) from workernode
- Instruments the logos bridge (heartbeat counter, reconnect counter, error counter)
- Instruments lane manager transitions (apply, sleep, wake, delete, reconfigure counters)
- Adds Traefik routing for `/metrics` on the server

## Test plan
- [ ] Verify logos-server starts and `/metrics` returns valid Prometheus text format
- [ ] Verify logos-workernode starts and `/metrics` returns valid Prometheus text format
- [ ] Send test requests and verify counters increment (`logos_requests_total`, `logos_request_duration_seconds`)
- [ ] Verify GPU metrics appear when nvidia-smi is available
- [ ] Verify lane state gauges update after sleep/wake operations
- [ ] Verify capacity planner metrics update each cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)