### PR TITLE
`Logos`: Fix calibration binary search to start from floor instead of ceiling

### DIFF
--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -4,11 +4,11 @@ Extracts the reusable calibration functions so they can be imported both by
 the standalone CLI tool (``tools/calibrate_vram_profiles.py``) and by the
 worker's startup flow (``main.py``).
 
-The calibration process binary-searches for the minimum KV cache each model
-needs (starting at ``_KV_CACHE_VRAM_CAP_RATIO`` of GPU VRAM, narrowing to
-±``_KV_CACHE_MIN_STEP_MB``), then adds ``_KV_CACHE_MIN_STEP_MB`` as a safety
-margin.  It measures real VRAM in awake and sleeping states and persists the
-results to ``model_profiles.yml``.
+The calibration process binary-searches upward for the maximum KV cache each
+model can use (starting at ``_KV_CACHE_MIN_STEP_MB`` floor, searching up to
+``_KV_CACHE_VRAM_CAP_RATIO`` of per-GPU VRAM with
+±``_KV_CACHE_MIN_STEP_MB`` precision).  It measures real VRAM in awake and
+sleeping states and persists the results to ``model_profiles.yml``.
 
 VRAM decomposition (exact, no guessing)::
 
@@ -574,13 +574,13 @@ def calibrate_model(
             "  Could not query GPU VRAM for KV cache cap: %s — no cap applied", exc,
         )
 
-    # Phase 2 — Find the minimum KV cache the model needs, then add margin.
+    # Phase 2 — Find the maximum KV cache the model can use.
     #
-    # 1. Try the ceiling (_KV_CACHE_VRAM_CAP_RATIO of GPU VRAM) to verify
-    #    the model can start at all.
-    # 2. Binary-search downward to find the minimum KV cache that still
-    #    allows vLLM to start (±_KV_CACHE_MIN_STEP_MB precision).
-    # 3. Add _KV_CACHE_MIN_STEP_MB as a safety margin on top.
+    # 1. Probe the floor (_KV_CACHE_MIN_STEP_MB) to verify the model can
+    #    start at all — if even the minimum KV cache OOMs, the model
+    #    weights themselves exceed available GPU VRAM.
+    # 2. Binary-search upward to find the maximum KV cache that still
+    #    fits (±_KV_CACHE_MIN_STEP_MB precision).
     #
     # A per-model override (plan["kv_cache_memory_bytes"]) skips the
     # search and uses the fixed value.
@@ -599,9 +599,9 @@ def calibrate_model(
         # Round down to whole GB
         kv_cache_sent_mb = math.floor(kv_cache_sent_mb / 1024.0) * 1024.0
         logger.info(
-            "  [2/6] Searching min KV cache (ceiling=%.0f MB, "
-            "step=%.0f MB)...",
-            kv_cache_sent_mb, _KV_CACHE_MIN_STEP_MB,
+            "  [2/6] Searching max KV cache (floor=%.0f MB, "
+            "ceiling=%.0f MB, step=%.0f MB)...",
+            _KV_CACHE_MIN_STEP_MB, kv_cache_sent_mb, _KV_CACHE_MIN_STEP_MB,
         )
 
     failed_path = log_dir / _FAILED_COMMANDS_FILE
@@ -657,50 +657,49 @@ def calibrate_model(
     proc: subprocess.Popen[str] | None = None
 
     if kv_search:
-        # First verify the model starts at all with the ceiling KV
-        search_lo = _KV_CACHE_MIN_STEP_MB
-        search_hi = kv_cache_sent_mb
+        search_lo = _KV_CACHE_MIN_STEP_MB  # 1 GB floor
+        search_hi = kv_cache_sent_mb       # ceiling (80% of per-GPU VRAM)
 
-        proc = _try_start(search_hi)
+        # Phase 2a: Verify the model loads at all with minimum KV cache.
+        # If even 1 GB KV fails, the model simply doesn't fit.
+        logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
+        proc = _try_start(search_lo)
         if proc is None:
             partial.error = (
-                f"Model cannot start even with max KV cache "
-                f"{_format_kv_mb(search_hi)} on tp={tp}"
+                f"Model cannot start even with minimum KV cache "
+                f"{_format_kv_mb(search_lo)} on tp={tp}. "
+                f"Model weights likely exceed available GPU VRAM."
             )
             logger.warning("  ERROR: %s", partial.error)
             return partial
 
-        # Ceiling works — now binary-search for the minimum KV cache
+        # Floor works — now binary-search upward to find maximum KV cache that fits
         stop_vllm(proc)
         time.sleep(_VRAM_SETTLE_S)
         proc = None
-        best_kv = search_hi
+        best_kv = search_lo
 
         while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
             mid = _round_up_gb((search_lo + search_hi) / 2.0)
-            if mid >= search_hi:
+            if mid <= search_lo:
                 break
             proc = _try_start(mid)
             if proc is not None:
-                # Works at this size — try even lower
+                # Works at this size — try even higher
                 best_kv = mid
                 stop_vllm(proc)
                 time.sleep(_VRAM_SETTLE_S)
                 proc = None
-                search_hi = mid
+                search_lo = mid
             else:
-                # Too small — minimum is higher
-                search_lo = mid + _KV_CACHE_MIN_STEP_MB
+                # Too large — maximum is lower
+                search_hi = mid - _KV_CACHE_MIN_STEP_MB
 
-        # Add safety margin on top of the minimum
-        kv_cache_sent_mb = min(
-            best_kv + _KV_CACHE_MIN_STEP_MB,
-            max_kv_mb if max_kv_mb < float("inf") else best_kv + _KV_CACHE_MIN_STEP_MB,
-        )
+        kv_cache_sent_mb = best_kv
         logger.info(
-            "  KV cache search result: min_working=%.0f MB, "
-            "with %.0f MB safety margin -> final=%.0f MB",
-            best_kv, _KV_CACHE_MIN_STEP_MB, kv_cache_sent_mb,
+            "  KV cache search result: max_working=%.0f MB (search range exhausted, "
+            "precision=%.0f MB)",
+            best_kv, _KV_CACHE_MIN_STEP_MB,
         )
 
         # Start vLLM at the final KV size for measurement

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -22,6 +22,7 @@ import yaml
 from logos_worker_node.calibration import (
     CalibrationResult,
     _format_kv_mb,
+    _KV_CACHE_MIN_STEP_MB,
     _max_tp_for_plan,
     _parse_kv_to_mb,
     _round_up_gb,
@@ -601,12 +602,13 @@ def _patch_calibration_infra(
     """
     patches = {}
 
-    # spawn_vllm → returns a mock Popen
+    # spawn_vllm → returns (mock_popen, ["cmd"]) tuple
     mock_popen = MagicMock()
     mock_popen.pid = 12345
     mock_popen.poll.return_value = None
     patches["spawn"] = patch(
-        "logos_worker_node.calibration.spawn_vllm", return_value=mock_popen
+        "logos_worker_node.calibration.spawn_vllm",
+        return_value=(mock_popen, ["vllm", "serve"]),
     )
 
     # stop_vllm → no-op
@@ -646,6 +648,11 @@ def _patch_calibration_infra(
     # _kill_stale_vllm_workers → no-op (avoids scanning /proc in tests)
     patches["kill_stale"] = patch(
         "logos_worker_node.calibration._kill_stale_vllm_workers"
+    )
+
+    # _load_failed_commands → always empty (no cross-test contamination)
+    patches["load_failed"] = patch(
+        "logos_worker_node.calibration._load_failed_commands", return_value=set()
     )
 
     return patches
@@ -776,3 +783,239 @@ def test_profile_dict_has_calibration_kv_field():
 
     assert "calibration_kv_cache_memory_bytes" in d
     assert d["calibration_kv_cache_memory_bytes"] == "5G"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Group 9 — KV cache search direction (floor-to-ceiling)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _make_search_plan(model: str = "org/test-model", **overrides) -> dict:
+    """Plan WITHOUT kv_cache_memory_bytes so kv_search=True is triggered."""
+    plan: dict = {"model": model}
+    plan.update(overrides)
+    return plan
+
+
+def _patch_search_infra(
+    *,
+    wait_ready_side_effect,
+    sample_vram_sequence=None,
+    gpu_vram_total_mb: float = 48000.0,
+):
+    """Like _patch_calibration_infra but tailored for kv_search=True tests.
+
+    Returns patches dict.  ``wait_ready_side_effect`` controls which
+    _try_start probes succeed (None) or fail (RuntimeError).
+    """
+    patches = {}
+
+    # spawn_vllm → returns (mock_popen, ["cmd"]) tuple
+    mock_popen = MagicMock()
+    mock_popen.pid = 12345
+    mock_popen.poll.return_value = None
+    patches["spawn"] = patch(
+        "logos_worker_node.calibration.spawn_vllm",
+        return_value=(mock_popen, ["vllm", "serve"]),
+    )
+
+    patches["stop"] = patch("logos_worker_node.calibration.stop_vllm")
+
+    patches["ready"] = patch(
+        "logos_worker_node.calibration.wait_ready",
+        side_effect=wait_ready_side_effect,
+    )
+
+    snap = _gpu_vram_snapshot(total_mb=gpu_vram_total_mb)
+    patches["gpu_vram"] = patch(
+        "logos_worker_node.calibration.query_gpu_vram", return_value=snap
+    )
+
+    if sample_vram_sequence is None:
+        sample_vram_sequence = [500.0, 7500.0, 600.0]  # baseline, awake, sleeping
+    patches["sample"] = patch(
+        "logos_worker_node.calibration.sample_vram_mb",
+        side_effect=sample_vram_sequence,
+    )
+
+    patches["sleep"] = patch("logos_worker_node.calibration.time.sleep")
+    patches["wait_sleep"] = patch("logos_worker_node.calibration.wait_sleep_state")
+    patches["post"] = patch(
+        "logos_worker_node.calibration._post", return_value=(200, {})
+    )
+    patches["kill_stale"] = patch(
+        "logos_worker_node.calibration._kill_stale_vllm_workers"
+    )
+
+    # _load_failed_commands → always empty (no cross-test contamination)
+    patches["load_failed"] = patch(
+        "logos_worker_node.calibration._load_failed_commands", return_value=set()
+    )
+
+    return patches
+
+
+def _run_search_calibrate(patches, plan=None):
+    """Enter all patches and call calibrate_model with a search plan."""
+    plan = plan or _make_search_plan()
+    log_dir = Path("/tmp/test-calibration-logs")
+
+    managers = {k: p.__enter__() for k, p in patches.items()}
+    try:
+        result = calibrate_model(
+            plan,
+            vllm_binary="vllm",
+            port=11499,
+            log_dir=log_dir,
+            sleep_level=1,
+            ready_timeout_s=60.0,
+        )
+    finally:
+        for p in patches.values():
+            p.__exit__(None, None, None)
+
+    return result, managers
+
+
+def test_search_starts_from_floor_not_ceiling():
+    """First probe should be at the floor (1 GB), not the ceiling.
+
+    Mock: succeed at 1 GB and 4 GB, fail at 8 GB+.
+    GPU = 48 GB → ceiling = 48000*0.8 = 38400 → rounded down = 37888 MB (37 GB).
+    Search: floor=1024, ceiling=37888.
+    Mid = round_up_gb((1024+37888)/2) = round_up_gb(19456) = 19456 (already GB-aligned).
+    """
+    # We need enough side_effect entries for:
+    #  1. floor probe (1 GB) → OK
+    #  2. binary search probes → need to figure out exact midpoints
+    # With 48 GB GPU: ceiling = floor(48000*0.8/1024)*1024 = floor(37.5)*1024 = 37*1024 = 37888
+    # Actually: 48000 * 0.8 = 38400.  floor(38400/1024)*1024 = 37*1024 = 37888.
+    # Search: lo=1024, hi=37888.
+    #   mid=round_up_gb((1024+37888)/2)=round_up_gb(19456)=19456  → fail
+    #   hi = 19456-1024 = 18432
+    #   mid=round_up_gb((1024+18432)/2)=round_up_gb(9728)=10240   → fail
+    #   hi = 10240-1024 = 9216
+    #   mid=round_up_gb((1024+9216)/2)=round_up_gb(5120)=5120     → fail
+    #   hi = 5120-1024 = 4096
+    #   mid=round_up_gb((1024+4096)/2)=round_up_gb(2560)=3072     → OK, best_kv=3072
+    #   lo = 3072, hi = 4096
+    #   hi-lo = 1024 >= 1024 → continue
+    #   mid=round_up_gb((3072+4096)/2)=round_up_gb(3584)=4096     → OK, best_kv=4096
+    #   lo = 4096, hi = 4096 → hi-lo=0 < 1024, stop
+    # best_kv = 4096
+    # Final measurement probe at 4096 → OK.
+    # Total probes: floor(1024), 19456, 10240, 5120, 3072, 4096, final(4096) = 7 wait_ready calls
+    # Plus awake/sleeping measurement calls (wait_sleep_state etc.)
+
+    kv_calls = []
+
+    def spawn_side_effect(plan, vllm_binary, host, port, log_path, kv_cache_memory_bytes):
+        kv_calls.append(kv_cache_memory_bytes)
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        return (mock_proc, ["vllm", "serve"])
+
+    kv_fail_threshold_mb = 5120  # fail at 5 GB and above
+
+    def wait_ready_side_effect(*args, **kwargs):
+        # The last spawned process has the kv from kv_calls[-1]
+        last_kv = _parse_kv_to_mb(kv_calls[-1])
+        if last_kv >= kv_fail_threshold_mb:
+            raise RuntimeError("OOM")
+
+    patches = _patch_search_infra(
+        wait_ready_side_effect=wait_ready_side_effect,
+        gpu_vram_total_mb=48000.0,
+    )
+    # Override spawn and ready with our custom versions
+    patches["spawn"] = patch(
+        "logos_worker_node.calibration.spawn_vllm",
+        side_effect=spawn_side_effect,
+    )
+    patches["ready"] = patch(
+        "logos_worker_node.calibration.wait_ready",
+        side_effect=wait_ready_side_effect,
+    )
+
+    result, _ = _run_search_calibrate(patches, plan=_make_search_plan())
+
+    assert result.success
+    # First probe must be at the floor (1 GB), NOT the ceiling
+    assert kv_calls[0] == "1G", f"First probe should be 1G (floor), got {kv_calls[0]}"
+    # best_kv should be 4096 MB (4 GB) — the highest that fits below 5 GB
+    assert result.kv_cache_sent_mb == pytest.approx(4096.0)
+
+
+def test_floor_failure_gives_clear_error():
+    """When even 1 GB KV cache fails, report that model weights exceed VRAM."""
+    patches = _patch_search_infra(
+        wait_ready_side_effect=[RuntimeError("OOM at floor")],
+        gpu_vram_total_mb=48000.0,
+    )
+
+    result, mocks = _run_search_calibrate(patches, plan=_make_search_plan())
+
+    assert not result.success
+    assert "minimum kv cache" in result.error.lower()
+    assert "model weights likely exceed" in result.error.lower()
+    # Only one probe — the floor attempt
+    assert mocks["spawn"].call_count == 1
+
+
+def test_ceiling_reachable():
+    """When all probes succeed, best_kv should reach the ceiling value."""
+    # All wait_ready calls succeed (never raise)
+    # With 24 GB GPU: ceiling = floor(24000*0.8/1024)*1024 = floor(18.75)*1024 = 18*1024 = 18432
+    # The search will binary-search up and eventually reach 18432.
+
+    patches = _patch_search_infra(
+        wait_ready_side_effect=None,  # will be overridden below
+        gpu_vram_total_mb=24000.0,
+    )
+    # All probes succeed
+    patches["ready"] = patch(
+        "logos_worker_node.calibration.wait_ready",
+    )
+
+    result, _ = _run_search_calibrate(patches, plan=_make_search_plan())
+
+    assert result.success
+    # ceiling = floor(24000 * 0.8 / 1024) * 1024 = 18432
+    expected_ceiling = 18432.0
+    assert result.kv_cache_sent_mb == pytest.approx(expected_ceiling)
+
+
+def test_search_direction_never_probes_ceiling_first():
+    """Ensure the search NEVER probes the full ceiling as the first attempt.
+
+    This is the core behavioral guarantee: the old code probed the ceiling
+    first (which OOMed on large models), the new code probes the floor first.
+    """
+    kv_calls = []
+
+    def spawn_side_effect(plan, vllm_binary, host, port, log_path, kv_cache_memory_bytes):
+        kv_calls.append(_parse_kv_to_mb(kv_cache_memory_bytes))
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        return (mock_proc, ["vllm", "serve"])
+
+    patches = _patch_search_infra(
+        wait_ready_side_effect=None,
+        gpu_vram_total_mb=48000.0,
+    )
+    patches["spawn"] = patch(
+        "logos_worker_node.calibration.spawn_vllm",
+        side_effect=spawn_side_effect,
+    )
+    patches["ready"] = patch("logos_worker_node.calibration.wait_ready")
+
+    result, _ = _run_search_calibrate(patches, plan=_make_search_plan())
+
+    assert result.success
+    # ceiling = floor(48000*0.8/1024)*1024 = 37888
+    ceiling = 37888.0
+    # First probe must be the floor (1024 MB), not the ceiling
+    assert kv_calls[0] == pytest.approx(_KV_CACHE_MIN_STEP_MB)
+    assert kv_calls[0] != pytest.approx(ceiling)


### PR DESCRIPTION
## Problem

The KV cache binary search in `calibrate_model()` started from the **ceiling** (80% of per-GPU VRAM, ~38 GB on a 48 GB GPU) and searched downward. This was fatally flawed:

1. **vLLM loads model weights first**, then allocates KV cache
2. The first probe (weights + 38 GB KV) almost always **exceeds GPU VRAM** → OOM
3. vLLM **crashes on OOM** — the process dies, the binary search never tries a smaller value
4. Calibration reports failure → model stays uncalibrated → server never schedules it

### Affected models (2× NVIDIA RTX 6000 Ada, 48 GB each)
- `google/gemma-4-31B` (30 GB weights + 38 GB KV = 68 GB → OOM on 48 GB)
- `google/gemma-3-12b-it`, `google/gemma-3-27b-it`
- `Qwen/Qwen3.5-*` (multiple sizes)
- `meta-llama/Llama-3.3-70B-Instruct`
- `mistralai/Mistral-Small-3.1-24B-Instruct-2503`

Models with small weights relative to the ceiling (e.g., MoE models) calibrated fine.

## Fix

Reverse the binary search direction — **start from a small KV cache (guaranteed to work) and search upward** to find the maximum that fits.

### New approach

1. **Phase 2a — Probe floor** (`_KV_CACHE_MIN_STEP_MB` = 1 GB): Any model that fits on the GPUs will load with minimal KV cache. If even 1 GB fails → model weights genuinely exceed VRAM → fail fast with clear error.

2. **Phase 2b — Binary search upward**: Find the maximum KV cache that fits (±1 GB precision).
   - `lo = 1 GB` (proven to work), `hi = 80% VRAM` (ceiling)
   - Probe midpoint: works → raise lo, fails → lower hi
   - Result: `best_kv` = highest KV that worked

3. **Phase 2c — Final measurement** at `best_kv` (unchanged from before).

### Key insight
The old approach added a safety margin on top of the *minimum* working KV. The new approach finds the *maximum* working KV directly — no safety margin arithmetic needed.

## What changed

- **`calibration.py`**: Reversed binary search in `calibrate_model()`, updated docstring and log messages
- **`test_calibration.py`**: 4 new tests covering floor-first search, floor failure, ceiling reachability, and search direction guarantee. Also fixed pre-existing test infrastructure bugs (spawn_vllm mock returned bare MagicMock instead of expected tuple, added cross-test blacklist isolation).

## What did NOT change

- `auto_calibrate_models()` TP escalation logic
- `calibrate_vram_profiles.py` CLI tool
- Profile persistence format
- `_try_start()` helper
- Phase 3–5 measurement logic
- `explicit_kv` bypass (user-specified KV cache)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated KV-cache calibration strategy to determine maximum usable capacity instead of minimum required, using an upward binary search approach without safety margins.

* **Tests**
  * Expanded test coverage for KV-cache calibration behavior, including edge cases and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->