### PR TITLE
`Iris`: Add deep linking to citations in global search

### DIFF
--- a/iris/src/iris/domain/search/lecture_search_dto.py
+++ b/iris/src/iris/domain/search/lecture_search_dto.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
@@ -30,6 +32,7 @@ class LectureUnitInfo(BaseModel):
     name: str
     link: str
     page_number: int = Field(alias="pageNumber")
+    start_time: Optional[int] = Field(default=None, alias="startTime")
 
 
 class LectureSearchResultDTO(BaseModel):
@@ -42,8 +45,14 @@ class LectureSearchResultDTO(BaseModel):
 
 
 class LectureSearchAskRequestDTO(BaseModel):
+    """Request DTO for the async Ask Iris search endpoint."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
     query: str = Field(min_length=1)
     limit: int = Field(default=5, ge=1, le=10)
+    artemis_base_url: str = Field(alias="artemisBaseUrl")
+    authentication_token: str = Field(alias="authenticationToken")
 
     @field_validator("query")
     @classmethod
@@ -54,6 +63,8 @@ class LectureSearchAskRequestDTO(BaseModel):
 
 
 class LectureSearchAskResponseDTO(BaseModel):
+    """Response DTO for the Ask Iris search endpoint."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     answer: str

--- a/iris/src/iris/domain/status/search_answer_status_update_dto.py
+++ b/iris/src/iris/domain/status/search_answer_status_update_dto.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from iris.domain.search.lecture_search_dto import LectureSearchResultDTO
+
+
+class SearchAnswerStatusUpdateDTO(BaseModel):
+    """Callback body sent to Artemis twice during Ask Iris processing.
+
+    First push (cited=False): plain answer with [cite-loading:keyword] skeleton markers.
+    Second push (cited=True): answer with full [cite:L:...] inline citation markers.
+    Sources are identical on both pushes so Artemis can render cards immediately.
+    """
+
+    cited: bool
+    answer: str
+    sources: List[LectureSearchResultDTO]

--- a/iris/src/iris/pipeline/lecture_search_answer_pipeline.py
+++ b/iris/src/iris/pipeline/lecture_search_answer_pipeline.py
@@ -8,9 +8,17 @@ from weaviate import WeaviateClient
 
 from iris.common.logging_config import get_logger
 from iris.common.pipeline_enum import PipelineEnum
+from iris.domain.retrieval.lecture.lecture_retrieval_dto import (
+    LectureRetrievalDTO,
+    LectureTranscriptionRetrievalDTO,
+    LectureUnitPageChunkRetrievalDTO,
+)
 from iris.domain.search.lecture_search_dto import (
-    LectureSearchAskResponseDTO,
+    LectureSearchAskRequestDTO,
     LectureSearchResultDTO,
+)
+from iris.domain.status.search_answer_status_update_dto import (
+    SearchAnswerStatusUpdateDTO,
 )
 from iris.llm import CompletionArguments, LlmRequestHandler
 from iris.llm.langchain import IrisLangchainChatModel
@@ -19,23 +27,36 @@ from iris.pipeline.prompts.lecture_search_prompts import (
     answer_system_prompt,
     hyde_system_prompt,
 )
+from iris.pipeline.shared.citation_pipeline import CitationPipeline, InformationType
 from iris.pipeline.sub_pipeline import SubPipeline
 from iris.retrieval.lecture.lecture_global_search_retrieval import (
     LectureGlobalSearchRetrieval,
 )
 from iris.tracing import observe
+from iris.web.status.status_update import SearchAnswerCallback
 
 logger = get_logger(__name__)
+
+# Matches [cite-loading:N] placeholders embedded by the answer LLM (1-based index)
+_CITE_LOADING_INDEX_PATTERN = re.compile(r"\[cite-loading:(\d+)\]")
+
+# Matches [cite-loading:any text] after index substitution, used to strip before citation pipeline
+_CITE_LOADING_PATTERN = re.compile(r"\[cite-loading:[^\]]*\]")
 
 
 class LectureSearchAnswerPipeline(SubPipeline):
     """
-    Pipeline that answers a student's question by retrieving relevant lecture content
-    using HyDE (Hypothetical Document Embedding) and then generating a concise answer.
+    Two-phase Ask Iris pipeline:
 
-    HyDE improves retrieval precision for Q&A: instead of embedding the question directly,
-    it generates a short hypothetical answer first and embeds that. This works because
-    answers live closer to answers in the vector space than questions do.
+    Phase 1 (~3-4s): HyDE retrieval + answer generation. Posts plain answer with
+    [cite-loading:keyword] skeleton markers to Artemis so the UI can render immediately.
+
+    Phase 2 (~7-9s): CitationPipeline enriches the answer with full [cite:L:...] markers.
+    Posts the cited answer to Artemis so inline citation bubbles replace the skeletons.
+
+    HyDE (Hypothetical Document Embedding) improves retrieval precision by generating a
+    short hypothetical answer first and embedding that instead of the raw question.
+    Answer-space embeddings retrieve better matches than question-space embeddings.
     """
 
     hyde_llm: IrisLangchainChatModel
@@ -47,94 +68,104 @@ class LectureSearchAnswerPipeline(SubPipeline):
         super().__init__(implementation_id="lecture_search_answer_pipeline")
         self.tokens = []
         self.retriever = LectureGlobalSearchRetrieval(client)
+        self.citation_pipeline = CitationPipeline(local=local)
 
         pipeline_id = "lecture_search_answer_pipeline"
         hyde_model = resolve_model(pipeline_id, "default", "hyde", local=local)
         answer_model = resolve_model(pipeline_id, "default", "answer", local=local)
 
-        hyde_completion_args = CompletionArguments(temperature=0.7)
-        answer_completion_args = CompletionArguments(
-            temperature=0.3, response_format="JSON"
-        )
         self.hyde_llm = IrisLangchainChatModel(
             request_handler=LlmRequestHandler(model_id=hyde_model),
-            completion_args=hyde_completion_args,
+            completion_args=CompletionArguments(temperature=0.7),
         )
         self.answer_llm = IrisLangchainChatModel(
             request_handler=LlmRequestHandler(model_id=answer_model),
-            completion_args=answer_completion_args,
+            completion_args=CompletionArguments(
+                temperature=0.3, response_format="JSON"
+            ),
         )
-        self.hyde_pipeline = self.hyde_llm | StrOutputParser()
-        self.answer_pipeline = self.answer_llm | StrOutputParser()
+        hyde_pipeline = self.hyde_llm | StrOutputParser()
+        answer_pipeline = self.answer_llm | StrOutputParser()
 
-        self.hyde_prompt = ChatPromptTemplate.from_messages(
+        hyde_prompt = ChatPromptTemplate.from_messages(
             [("system", hyde_system_prompt), ("user", "{query}")]
         )
-        self.answer_prompt = ChatPromptTemplate.from_messages(
+        answer_prompt = ChatPromptTemplate.from_messages(
             [
                 ("system", answer_system_prompt),
                 ("user", "Lecture content:\n{context}\n\nQuestion: {query}"),
             ]
         )
 
+        # Store as composed chains so they can be mocked in tests
+        self._hyde_chain = hyde_prompt | hyde_pipeline
+        self._answer_chain = answer_prompt | answer_pipeline
+
     @observe(name="Lecture Search Answer Pipeline")
     def __call__(
-        self, query: str, limit: int = 5, **_kwargs
-    ) -> LectureSearchAskResponseDTO:
+        self,
+        dto: LectureSearchAskRequestDTO,
+        callback: SearchAnswerCallback,
+        **_kwargs,
+    ) -> None:
         """
-        Answer a student's question using lecture content retrieved via HyDE.
+        Run the two-phase Ask Iris pipeline and push both results to Artemis via callback.
 
-        :param query: The student's question or search text.
-        :param limit: Maximum number of source segments to retrieve.
-        :return: An answer with source references.
+        :param dto: Request containing query, limit, and Artemis callback coordinates.
+        :param callback: Sends HTTP POSTs back to Artemis at phase 1 and phase 2.
         """
-        # Step 1: Generate a short hypothetical answer to use as the search vector
-        hypothetical_answer = (self.hyde_prompt | self.hyde_pipeline).invoke(
-            {"query": query}
-        )
+        # ── Phase 1: retrieve + generate answer ──────────────────────────────────────
+
+        # Step 1: HyDE — embed a hypothetical answer for better retrieval
+        hypothetical_answer = self._hyde_chain.invoke({"query": dto.query})
         self._append_tokens(
             self.hyde_llm.tokens, PipelineEnum.IRIS_LECTURE_SEARCH_ANSWER_PIPELINE
         )
-        logger.debug("HyDE hypothetical answer | output=%r", hypothetical_answer[:200])
+        logger.debug("HyDE output | %r", hypothetical_answer[:200])
 
-        # Step 2: Search using the hypothetical answer embedding (answer-space → answer-space)
+        # Step 2: Retrieve using the hypothetical answer embedding
         sources: list[LectureSearchResultDTO] = (
             self.retriever.search_with_vector_override(
-                query=query,
+                query=dto.query,
                 vector_text=hypothetical_answer,
                 alpha=0.7,
-                limit=limit,
+                limit=dto.limit,
             )
         )
 
         if not sources:
-            return LectureSearchAskResponseDTO(
-                answer="No relevant course material was found for this query.",
-                sources=[],
+            callback.send(
+                SearchAnswerStatusUpdateDTO(
+                    cited=False,
+                    answer="No relevant course material was found for this query.",
+                    sources=[],
+                )
             )
+            return
 
-        # Step 3: Generate the real answer using numbered context (with metadata so the
-        # model knows the course/lecture name and can reference them explicitly)
         grounded_sources = [s for s in sources if s.snippet]
         if not grounded_sources:
-            return LectureSearchAskResponseDTO(
-                answer="No relevant course material was found for this query.",
-                sources=[],
+            callback.send(
+                SearchAnswerStatusUpdateDTO(
+                    cited=False,
+                    answer="No relevant course material was found for this query.",
+                    sources=[],
+                )
             )
+            return
 
+        # Step 3: Generate answer with [cite-loading:N] skeleton markers
         context = "\n\n".join(
             f"[{i + 1}] [{s.course.name} — {s.lecture.name}, Slide {s.lecture_unit.page_number}]\n{s.snippet}"
             for i, s in enumerate(grounded_sources)
         )
-        raw = (self.answer_prompt | self.answer_pipeline).invoke(
-            {"context": context, "query": query}
-        )
+        raw = self._answer_chain.invoke({"context": context, "query": dto.query})
 
-        # Parse structured response — strip markdown code fences if present
+        # Step 4: Parse structured JSON response
         try:
             cleaned = re.sub(r"```(?:json)?\s*|\s*```", "", raw).strip()
             parsed = json.loads(cleaned)
-            answer = parsed.get("answer", raw)
+            answer_with_indices = parsed.get("answer", raw)
             used_indices = {
                 i - 1
                 for i in parsed.get("used_sources", [])
@@ -144,14 +175,131 @@ class LectureSearchAnswerPipeline(SubPipeline):
                 s for i, s in enumerate(grounded_sources) if i in used_indices
             ]
         except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
-            logger.warning(
-                "Failed to parse structured answer response, returning all sources"
-            )
-            answer = raw
+            logger.warning("Failed to parse structured answer, using raw response")
+            answer_with_indices = raw
             used_sources = grounded_sources
 
         self._append_tokens(
             self.answer_llm.tokens, PipelineEnum.IRIS_LECTURE_SEARCH_ANSWER_PIPELINE
         )
 
-        return LectureSearchAskResponseDTO(answer=answer, sources=used_sources)
+        # Step 5: Replace [cite-loading:N] indices with unit names
+        # grounded_sources is 1-indexed in the LLM context, 0-indexed in the list
+        answer_with_names = _CITE_LOADING_INDEX_PATTERN.sub(
+            lambda m: _index_to_skeleton(m, grounded_sources),
+            answer_with_indices,
+        )
+
+        # Phase 1 callback — plain answer with skeleton markers, cards available immediately
+        callback.send(
+            SearchAnswerStatusUpdateDTO(
+                cited=False,
+                answer=answer_with_names,
+                sources=used_sources,
+            )
+        )
+
+        if not used_sources:
+            return
+
+        # ── Phase 2: enrich with full citations ──────────────────────────────────────
+
+        # Step 6: Strip skeleton markers → clean prose for CitationPipeline input
+        clean_answer = _CITE_LOADING_PATTERN.sub("", answer_with_names).strip()
+
+        # Step 7: Adapt used_sources to LectureRetrievalDTO (CitationPipeline expects this)
+        retrieval_dto = _to_lecture_retrieval_dto(used_sources)
+
+        # Step 8: Run CitationPipeline — adds [cite:L:unit_id:page:::keyword:summary] markers
+        try:
+            cited_answer = self.citation_pipeline(
+                retrieval_dto,
+                clean_answer,
+                InformationType.PARAGRAPHS,
+                variant="default",
+                user_language="en",
+            )
+        except Exception as e:
+            logger.error(
+                "CitationPipeline failed, skipping phase 2 callback", exc_info=e
+            )
+            return
+
+        # Phase 2 callback — answer with full inline citation markers
+        callback.send(
+            SearchAnswerStatusUpdateDTO(
+                cited=True,
+                answer=cited_answer,
+                sources=used_sources,
+            )
+        )
+
+
+def _index_to_skeleton(match: re.Match, sources: list[LectureSearchResultDTO]) -> str:
+    """Replace [cite-loading:N] with [cite-loading:unit_name] using the sources list."""
+    idx = int(match.group(1)) - 1  # convert 1-based LLM index to 0-based list index
+    if 0 <= idx < len(sources):
+        return f"[cite-loading:{sources[idx].lecture_unit.name}]"
+    return ""  # out of range — remove the placeholder
+
+
+def _to_lecture_retrieval_dto(
+    sources: list[LectureSearchResultDTO],
+) -> LectureRetrievalDTO:
+    """
+    Adapt global search results to the format CitationPipeline expects.
+
+    Sources with a start_time (video segments) are mapped to LectureTranscriptionRetrievalDTO
+    so CitationPipeline generates [cite:L:unit_id:page:start::keyword:summary] tags with a
+    video timestamp. Sources without start_time (slide-only) map to
+    LectureUnitPageChunkRetrievalDTO and produce page-only citation tags.
+    """
+    page_chunks = []
+    transcriptions = []
+    for s in sources:
+        if not s.snippet:
+            continue
+        if s.lecture_unit.start_time is not None:
+            transcriptions.append(
+                LectureTranscriptionRetrievalDTO(
+                    uuid="",
+                    course_id=s.course.id,
+                    course_name=s.course.name,
+                    course_description="",
+                    lecture_id=s.lecture.id,
+                    lecture_name=s.lecture.name,
+                    lecture_unit_id=s.lecture_unit.id,
+                    lecture_unit_name=s.lecture_unit.name,
+                    video_link="",
+                    language="en",
+                    segment_start_time=float(s.lecture_unit.start_time),
+                    segment_end_time=None,
+                    page_number=s.lecture_unit.page_number,
+                    segment_summary=s.snippet,
+                    segment_text=s.snippet,
+                    base_url="",
+                )
+            )
+        else:
+            page_chunks.append(
+                LectureUnitPageChunkRetrievalDTO(
+                    uuid="",
+                    course_id=s.course.id,
+                    course_name=s.course.name,
+                    course_description="",
+                    lecture_id=s.lecture.id,
+                    lecture_name=s.lecture.name,
+                    lecture_unit_id=s.lecture_unit.id,
+                    lecture_unit_name=s.lecture_unit.name,
+                    lecture_unit_link=s.lecture_unit.link,
+                    course_language="en",
+                    page_number=s.lecture_unit.page_number,
+                    page_text_content=s.snippet,
+                    base_url="",
+                )
+            )
+    return LectureRetrievalDTO(
+        lecture_unit_segments=[],
+        lecture_transcriptions=transcriptions,
+        lecture_unit_page_chunks=page_chunks,
+    )

--- a/iris/src/iris/pipeline/prompts/lecture_search_prompts.py
+++ b/iris/src/iris/pipeline/prompts/lecture_search_prompts.py
@@ -23,8 +23,12 @@ mention all of them. If no course name is available, fall back to 'This course c
    - Exhaustiveness: Cover ALL distinct lectures, topics, or items present across ALL provided sources
 — not just the first or most prominent one.
 2. Source Attribution: You must track which source numbers (1-based index) you actually use to
-formulate your answer. Collect them into used_sources. Do NOT write any inline citations like [1] or
-[2] in the answer text. If you decline to answer or no source was relevant, leave the list empty.
+formulate your answer. Collect them into used_sources. Additionally, embed a citation placeholder
+immediately after each sentence that uses a source, using the format [cite-loading:<index>] where
+<index> is the 1-based source number. If a sentence uses multiple sources, add one placeholder per
+source separated by a space.
+Example: "Backprop computes gradients via the chain rule. [cite-loading:1] [cite-loading:3]"
+If you decline to answer or no source was relevant, leave used_sources empty and add no placeholders.
 3. Language: Match the exact language of the student's question.
 4. Length: Keep your answer under 200 words unless the question explicitly asks for a full overview
 or summary of a course/lecture.

--- a/iris/src/iris/retrieval/lecture/lecture_global_search_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_global_search_retrieval.py
@@ -12,6 +12,10 @@ from iris.domain.search.lecture_search_dto import (
 )
 from iris.llm import LlmRequestHandler
 from iris.llm.llm_configuration import resolve_model
+from iris.vector_database.lecture_transcription_schema import (
+    LectureTranscriptionSchema,
+    init_lecture_transcription_schema,
+)
 from iris.vector_database.lecture_unit_schema import (
     LectureUnitSchema,
     init_lecture_unit_schema,
@@ -38,6 +42,7 @@ class LectureGlobalSearchRetrieval:
         self.llm_embedding = LlmRequestHandler(model_id=embedding_model)
         self.collection = init_lecture_unit_segment_schema(client)
         self.lecture_unit_collection = init_lecture_unit_schema(client)
+        self.transcription_collection = init_lecture_transcription_schema(client)
 
     def search(self, query: str, limit: int) -> list[LectureSearchResultDTO]:
         """
@@ -93,12 +98,54 @@ class LectureGlobalSearchRetrieval:
         )
         lu_by_id = self._fetch_lecture_units(unit_ids)
 
+        unit_page_pairs = [
+            (
+                obj.properties[LectureUnitSegmentSchema.LECTURE_UNIT_ID.value],
+                obj.properties[LectureUnitSegmentSchema.PAGE_NUMBER.value],
+            )
+            for obj in results
+            if obj.properties.get(LectureUnitSegmentSchema.LECTURE_UNIT_ID.value)
+            is not None
+            and obj.properties.get(LectureUnitSegmentSchema.PAGE_NUMBER.value)
+            is not None
+        ]
+        start_times = self._fetch_transcription_start_times(unit_page_pairs)
+
         search_results = []
         for obj in results:
-            result = self._to_search_result_dto(obj.properties, lu_by_id)
+            result = self._to_search_result_dto(obj.properties, lu_by_id, start_times)
             if result is not None:
                 search_results.append(result)
         return search_results
+
+    def _fetch_transcription_start_times(
+        self, unit_page_pairs: list[tuple[int, int]]
+    ) -> dict[tuple[int, int], int]:
+        """Fetch the earliest start_time (seconds) from LectureTranscriptions for each (unit_id, page_number) pair."""
+        if not unit_page_pairs:
+            return {}
+        requested = set(unit_page_pairs)
+        unit_ids = list({uid for uid, _ in unit_page_pairs})
+        transcriptions = self.transcription_collection.query.fetch_objects(
+            filters=Filter.by_property(
+                LectureTranscriptionSchema.LECTURE_UNIT_ID.value
+            ).contains_any(unit_ids),
+            limit=500,
+        ).objects
+        times: dict[tuple[int, int], int] = {}
+        for t in transcriptions:
+            props = t.properties
+            uid = props.get(LectureTranscriptionSchema.LECTURE_UNIT_ID.value)
+            page = props.get(LectureTranscriptionSchema.PAGE_NUMBER.value)
+            start = props.get(LectureTranscriptionSchema.SEGMENT_START_TIME.value)
+            if uid is None or page is None or start is None:
+                continue
+            key = (uid, page)
+            if key not in requested:
+                continue
+            if key not in times or start < times[key]:
+                times[key] = int(start)
+        return times
 
     def _fetch_lecture_units(self, unit_ids: list[int]) -> dict[int, Any]:
         """Fetch lecture unit metadata for the given IDs in a single Weaviate query."""
@@ -117,7 +164,9 @@ class LectureGlobalSearchRetrieval:
 
     @staticmethod
     def _to_search_result_dto(
-        segment_props: dict[str, Any], lu_by_id: dict[int, Any]
+        segment_props: dict[str, Any],
+        lu_by_id: dict[int, Any],
+        start_times: dict[tuple[int, int], int],
     ) -> LectureSearchResultDTO | None:
         """Map segment properties to a result DTO using pre-fetched lecture unit metadata."""
         snippet = segment_props[LectureUnitSegmentSchema.SEGMENT_SUMMARY.value]
@@ -131,6 +180,8 @@ class LectureGlobalSearchRetrieval:
 
         course_id = segment_props[LectureUnitSegmentSchema.COURSE_ID.value]
         lecture_id = segment_props[LectureUnitSegmentSchema.LECTURE_ID.value]
+        page_number = segment_props[LectureUnitSegmentSchema.PAGE_NUMBER.value]
+        start_time = start_times.get((unit_id, page_number))
 
         return LectureSearchResultDTO(
             course=CourseInfo(
@@ -145,7 +196,8 @@ class LectureGlobalSearchRetrieval:
                 id=unit_id,
                 name=lu[LectureUnitSchema.LECTURE_UNIT_NAME.value],
                 link=f"/courses/{course_id}/lectures/{lecture_id}",
-                pageNumber=segment_props[LectureUnitSegmentSchema.PAGE_NUMBER.value],
+                pageNumber=page_number,
+                startTime=start_time,
             ),
             snippet=snippet,
         )

--- a/iris/src/iris/web/routers/search.py
+++ b/iris/src/iris/web/routers/search.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter, Depends
+from threading import Thread
 
-from iris.common.logging_config import get_logger
+from fastapi import APIRouter, Depends
+from fastapi import status as http_status
+
+from iris.common.logging_config import get_logger, get_request_id, set_request_id
 from iris.dependencies import TokenValidator
 from iris.domain.search.lecture_search_dto import (
     LectureSearchAskRequestDTO,
-    LectureSearchAskResponseDTO,
     LectureSearchRequestDTO,
     LectureSearchResultDTO,
 )
@@ -13,6 +15,7 @@ from iris.retrieval.lecture.lecture_global_search_retrieval import (
     LectureGlobalSearchRetrieval,
 )
 from iris.vector_database.database import VectorDatabase
+from iris.web.status.status_update import SearchAnswerCallback
 
 router = APIRouter(prefix="/api/v1/search", tags=["search"])
 logger = get_logger(__name__)
@@ -31,17 +34,41 @@ def lecture_search(dto: LectureSearchRequestDTO) -> list[LectureSearchResultDTO]
     return LectureGlobalSearchRetrieval(client).search(dto.query, dto.limit)
 
 
+def _run_search_ask_worker(dto: LectureSearchAskRequestDTO, request_id: str) -> None:
+    """Worker function run in a background thread for the Ask Iris pipeline."""
+    set_request_id(request_id)
+    callback = SearchAnswerCallback(
+        run_id=dto.authentication_token,
+        base_url=dto.artemis_base_url,
+    )
+    try:
+        client = VectorDatabase().get_client()
+        LectureSearchAnswerPipeline(client)(dto=dto, callback=callback)
+    except Exception as e:
+        logger.error("Search ask pipeline worker failed", exc_info=e)
+        callback.error("Fatal error in search pipeline.", exception=e)
+
+
 @router.post(
-    "/ask", dependencies=[Depends(TokenValidator())], response_model_by_alias=True
+    "/ask",
+    status_code=http_status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(TokenValidator())],
 )
-def lecture_ask(dto: LectureSearchAskRequestDTO) -> LectureSearchAskResponseDTO:
+def lecture_ask(dto: LectureSearchAskRequestDTO) -> dict:
     """
-    Answer a student's question using lecture content retrieved.
+    Answer a student's question using lecture content retrieved via HyDE.
 
-    Retrieves relevant lecture segments using Hypothetical Document Embedding (HyDE)
-    and generates a concise answer grounded in the retrieved content.
+    Returns 202 immediately. Results are pushed asynchronously to Artemis via two
+    HTTP callbacks:
+      - cited=false: plain answer with [cite-loading:keyword] skeleton markers (~3-4s)
+      - cited=true:  answer with full [cite:L:...] inline citation markers (~7-9s)
 
-    :return: An answer with clickable source references.
+    :return: {"token": "<authentication_token>"} for the client to subscribe on WebSocket.
     """
-    client = VectorDatabase().get_client()
-    return LectureSearchAnswerPipeline(client)(query=dto.query, limit=dto.limit)
+    request_id = get_request_id()
+    thread = Thread(
+        target=_run_search_ask_worker,
+        args=(dto, request_id),
+    )
+    thread.start()
+    return {"token": dto.authentication_token}

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -32,6 +32,9 @@ from iris.domain.status.lecture_chat_status_update_dto import (
 from iris.domain.status.rewriting_status_update_dto import (
     RewritingStatusUpdateDTO,
 )
+from iris.domain.status.search_answer_status_update_dto import (
+    SearchAnswerStatusUpdateDTO,
+)
 from iris.domain.status.stage_dto import StageDTO
 from iris.domain.status.stage_state_dto import StageStateEnum
 from iris.domain.status.status_update_dto import StatusUpdateDTO
@@ -552,3 +555,51 @@ class AutonomousTutorCallback(StatusCallback):
             stages[stage],
             stage,
         )
+
+
+class SearchAnswerCallback:
+    """Callback for Ask Iris search answer pipeline.
+
+    Sends two HTTP POSTs to Artemis during processing:
+    - Phase 1 (cited=False): plain answer with [cite-loading:keyword] skeleton markers
+    - Phase 2 (cited=True): answer with full [cite:L:...] inline citation markers
+
+    Does not use the stage machinery of StatusCallback — search has no progress stages,
+    only two discrete result pushes.
+    """
+
+    _search_api_url: str = "api/iris/internal/search/runs"
+
+    def __init__(self, run_id: str, base_url: str):
+        self.run_id = run_id
+        self.url = f"{base_url}/{self._search_api_url}/{run_id}/status"
+
+    def send(self, dto: SearchAnswerStatusUpdateDTO) -> bool:
+        """POST a search answer update to Artemis."""
+        try:
+            resp = requests.post(
+                self.url,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self.run_id}",
+                },
+                json=dto.model_dump(by_alias=True),
+                timeout=200,
+            )
+            logger.info(
+                "Search answer callback to %s returned %d", self.url, resp.status_code
+            )
+            resp.raise_for_status()
+            return True
+        except requests.exceptions.RequestException as e:
+            logger.error("Search answer callback POST failed: %s", e)
+            capture_exception(e)
+            return False
+
+    def error(self, message: str, exception: Exception = None):
+        """Log a fatal pipeline error. No HTTP push — Artemis will time out the job."""
+        logger.error(
+            "Search answer pipeline fatal error for run %s: %s", self.run_id, message
+        )
+        if exception:
+            capture_exception(exception)


### PR DESCRIPTION
## Motivation

Ask Iris returned answers with sources but no inline citations and no deep linking. Source cards opened the lecture page without navigating to the relevant slide or video moment.

## Summary

The `/api/v1/search/ask` endpoint now returns 202 and pushes two callbacks to Artemis. The first arrives fast with a plain answer and skeleton citation markers so the UI can show loading bubbles immediately. The second replaces them with real inline citation tags once the citation pipeline finishes.

Search results now include `startTime` — the earliest video timestamp for that slide, fetched from the transcript segments. Artemis can use this alongside the page number to deep link into both the PDF and the video. Slide-only units get `startTime: null`. This applies to both the search and ask endpoints.

## Test plan

- POST /api/v1/search/ask returns 202 immediately
- First callback arrives fast with skeleton markers and sources
- Second callback has full citation tags with page and timestamp where available
- Slide-only results have null startTime, video results have seconds
- Source cards and citations deep link to the right place

**Artemis counterpart:** https://github.com/ls1intum/Artemis/pull/12522

Closes IRIS-289