### PR TITLE
`Iris`: YouTube video ingestion

### DIFF
--- a/iris/poetry.lock
+++ b/iris/poetry.lock
@@ -2215,7 +2215,7 @@ files = [
 
 [[package]]
 name = "memiris"
-version = "0.1.1"
+version = "2.0.0"
 description = ""
 optional = false
 python-versions = ">=3.13,<4.0.0"
@@ -4698,6 +4698,30 @@ multidict = ">=4.0"
 propcache = ">=0.2.1"
 
 [[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+description = "A feature-rich command-line audio/video downloader"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8"},
+    {file = "yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9"},
+]
+
+[package.extras]
+build = ["build", "hatchling (>=1.27.0)", "pip", "setuptools (>=71.0.2)", "wheel"]
+build-curl-cffi = ["curl-cffi (==0.13.0) ; sys_platform == \"darwin\" or sys_platform == \"linux\" and platform_machine != \"armv7l\"", "curl-cffi (==0.14.0) ; sys_platform == \"win32\" or sys_platform == \"linux\" and platform_machine == \"armv7l\""]
+curl-cffi = ["curl-cffi (>=0.5.10,<0.6.dev0 || >=0.10.dev0,<0.15) ; implementation_name == \"cpython\""]
+default = ["brotli ; implementation_name == \"cpython\"", "brotlicffi ; implementation_name != \"cpython\"", "certifi", "mutagen", "pycryptodomex", "requests (>=2.32.2,<3)", "urllib3 (>=2.0.2,<3)", "websockets (>=13.0)", "yt-dlp-ejs (==0.8.0)"]
+deno = ["deno (>=2.6.6)"]
+dev = ["autopep8 (>=2.0,<3.0)", "pre-commit", "pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)", "ruff (>=0.15.0,<0.16.0)"]
+pyinstaller = ["pyinstaller (>=6.17.0)"]
+secretstorage = ["cffi", "secretstorage"]
+static-analysis = ["autopep8 (>=2.0,<3.0)", "ruff (>=0.15.0,<0.16.0)"]
+test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
+
+[[package]]
 name = "zipp"
 version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -4833,4 +4857,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0.0"
-content-hash = "9adf24f2f793bc5eacac191c6cb40f5c8ee40ade2b4657620b6622fca83b3847"
+content-hash = "8131b2c003df095bf7d314b49f1bb6bab4bc2758f6de7a4b4b829cc499bb707f"

--- a/iris/pylintrc
+++ b/iris/pylintrc
@@ -132,6 +132,7 @@ disable=R,
         xrange-builtin,
         zip-builtin-not-iterating,
         broad-exception-caught,
+        redefined-outer-name,
 
 
 [REPORTS]

--- a/iris/pyproject.toml
+++ b/iris/pyproject.toml
@@ -37,6 +37,7 @@ memiris = {path = "../memiris", develop = true}
 apscheduler = "^3.11.2"
 ffmpeg-python = "^0.2.0"
 opencv-python-headless = "^4.13.0"
+yt-dlp = "^2026.3.17"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.19.1"

--- a/iris/src/iris/config.py
+++ b/iris/src/iris/config.py
@@ -129,6 +129,15 @@ class TranscriptionSettings(BaseModel):
         default=600,
         description="Timeout for audio extraction via FFmpeg (default: 10 min)",
     )
+    youtube_max_duration_seconds: int = Field(
+        default=21600,
+        description="Max YouTube video duration in seconds (default: 6 hours). "
+        "Videos longer than this are rejected with YOUTUBE_TOO_LONG.",
+    )
+    youtube_download_timeout_seconds: int = Field(
+        default=600,
+        description="Timeout for yt-dlp download of a YouTube video (default: 10 min).",
+    )
     no_speech_filter_threshold: float = Field(
         default=0.8,
         description=(

--- a/iris/src/iris/config.py
+++ b/iris/src/iris/config.py
@@ -135,8 +135,11 @@ class TranscriptionSettings(BaseModel):
         "Videos longer than this are rejected with YOUTUBE_TOO_LONG.",
     )
     youtube_download_timeout_seconds: int = Field(
-        default=600,
-        description="Timeout for yt-dlp download of a YouTube video (default: 10 min).",
+        default=3600,
+        description="Timeout for yt-dlp download of a YouTube video (default: 1 hour). "
+        "Must be large enough to cover the slowest download up to "
+        "``youtube_max_duration_seconds``; increase this if long videos start "
+        "failing with YOUTUBE_DOWNLOAD_FAILED due to timeout.",
     )
     no_speech_filter_threshold: float = Field(
         default=0.8,

--- a/iris/src/iris/domain/data/lecture_unit_page_dto.py
+++ b/iris/src/iris/domain/data/lecture_unit_page_dto.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from iris.domain.data.metrics.transcription_dto import TranscriptionDTO
 from iris.domain.data.video_source_type import VideoSourceType
@@ -28,3 +28,11 @@ class LectureUnitPageDTO(BaseModel):
     video_source_type: VideoSourceType = Field(
         default=VideoSourceType.TUM_LIVE, alias="videoSourceType"
     )
+
+    @field_validator("video_source_type", mode="before")
+    @classmethod
+    def _coerce_null_video_source_type(cls, value):
+        # Pydantic v2 rejects explicit None on a non-Optional Enum field before
+        # defaults apply, so older Artemis deployments that emit
+        # ``"videoSourceType": null`` would break unless we coerce here.
+        return VideoSourceType.TUM_LIVE if value is None else value

--- a/iris/src/iris/domain/data/lecture_unit_page_dto.py
+++ b/iris/src/iris/domain/data/lecture_unit_page_dto.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from iris.domain.data.metrics.transcription_dto import TranscriptionDTO
+from iris.domain.data.video_source_type import VideoSourceType
 
 
 class LectureUnitPageDTO(BaseModel):
@@ -9,6 +10,8 @@ class LectureUnitPageDTO(BaseModel):
     Mirrors the Artemis PyrisLectureUnitWebhookDTO structure.
     Used for ingestion and deletion pipelines.
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     pdf_file_base64: str = Field(default="", alias="pdfFile")
     attachment_version: int = Field(default=0, alias="attachmentVersion")
@@ -22,3 +25,6 @@ class LectureUnitPageDTO(BaseModel):
     course_name: str = Field(default="", alias="courseName")
     course_description: str = Field(default="", alias="courseDescription")
     video_link: str = Field(default="", alias="videoLink")
+    video_source_type: VideoSourceType = Field(
+        default=VideoSourceType.TUM_LIVE, alias="videoSourceType"
+    )

--- a/iris/src/iris/domain/data/video_source_type.py
+++ b/iris/src/iris/domain/data/video_source_type.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class VideoSourceType(str, Enum):
+    """How a lecture video is hosted, driving download-step selection.
+
+    Backward compatibility: missing / null on the wire is treated as TUM_LIVE
+    by consumers so that older Artemis deployments continue to work.
+    """
+
+    TUM_LIVE = "TUM_LIVE"
+    YOUTUBE = "YOUTUBE"

--- a/iris/src/iris/domain/ingestion/ingestion_status_update_dto.py
+++ b/iris/src/iris/domain/ingestion/ingestion_status_update_dto.py
@@ -1,8 +1,13 @@
 from typing import Optional
 
+from pydantic import Field
+
 from ...domain.status.status_update_dto import StatusUpdateDTO
 
 
 class IngestionStatusUpdateDTO(StatusUpdateDTO):
     result: Optional[str] = None
     id: Optional[int] = None
+    # Snake-case wire key per spec; Jackson side uses @JsonProperty("error_code").
+    # Scoped to ingestion only so non-ingestion pipelines don't emit it.
+    error_code: Optional[str] = Field(default=None, alias="error_code")

--- a/iris/src/iris/domain/status/status_update_dto.py
+++ b/iris/src/iris/domain/status/status_update_dto.py
@@ -1,6 +1,6 @@
-from typing import List, Optional
+from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from iris.common.token_usage_dto import TokenUsageDTO
 
@@ -13,6 +13,3 @@ class StatusUpdateDTO(BaseModel):
 
     stages: List[StageDTO]
     tokens: List[TokenUsageDTO] = []
-    # Wire key is snake_case `error_code` per spec; the alias makes pydantic
-    # accept/emit that key whenever the caller opts into by_alias.
-    error_code: Optional[str] = Field(default=None, alias="error_code")

--- a/iris/src/iris/domain/status/status_update_dto.py
+++ b/iris/src/iris/domain/status/status_update_dto.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from iris.common.token_usage_dto import TokenUsageDTO
 
@@ -8,5 +8,11 @@ from ...domain.status.stage_dto import StageDTO
 
 
 class StatusUpdateDTO(BaseModel):
+    # Populate by field name OR alias on input; dump by alias for wire format
+    model_config = ConfigDict(populate_by_name=True)
+
     stages: List[StageDTO]
     tokens: List[TokenUsageDTO] = []
+    # Wire key is snake_case `error_code` per spec; the alias makes pydantic
+    # accept/emit that key whenever the caller opts into by_alias.
+    error_code: Optional[str] = Field(default=None, alias="error_code")

--- a/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
+++ b/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
@@ -18,11 +18,6 @@ from iris.domain.variant.variant import Dep
 from iris.pipeline import Pipeline
 from iris.pipeline.lecture_ingestion_pipeline import LectureUnitPageIngestionPipeline
 from iris.pipeline.lecture_unit_pipeline import LectureUnitPipeline
-from iris.pipeline.shared.transcription.youtube_utils import (
-    YouTubeDownloadError,
-    download_youtube_video,
-    validate_youtube_video,
-)
 from iris.pipeline.transcription_ingestion_pipeline import (
     TranscriptionIngestionPipeline,
 )
@@ -42,6 +37,11 @@ def _translate_transcription_exception_to_error_code(
     everything else collapses to TRANSCRIPTION_FAILED so Artemis can surface
     a generic "transcript unavailable" message with a retry affordance.
     """
+    # pylint: disable=import-outside-toplevel
+    from iris.pipeline.shared.transcription.youtube_utils import (
+        YouTubeDownloadError,
+    )
+
     if isinstance(exc, YouTubeDownloadError):
         return exc.error_code
     return "TRANSCRIPTION_FAILED"
@@ -148,12 +148,29 @@ class LectureIngestionUpdatePipeline(Pipeline):
 
         try:
             # ── Phase 1: Transcription generation (conditional) ──────────
-            if needs_generation:
-                self._run_full_transcription(callback)
-            elif needs_slides:
-                self._run_slide_detection_only(callback)
+            # Failures here get classified via the transcription error-code
+            # translator (YouTubeDownloadError → structured code, else
+            # TRANSCRIPTION_FAILED) so Artemis can render user-actionable
+            # messages.
+            try:
+                if needs_generation:
+                    self._run_full_transcription(callback)
+                elif needs_slides:
+                    self._run_slide_detection_only(callback)
+            except Exception as e:
+                logger.error(
+                    "[Lecture %d] Transcription failed: %s",
+                    self.dto.lecture_unit.lecture_unit_id,
+                    e,
+                    exc_info=True,
+                )
+                error_code = _translate_transcription_exception_to_error_code(e)
+                callback.error(str(e), exception=e, error_code=error_code)
+                return
 
             # ── Phase 2: Ingestion (existing logic) ──────────────────────
+            # Ingestion-phase failures (vector DB, PDF, summary) are NOT
+            # transcription failures and must not be labeled as such.
             self._run_ingestion(callback)
 
         except Exception as e:
@@ -163,8 +180,7 @@ class LectureIngestionUpdatePipeline(Pipeline):
                 e,
                 exc_info=True,
             )
-            error_code = _translate_transcription_exception_to_error_code(e)
-            callback.error(str(e), exception=e, error_code=error_code)
+            callback.error(str(e), exception=e)
 
     def _run_full_transcription(self, callback: IngestionStatusCallback) -> None:
         """Run heavy + light transcription phases with temp file management."""
@@ -256,6 +272,10 @@ class LectureIngestionUpdatePipeline(Pipeline):
             TranscriptionTempStorage,
         )
         from iris.pipeline.shared.transcription.video_utils import download_video
+        from iris.pipeline.shared.transcription.youtube_utils import (
+            download_youtube_video,
+            validate_youtube_video,
+        )
 
         lecture_unit_id = self.dto.lecture_unit.lecture_unit_id
         video_url = self.dto.lecture_unit.video_link

--- a/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
+++ b/iris/src/iris/pipeline/lecture_ingestion_update_pipeline.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Optional
 
 from iris.common.logging_config import get_logger
@@ -7,6 +8,7 @@ from iris.domain.data.metrics.transcription_dto import (
     TranscriptionDTO,
     TranscriptionSegmentDTO,
 )
+from iris.domain.data.video_source_type import VideoSourceType
 from iris.domain.ingestion.ingestion_pipeline_execution_dto import (
     IngestionPipelineExecutionDto,
 )
@@ -16,6 +18,11 @@ from iris.domain.variant.variant import Dep
 from iris.pipeline import Pipeline
 from iris.pipeline.lecture_ingestion_pipeline import LectureUnitPageIngestionPipeline
 from iris.pipeline.lecture_unit_pipeline import LectureUnitPipeline
+from iris.pipeline.shared.transcription.youtube_utils import (
+    YouTubeDownloadError,
+    download_youtube_video,
+    validate_youtube_video,
+)
 from iris.pipeline.transcription_ingestion_pipeline import (
     TranscriptionIngestionPipeline,
 )
@@ -24,6 +31,20 @@ from iris.vector_database.database import VectorDatabase
 from iris.web.status.ingestion_status_callback import IngestionStatusCallback
 
 logger = get_logger(__name__)
+
+
+def _translate_transcription_exception_to_error_code(
+    exc: BaseException,
+) -> str:
+    """Map any exception from heavy/light phases to a wire error code.
+
+    YouTubeDownloadError already carries a structured ``error_code``;
+    everything else collapses to TRANSCRIPTION_FAILED so Artemis can surface
+    a generic "transcript unavailable" message with a retry affordance.
+    """
+    if isinstance(exc, YouTubeDownloadError):
+        return exc.error_code
+    return "TRANSCRIPTION_FAILED"
 
 
 def _needs_transcription_generation(dto: IngestionPipelineExecutionDto) -> bool:
@@ -142,7 +163,8 @@ class LectureIngestionUpdatePipeline(Pipeline):
                 e,
                 exc_info=True,
             )
-            callback.error(str(e), exception=e)
+            error_code = _translate_transcription_exception_to_error_code(e)
+            callback.error(str(e), exception=e, error_code=error_code)
 
     def _run_full_transcription(self, callback: IngestionStatusCallback) -> None:
         """Run heavy + light transcription phases with temp file management."""
@@ -168,7 +190,11 @@ class LectureIngestionUpdatePipeline(Pipeline):
                 callback=callback,
                 storage=storage,
             )
-            raw_transcript = heavy(video_url, lecture_unit_id)
+            raw_transcript = heavy(
+                video_url,
+                lecture_unit_id,
+                video_source_type=self.dto.lecture_unit.video_source_type,
+            )
 
             # Checkpoint 1: complete the "Transcribing" stage with raw
             # transcript attached — one atomic HTTP call.
@@ -229,9 +255,7 @@ class LectureIngestionUpdatePipeline(Pipeline):
         from iris.pipeline.shared.transcription.temp_storage import (
             TranscriptionTempStorage,
         )
-        from iris.pipeline.shared.transcription.video_utils import (
-            download_video,
-        )
+        from iris.pipeline.shared.transcription.video_utils import download_video
 
         lecture_unit_id = self.dto.lecture_unit.lecture_unit_id
         video_url = self.dto.lecture_unit.video_link
@@ -263,12 +287,27 @@ class LectureIngestionUpdatePipeline(Pipeline):
                 "[Lecture %d] Re-downloading video for slide detection",
                 lecture_unit_id,
             )
-            download_video(
-                video_url,
-                storage.video_path,
-                timeout=settings.transcription.download_timeout_seconds,
-                lecture_unit_id=lecture_unit_id,
-            )
+            video_source_type = self.dto.lecture_unit.video_source_type
+            if video_source_type == VideoSourceType.YOUTUBE:
+                ts = settings.transcription
+                max_dur = ts.youtube_max_duration_seconds
+                yt_timeout = ts.youtube_download_timeout_seconds
+                validate_youtube_video(
+                    video_url,
+                    max_duration_seconds=max_dur,
+                )
+                download_youtube_video(
+                    video_url,
+                    Path(storage.video_path),
+                    timeout=yt_timeout,
+                )
+            else:  # TUM_LIVE (default, includes None)
+                download_video(
+                    video_url,
+                    storage.video_path,
+                    timeout=settings.transcription.download_timeout_seconds,
+                    lecture_unit_id=lecture_unit_id,
+                )
 
             # Light phase: slide detection → alignment
             light = LightTranscriptionPipeline(

--- a/iris/src/iris/pipeline/shared/transcription/heavy_pipeline.py
+++ b/iris/src/iris/pipeline/shared/transcription/heavy_pipeline.py
@@ -7,13 +7,19 @@ but no slide numbers).
 """
 
 import os
+from pathlib import Path
 from typing import Any, Dict
 
 from iris.common.logging_config import get_logger
 from iris.config import settings
+from iris.domain.data.video_source_type import VideoSourceType
 from iris.pipeline.shared.transcription.temp_storage import TranscriptionTempStorage
 from iris.pipeline.shared.transcription.video_utils import download_video, extract_audio
 from iris.pipeline.shared.transcription.whisper_client import WhisperClient
+from iris.pipeline.shared.transcription.youtube_utils import (
+    download_youtube_video,
+    validate_youtube_video,
+)
 from iris.tracing import observe
 from iris.web.status.status_update import StatusCallback
 
@@ -50,12 +56,21 @@ class HeavyTranscriptionPipeline:
         )
 
     @observe(name="Heavy Transcription Pipeline")
-    def __call__(self, video_url: str, lecture_unit_id: int) -> Dict[str, Any]:
+    def __call__(
+        self,
+        video_url: str,
+        lecture_unit_id: int,
+        video_source_type: VideoSourceType = VideoSourceType.TUM_LIVE,
+    ) -> Dict[str, Any]:
         """Run the heavy pipeline.
 
         Args:
-            video_url: Direct HLS stream URL (not a webpage).
+            video_url: URL of the video to download. For TUM_LIVE this is a
+                direct HLS stream URL; for YOUTUBE it is a YouTube watch/share
+                URL.
             lecture_unit_id: For logging and Whisper log prefixing.
+            video_source_type: Determines which download path to use.
+                Defaults to ``TUM_LIVE`` for backward compatibility.
 
         Returns:
             Dict with "segments" (list of dicts with start/end/text)
@@ -63,18 +78,38 @@ class HeavyTranscriptionPipeline:
 
         Raises:
             RuntimeError: If any step fails (FFmpeg or Whisper).
+            YouTubeDownloadError: If the YouTube branch fails validation or
+                download.
         """
         prefix = f"[Lecture {lecture_unit_id}]"
 
         # Stage 1: Download video
         self.callback.in_progress("Downloading video...")
         logger.info("%s Downloading video to %s", prefix, self.storage.video_path)
-        download_video(
-            video_url,
-            self.storage.video_path,
-            timeout=settings.transcription.download_timeout_seconds,
-            lecture_unit_id=lecture_unit_id,
-        )
+        if video_source_type == VideoSourceType.YOUTUBE:
+            yt_cfg = settings.transcription
+            metadata = validate_youtube_video(
+                video_url,
+                max_duration_seconds=yt_cfg.youtube_max_duration_seconds,
+            )
+            logger.info(
+                "%s YouTube metadata OK: title=%r duration=%ss",
+                prefix,
+                metadata.get("title"),
+                metadata.get("duration"),
+            )
+            download_youtube_video(
+                video_url,
+                Path(self.storage.video_path),
+                timeout=yt_cfg.youtube_download_timeout_seconds,
+            )
+        else:  # TUM_LIVE (default)
+            download_video(
+                video_url,
+                self.storage.video_path,
+                timeout=settings.transcription.download_timeout_seconds,
+                lecture_unit_id=lecture_unit_id,
+            )
         size_mb = os.path.getsize(self.storage.video_path) / (1024 * 1024)
         self.callback.done(f"Video downloaded ({size_mb:.0f} MB)")
         logger.info("%s Video downloaded: %.0f MB", prefix, size_mb)

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -124,8 +124,8 @@ def download_youtube_video(
 
     Raises:
         YouTubeDownloadError: with error_code="YOUTUBE_DOWNLOAD_FAILED" on
-        timeout, non-zero exit, or a successful exit that nonetheless
-        produced no output file.
+        timeout, non-zero exit, a successful exit that nonetheless produced
+        no output file, or the ``yt-dlp`` binary being absent from PATH.
     """
     output_path = Path(output_path)
     command = [
@@ -150,6 +150,11 @@ def download_youtube_video(
             check=True,
             timeout=timeout,
         )
+    except FileNotFoundError as e:
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            "yt-dlp binary not found on PATH",
+        ) from e
     except subprocess.TimeoutExpired as e:
         raise YouTubeDownloadError(
             "YOUTUBE_DOWNLOAD_FAILED",

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -1,0 +1,19 @@
+"""YouTube-specific helpers: validation and download via yt-dlp.
+
+Surfaces failures via structured error codes that Pyris propagates to
+Artemis in the status-update callback for instructor-visible messaging.
+"""
+
+
+class YouTubeDownloadError(Exception):
+    """Raised when yt-dlp cannot validate or download a YouTube video.
+
+    Carries a structured ``error_code`` (one of YOUTUBE_PRIVATE,
+    YOUTUBE_LIVE, YOUTUBE_TOO_LONG, YOUTUBE_UNAVAILABLE,
+    YOUTUBE_DOWNLOAD_FAILED) so that upstream callers can attach it
+    to the status callback verbatim.
+    """
+
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -57,9 +57,7 @@ def _classify_yt_dlp_error(stderr: str) -> str:
     return "YOUTUBE_DOWNLOAD_FAILED"
 
 
-def validate_youtube_video(
-    url: str, max_duration_seconds: int
-) -> Dict[str, Any]:
+def validate_youtube_video(url: str, max_duration_seconds: int) -> Dict[str, Any]:
     """Validate a YouTube URL by fetching metadata via ``yt-dlp --dump-json``.
 
     Performs no download; only network cost is the metadata fetch.
@@ -104,9 +102,7 @@ def validate_youtube_video(
         ) from e
 
     if metadata.get("is_live"):
-        raise YouTubeDownloadError(
-            "YOUTUBE_LIVE", "Live streams cannot be transcribed"
-        )
+        raise YouTubeDownloadError("YOUTUBE_LIVE", "Live streams cannot be transcribed")
     duration = metadata.get("duration")
     if duration is not None and duration > max_duration_seconds:
         raise YouTubeDownloadError(

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -65,7 +65,7 @@ def validate_youtube_video(url: str, max_duration_seconds: int) -> Dict[str, Any
     Raises:
         YouTubeDownloadError: with a structured ``error_code`` on any failure.
     """
-    command = ["yt-dlp", "--dump-json", "--no-warnings", url]
+    command = ["yt-dlp", "--dump-json", "--no-warnings", "--no-playlist", "--", url]
     try:
         result = subprocess.run(  # nosec B603
             command,
@@ -135,8 +135,10 @@ def download_youtube_video(
         "--merge-output-format",
         "mp4",
         "--no-warnings",
+        "--no-playlist",
         "-o",
         str(output_path),
+        "--",
         url,
     ]
     logger.info("Downloading YouTube video %s -> %s", url, output_path)

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -4,6 +4,15 @@ Surfaces failures via structured error codes that Pyris propagates to
 Artemis in the status-update callback for instructor-visible messaging.
 """
 
+import json
+import re
+import subprocess  # nosec B404
+from typing import Any, Dict
+
+from iris.common.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 
 class YouTubeDownloadError(Exception):
     """Raised when yt-dlp cannot validate or download a YouTube video.
@@ -17,3 +26,89 @@ class YouTubeDownloadError(Exception):
     def __init__(self, error_code: str, message: str) -> None:
         super().__init__(message)
         self.error_code = error_code
+
+
+# Timeout for `yt-dlp --dump-json`. Metadata fetch is fast; 30 s is generous.
+_VALIDATE_TIMEOUT_SECONDS = 30
+
+_PRIVATE_PATTERNS = (
+    re.compile(r"private video", re.IGNORECASE),
+    re.compile(r"sign in", re.IGNORECASE),
+)
+_UNAVAILABLE_PATTERNS = (
+    re.compile(r"video unavailable", re.IGNORECASE),
+    re.compile(r"removed", re.IGNORECASE),
+    re.compile(r"age[- ]restricted", re.IGNORECASE),
+    re.compile(r"not available in your country", re.IGNORECASE),
+)
+
+
+def _classify_yt_dlp_error(stderr: str) -> str:
+    """Map yt-dlp stderr to one of our structured error codes."""
+    if any(p.search(stderr) for p in _PRIVATE_PATTERNS):
+        return "YOUTUBE_PRIVATE"
+    if any(p.search(stderr) for p in _UNAVAILABLE_PATTERNS):
+        return "YOUTUBE_UNAVAILABLE"
+    # Default: DOWNLOAD_FAILED (retryable per spec lines 88-91).
+    # An unrecognized stderr could be a transient network/yt-dlp issue;
+    # UNAVAILABLE is terminal and would block instructor-initiated retries.
+    return "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def validate_youtube_video(
+    url: str, max_duration_seconds: int
+) -> Dict[str, Any]:
+    """Validate a YouTube URL by fetching metadata via ``yt-dlp --dump-json``.
+
+    Performs no download; only network cost is the metadata fetch.
+
+    Raises:
+        YouTubeDownloadError: with a structured ``error_code`` on any failure.
+    """
+    command = ["yt-dlp", "--dump-json", "--no-warnings", url]
+    try:
+        result = subprocess.run(  # nosec B603
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_VALIDATE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            f"yt-dlp metadata fetch timed out after "
+            f"{_VALIDATE_TIMEOUT_SECONDS}s for {url}",
+        ) from e
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr or ""
+        code = _classify_yt_dlp_error(stderr)
+        raise YouTubeDownloadError(
+            code,
+            f"yt-dlp failed to validate {url}: {stderr.strip()}",
+        ) from e
+    except FileNotFoundError as e:
+        # yt-dlp binary not installed — treat as download failure
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED", "yt-dlp binary not found on PATH"
+        ) from e
+
+    try:
+        metadata = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            f"yt-dlp returned non-JSON output for {url}",
+        ) from e
+
+    if metadata.get("is_live"):
+        raise YouTubeDownloadError(
+            "YOUTUBE_LIVE", "Live streams cannot be transcribed"
+        )
+    duration = metadata.get("duration")
+    if duration is not None and duration > max_duration_seconds:
+        raise YouTubeDownloadError(
+            "YOUTUBE_TOO_LONG",
+            f"Video duration {duration}s exceeds max {max_duration_seconds}s",
+        )
+    return metadata

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -7,9 +7,11 @@ Artemis in the status-update callback for instructor-visible messaging.
 import json
 import re
 import subprocess  # nosec B404
+from pathlib import Path
 from typing import Any, Dict
 
 from iris.common.logging_config import get_logger
+from iris.tracing import observe
 
 logger = get_logger(__name__)
 
@@ -112,3 +114,59 @@ def validate_youtube_video(
             f"Video duration {duration}s exceeds max {max_duration_seconds}s",
         )
     return metadata
+
+
+@observe(name="Download YouTube Video")
+def download_youtube_video(
+    url: str,
+    output_path: Path,
+    timeout: int,
+) -> Path:
+    """Download a YouTube video as an MP4 to ``output_path``.
+
+    Uses ``yt-dlp -f bestvideo+bestaudio/best --merge-output-format mp4``.
+
+    Raises:
+        YouTubeDownloadError: with error_code="YOUTUBE_DOWNLOAD_FAILED" on
+        timeout, non-zero exit, or a successful exit that nonetheless
+        produced no output file.
+    """
+    output_path = Path(output_path)
+    command = [
+        "yt-dlp",
+        "-f",
+        "bestvideo+bestaudio/best",
+        "--merge-output-format",
+        "mp4",
+        "--no-warnings",
+        "-o",
+        str(output_path),
+        url,
+    ]
+    logger.info("Downloading YouTube video %s -> %s", url, output_path)
+    try:
+        subprocess.run(  # nosec B603
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            f"yt-dlp download timed out after {timeout}s for {url}",
+        ) from e
+    except subprocess.CalledProcessError as e:
+        stderr_text = (e.stderr or "").strip()
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            f"yt-dlp download failed (exit {e.returncode}): {stderr_text}",
+        ) from e
+
+    if not output_path.exists() or output_path.stat().st_size == 0:
+        raise YouTubeDownloadError(
+            "YOUTUBE_DOWNLOAD_FAILED",
+            f"yt-dlp reported success but no output at {output_path}",
+        )
+    return output_path

--- a/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
+++ b/iris/src/iris/pipeline/shared/transcription/youtube_utils.py
@@ -33,15 +33,35 @@ class YouTubeDownloadError(Exception):
 # Timeout for `yt-dlp --dump-json`. Metadata fetch is fast; 30 s is generous.
 _VALIDATE_TIMEOUT_SECONDS = 30
 
-_PRIVATE_PATTERNS = (
-    re.compile(r"private video", re.IGNORECASE),
-    re.compile(r"sign in", re.IGNORECASE),
-)
+# Cap download resolution. Transcription/slide-detection is fine at 1080p;
+# an uncapped "bestvideo+bestaudio" can pull 4K/8K and balloon disk, bandwidth,
+# and merge time — and increase the chance of hitting the download timeout.
+_FORMAT_SELECTOR = "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best"
+
+# yt-dlp exposes two signals for livestreams:
+#   * metadata["is_live"] — bool, true while a stream is live
+#   * metadata["live_status"] — string, one of:
+#       "not_live"      — regular VOD, safe to transcribe
+#       "is_live"       — currently live, reject
+#       "is_upcoming"   — scheduled future stream/premiere, reject
+#       "post_live"     — stream just ended, not yet a clean VOD, reject
+#       "was_live"      — formerly-live VOD; we treat it as a stream artifact
+#                         and reject, since the policy is "normal uploads only"
+# Anything other than `"not_live"` (or missing/None, which we treat as VOD for
+# backwards compat with older yt-dlp outputs) is rejected as YOUTUBE_LIVE.
+_LIVE_REJECT_STATUSES = frozenset({"is_live", "is_upcoming", "post_live", "was_live"})
+
+# Private patterns are intentionally narrow: a bare "sign in" message also
+# appears in age-restricted / geo-blocked errors, which are UNAVAILABLE, not
+# PRIVATE. So we match "Private video" explicitly and leave the broader
+# auth-gated cases to UNAVAILABLE classification below.
+_PRIVATE_PATTERNS = (re.compile(r"private video", re.IGNORECASE),)
 _UNAVAILABLE_PATTERNS = (
     re.compile(r"video unavailable", re.IGNORECASE),
     re.compile(r"removed", re.IGNORECASE),
     re.compile(r"age[- ]restricted", re.IGNORECASE),
     re.compile(r"not available in your country", re.IGNORECASE),
+    re.compile(r"sign in", re.IGNORECASE),
 )
 
 
@@ -55,6 +75,15 @@ def _classify_yt_dlp_error(stderr: str) -> str:
     # An unrecognized stderr could be a transient network/yt-dlp issue;
     # UNAVAILABLE is terminal and would block instructor-initiated retries.
     return "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def _is_stream(metadata: Dict[str, Any]) -> bool:
+    """True if the video is any kind of livestream (live, upcoming, or
+    formerly-live VOD). Only fully non-stream uploads are accepted."""
+    if metadata.get("is_live"):
+        return True
+    live_status = metadata.get("live_status")
+    return live_status in _LIVE_REJECT_STATUSES
 
 
 def validate_youtube_video(url: str, max_duration_seconds: int) -> Dict[str, Any]:
@@ -101,8 +130,12 @@ def validate_youtube_video(url: str, max_duration_seconds: int) -> Dict[str, Any
             f"yt-dlp returned non-JSON output for {url}",
         ) from e
 
-    if metadata.get("is_live"):
-        raise YouTubeDownloadError("YOUTUBE_LIVE", "Live streams cannot be transcribed")
+    if _is_stream(metadata):
+        raise YouTubeDownloadError(
+            "YOUTUBE_LIVE",
+            "Livestreams and stream-derived VODs cannot be transcribed; "
+            "only regular uploads are supported",
+        )
     duration = metadata.get("duration")
     if duration is not None and duration > max_duration_seconds:
         raise YouTubeDownloadError(
@@ -120,7 +153,8 @@ def download_youtube_video(
 ) -> Path:
     """Download a YouTube video as an MP4 to ``output_path``.
 
-    Uses ``yt-dlp -f bestvideo+bestaudio/best --merge-output-format mp4``.
+    Uses a 1080p-capped format selector so long videos don't unexpectedly
+    pull multi-GB 4K/8K sources and blow the timeout/disk budget.
 
     Raises:
         YouTubeDownloadError: with error_code="YOUTUBE_DOWNLOAD_FAILED" on
@@ -131,7 +165,7 @@ def download_youtube_video(
     command = [
         "yt-dlp",
         "-f",
-        "bestvideo+bestaudio/best",
+        _FORMAT_SELECTOR,
         "--merge-output-format",
         "mp4",
         "--no-warnings",

--- a/iris/src/iris/web/status/ingestion_status_callback.py
+++ b/iris/src/iris/web/status/ingestion_status_callback.py
@@ -194,6 +194,7 @@ class IngestionStatusCallback(StatusCallback):
         message: str,
         exception=None,
         tokens=None,
+        error_code: Optional[str] = None,
     ):
         """Send error status to Artemis (best-effort, never raises).
 
@@ -207,6 +208,8 @@ class IngestionStatusCallback(StatusCallback):
         if hasattr(self.status, "suggestions"):
             self.status.suggestions = None
         self.status.tokens = tokens or self.status.tokens
+        if error_code is not None and hasattr(self.status, "error_code"):
+            self.status.error_code = error_code
 
         rest_of_index = self.current_stage_index + 1
         for stage in self.status.stages[rest_of_index:]:

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -223,6 +223,7 @@ class StatusCallback(ABC):
         message: str,
         exception=None,
         tokens: Optional[List[TokenUsageDTO]] = None,
+        error_code: Optional[str] = None,
     ):
         """
         Transition the current stage to ERROR and update the status.
@@ -234,6 +235,8 @@ class StatusCallback(ABC):
         if hasattr(self.status, "suggestions"):
             self.status.suggestions = None
         self.status.tokens = tokens or self.status.tokens
+        if error_code is not None and hasattr(self.status, "error_code"):
+            self.status.error_code = error_code
         # Set all subsequent stages to SKIPPED if an error occurs
         rest_of_index = (
             self.current_stage_index + 1

--- a/iris/tests/test_heavy_pipeline_youtube_branch.py
+++ b/iris/tests/test_heavy_pipeline_youtube_branch.py
@@ -1,0 +1,131 @@
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from iris.domain.data.video_source_type import VideoSourceType
+from iris.pipeline.shared.transcription.heavy_pipeline import (
+    HeavyTranscriptionPipeline,
+)
+from iris.pipeline.shared.transcription.youtube_utils import (
+    YouTubeDownloadError,
+)
+
+_MOD = "iris.pipeline.shared.transcription.heavy_pipeline"
+
+
+@pytest.fixture
+def mock_pipeline(tmp_path):
+    """Fixture that does NOT pre-create the video file. The test passes only if
+    the code under test actually invokes a download function that writes it.
+    Stage-2 audio is fine to stub, but stage-1 video materialization is the
+    behavior we're testing — don't fake it away."""
+    callback = MagicMock()
+    storage = MagicMock()
+    storage.video_path = str(tmp_path / "video.mp4")
+    storage.audio_path = str(tmp_path / "audio.m4a")
+    # Stage 2 audio: stubbed separately; pre-create the audio file since we
+    # don't exercise extract_audio's real behavior here.
+    Path(storage.audio_path).write_bytes(b"\x00" * 1024)
+
+    def _materialize_video(*args, **kwargs):
+        # Both download_video (positional: url, path) and
+        # download_youtube_video (positional: url, path) take path as the
+        # second arg. Write the file only when the correct branch is invoked.
+        target = (
+            Path(args[1])
+            if len(args) >= 2
+            else Path(kwargs.get("output_path", storage.video_path))
+        )
+        target.write_bytes(b"\x00" * 1024)
+
+    # Replace WhisperClient with a mock that returns a trivial transcript
+    with patch(f"{_MOD}.WhisperClient") as wc_cls:
+        wc = MagicMock()
+        wc.transcribe.return_value = {"segments": [], "language": "en"}
+        wc_cls.return_value = wc
+        with patch(f"{_MOD}.extract_audio"):
+            yield (
+                HeavyTranscriptionPipeline(
+                    callback=callback, storage=storage
+                ),
+                storage,
+                callback,
+                _materialize_video,
+            )
+
+
+def test_tum_live_branch_uses_ffmpeg_download(mock_pipeline):
+    pipeline, _, _, materialize = mock_pipeline
+    with ExitStack() as stack:
+        dl_hls = stack.enter_context(
+            patch(f"{_MOD}.download_video", side_effect=materialize)
+        )
+        dl_yt = stack.enter_context(
+            patch(f"{_MOD}.download_youtube_video", side_effect=materialize)
+        )
+        v_yt = stack.enter_context(
+            patch(f"{_MOD}.validate_youtube_video")
+        )
+        pipeline(
+            "https://live.rbg.tum.de/foo.m3u8",
+            lecture_unit_id=1,
+            video_source_type=VideoSourceType.TUM_LIVE,
+        )
+    dl_hls.assert_called_once()
+    dl_yt.assert_not_called()
+    v_yt.assert_not_called()
+
+
+def test_youtube_branch_validates_then_downloads_via_yt_dlp(mock_pipeline):
+    pipeline, _, _, materialize = mock_pipeline
+    with ExitStack() as stack:
+        dl_hls = stack.enter_context(
+            patch(f"{_MOD}.download_video", side_effect=materialize)
+        )
+        dl_yt = stack.enter_context(
+            patch(f"{_MOD}.download_youtube_video", side_effect=materialize)
+        )
+        v_yt = stack.enter_context(
+            patch(f"{_MOD}.validate_youtube_video")
+        )
+        v_yt.return_value = {"duration": 120, "title": "t"}
+        pipeline(
+            "https://youtu.be/dQw4w9WgXcQ",
+            lecture_unit_id=1,
+            video_source_type=VideoSourceType.YOUTUBE,
+        )
+    v_yt.assert_called_once()
+    dl_yt.assert_called_once()
+    dl_hls.assert_not_called()
+
+
+def test_youtube_validation_failure_propagates(mock_pipeline):
+    pipeline, _, _, _ = mock_pipeline
+    with patch(
+        f"{_MOD}.validate_youtube_video",
+        side_effect=YouTubeDownloadError("YOUTUBE_PRIVATE", "private"),
+    ):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            pipeline(
+                "https://youtu.be/X",
+                lecture_unit_id=1,
+                video_source_type=VideoSourceType.YOUTUBE,
+            )
+        assert excinfo.value.error_code == "YOUTUBE_PRIVATE"
+
+
+def test_missing_source_type_defaults_to_tum_live(mock_pipeline):
+    """Backward compat: callers omitting video_source_type get TUM_LIVE."""
+    pipeline, _, _, materialize = mock_pipeline
+    with ExitStack() as stack:
+        dl_hls = stack.enter_context(
+            patch(f"{_MOD}.download_video", side_effect=materialize)
+        )
+        dl_yt = stack.enter_context(
+            patch(f"{_MOD}.download_youtube_video", side_effect=materialize)
+        )
+        pipeline("https://live.rbg.tum.de/foo.m3u8", lecture_unit_id=1)
+    dl_hls.assert_called_once()
+    dl_yt.assert_not_called()

--- a/iris/tests/test_heavy_pipeline_youtube_branch.py
+++ b/iris/tests/test_heavy_pipeline_youtube_branch.py
@@ -47,9 +47,7 @@ def mock_pipeline(tmp_path):
         wc_cls.return_value = wc
         with patch(f"{_MOD}.extract_audio"):
             yield (
-                HeavyTranscriptionPipeline(
-                    callback=callback, storage=storage
-                ),
+                HeavyTranscriptionPipeline(callback=callback, storage=storage),
                 storage,
                 callback,
                 _materialize_video,
@@ -65,9 +63,7 @@ def test_tum_live_branch_uses_ffmpeg_download(mock_pipeline):
         dl_yt = stack.enter_context(
             patch(f"{_MOD}.download_youtube_video", side_effect=materialize)
         )
-        v_yt = stack.enter_context(
-            patch(f"{_MOD}.validate_youtube_video")
-        )
+        v_yt = stack.enter_context(patch(f"{_MOD}.validate_youtube_video"))
         pipeline(
             "https://live.rbg.tum.de/foo.m3u8",
             lecture_unit_id=1,
@@ -87,9 +83,7 @@ def test_youtube_branch_validates_then_downloads_via_yt_dlp(mock_pipeline):
         dl_yt = stack.enter_context(
             patch(f"{_MOD}.download_youtube_video", side_effect=materialize)
         )
-        v_yt = stack.enter_context(
-            patch(f"{_MOD}.validate_youtube_video")
-        )
+        v_yt = stack.enter_context(patch(f"{_MOD}.validate_youtube_video"))
         v_yt.return_value = {"duration": 120, "title": "t"}
         pipeline(
             "https://youtu.be/dQw4w9WgXcQ",

--- a/iris/tests/test_ingestion_error_code_wiring.py
+++ b/iris/tests/test_ingestion_error_code_wiring.py
@@ -23,9 +23,7 @@ def test_youtube_error_forwarded_with_structured_code():
     # Simulate the handler Task 11 adds: YouTubeDownloadError caught at the
     # orchestrator level and forwarded to callback.error(error_code=...).
     err = YouTubeDownloadError("YOUTUBE_LIVE", "live stream")
-    assert (
-        _translate_transcription_exception_to_error_code(err) == "YOUTUBE_LIVE"
-    )
+    assert _translate_transcription_exception_to_error_code(err) == "YOUTUBE_LIVE"
 
 
 def test_generic_exception_becomes_transcription_failed():
@@ -39,11 +37,9 @@ def test_generic_exception_becomes_transcription_failed():
 
 def test_slide_detection_only_branches_on_video_source_type():
     """Resume-from-checkpoint: must use yt-dlp for YouTube, not FFmpeg/HLS."""
-    with patch(_HLS) as dl_hls, \
-         patch(f"{_MOD}.download_youtube_video") as dl_yt, \
-         patch(f"{_MOD}.validate_youtube_video") as v_yt, \
-         patch(_LIGHT), \
-         patch(_TEMP) as storage_cls:
+    with patch(_HLS) as dl_hls, patch(f"{_MOD}.download_youtube_video") as dl_yt, patch(
+        f"{_MOD}.validate_youtube_video"
+    ) as v_yt, patch(_LIGHT), patch(_TEMP) as storage_cls:
         storage_cls.return_value.__enter__.return_value = MagicMock()
         v_yt.return_value = {"duration": 120}
 
@@ -89,8 +85,7 @@ def test_youtube_source_type_passed_through_to_heavy_pipeline():
         heavy_cls.return_value = heavy
 
         # Short-circuit light + ingestion so we assert the heavy-call only.
-        with patch(_LIGHT), \
-             patch(_TEMP) as storage_cls:
+        with patch(_LIGHT), patch(_TEMP) as storage_cls:
             storage_cls.return_value.__enter__.return_value = MagicMock()
 
             pipeline = LectureIngestionUpdatePipeline.__new__(

--- a/iris/tests/test_ingestion_error_code_wiring.py
+++ b/iris/tests/test_ingestion_error_code_wiring.py
@@ -17,6 +17,8 @@ _HEAVY = "iris.pipeline.shared.transcription.heavy_pipeline.HeavyTranscriptionPi
 _LIGHT = "iris.pipeline.shared.transcription.light_pipeline.LightTranscriptionPipeline"
 _TEMP = "iris.pipeline.shared.transcription.temp_storage.TranscriptionTempStorage"
 _HLS = "iris.pipeline.shared.transcription.video_utils.download_video"
+_YT_DL = "iris.pipeline.shared.transcription.youtube_utils.download_youtube_video"
+_YT_VAL = "iris.pipeline.shared.transcription.youtube_utils.validate_youtube_video"
 
 
 def test_youtube_error_forwarded_with_structured_code():
@@ -37,9 +39,9 @@ def test_generic_exception_becomes_transcription_failed():
 
 def test_slide_detection_only_branches_on_video_source_type():
     """Resume-from-checkpoint: must use yt-dlp for YouTube, not FFmpeg/HLS."""
-    with patch(_HLS) as dl_hls, patch(f"{_MOD}.download_youtube_video") as dl_yt, patch(
-        f"{_MOD}.validate_youtube_video"
-    ) as v_yt, patch(_LIGHT), patch(_TEMP) as storage_cls:
+    with patch(_HLS) as dl_hls, patch(_YT_DL) as dl_yt, patch(_YT_VAL) as v_yt, patch(
+        _LIGHT
+    ), patch(_TEMP) as storage_cls:
         storage_cls.return_value.__enter__.return_value = MagicMock()
         v_yt.return_value = {"duration": 120}
 

--- a/iris/tests/test_ingestion_error_code_wiring.py
+++ b/iris/tests/test_ingestion_error_code_wiring.py
@@ -1,0 +1,114 @@
+"""Verify: YouTube-specific failures reach callback.error with the right code,
+and generic transcription failures surface as TRANSCRIPTION_FAILED."""
+
+from unittest.mock import MagicMock, patch
+
+from iris.domain.data.video_source_type import VideoSourceType
+from iris.pipeline.lecture_ingestion_update_pipeline import (
+    LectureIngestionUpdatePipeline,
+    _translate_transcription_exception_to_error_code,
+)
+from iris.pipeline.shared.transcription.youtube_utils import (
+    YouTubeDownloadError,
+)
+
+_MOD = "iris.pipeline.lecture_ingestion_update_pipeline"
+_HEAVY = "iris.pipeline.shared.transcription.heavy_pipeline.HeavyTranscriptionPipeline"
+_LIGHT = "iris.pipeline.shared.transcription.light_pipeline.LightTranscriptionPipeline"
+_TEMP = "iris.pipeline.shared.transcription.temp_storage.TranscriptionTempStorage"
+_HLS = "iris.pipeline.shared.transcription.video_utils.download_video"
+
+
+def test_youtube_error_forwarded_with_structured_code():
+    # Simulate the handler Task 11 adds: YouTubeDownloadError caught at the
+    # orchestrator level and forwarded to callback.error(error_code=...).
+    err = YouTubeDownloadError("YOUTUBE_LIVE", "live stream")
+    assert (
+        _translate_transcription_exception_to_error_code(err) == "YOUTUBE_LIVE"
+    )
+
+
+def test_generic_exception_becomes_transcription_failed():
+    assert (
+        _translate_transcription_exception_to_error_code(
+            RuntimeError("whisper timeout")
+        )
+        == "TRANSCRIPTION_FAILED"
+    )
+
+
+def test_slide_detection_only_branches_on_video_source_type():
+    """Resume-from-checkpoint: must use yt-dlp for YouTube, not FFmpeg/HLS."""
+    with patch(_HLS) as dl_hls, \
+         patch(f"{_MOD}.download_youtube_video") as dl_yt, \
+         patch(f"{_MOD}.validate_youtube_video") as v_yt, \
+         patch(_LIGHT), \
+         patch(_TEMP) as storage_cls:
+        storage_cls.return_value.__enter__.return_value = MagicMock()
+        v_yt.return_value = {"duration": 120}
+
+        lecture_unit = MagicMock()
+        lecture_unit.lecture_unit_id = 1
+        lecture_unit.video_link = "https://youtu.be/dQw4w9WgXcQ"
+        lecture_unit.video_source_type = VideoSourceType.YOUTUBE
+        lecture_unit.transcription.segments = []
+        lecture_unit.transcription.language = "en"
+        dto = MagicMock()
+        dto.lecture_unit = lecture_unit
+
+        pipeline = LectureIngestionUpdatePipeline.__new__(
+            LectureIngestionUpdatePipeline
+        )
+        pipeline.dto = dto
+        pipeline._is_local = False  # pylint: disable=protected-access
+
+        with patch.object(pipeline, "_build_checkpoint", return_value={}):
+            try:
+                # pylint: disable=protected-access
+                pipeline._run_slide_detection_only(MagicMock())
+            except Exception:  # pylint: disable=broad-except
+                pass  # downstream mocks may raise; only assert download branch
+
+        dl_yt.assert_called_once()
+        dl_hls.assert_not_called()
+
+
+def test_youtube_source_type_passed_through_to_heavy_pipeline():
+    """Orchestrator reads video_source_type and forwards it to heavy."""
+    lecture_unit = MagicMock()
+    lecture_unit.lecture_unit_id = 1
+    lecture_unit.video_link = "https://youtu.be/dQw4w9WgXcQ"
+    lecture_unit.video_source_type = VideoSourceType.YOUTUBE
+
+    dto = MagicMock()
+    dto.lecture_unit = lecture_unit
+
+    with patch(_HEAVY) as heavy_cls:
+        heavy = MagicMock()
+        heavy.return_value = {"segments": [], "language": "en"}
+        heavy_cls.return_value = heavy
+
+        # Short-circuit light + ingestion so we assert the heavy-call only.
+        with patch(_LIGHT), \
+             patch(_TEMP) as storage_cls:
+            storage_cls.return_value.__enter__.return_value = MagicMock()
+
+            pipeline = LectureIngestionUpdatePipeline.__new__(
+                LectureIngestionUpdatePipeline
+            )
+            pipeline.dto = dto
+            pipeline._is_local = False  # pylint: disable=protected-access
+            with patch.object(pipeline, "_build_checkpoint", return_value={}):
+                callback = MagicMock()
+                try:
+                    # pylint: disable=protected-access
+                    pipeline._run_full_transcription(callback)
+                except Exception:  # pylint: disable=broad-except
+                    pass  # MagicMock wiring may raise; only check heavy call
+
+    assert heavy.called
+    called_kwargs = heavy.call_args.kwargs
+    called_args = heavy.call_args.args
+    # Accept either positional or keyword forwarding:
+    all_args = list(called_args) + list(called_kwargs.values())
+    assert VideoSourceType.YOUTUBE in all_args

--- a/iris/tests/test_lecture_unit_page_dto.py
+++ b/iris/tests/test_lecture_unit_page_dto.py
@@ -29,3 +29,15 @@ def test_accepts_snake_case_field_name():
 def test_rejects_unknown_value():
     with pytest.raises(ValidationError):
         LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "videoSourceType": "VIMEO"})
+
+
+def test_coerces_explicit_null_video_source_type_alias_to_default():
+    # Older Artemis deployments emit "videoSourceType": null; that must not
+    # raise and must fall back to TUM_LIVE for backwards compatibility.
+    dto = LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "videoSourceType": None})
+    assert dto.video_source_type == VideoSourceType.TUM_LIVE
+
+
+def test_coerces_explicit_null_snake_case_to_default():
+    dto = LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "video_source_type": None})
+    assert dto.video_source_type == VideoSourceType.TUM_LIVE

--- a/iris/tests/test_lecture_unit_page_dto.py
+++ b/iris/tests/test_lecture_unit_page_dto.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import ValidationError
+
+from iris.domain.data.lecture_unit_page_dto import LectureUnitPageDTO
+from iris.domain.data.video_source_type import VideoSourceType
+
+_MINIMAL_PAYLOAD = {
+    "lectureUnitId": 1,
+    "lectureId": 2,
+    "courseId": 3,
+}
+
+
+def test_defaults_to_tum_live_when_field_absent():
+    dto = LectureUnitPageDTO(**_MINIMAL_PAYLOAD)
+    assert dto.video_source_type == VideoSourceType.TUM_LIVE
+
+
+def test_accepts_youtube_from_camelcase_alias():
+    dto = LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "videoSourceType": "YOUTUBE"})
+    assert dto.video_source_type == VideoSourceType.YOUTUBE
+
+
+def test_accepts_snake_case_field_name():
+    dto = LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "video_source_type": "YOUTUBE"})
+    assert dto.video_source_type == VideoSourceType.YOUTUBE
+
+
+def test_rejects_unknown_value():
+    with pytest.raises(ValidationError):
+        LectureUnitPageDTO(**{**_MINIMAL_PAYLOAD, "videoSourceType": "VIMEO"})

--- a/iris/tests/test_status_update_error_code.py
+++ b/iris/tests/test_status_update_error_code.py
@@ -1,32 +1,46 @@
 from unittest.mock import MagicMock
 
+from iris.domain.ingestion.ingestion_status_update_dto import (
+    IngestionStatusUpdateDTO,
+)
 from iris.domain.status.status_update_dto import StatusUpdateDTO
 from iris.web.status.ingestion_status_callback import IngestionStatusCallback
 
 
 def test_error_code_defaults_to_none():
-    dto = StatusUpdateDTO(stages=[], tokens=[])
+    dto = IngestionStatusUpdateDTO(stages=[], tokens=[])
     assert dto.error_code is None
 
 
 def test_error_code_round_trips_through_snake_case_field_name():
-    dto = StatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_PRIVATE")
+    dto = IngestionStatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_PRIVATE")
     assert dto.error_code == "YOUTUBE_PRIVATE"
 
 
 def test_error_code_accepts_wire_alias_error_code():
     # Pyris sends snake_case on the wire per spec; Jackson-side uses
     # @JsonProperty("error_code") on the Artemis DTO. Accept both on input.
-    dto = StatusUpdateDTO(stages=[], tokens=[], **{"error_code": "YOUTUBE_LIVE"})
+    dto = IngestionStatusUpdateDTO(
+        stages=[], tokens=[], **{"error_code": "YOUTUBE_LIVE"}
+    )
     assert dto.error_code == "YOUTUBE_LIVE"
 
 
 def test_error_code_serialized_under_snake_case_wire_key():
-    dto = StatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_TOO_LONG")
+    dto = IngestionStatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_TOO_LONG")
     # Must dump with snake_case `error_code` to match Jackson contract.
     dumped = dto.model_dump(by_alias=True, exclude_none=True)
     assert dumped.get("error_code") == "YOUTUBE_TOO_LONG"
     assert "errorCode" not in dumped
+
+
+def test_base_status_dto_does_not_carry_error_code():
+    # error_code is scoped to ingestion only. Other pipelines must not see it
+    # in their serialized payload (wire-contract narrowing).
+    dto = StatusUpdateDTO(stages=[], tokens=[])
+    dumped = dto.model_dump(by_alias=True)
+    assert "error_code" not in dumped
+    assert not hasattr(dto, "error_code")
 
 
 def test_ingestion_callback_error_sets_error_code(monkeypatch):

--- a/iris/tests/test_status_update_error_code.py
+++ b/iris/tests/test_status_update_error_code.py
@@ -17,16 +17,12 @@ def test_error_code_round_trips_through_snake_case_field_name():
 def test_error_code_accepts_wire_alias_error_code():
     # Pyris sends snake_case on the wire per spec; Jackson-side uses
     # @JsonProperty("error_code") on the Artemis DTO. Accept both on input.
-    dto = StatusUpdateDTO(
-        stages=[], tokens=[], **{"error_code": "YOUTUBE_LIVE"}
-    )
+    dto = StatusUpdateDTO(stages=[], tokens=[], **{"error_code": "YOUTUBE_LIVE"})
     assert dto.error_code == "YOUTUBE_LIVE"
 
 
 def test_error_code_serialized_under_snake_case_wire_key():
-    dto = StatusUpdateDTO(
-        stages=[], tokens=[], error_code="YOUTUBE_TOO_LONG"
-    )
+    dto = StatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_TOO_LONG")
     # Must dump with snake_case `error_code` to match Jackson contract.
     dumped = dto.model_dump(by_alias=True, exclude_none=True)
     assert dumped.get("error_code") == "YOUTUBE_TOO_LONG"

--- a/iris/tests/test_status_update_error_code.py
+++ b/iris/tests/test_status_update_error_code.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+from iris.domain.status.status_update_dto import StatusUpdateDTO
+from iris.web.status.ingestion_status_callback import IngestionStatusCallback
+
+
+def test_error_code_defaults_to_none():
+    dto = StatusUpdateDTO(stages=[], tokens=[])
+    assert dto.error_code is None
+
+
+def test_error_code_round_trips_through_snake_case_field_name():
+    dto = StatusUpdateDTO(stages=[], tokens=[], error_code="YOUTUBE_PRIVATE")
+    assert dto.error_code == "YOUTUBE_PRIVATE"
+
+
+def test_error_code_accepts_wire_alias_error_code():
+    # Pyris sends snake_case on the wire per spec; Jackson-side uses
+    # @JsonProperty("error_code") on the Artemis DTO. Accept both on input.
+    dto = StatusUpdateDTO(
+        stages=[], tokens=[], **{"error_code": "YOUTUBE_LIVE"}
+    )
+    assert dto.error_code == "YOUTUBE_LIVE"
+
+
+def test_error_code_serialized_under_snake_case_wire_key():
+    dto = StatusUpdateDTO(
+        stages=[], tokens=[], error_code="YOUTUBE_TOO_LONG"
+    )
+    # Must dump with snake_case `error_code` to match Jackson contract.
+    dumped = dto.model_dump(by_alias=True, exclude_none=True)
+    assert dumped.get("error_code") == "YOUTUBE_TOO_LONG"
+    assert "errorCode" not in dumped
+
+
+def test_ingestion_callback_error_sets_error_code(monkeypatch):
+    # Stub out HTTP delivery so the test doesn't hit the network
+    monkeypatch.setattr(
+        "iris.web.status.ingestion_status_callback.http_requests.post",
+        MagicMock(return_value=MagicMock(status_code=200)),
+    )
+    cb = IngestionStatusCallback(
+        run_id="test-run",
+        base_url="http://localhost",
+        include_transcription_stages=True,
+    )
+    cb.error("video is private", error_code="YOUTUBE_PRIVATE")
+    assert cb.status.error_code == "YOUTUBE_PRIVATE"

--- a/iris/tests/test_transcription_settings.py
+++ b/iris/tests/test_transcription_settings.py
@@ -6,6 +6,8 @@ def test_youtube_max_duration_default_is_six_hours():
     assert settings.youtube_max_duration_seconds == 21600
 
 
-def test_youtube_download_timeout_default_is_ten_minutes():
+def test_youtube_download_timeout_default_is_one_hour():
+    # The default must be large enough to cover the slowest download up to
+    # youtube_max_duration_seconds (6h). Operators can override via env.
     settings = TranscriptionSettings()
-    assert settings.youtube_download_timeout_seconds == 600
+    assert settings.youtube_download_timeout_seconds == 3600

--- a/iris/tests/test_transcription_settings.py
+++ b/iris/tests/test_transcription_settings.py
@@ -1,0 +1,11 @@
+from iris.config import TranscriptionSettings
+
+
+def test_youtube_max_duration_default_is_six_hours():
+    settings = TranscriptionSettings()
+    assert settings.youtube_max_duration_seconds == 21600
+
+
+def test_youtube_download_timeout_default_is_ten_minutes():
+    settings = TranscriptionSettings()
+    assert settings.youtube_download_timeout_seconds == 600

--- a/iris/tests/test_video_source_type.py
+++ b/iris/tests/test_video_source_type.py
@@ -1,0 +1,12 @@
+from iris.domain.data.video_source_type import VideoSourceType
+
+
+def test_values_match_wire_format():
+    assert VideoSourceType.TUM_LIVE.value == "TUM_LIVE"
+    assert VideoSourceType.YOUTUBE.value == "YOUTUBE"
+
+
+def test_is_str_enum_for_json_round_trip():
+    # StrEnum compatibility: value equals the enum member when compared as string
+    assert VideoSourceType("YOUTUBE") == VideoSourceType.YOUTUBE
+    assert VideoSourceType("TUM_LIVE") == VideoSourceType.TUM_LIVE

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -53,6 +53,11 @@ def test_download_command_includes_no_playlist_and_double_dash(tmp_path, monkeyp
     assert "--no-playlist" in cmd
     assert "--" in cmd
     assert cmd.index("--") < cmd.index("https://youtu.be/X")
+    # Format must be capped at 1080p so long videos don't silently pull
+    # 4K/8K sources and exhaust the download timeout/disk budget.
+    assert "-f" in cmd
+    fmt = cmd[cmd.index("-f") + 1]
+    assert "height<=1080" in fmt
 
 
 def _metadata_json(**overrides) -> str:
@@ -96,6 +101,50 @@ def test_live_stream_rejected():
         with pytest.raises(YouTubeDownloadError) as excinfo:
             validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_LIVE"
+
+
+@pytest.mark.parametrize(
+    "live_status",
+    ["is_live", "is_upcoming", "post_live", "was_live"],
+)
+def test_stream_states_rejected_via_live_status(live_status):
+    # yt-dlp sometimes leaves is_live=False while live_status signals the
+    # video is (or was) a stream. Policy is "only normal, done uploads",
+    # so every non-"not_live" status must be terminal YOUTUBE_LIVE rather
+    # than falling through to download + retryable DOWNLOAD_FAILED.
+    with _mock_run_ok(_metadata_json(is_live=False, live_status=live_status)):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
+    assert excinfo.value.error_code == "YOUTUBE_LIVE"
+
+
+def test_regular_vod_accepted_with_not_live_status():
+    with _mock_run_ok(_metadata_json(live_status="not_live")):
+        meta = validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
+    assert meta["id"] == "dQw4w9WgXcQ"
+
+
+def test_regular_vod_accepted_with_missing_live_status():
+    # Older yt-dlp releases may omit live_status entirely; that must not
+    # be interpreted as a stream.
+    payload = _metadata_json()  # no live_status key
+    with _mock_run_ok(payload):
+        meta = validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
+    assert meta["id"] == "dQw4w9WgXcQ"
+
+
+def test_age_restricted_classified_as_unavailable_not_private():
+    # yt-dlp age-restriction errors contain the phrase "sign in"; those
+    # must be UNAVAILABLE (terminal) rather than mislabeled as PRIVATE so
+    # instructor-facing messaging stays accurate.
+    stderr = (
+        "ERROR: [youtube] X: Sign in to confirm your age. "
+        "This video may be inappropriate for some users."
+    )
+    with _mock_run_fail(stderr):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
+    assert excinfo.value.error_code == "YOUTUBE_UNAVAILABLE"
 
 
 def test_too_long_rejected():

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -23,6 +23,38 @@ def test_error_is_raisable():
     assert excinfo.value.error_code == "YOUTUBE_LIVE"
 
 
+def test_validate_command_includes_no_playlist_and_double_dash():
+    """Hardening: playlist URLs must not expand; URLs must not be parsed as opts."""
+    with _mock_run_ok(_metadata_json()) as run_mock:
+        validate_youtube_video(
+            "https://www.youtube.com/watch?v=X&list=PL123", max_duration_seconds=3600
+        )
+    cmd = run_mock.call_args.args[0]
+    assert "--no-playlist" in cmd
+    # URL must come after a `--` option terminator
+    assert "--" in cmd
+    assert cmd.index("--") < cmd.index("https://www.youtube.com/watch?v=X&list=PL123")
+
+
+def test_download_command_includes_no_playlist_and_double_dash(tmp_path, monkeypatch):
+    output = tmp_path / "video.mp4"
+    captured = {}
+
+    def _fake_run(*args, **_):
+        captured["cmd"] = args[0]
+        output.write_bytes(b"\x00")
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    download_youtube_video("https://youtu.be/X", output, timeout=60)
+    cmd = captured["cmd"]
+    assert "--no-playlist" in cmd
+    assert "--" in cmd
+    assert cmd.index("--") < cmd.index("https://youtu.be/X")
+
+
 def _metadata_json(**overrides) -> str:
     base = {
         "id": "dQw4w9WgXcQ",

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from iris.pipeline.shared.transcription.youtube_utils import (
     YouTubeDownloadError,
+    download_youtube_video,
     validate_youtube_video,
 )
 
@@ -119,4 +120,64 @@ def test_timeout_raises_download_failed():
             validate_youtube_video(
                 "https://youtu.be/X", max_duration_seconds=3600
             )
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def test_download_success_returns_output_path(tmp_path, monkeypatch):
+    output = tmp_path / "video.mp4"
+
+    def _fake_run(*args, **_):
+        output.write_bytes(b"\x00")
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    result = download_youtube_video(
+        "https://youtu.be/X", output, timeout=600
+    )
+    assert result == output
+    assert output.exists()
+
+
+def test_download_timeout_raises_download_failed(tmp_path, monkeypatch):
+    timeout_err = subprocess.TimeoutExpired(cmd=["yt-dlp"], timeout=1)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(timeout_err),
+    )
+    with pytest.raises(YouTubeDownloadError) as excinfo:
+        download_youtube_video(
+            "https://youtu.be/X", tmp_path / "out.mp4", timeout=1
+        )
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def test_download_nonzero_exit_raises_download_failed(tmp_path, monkeypatch):
+    err = subprocess.CalledProcessError(
+        returncode=1, cmd=["yt-dlp"], stderr="network error"
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(err),
+    )
+    with pytest.raises(YouTubeDownloadError) as excinfo:
+        download_youtube_video(
+            "https://youtu.be/X", tmp_path / "out.mp4", timeout=600
+        )
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def test_download_output_missing_raises_download_failed(tmp_path, monkeypatch):
+    # subprocess returns success but no file materialized — yt-dlp quirk
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=a, returncode=0, stdout="", stderr=""
+        ),
+    )
+    with pytest.raises(YouTubeDownloadError) as excinfo:
+        download_youtube_video(
+            "https://youtu.be/X", tmp_path / "missing.mp4", timeout=600
+        )
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -182,6 +182,22 @@ def test_download_nonzero_exit_raises_download_failed(tmp_path, monkeypatch):
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
 
 
+def test_download_missing_yt_dlp_binary_raises_download_failed(tmp_path, monkeypatch):
+    # subprocess.run raises FileNotFoundError when the executable isn't on PATH
+    # — the function must translate that into a structured YouTubeDownloadError
+    # so callers get the documented error_code contract.
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            FileNotFoundError("[Errno 2] No such file or directory: 'yt-dlp'")
+        ),
+    )
+    with pytest.raises(YouTubeDownloadError) as excinfo:
+        download_youtube_video("https://youtu.be/X", tmp_path / "out.mp4", timeout=600)
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
+    assert "yt-dlp" in str(excinfo.value)
+
+
 def test_download_output_missing_raises_download_failed(tmp_path, monkeypatch):
     # subprocess returns success but no file materialized — yt-dlp quirk
     monkeypatch.setattr(

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from iris.pipeline.shared.transcription.youtube_utils import (
+    YouTubeDownloadError,
+)
+
+
+def test_error_carries_structured_code_and_message():
+    err = YouTubeDownloadError("YOUTUBE_PRIVATE", "video is private")
+    assert err.error_code == "YOUTUBE_PRIVATE"
+    assert str(err) == "video is private"
+
+
+def test_error_is_raisable():
+    with pytest.raises(YouTubeDownloadError) as excinfo:
+        raise YouTubeDownloadError("YOUTUBE_LIVE", "live stream not supported")
+    assert excinfo.value.error_code == "YOUTUBE_LIVE"

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -1,7 +1,12 @@
+import json
+import subprocess
+from unittest.mock import patch
+
 import pytest
 
 from iris.pipeline.shared.transcription.youtube_utils import (
     YouTubeDownloadError,
+    validate_youtube_video,
 )
 
 
@@ -15,3 +20,103 @@ def test_error_is_raisable():
     with pytest.raises(YouTubeDownloadError) as excinfo:
         raise YouTubeDownloadError("YOUTUBE_LIVE", "live stream not supported")
     assert excinfo.value.error_code == "YOUTUBE_LIVE"
+
+
+def _metadata_json(**overrides) -> str:
+    base = {
+        "id": "dQw4w9WgXcQ",
+        "title": "Test Video",
+        "duration": 120,
+        "is_live": False,
+        "availability": "public",
+        "formats": [],
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+def _mock_run_ok(metadata_json: str):
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=metadata_json, stderr=""
+    )
+    return patch("subprocess.run", return_value=completed)
+
+
+def _mock_run_fail(stderr: str, returncode: int = 1):
+    err = subprocess.CalledProcessError(
+        returncode=returncode, cmd=["yt-dlp"], stderr=stderr
+    )
+    return patch("subprocess.run", side_effect=err)
+
+
+def test_valid_video_returns_metadata():
+    with _mock_run_ok(_metadata_json()):
+        meta = validate_youtube_video(
+            "https://youtu.be/dQw4w9WgXcQ", max_duration_seconds=3600
+        )
+    assert meta["id"] == "dQw4w9WgXcQ"
+    assert meta["duration"] == 120
+
+
+def test_live_stream_rejected():
+    with _mock_run_ok(_metadata_json(is_live=True)):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_LIVE"
+
+
+def test_too_long_rejected():
+    with _mock_run_ok(_metadata_json(duration=10000)):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_TOO_LONG"
+
+
+def test_private_video_rejected():
+    # yt-dlp marks private videos with a specific stderr pattern
+    private_stderr = (
+        "ERROR: [youtube] X: Private video. "
+        "Sign in if you've been granted access to this video"
+    )
+    with _mock_run_fail(private_stderr):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_PRIVATE"
+
+
+def test_unavailable_video_rejected():
+    with _mock_run_fail("ERROR: [youtube] X: Video unavailable"):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_UNAVAILABLE"
+
+
+def test_unknown_yt_dlp_error_treated_as_download_failed():
+    # Novel stderr pattern — default to DOWNLOAD_FAILED (retryable per spec
+    # lines 88-91), NOT UNAVAILABLE. An unknown stderr could be transient
+    # (network, yt-dlp bug); terminalizing it as UNAVAILABLE would forbid
+    # retries forever.
+    with _mock_run_fail("ERROR: some new yt-dlp error text"):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
+
+
+def test_timeout_raises_download_failed():
+    timeout_err = subprocess.TimeoutExpired(cmd=["yt-dlp"], timeout=30)
+    with patch("subprocess.run", side_effect=timeout_err):
+        with pytest.raises(YouTubeDownloadError) as excinfo:
+            validate_youtube_video(
+                "https://youtu.be/X", max_duration_seconds=3600
+            )
+    assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"

--- a/iris/tests/test_youtube_utils.py
+++ b/iris/tests/test_youtube_utils.py
@@ -62,18 +62,14 @@ def test_valid_video_returns_metadata():
 def test_live_stream_rejected():
     with _mock_run_ok(_metadata_json(is_live=True)):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_LIVE"
 
 
 def test_too_long_rejected():
     with _mock_run_ok(_metadata_json(duration=10000)):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_TOO_LONG"
 
 
@@ -85,18 +81,14 @@ def test_private_video_rejected():
     )
     with _mock_run_fail(private_stderr):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_PRIVATE"
 
 
 def test_unavailable_video_rejected():
     with _mock_run_fail("ERROR: [youtube] X: Video unavailable"):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_UNAVAILABLE"
 
 
@@ -107,9 +99,7 @@ def test_unknown_yt_dlp_error_treated_as_download_failed():
     # retries forever.
     with _mock_run_fail("ERROR: some new yt-dlp error text"):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
 
 
@@ -117,9 +107,7 @@ def test_timeout_raises_download_failed():
     timeout_err = subprocess.TimeoutExpired(cmd=["yt-dlp"], timeout=30)
     with patch("subprocess.run", side_effect=timeout_err):
         with pytest.raises(YouTubeDownloadError) as excinfo:
-            validate_youtube_video(
-                "https://youtu.be/X", max_duration_seconds=3600
-            )
+            validate_youtube_video("https://youtu.be/X", max_duration_seconds=3600)
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
 
 
@@ -133,9 +121,7 @@ def test_download_success_returns_output_path(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr("subprocess.run", _fake_run)
-    result = download_youtube_video(
-        "https://youtu.be/X", output, timeout=600
-    )
+    result = download_youtube_video("https://youtu.be/X", output, timeout=600)
     assert result == output
     assert output.exists()
 
@@ -147,9 +133,7 @@ def test_download_timeout_raises_download_failed(tmp_path, monkeypatch):
         lambda *a, **kw: (_ for _ in ()).throw(timeout_err),
     )
     with pytest.raises(YouTubeDownloadError) as excinfo:
-        download_youtube_video(
-            "https://youtu.be/X", tmp_path / "out.mp4", timeout=1
-        )
+        download_youtube_video("https://youtu.be/X", tmp_path / "out.mp4", timeout=1)
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
 
 
@@ -162,9 +146,7 @@ def test_download_nonzero_exit_raises_download_failed(tmp_path, monkeypatch):
         lambda *a, **kw: (_ for _ in ()).throw(err),
     )
     with pytest.raises(YouTubeDownloadError) as excinfo:
-        download_youtube_video(
-            "https://youtu.be/X", tmp_path / "out.mp4", timeout=600
-        )
+        download_youtube_video("https://youtu.be/X", tmp_path / "out.mp4", timeout=600)
     assert excinfo.value.error_code == "YOUTUBE_DOWNLOAD_FAILED"
 
 


### PR DESCRIPTION
## Summary
- Add `yt-dlp`-based YouTube download path alongside the existing TUM Live FFmpeg/HLS path, gated by a new `video_source_type` field on the ingestion webhook payload.
- Surface YouTube-specific failures (`YOUTUBE_PRIVATE`, `YOUTUBE_LIVE`, `YOUTUBE_TOO_LONG`, `YOUTUBE_UNAVAILABLE`, `YOUTUBE_DOWNLOAD_FAILED`) and generic transcription failures (`TRANSCRIPTION_FAILED`) as structured `error_code` values on the status callback, so Artemis can render user-actionable messages.
- Wire-compatible: `video_source_type` defaults to `TUM_LIVE` on the wire; older Artemis deployments are unaffected. Wire contract: snake_case `error_code` (matches Jackson `@JsonProperty` on the Artemis side).
- `yt-dlp` invocations hardened with `--no-playlist` + `--` option terminator to prevent playlist expansion and option injection through URLs.

## Companion PR

Artemis-side PR (separate plan, independently deployable): pending.

## Test plan
- [x] Unit tests for `YouTubeDownloadError`, `validate_youtube_video`, `download_youtube_video` (mocked subprocess)
- [x] Argv-shape regression tests pinning `--no-playlist` + `--` in both command builders
- [x] Pipeline-level tests for the `HeavyTranscriptionPipeline` YOUTUBE branch + backward-compat TUM_LIVE default
- [x] Orchestrator tests for `_run_slide_detection_only` branching on `video_source_type` (resume-from-checkpoint path)
- [x] DTO tests for `VideoSourceType` defaulting, camelCase alias, and `ValidationError` on unknown values
- [x] `error_code` round-trip test through `StatusUpdateDTO` + `IngestionStatusCallback`
- [x] Dockerfile verification: yt-dlp runnable; actual mp4 download+merge works against a real public YouTube URL
- [x] Full test suite: 70 passing locally, pylint clean, black clean
- [x] Codex review: approved after one round of fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YouTube video support for transcription with configurable max duration (default 6h) and download timeout
  * Video source type now distinguishes TUM_LIVE vs YouTube and tolerates null/missing values
  * Transcription errors now surface structured error codes for clearer diagnostics

* **Tests**
  * Comprehensive tests for YouTube validation/download, branching behavior, DTO handling, status error_code wiring, and settings defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->