### PR TITLE
`Logos`: Calibration log history, tp fallback, and GPU cleanup

### DIFF
--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -60,7 +60,9 @@ _PROFILES_FILE = "model_profiles.yml"
 _CALIBRATION_PORT = 11499
 _KV_CACHE_MIN_STEP_MB = 1024.0  # binary search precision and safety margin
 _KV_CACHE_VRAM_CAP_RATIO = 0.8  # fraction of total GPU VRAM used as KV search ceiling
+_FINAL_MEASUREMENT_RETRIES = 3  # retries for the final VRAM measurement startup
 _FAILED_COMMANDS_FILE = "calibration_failed_commands.txt"
+_SUCCEEDED_COMMANDS_FILE = "calibration_succeeded_commands.txt"
 
 # ---------------------------------------------------------------------------
 # KV-cache size parsing
@@ -136,6 +138,46 @@ def _record_failed_command(failed_path: Path, fingerprint: str) -> None:
     with failed_path.open("a", encoding="utf-8") as f:
         f.write(fingerprint + "\n")
     logger.info("  Blacklisted command → %s", failed_path)
+
+
+def _load_succeeded_commands(succeeded_path: Path) -> set[str]:
+    if not succeeded_path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in succeeded_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+
+def _record_succeeded_command(succeeded_path: Path, fingerprint: str) -> None:
+    succeeded_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _load_succeeded_commands(succeeded_path)
+    if fingerprint not in existing:
+        with succeeded_path.open("a", encoding="utf-8") as f:
+            f.write(fingerprint + "\n")
+
+
+def _remove_failed_command(failed_path: Path, fingerprint: str) -> None:
+    """Remove a fingerprint from the blacklist file (whitelisted success overrides)."""
+    if not failed_path.exists():
+        return
+    lines = failed_path.read_text(encoding="utf-8").splitlines()
+    remaining = [ln for ln in lines if ln.strip() != fingerprint]
+    if len(remaining) < len(lines):
+        failed_path.write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
+
+
+def _extract_kv_from_fingerprint(fingerprint: str) -> float | None:
+    """Extract the KV cache size in MB from a command fingerprint."""
+    parts = fingerprint.split()
+    for i, tok in enumerate(parts):
+        if tok == "--kv-cache-memory-bytes" and i + 1 < len(parts):
+            try:
+                return _parse_kv_to_mb(parts[i + 1])
+            except (ValueError, IndexError):
+                return None
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -645,7 +687,9 @@ def calibrate_model(
         )
 
     failed_path = log_dir / _FAILED_COMMANDS_FILE
+    succeeded_path = log_dir / _SUCCEEDED_COMMANDS_FILE
     failed_commands = _load_failed_commands(failed_path)
+    succeeded_commands = _load_succeeded_commands(succeeded_path)
 
     # Lazy RAM-cache flag: only cache the model into tmpfs on the first
     # actual vLLM spawn (not on blacklist-skipped probes).
@@ -654,21 +698,29 @@ def calibrate_model(
     def _try_start(kv_mb: float) -> subprocess.Popen[str] | None:
         """Try to start vLLM with the given KV cache.  Returns the
         running process on success, ``None`` on failure (process is
-        cleaned up).  Blacklisted commands are skipped immediately."""
+        cleaned up).  Blacklisted commands are skipped immediately
+        unless they are also whitelisted (previous success overrides)."""
         nonlocal hf_home, _ram_cached
         kv_str = _format_kv_mb(kv_mb)
         planned = {**plan, "kv_cache_memory_bytes": kv_str}
-        # Check the blacklist *before* spawning to avoid wasting time.
         fingerprint = _cmd_fingerprint(
             _build_vllm_cmd(planned, vllm_binary, host, port, kv_str)
         )
-        if fingerprint in failed_commands:
+        # Whitelist overrides blacklist: a previously successful command
+        # should be retried even if a later run (e.g. stuck GPU) failed.
+        if fingerprint in failed_commands and fingerprint not in succeeded_commands:
             logger.warning(
                 "        SKIP kv_cache=%s — command previously failed "
                 "(remove line from %s to retry)",
                 kv_str, failed_path,
             )
             return None
+        if fingerprint in failed_commands and fingerprint in succeeded_commands:
+            logger.info(
+                "        kv_cache=%s — blacklisted but also whitelisted "
+                "(previous success), retrying",
+                kv_str,
+            )
         # Lazy RAM cache: copy model into tmpfs on first real spawn.
         if not _ram_cached and model_cache is not None:
             logger.info("  [RAM cache] Caching %s into tmpfs before first probe...", model)
@@ -699,6 +751,15 @@ def calibrate_model(
                 "        OK kv_cache=%s ready in %.1fs",
                 kv_str, time.perf_counter() - t0,
             )
+            # Record success — whitelist this command for future runs.
+            _record_succeeded_command(succeeded_path, fingerprint)
+            succeeded_commands.add(fingerprint)
+            # Remove from blacklist if it was there (stale entry from e.g.
+            # a previous stuck-GPU session).
+            if fingerprint in failed_commands:
+                _remove_failed_command(failed_path, fingerprint)
+                failed_commands.discard(fingerprint)
+                logger.info("        Removed stale blacklist entry for kv_cache=%s", kv_str)
             return proc
         except (RuntimeError, TimeoutError) as exc:
             log_tail = _read_log_tail(log_path)
@@ -711,6 +772,8 @@ def calibrate_model(
             time.sleep(_VRAM_SETTLE_S)
             _record_failed_command(failed_path, fingerprint)
             failed_commands.add(fingerprint)
+            # Remove stale whitelist entry — this command no longer works.
+            succeeded_commands.discard(fingerprint)
             return None
 
     proc: subprocess.Popen[str] | None = None
@@ -720,101 +783,51 @@ def calibrate_model(
         search_hi = kv_cache_sent_mb       # ceiling (80% of per-GPU VRAM)
         original_ceiling = search_hi
 
-        # Phase 2a: Find the maximum KV cache the model can start with.
-        #
-        # The floor probe can fail for two distinct reasons:
-        #   a) Model weights alone exceed GPU VRAM (truly doesn't fit).
-        #   b) The model's native max_position_embeddings requires more KV
-        #      cache than the floor — vLLM refuses to start because it
-        #      cannot serve even one full-length request in the KV pool.
-        #
-        # When the floor fails, probe the ceiling to distinguish (a)/(b).
-        # If the ceiling also fails (weights + full KV exceeds VRAM), the
-        # working range lies strictly in between — search inward.
-        logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
-        floor_proc = _try_start(search_lo)
-
-        if floor_proc is not None:
-            # Floor works — binary-search upward from floor to ceiling.
-            stop_vllm(floor_proc)
-            time.sleep(_VRAM_SETTLE_S)
-            best_kv = search_lo
-
-            while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
-                mid = _round_up_gb((search_lo + search_hi) / 2.0)
-                if mid <= search_lo:
-                    break
-                proc = _try_start(mid)
-                if proc is not None:
-                    best_kv = mid
-                    stop_vllm(proc)
-                    time.sleep(_VRAM_SETTLE_S)
-                    proc = None
-                    search_lo = mid
-                else:
-                    search_hi = mid - _KV_CACHE_MIN_STEP_MB
-        else:
-            # Floor failed — probe the ceiling before giving up.
+        # Whitelist fast-path: if a previous calibration run found a working
+        # KV size for this model+tp combo, try it directly.  This skips the
+        # entire binary search on restarts / recalibrations, saving minutes.
+        _whitelist_kv_sizes = sorted(
+            (kv for fp in succeeded_commands
+             if model in fp and f"--tensor-parallel-size {tp}" in fp
+             for kv in [_extract_kv_from_fingerprint(fp)]
+             if kv is not None and search_lo <= kv <= search_hi),
+            reverse=True,  # largest first — calibration wants the max
+        )
+        if _whitelist_kv_sizes:
+            _wl_kv = _whitelist_kv_sizes[0]
             logger.info(
-                "        Floor probe failed — probing ceiling kv_cache=%s "
-                "to check if model fits with more KV cache...",
-                _format_kv_mb(search_hi),
+                "        Whitelist fast-path: trying previously successful "
+                "kv_cache=%s...",
+                _format_kv_mb(_wl_kv),
             )
-            ceil_proc = _try_start(search_hi)
-
-            if ceil_proc is not None:
-                # Ceiling works — it is already the maximum.
-                stop_vllm(ceil_proc)
-                time.sleep(_VRAM_SETTLE_S)
-                best_kv = search_hi
-            else:
-                # Both extremes failed.  Floor: KV too small for
-                # max_position_embeddings.  Ceiling: KV + weights exceeds
-                # VRAM.  The working range lies strictly between them.
-                #
-                # Strategy: probe a handful of interior points to find ANY
-                # working KV size, then binary-search upward from there to
-                # find the maximum.
+            _wl_proc = _try_start(_wl_kv)
+            if _wl_proc is not None:
+                # Still works — use it directly, skip the full search.
+                kv_cache_sent_mb = _wl_kv
+                proc = _wl_proc
                 logger.info(
-                    "        Both floor and ceiling failed — searching "
-                    "middle range for a working KV size...",
+                    "  KV cache search result: best_working=%.0f MB "
+                    "(whitelist fast-path, search skipped)",
+                    _wl_kv,
                 )
-                best_kv = None
-                frac_candidates = [0.5, 0.75, 0.25, 0.625, 0.375, 0.875, 0.125]
-                span = original_ceiling - _KV_CACHE_MIN_STEP_MB
-                candidates = []
-                seen: set[float] = set()
-                for frac in frac_candidates:
-                    c = _round_up_gb(_KV_CACHE_MIN_STEP_MB + span * frac)
-                    if c not in seen and _KV_CACHE_MIN_STEP_MB < c < original_ceiling:
-                        candidates.append(c)
-                        seen.add(c)
+                # Jump past the search to the measurement phase.
+            else:
+                logger.info(
+                    "        Whitelist fast-path failed — falling back to "
+                    "full search",
+                )
 
-                for kv in candidates:
-                    logger.info(
-                        "        Trying interior kv_cache=%s...",
-                        _format_kv_mb(kv),
-                    )
-                    p = _try_start(kv)
-                    if p is not None:
-                        best_kv = kv
-                        stop_vllm(p)
-                        time.sleep(_VRAM_SETTLE_S)
-                        break
+        if proc is None:
+            # Full search — whitelist fast-path didn't apply or failed.
+            logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
+            floor_proc = _try_start(search_lo)
 
-                if best_kv is None:
-                    partial.error = (
-                        f"No working KV cache size found between "
-                        f"{_format_kv_mb(_KV_CACHE_MIN_STEP_MB)} and "
-                        f"{_format_kv_mb(original_ceiling)} on tp={tp}. "
-                        f"Model weights likely exceed available GPU VRAM."
-                    )
-                    logger.warning("  ERROR: %s", partial.error)
-                    return partial
+            if floor_proc is not None:
+                # Floor works — binary-search upward from floor to ceiling.
+                stop_vllm(floor_proc)
+                time.sleep(_VRAM_SETTLE_S)
+                best_kv = search_lo
 
-                # Found a working point — binary-search upward for the max.
-                search_lo = best_kv
-                search_hi = original_ceiling
                 while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
                     mid = _round_up_gb((search_lo + search_hi) / 2.0)
                     if mid <= search_lo:
@@ -827,23 +840,116 @@ def calibrate_model(
                         search_lo = mid
                     else:
                         search_hi = mid - _KV_CACHE_MIN_STEP_MB
+            else:
+                # Floor failed — probe the ceiling before giving up.
+                logger.info(
+                    "        Floor probe failed — probing ceiling kv_cache=%s "
+                    "to check if model fits with more KV cache...",
+                    _format_kv_mb(search_hi),
+                )
+                ceil_proc = _try_start(search_hi)
 
-        kv_cache_sent_mb = best_kv
-        logger.info(
-            "  KV cache search result: best_working=%.0f MB (search range exhausted, "
-            "precision=%.0f MB)",
-            best_kv, _KV_CACHE_MIN_STEP_MB,
-        )
+                if ceil_proc is not None:
+                    # Ceiling works — it is already the maximum.
+                    stop_vllm(ceil_proc)
+                    time.sleep(_VRAM_SETTLE_S)
+                    best_kv = search_hi
+                else:
+                    # Both extremes failed.  The working range lies strictly
+                    # between them.  Probe interior points, then binary-search
+                    # upward from the first hit.
+                    logger.info(
+                        "        Both floor and ceiling failed — searching "
+                        "middle range for a working KV size...",
+                    )
+                    best_kv = None
+                    frac_candidates = [0.5, 0.75, 0.25, 0.625, 0.375, 0.875, 0.125]
+                    span = original_ceiling - _KV_CACHE_MIN_STEP_MB
+                    candidates = []
+                    seen: set[float] = set()
+                    for frac in frac_candidates:
+                        c = _round_up_gb(_KV_CACHE_MIN_STEP_MB + span * frac)
+                        if c not in seen and _KV_CACHE_MIN_STEP_MB < c < original_ceiling:
+                            candidates.append(c)
+                            seen.add(c)
 
-        # Start vLLM at the final KV size for measurement
-        proc = _try_start(kv_cache_sent_mb)
-        if proc is None:
-            partial.error = (
-                f"Model failed to start at final KV cache "
-                f"{_format_kv_mb(kv_cache_sent_mb)} on tp={tp}"
+                    for kv in candidates:
+                        logger.info(
+                            "        Trying interior kv_cache=%s...",
+                            _format_kv_mb(kv),
+                        )
+                        p = _try_start(kv)
+                        if p is not None:
+                            best_kv = kv
+                            stop_vllm(p)
+                            time.sleep(_VRAM_SETTLE_S)
+                            break
+
+                    if best_kv is None:
+                        partial.error = (
+                            f"No working KV cache size found between "
+                            f"{_format_kv_mb(_KV_CACHE_MIN_STEP_MB)} and "
+                            f"{_format_kv_mb(original_ceiling)} on tp={tp}. "
+                            f"Model weights likely exceed available GPU VRAM."
+                        )
+                        logger.warning("  ERROR: %s", partial.error)
+                        return partial
+
+                    # Found a working point — binary-search upward for max.
+                    search_lo = best_kv
+                    search_hi = original_ceiling
+                    while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
+                        mid = _round_up_gb((search_lo + search_hi) / 2.0)
+                        if mid <= search_lo:
+                            break
+                        p = _try_start(mid)
+                        if p is not None:
+                            best_kv = mid
+                            stop_vllm(p)
+                            time.sleep(_VRAM_SETTLE_S)
+                            search_lo = mid
+                        else:
+                            search_hi = mid - _KV_CACHE_MIN_STEP_MB
+
+            kv_cache_sent_mb = best_kv
+            logger.info(
+                "  KV cache search result: best_working=%.0f MB "
+                "(search range exhausted, precision=%.0f MB)",
+                best_kv, _KV_CACHE_MIN_STEP_MB,
             )
-            logger.warning("  ERROR: %s", partial.error)
-            return partial
+
+            # Start vLLM at the final KV size for measurement.
+            # Retry with step-down on flaky CUDA failures.
+            _final_kv = kv_cache_sent_mb
+            for _attempt in range(_FINAL_MEASUREMENT_RETRIES):
+                _final_kv_str = _format_kv_mb(_final_kv)
+                _final_planned = {**plan, "kv_cache_memory_bytes": _final_kv_str}
+                _final_fp = _cmd_fingerprint(
+                    _build_vllm_cmd(_final_planned, vllm_binary, host, port, _final_kv_str)
+                )
+                failed_commands.discard(_final_fp)
+                proc = _try_start(_final_kv)
+                if proc is not None:
+                    kv_cache_sent_mb = _final_kv
+                    break
+                logger.warning(
+                    "        Final measurement attempt %d/%d at %s failed — %s",
+                    _attempt + 1, _FINAL_MEASUREMENT_RETRIES,
+                    _format_kv_mb(_final_kv),
+                    "stepping down" if _final_kv > _KV_CACHE_MIN_STEP_MB else "giving up",
+                )
+                _final_kv -= _KV_CACHE_MIN_STEP_MB
+                if _final_kv < _KV_CACHE_MIN_STEP_MB:
+                    break
+
+            if proc is None:
+                partial.error = (
+                    f"Model failed to start for final measurement "
+                    f"(tried down to {_format_kv_mb(_final_kv + _KV_CACHE_MIN_STEP_MB)}) "
+                    f"on tp={tp}"
+                )
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
     else:
         # Fixed KV cache — single attempt
         proc = _try_start(kv_cache_sent_mb)

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -339,8 +339,20 @@ def spawn_vllm(
         env["CUDA_VISIBLE_DEVICES"] = gpu_devices
 
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_file = log_path.open("w", encoding="utf-8")
+    # Append mode — preserves logs from earlier calibration attempts so the
+    # full search history is visible in a single file, not just the last probe.
+    log_file = log_path.open("a", encoding="utf-8")
     try:
+        kv_bytes = str(plan.get("kv_cache_memory_bytes") or kv_cache_memory_bytes)
+        _sep = "=" * 72
+        log_file.write(
+            f"\n{_sep}\n"
+            f"  Calibration probe — {time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"  KV cache: {kv_bytes}  TP: {tp}\n"
+            f"  Command: {' '.join(cmd)}\n"
+            f"{_sep}\n\n"
+        )
+        log_file.flush()
         proc = subprocess.Popen(
             cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT, text=True,
             start_new_session=True,
@@ -390,7 +402,7 @@ def _kill_stale_vllm_workers() -> None:
         time.sleep(_VRAM_SETTLE_S)  # let GPU memory release
 
 
-def _read_log_tail(log_path: Path, max_lines: int = 40) -> str:
+def _read_log_tail(log_path: Path, max_lines: int = 80) -> str:
     """Read the last *max_lines* of a vLLM log file, or '' on failure."""
     try:
         lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -919,6 +931,10 @@ def calibrate_model(
     finally:
         logger.info("  Stopping vLLM...")
         stop_vllm(proc)
+        # Kill any orphaned TP workers left behind by CUDA/NCCL crashes during
+        # the binary search.  Process-group kill handles the happy path, but
+        # crashes can leave detached workers holding GPU memory.
+        _kill_stale_vllm_workers()
         # Let the GPU release memory before the next model
         logger.info("  Waiting %.0fs for GPU memory release...", _VRAM_SETTLE_S)
         time.sleep(_VRAM_SETTLE_S)
@@ -1217,17 +1233,23 @@ def auto_calibrate_models(
             current_plan = {**plan, "tensor_parallel_size": tp}
             result = _try_calibrate(current_plan, **model_cal_kwargs)
 
-        # If even max tp fails, the model cannot run — skip it.
+        # If max tp fails, try the configured (original) tp before giving up.
+        # Models may have attention-head counts that aren't divisible by max_tp
+        # (e.g. 64 heads on 3 GPUs) but work fine at the configured tp.
         _fatal = (
             "does not recognize this architecture" in (result.error or "")
             or "Cannot access gated repo" in (result.error or "")
         )
+        if not result.success and not _fatal and tp > original_tp:
+            logger.info(
+                "  %s failed at max tp=%d — falling back to configured tp=%d",
+                model_name, tp, original_tp,
+            )
+            tp = original_tp
+            current_plan = {**plan, "tensor_parallel_size": tp}
+            result = _try_calibrate(current_plan, **model_cal_kwargs)
+
         if not result.success or _fatal:
-            if tp > original_tp:
-                logger.warning(
-                    "  %s failed even with max tp=%d — skipping",
-                    model_name, tp,
-                )
             results[model_name] = result
             if not result.success:
                 logger.warning(

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -823,7 +823,7 @@ def calibrate_model(
                 "        FAIL kv_cache=%s: %s", kv_str, exc,
             )
             if log_tail:
-                logger.warning("  -- vLLM log tail --\n%s", log_tail)
+                logger.warning("  -- vLLM log tail --\n%s%s%s", _C_DIM, log_tail, _C_RESET)
             stop_vllm(proc)
             time.sleep(_VRAM_SETTLE_S)
             _record_failed_command(failed_path, fingerprint)

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -168,18 +168,6 @@ def _remove_failed_command(failed_path: Path, fingerprint: str) -> None:
         failed_path.write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
 
 
-def _extract_kv_from_fingerprint(fingerprint: str) -> float | None:
-    """Extract the KV cache size in MB from a command fingerprint."""
-    parts = fingerprint.split()
-    for i, tok in enumerate(parts):
-        if tok == "--kv-cache-memory-bytes" and i + 1 < len(parts):
-            try:
-                return _parse_kv_to_mb(parts[i + 1])
-            except (ValueError, IndexError):
-                return None
-    return None
-
-
 # ---------------------------------------------------------------------------
 # GPU VRAM helpers
 # ---------------------------------------------------------------------------
@@ -695,32 +683,44 @@ def calibrate_model(
     # actual vLLM spawn (not on blacklist-skipped probes).
     _ram_cached = hf_home is not None  # already cached if hf_home was passed
 
-    def _try_start(kv_mb: float) -> subprocess.Popen[str] | None:
-        """Try to start vLLM with the given KV cache.  Returns the
-        running process on success, ``None`` on failure (process is
-        cleaned up).  Blacklisted commands are skipped immediately
-        unless they are also whitelisted (previous success overrides)."""
+    # Sentinel returned by _try_start when a whitelisted probe is skipped
+    # (trusted success without spawning).  Callers check ``is _WHITELIST_HIT``
+    # to distinguish from a real running process.
+    _WHITELIST_HIT = object()
+
+    def _try_start(kv_mb: float) -> subprocess.Popen[str] | object | None:
+        """Try to start vLLM with the given KV cache.
+
+        Returns:
+          - A running ``Popen`` on real success.
+          - ``_WHITELIST_HIT`` sentinel if the command is whitelisted
+            (known-good from a previous run) — no process spawned.
+          - ``None`` on failure or blacklist skip.
+        """
         nonlocal hf_home, _ram_cached
         kv_str = _format_kv_mb(kv_mb)
         planned = {**plan, "kv_cache_memory_bytes": kv_str}
         fingerprint = _cmd_fingerprint(
             _build_vllm_cmd(planned, vllm_binary, host, port, kv_str)
         )
-        # Whitelist overrides blacklist: a previously successful command
-        # should be retried even if a later run (e.g. stuck GPU) failed.
-        if fingerprint in failed_commands and fingerprint not in succeeded_commands:
+        # Whitelist: known-good from a previous calibration run.  Trust the
+        # result — skip the expensive vLLM spawn during the binary search.
+        if fingerprint in succeeded_commands:
+            if fingerprint in failed_commands:
+                # Also blacklisted (e.g. stuck-GPU session added it later).
+                # Whitelist wins — clean up the stale blacklist entry.
+                _remove_failed_command(failed_path, fingerprint)
+                failed_commands.discard(fingerprint)
+            logger.info("        OK kv_cache=%s (whitelisted, skipping spawn)", kv_str)
+            return _WHITELIST_HIT
+        # Blacklist: known-bad, skip.
+        if fingerprint in failed_commands:
             logger.warning(
                 "        SKIP kv_cache=%s — command previously failed "
                 "(remove line from %s to retry)",
                 kv_str, failed_path,
             )
             return None
-        if fingerprint in failed_commands and fingerprint in succeeded_commands:
-            logger.info(
-                "        kv_cache=%s — blacklisted but also whitelisted "
-                "(previous success), retrying",
-                kv_str,
-            )
         # Lazy RAM cache: copy model into tmpfs on first real spawn.
         if not _ram_cached and model_cache is not None:
             logger.info("  [RAM cache] Caching %s into tmpfs before first probe...", model)
@@ -783,51 +783,91 @@ def calibrate_model(
         search_hi = kv_cache_sent_mb       # ceiling (80% of per-GPU VRAM)
         original_ceiling = search_hi
 
-        # Whitelist fast-path: if a previous calibration run found a working
-        # KV size for this model+tp combo, try it directly.  This skips the
-        # entire binary search on restarts / recalibrations, saving minutes.
-        _whitelist_kv_sizes = sorted(
-            (kv for fp in succeeded_commands
-             if model in fp and f"--tensor-parallel-size {tp}" in fp
-             for kv in [_extract_kv_from_fingerprint(fp)]
-             if kv is not None and search_lo <= kv <= search_hi),
-            reverse=True,  # largest first — calibration wants the max
-        )
-        if _whitelist_kv_sizes:
-            _wl_kv = _whitelist_kv_sizes[0]
-            logger.info(
-                "        Whitelist fast-path: trying previously successful "
-                "kv_cache=%s...",
-                _format_kv_mb(_wl_kv),
-            )
-            _wl_proc = _try_start(_wl_kv)
-            if _wl_proc is not None:
-                # Still works — use it directly, skip the full search.
-                kv_cache_sent_mb = _wl_kv
-                proc = _wl_proc
-                logger.info(
-                    "  KV cache search result: best_working=%.0f MB "
-                    "(whitelist fast-path, search skipped)",
-                    _wl_kv,
-                )
-                # Jump past the search to the measurement phase.
-            else:
-                logger.info(
-                    "        Whitelist fast-path failed — falling back to "
-                    "full search",
-                )
-
-        if proc is None:
-            # Full search — whitelist fast-path didn't apply or failed.
-            logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
-            floor_proc = _try_start(search_lo)
-
-            if floor_proc is not None:
-                # Floor works — binary-search upward from floor to ceiling.
-                stop_vllm(floor_proc)
+        # Phase 2a: Find the maximum KV cache the model can start with.
+        # Whitelisted probes (known-good from previous runs) are treated as
+        # instant successes by _try_start, so the binary search skips them
+        # instead of wasting minutes re-spawning vLLM.
+        def _stop_if_real(result: object) -> None:
+            """Stop the vLLM process unless it's a whitelist sentinel."""
+            if result is not _WHITELIST_HIT and result is not None:
+                stop_vllm(result)  # type: ignore[arg-type]
                 time.sleep(_VRAM_SETTLE_S)
-                best_kv = search_lo
 
+        logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
+        floor_proc = _try_start(search_lo)
+
+        if floor_proc is not None:
+            # Floor works — binary-search upward from floor to ceiling.
+            _stop_if_real(floor_proc)
+            best_kv = search_lo
+
+            while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
+                mid = _round_up_gb((search_lo + search_hi) / 2.0)
+                if mid <= search_lo:
+                    break
+                p = _try_start(mid)
+                if p is not None:
+                    best_kv = mid
+                    _stop_if_real(p)
+                    search_lo = mid
+                else:
+                    search_hi = mid - _KV_CACHE_MIN_STEP_MB
+        else:
+            # Floor failed — probe the ceiling before giving up.
+            logger.info(
+                "        Floor probe failed — probing ceiling kv_cache=%s "
+                "to check if model fits with more KV cache...",
+                _format_kv_mb(search_hi),
+            )
+            ceil_proc = _try_start(search_hi)
+
+            if ceil_proc is not None:
+                # Ceiling works — it is already the maximum.
+                _stop_if_real(ceil_proc)
+                best_kv = search_hi
+            else:
+                # Both extremes failed.  The working range lies strictly
+                # between them.  Probe interior points, then binary-search
+                # upward from the first hit.
+                logger.info(
+                    "        Both floor and ceiling failed — searching "
+                    "middle range for a working KV size...",
+                )
+                best_kv = None
+                frac_candidates = [0.5, 0.75, 0.25, 0.625, 0.375, 0.875, 0.125]
+                span = original_ceiling - _KV_CACHE_MIN_STEP_MB
+                candidates = []
+                seen: set[float] = set()
+                for frac in frac_candidates:
+                    c = _round_up_gb(_KV_CACHE_MIN_STEP_MB + span * frac)
+                    if c not in seen and _KV_CACHE_MIN_STEP_MB < c < original_ceiling:
+                        candidates.append(c)
+                        seen.add(c)
+
+                for kv in candidates:
+                    logger.info(
+                        "        Trying interior kv_cache=%s...",
+                        _format_kv_mb(kv),
+                    )
+                    p = _try_start(kv)
+                    if p is not None:
+                        best_kv = kv
+                        _stop_if_real(p)
+                        break
+
+                if best_kv is None:
+                    partial.error = (
+                        f"No working KV cache size found between "
+                        f"{_format_kv_mb(_KV_CACHE_MIN_STEP_MB)} and "
+                        f"{_format_kv_mb(original_ceiling)} on tp={tp}. "
+                        f"Model weights likely exceed available GPU VRAM."
+                    )
+                    logger.warning("  ERROR: %s", partial.error)
+                    return partial
+
+                # Found a working point — binary-search upward for max.
+                search_lo = best_kv
+                search_hi = original_ceiling
                 while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
                     mid = _round_up_gb((search_lo + search_hi) / 2.0)
                     if mid <= search_lo:
@@ -835,123 +875,58 @@ def calibrate_model(
                     p = _try_start(mid)
                     if p is not None:
                         best_kv = mid
-                        stop_vllm(p)
-                        time.sleep(_VRAM_SETTLE_S)
+                        _stop_if_real(p)
                         search_lo = mid
                     else:
                         search_hi = mid - _KV_CACHE_MIN_STEP_MB
-            else:
-                # Floor failed — probe the ceiling before giving up.
-                logger.info(
-                    "        Floor probe failed — probing ceiling kv_cache=%s "
-                    "to check if model fits with more KV cache...",
-                    _format_kv_mb(search_hi),
-                )
-                ceil_proc = _try_start(search_hi)
 
-                if ceil_proc is not None:
-                    # Ceiling works — it is already the maximum.
-                    stop_vllm(ceil_proc)
-                    time.sleep(_VRAM_SETTLE_S)
-                    best_kv = search_hi
-                else:
-                    # Both extremes failed.  The working range lies strictly
-                    # between them.  Probe interior points, then binary-search
-                    # upward from the first hit.
-                    logger.info(
-                        "        Both floor and ceiling failed — searching "
-                        "middle range for a working KV size...",
-                    )
-                    best_kv = None
-                    frac_candidates = [0.5, 0.75, 0.25, 0.625, 0.375, 0.875, 0.125]
-                    span = original_ceiling - _KV_CACHE_MIN_STEP_MB
-                    candidates = []
-                    seen: set[float] = set()
-                    for frac in frac_candidates:
-                        c = _round_up_gb(_KV_CACHE_MIN_STEP_MB + span * frac)
-                        if c not in seen and _KV_CACHE_MIN_STEP_MB < c < original_ceiling:
-                            candidates.append(c)
-                            seen.add(c)
+        kv_cache_sent_mb = best_kv
+        logger.info(
+            "  KV cache search result: best_working=%.0f MB "
+            "(search range exhausted, precision=%.0f MB)",
+            best_kv, _KV_CACHE_MIN_STEP_MB,
+        )
 
-                    for kv in candidates:
-                        logger.info(
-                            "        Trying interior kv_cache=%s...",
-                            _format_kv_mb(kv),
-                        )
-                        p = _try_start(kv)
-                        if p is not None:
-                            best_kv = kv
-                            stop_vllm(p)
-                            time.sleep(_VRAM_SETTLE_S)
-                            break
-
-                    if best_kv is None:
-                        partial.error = (
-                            f"No working KV cache size found between "
-                            f"{_format_kv_mb(_KV_CACHE_MIN_STEP_MB)} and "
-                            f"{_format_kv_mb(original_ceiling)} on tp={tp}. "
-                            f"Model weights likely exceed available GPU VRAM."
-                        )
-                        logger.warning("  ERROR: %s", partial.error)
-                        return partial
-
-                    # Found a working point — binary-search upward for max.
-                    search_lo = best_kv
-                    search_hi = original_ceiling
-                    while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
-                        mid = _round_up_gb((search_lo + search_hi) / 2.0)
-                        if mid <= search_lo:
-                            break
-                        p = _try_start(mid)
-                        if p is not None:
-                            best_kv = mid
-                            stop_vllm(p)
-                            time.sleep(_VRAM_SETTLE_S)
-                            search_lo = mid
-                        else:
-                            search_hi = mid - _KV_CACHE_MIN_STEP_MB
-
-            kv_cache_sent_mb = best_kv
-            logger.info(
-                "  KV cache search result: best_working=%.0f MB "
-                "(search range exhausted, precision=%.0f MB)",
-                best_kv, _KV_CACHE_MIN_STEP_MB,
+        # Start vLLM at the final KV size for VRAM measurement.
+        # Must be a real process (not whitelist hit) so we can measure VRAM.
+        # Temporarily suppress whitelist so _try_start spawns for real.
+        _saved_succeeded = set(succeeded_commands)
+        succeeded_commands.clear()
+        _final_kv = kv_cache_sent_mb
+        for _attempt in range(_FINAL_MEASUREMENT_RETRIES):
+            _final_kv_str = _format_kv_mb(_final_kv)
+            _final_planned = {**plan, "kv_cache_memory_bytes": _final_kv_str}
+            _final_fp = _cmd_fingerprint(
+                _build_vllm_cmd(_final_planned, vllm_binary, host, port, _final_kv_str)
             )
+            failed_commands.discard(_final_fp)
+            proc = _try_start(_final_kv)
+            if proc is not None:
+                kv_cache_sent_mb = _final_kv
+                break
+            logger.warning(
+                "        Final measurement attempt %d/%d at %s failed — %s",
+                _attempt + 1, _FINAL_MEASUREMENT_RETRIES,
+                _format_kv_mb(_final_kv),
+                "stepping down" if _final_kv > _KV_CACHE_MIN_STEP_MB else "giving up",
+            )
+            _final_kv -= _KV_CACHE_MIN_STEP_MB
+            if _final_kv < _KV_CACHE_MIN_STEP_MB:
+                break
 
-            # Start vLLM at the final KV size for measurement.
-            # Retry with step-down on flaky CUDA failures.
-            _final_kv = kv_cache_sent_mb
-            for _attempt in range(_FINAL_MEASUREMENT_RETRIES):
-                _final_kv_str = _format_kv_mb(_final_kv)
-                _final_planned = {**plan, "kv_cache_memory_bytes": _final_kv_str}
-                _final_fp = _cmd_fingerprint(
-                    _build_vllm_cmd(_final_planned, vllm_binary, host, port, _final_kv_str)
-                )
-                failed_commands.discard(_final_fp)
-                proc = _try_start(_final_kv)
-                if proc is not None:
-                    kv_cache_sent_mb = _final_kv
-                    break
-                logger.warning(
-                    "        Final measurement attempt %d/%d at %s failed — %s",
-                    _attempt + 1, _FINAL_MEASUREMENT_RETRIES,
-                    _format_kv_mb(_final_kv),
-                    "stepping down" if _final_kv > _KV_CACHE_MIN_STEP_MB else "giving up",
-                )
-                _final_kv -= _KV_CACHE_MIN_STEP_MB
-                if _final_kv < _KV_CACHE_MIN_STEP_MB:
-                    break
+        succeeded_commands.update(_saved_succeeded)
 
-            if proc is None:
-                partial.error = (
-                    f"Model failed to start for final measurement "
-                    f"(tried down to {_format_kv_mb(_final_kv + _KV_CACHE_MIN_STEP_MB)}) "
-                    f"on tp={tp}"
-                )
-                logger.warning("  ERROR: %s", partial.error)
-                return partial
+        if proc is None:
+            partial.error = (
+                f"Model failed to start for final measurement "
+                f"(tried down to {_format_kv_mb(_final_kv + _KV_CACHE_MIN_STEP_MB)}) "
+                f"on tp={tp}"
+            )
+            logger.warning("  ERROR: %s", partial.error)
+            return partial
     else:
-        # Fixed KV cache — single attempt
+        # Fixed KV cache — single attempt (need real process for measurement)
+        succeeded_commands.clear()
         proc = _try_start(kv_cache_sent_mb)
         if proc is None:
             partial.error = (

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -532,6 +532,7 @@ def calibrate_model(
     ready_timeout_s: float,
     nccl_p2p_available: bool = False,
     hf_home: str | None = None,
+    model_cache: Any | None = None,
 ) -> CalibrationResult:
     # Always force eager mode for calibration: CUDA graph capture is not
     # needed for VRAM measurement and can add 10-30 minutes of startup time.
@@ -646,10 +647,15 @@ def calibrate_model(
     failed_path = log_dir / _FAILED_COMMANDS_FILE
     failed_commands = _load_failed_commands(failed_path)
 
+    # Lazy RAM-cache flag: only cache the model into tmpfs on the first
+    # actual vLLM spawn (not on blacklist-skipped probes).
+    _ram_cached = hf_home is not None  # already cached if hf_home was passed
+
     def _try_start(kv_mb: float) -> subprocess.Popen[str] | None:
         """Try to start vLLM with the given KV cache.  Returns the
         running process on success, ``None`` on failure (process is
         cleaned up).  Blacklisted commands are skipped immediately."""
+        nonlocal hf_home, _ram_cached
         kv_str = _format_kv_mb(kv_mb)
         planned = {**plan, "kv_cache_memory_bytes": kv_str}
         # Check the blacklist *before* spawning to avoid wasting time.
@@ -663,6 +669,18 @@ def calibrate_model(
                 kv_str, failed_path,
             )
             return None
+        # Lazy RAM cache: copy model into tmpfs on first real spawn.
+        if not _ram_cached and model_cache is not None:
+            logger.info("  [RAM cache] Caching %s into tmpfs before first probe...", model)
+            _hf = model_cache.ensure_cached_sync(model) or None
+            if _hf:
+                is_tmpfs = hasattr(model_cache, "_cache_hub") and _hf == str(model_cache._cache_hub.parent)
+                if is_tmpfs:
+                    hf_home = _hf
+                    logger.info("  [RAM cache] %s → loading from tmpfs", model)
+                else:
+                    logger.info("  [RAM cache] %s → loading from disk (tmpfs full)", model)
+            _ram_cached = True
         proc, _ = spawn_vllm(
             planned,
             vllm_binary, host, port, log_path,
@@ -1087,6 +1105,7 @@ def _try_calibrate(
     ready_timeout_s: float,
     nccl_p2p_available: bool = False,
     hf_home: str | None = None,
+    model_cache: Any | None = None,
 ) -> CalibrationResult:
     """Call ``calibrate_model`` with exception → failure conversion."""
     model_name = plan["model"]
@@ -1100,6 +1119,7 @@ def _try_calibrate(
             ready_timeout_s=ready_timeout_s,
             nccl_p2p_available=nccl_p2p_available,
             hf_home=hf_home,
+            model_cache=model_cache,
         )
     except Exception as exc:
         logger.warning("Calibration failed for %s: %s", model_name, exc)
@@ -1197,21 +1217,12 @@ def auto_calibrate_models(
         original_tp = int(plan.get("tensor_parallel_size", 1))
         max_tp = _max_tp_for_plan(plan, available_gpus)
 
-        # Cache this model in tmpfs before calibration so vLLM loads from RAM.
-        # Only one model is ever in the cache at a time — evict after calibration.
-        hf_home: str | None = None
-        if model_cache is not None and getattr(model_cache, "enabled", False):
-            logger.info("  [RAM cache] Caching %s into tmpfs before calibration...", model_name)
-            hf_home = model_cache.ensure_cached_sync(model_name) or None
-            if hf_home:
-                is_tmpfs_path = hasattr(model_cache, "_cache_hub") and hf_home == str(model_cache._cache_hub.parent)
-                if is_tmpfs_path:
-                    logger.info("  [RAM cache] %s → loading from tmpfs (calibration will be faster)", model_name)
-                else:
-                    logger.info("  [RAM cache] %s → loading from disk (tmpfs full or model not found)", model_name)
-                    hf_home = None  # don't override HF_HOME if we're not using tmpfs
-
-        model_cal_kwargs = {**cal_kwargs, "hf_home": hf_home}
+        # RAM caching is deferred: calibrate_model triggers it on the first
+        # actual vLLM spawn so we don't waste time copying when all probes are
+        # blacklisted.  Pass the cache object through; it will call
+        # ensure_cached_sync only when needed.
+        _mc = model_cache if (model_cache is not None and getattr(model_cache, "enabled", False)) else None
+        model_cal_kwargs = {**cal_kwargs, "model_cache": _mc}
 
         # ----------------------------------------------------------
         # Strategy: "max-first, then search down"
@@ -1267,9 +1278,6 @@ def auto_calibrate_models(
                     model_name,
                     result.error,
                 )
-            if model_cache is not None and getattr(model_cache, "enabled", False):
-                logger.info("  [RAM cache] Evicting %s from tmpfs (calibration done)", model_name)
-                model_cache.evict(model_name)
             continue
 
         # Max tp succeeded — now binary-search down to find minimum tp.
@@ -1324,10 +1332,6 @@ def auto_calibrate_models(
                 model_name,
                 result.error,
             )
-
-        if model_cache is not None and getattr(model_cache, "enabled", False):
-            logger.info("  [RAM cache] Evicting %s from tmpfs (calibration done, freeing space)", model_name)
-            model_cache.evict(model_name)
 
     ok = [r for r in results.values() if r.success]
     fail = [r for r in results.values() if not r.success]

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1060,11 +1060,21 @@ def plans_from_config(config_path: Path) -> list[dict[str, Any]]:
 
 
 def _max_tp_for_plan(plan: dict[str, Any], available_gpus: int) -> int:
-    """Return the maximum tensor_parallel_size allowed for *plan*."""
+    """Return the maximum tensor_parallel_size allowed for *plan*.
+
+    TP must be a power of 2 for most model architectures (attention heads
+    must be evenly divisible).  Round down to the largest power of 2 that
+    fits within the available GPUs.
+    """
     gpu_devices = str(plan.get("gpu_devices") or "").strip().lower()
     if not gpu_devices or gpu_devices == "all":
-        return available_gpus
-    return len([x for x in gpu_devices.split(",") if x.strip().isdigit()])
+        n = available_gpus
+    else:
+        n = len([x for x in gpu_devices.split(",") if x.strip().isdigit()])
+    # Largest power of 2 ≤ n  (e.g. 3 → 2, 5 → 4, 7 → 4, 8 → 8)
+    if n < 1:
+        return 1
+    return 1 << (n.bit_length() - 1)
 
 
 def _try_calibrate(

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -65,6 +65,62 @@ _FAILED_COMMANDS_FILE = "calibration_failed_commands.txt"
 _SUCCEEDED_COMMANDS_FILE = "calibration_succeeded_commands.txt"
 
 # ---------------------------------------------------------------------------
+# ANSI colours for calibration search visualisation
+# ---------------------------------------------------------------------------
+
+_C_RESET = "\033[0m"
+_C_GREEN = "\033[32m"       # success / best
+_C_RED = "\033[31m"         # failure
+_C_YELLOW = "\033[33m"      # blacklisted (skipped)
+_C_CYAN = "\033[36m"        # whitelisted (instant OK)
+_C_DIM = "\033[2m"          # untested
+_C_BOLD = "\033[1m"
+_C_GREEN_BG = "\033[42;30m"  # best marker
+
+
+def _render_search_bar(
+    floor_mb: float,
+    ceiling_mb: float,
+    step_mb: float,
+    probes: dict[float, str],  # kv_mb → "ok" | "fail" | "skip" | "whitelist" | "best"
+    best_kv: float | None = None,
+) -> str:
+    """Render a coloured ASCII bar showing the KV cache search state.
+
+    Example output::
+
+      1G [··✗··✓··✓·✗★·✗··✗···] 38G   best=18G
+           ↑fail  ↑ok      ↑best
+    """
+    slots: list[float] = []
+    kv = floor_mb
+    while kv <= ceiling_mb:
+        slots.append(kv)
+        kv += step_mb
+
+    bar_chars: list[str] = []
+    for s in slots:
+        status = probes.get(s)
+        if best_kv is not None and s == best_kv:
+            bar_chars.append(f"{_C_GREEN_BG}★{_C_RESET}")
+        elif status == "ok" or status == "whitelist":
+            c = _C_CYAN if status == "whitelist" else _C_GREEN
+            bar_chars.append(f"{c}✓{_C_RESET}")
+        elif status == "fail":
+            bar_chars.append(f"{_C_RED}✗{_C_RESET}")
+        elif status == "skip":
+            bar_chars.append(f"{_C_YELLOW}─{_C_RESET}")
+        else:
+            bar_chars.append(f"{_C_DIM}·{_C_RESET}")
+
+    bar = "".join(bar_chars)
+    lo_label = _format_kv_mb(floor_mb)
+    hi_label = _format_kv_mb(ceiling_mb)
+    best_label = f"  best={_C_BOLD}{_C_GREEN}{_format_kv_mb(best_kv)}{_C_RESET}" if best_kv else ""
+    return f"  {lo_label} [{bar}] {hi_label}{best_label}"
+
+
+# ---------------------------------------------------------------------------
 # KV-cache size parsing
 # ---------------------------------------------------------------------------
 
@@ -716,10 +772,10 @@ def calibrate_model(
         # Blacklist: known-bad, skip.
         if fingerprint in failed_commands:
             logger.warning(
-                "        SKIP kv_cache=%s — command previously failed "
-                "(remove line from %s to retry)",
-                kv_str, failed_path,
+                "        SKIP kv_cache=%s — blacklisted",
+                kv_str,
             )
+            _probes[kv_mb] = "skip"
             return None
         # Lazy RAM cache: copy model into tmpfs on first real spawn.
         if not _ram_cached and model_cache is not None:
@@ -783,18 +839,45 @@ def calibrate_model(
         search_hi = kv_cache_sent_mb       # ceiling (80% of per-GPU VRAM)
         original_ceiling = search_hi
 
-        # Phase 2a: Find the maximum KV cache the model can start with.
-        # Whitelisted probes (known-good from previous runs) are treated as
-        # instant successes by _try_start, so the binary search skips them
-        # instead of wasting minutes re-spawning vLLM.
+        # Track probe results for the visual search bar.
+        # Key: kv_mb, Value: "ok" | "fail" | "skip" | "whitelist"
+        _probes: dict[float, str] = {}
+        _best_kv_viz: float | None = None
+
         def _stop_if_real(result: object) -> None:
             """Stop the vLLM process unless it's a whitelist sentinel."""
             if result is not _WHITELIST_HIT and result is not None:
                 stop_vllm(result)  # type: ignore[arg-type]
                 time.sleep(_VRAM_SETTLE_S)
 
+        def _record_probe(kv_mb: float, result: object) -> None:
+            """Record probe result and log the visual search bar."""
+            nonlocal _best_kv_viz
+            if result is _WHITELIST_HIT:
+                _probes[kv_mb] = "whitelist"
+            elif result is not None:
+                _probes[kv_mb] = "ok"
+            elif kv_mb in _probes:
+                pass  # already recorded (e.g. blacklist skip)
+            else:
+                _probes[kv_mb] = "fail"
+            if result is not None:
+                _best_kv_viz = max(_best_kv_viz or 0, kv_mb)
+            bar = _render_search_bar(
+                _KV_CACHE_MIN_STEP_MB, original_ceiling, _KV_CACHE_MIN_STEP_MB,
+                _probes, _best_kv_viz,
+            )
+            logger.info(bar)
+
+        logger.info(
+            "  Legend: %s✓%s=ok  %s✗%s=fail  %s─%s=blacklisted  "
+            "%s✓%s=whitelisted  %s★%s=best  %s·%s=untested",
+            _C_GREEN, _C_RESET, _C_RED, _C_RESET, _C_YELLOW, _C_RESET,
+            _C_CYAN, _C_RESET, _C_GREEN_BG, _C_RESET, _C_DIM, _C_RESET,
+        )
         logger.info("        Probing floor kv_cache=%s...", _format_kv_mb(search_lo))
         floor_proc = _try_start(search_lo)
+        _record_probe(search_lo, floor_proc)
 
         if floor_proc is not None:
             # Floor works — binary-search upward from floor to ceiling.
@@ -806,6 +889,7 @@ def calibrate_model(
                 if mid <= search_lo:
                     break
                 p = _try_start(mid)
+                _record_probe(mid, p)
                 if p is not None:
                     best_kv = mid
                     _stop_if_real(p)
@@ -815,24 +899,19 @@ def calibrate_model(
         else:
             # Floor failed — probe the ceiling before giving up.
             logger.info(
-                "        Floor probe failed — probing ceiling kv_cache=%s "
-                "to check if model fits with more KV cache...",
+                "        Floor probe failed — probing ceiling kv_cache=%s...",
                 _format_kv_mb(search_hi),
             )
             ceil_proc = _try_start(search_hi)
+            _record_probe(search_hi, ceil_proc)
 
             if ceil_proc is not None:
                 # Ceiling works — it is already the maximum.
                 _stop_if_real(ceil_proc)
                 best_kv = search_hi
             else:
-                # Both extremes failed.  The working range lies strictly
-                # between them.  Probe interior points, then binary-search
-                # upward from the first hit.
-                logger.info(
-                    "        Both floor and ceiling failed — searching "
-                    "middle range for a working KV size...",
-                )
+                # Both extremes failed — search interior points.
+                logger.info("        Both extremes failed — searching middle range...")
                 best_kv = None
                 frac_candidates = [0.5, 0.75, 0.25, 0.625, 0.375, 0.875, 0.125]
                 span = original_ceiling - _KV_CACHE_MIN_STEP_MB
@@ -845,11 +924,8 @@ def calibrate_model(
                         seen.add(c)
 
                 for kv in candidates:
-                    logger.info(
-                        "        Trying interior kv_cache=%s...",
-                        _format_kv_mb(kv),
-                    )
                     p = _try_start(kv)
+                    _record_probe(kv, p)
                     if p is not None:
                         best_kv = kv
                         _stop_if_real(p)
@@ -873,6 +949,7 @@ def calibrate_model(
                     if mid <= search_lo:
                         break
                     p = _try_start(mid)
+                    _record_probe(mid, p)
                     if p is not None:
                         best_kv = mid
                         _stop_if_real(p)
@@ -882,9 +959,18 @@ def calibrate_model(
 
         kv_cache_sent_mb = best_kv
         logger.info(
-            "  KV cache search result: best_working=%.0f MB "
-            "(search range exhausted, precision=%.0f MB)",
-            best_kv, _KV_CACHE_MIN_STEP_MB,
+            "  KV cache search result: %s%sbest_working=%s%s "
+            "(precision=%.0f MB)",
+            _C_BOLD, _C_GREEN, _format_kv_mb(best_kv), _C_RESET,
+            _KV_CACHE_MIN_STEP_MB,
+        )
+        # Final search bar
+        _best_kv_viz = best_kv
+        logger.info(
+            _render_search_bar(
+                _KV_CACHE_MIN_STEP_MB, original_ceiling, _KV_CACHE_MIN_STEP_MB,
+                _probes, _best_kv_viz,
+            )
         )
 
         # Start vLLM at the final KV size for VRAM measurement.

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -463,6 +463,12 @@ class LaneManager:
             if lane_id not in self._handles:
                 raise KeyError(f"Lane '{lane_id}' not found")
             await self._remove_lane_unlocked(lane_id)
+            # Refresh GPU snapshot immediately after the process exits so the next
+            # status heartbeat to logos-server carries accurate free-VRAM numbers.
+            # Without this the server-side planner would see phantom VRAM (lanes=0
+            # but VRAM still reported as occupied) for up to the poll interval.
+            if self._gpu_force_poll is not None:
+                await self._gpu_force_poll()
             prom.LANE_TRANSITIONS_TOTAL.labels(action="delete").inc()
 
     async def reconfigure_lane(self, lane_id: str, updates: dict[str, Any]) -> LaneStatus:

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -41,6 +41,7 @@ _HANDLE_DESTROY_TIMEOUT = 45
 _HANDLE_CLOSE_TIMEOUT = 10
 _GPU_PLACEMENT_HEADROOM_RATIO = 0.10
 _GPU_PLACEMENT_MIN_HEADROOM_MB = 1024.0
+_CRASH_RESTART_COOLDOWN_S = 30.0
 
 
 class PortAllocator:
@@ -238,6 +239,7 @@ class LaneManager:
         self._stuck_polls: dict[str, int] = {}  # consecutive polls with no progress
         _STUCK_POLL_THRESHOLD = 6  # ~30s at 5s heartbeat
         self._stuck_poll_threshold = _STUCK_POLL_THRESHOLD
+        self._last_crash_restart_attempt_at: dict[str, float] = {}
 
     def validate_capabilities(self, capabilities_models: list[str]) -> list[str]:
         """Check which capabilities_models are available locally.
@@ -618,7 +620,54 @@ class LaneManager:
             statuses.append(status)
             self._record_profile_from_status(status)
         await self._check_stuck_lanes(statuses)
+        await self._recover_dead_lanes(statuses)
         return statuses
+
+    async def _recover_dead_lanes(self, statuses: list[LaneStatus]) -> None:
+        """Best-effort restart for lanes whose process died unexpectedly.
+
+        Keep this outside the status lock path and apply a cooldown so repeated
+        startup failures don't thrash the host.
+        """
+        now = asyncio.get_running_loop().time()
+        for status in statuses:
+            if status.runtime_state not in {"stopped", "error"}:
+                continue
+            lane_config = status.lane_config
+            if lane_config is None:
+                continue
+            lid = status.lane_id
+            last_attempt = self._last_crash_restart_attempt_at.get(lid, 0.0)
+            if now - last_attempt < _CRASH_RESTART_COOLDOWN_S:
+                continue
+
+            self._last_crash_restart_attempt_at[lid] = now
+            self._record_event(
+                lid,
+                "crash_restart_attempt",
+                model=lane_config.model,
+                details=f"runtime_state={status.runtime_state}",
+                port=status.port,
+            )
+            logger.warning(
+                "Lane '%s' process is %s; attempting automatic restart",
+                lid,
+                status.runtime_state,
+            )
+            try:
+                async with self._lock:
+                    handle = self._handles.get(lid)
+                    if handle is None:
+                        continue
+                    current = handle.status()
+                    if current.state not in {ProcessState.STOPPED, ProcessState.ERROR}:
+                        continue
+                    current_lc = handle.lane_config or lane_config
+                    await self._restart_lane_unlocked(lid, current_lc)
+                self._record_event(lid, "crash_restart_ok", model=current_lc.model, port=status.port)
+            except Exception:
+                logger.error("Lane '%s' automatic crash recovery failed", lid, exc_info=True)
+                self._record_event(lid, "crash_restart_failed", model=lane_config.model, port=status.port)
 
     async def get_lane_status(self, lane_id: str) -> LaneStatus:
         async with self._lock:
@@ -1138,8 +1187,12 @@ class LaneManager:
             except Exception:
                 pass
             await new_handle.close()
-            # Lane is now dead — remove it from handles so it doesn't linger
+            # Lane is now dead — remove it from handles and release all
+            # bookkeeping so the dead lane is not reported as active.
             self._handles.pop(lane_id, None)
+            self._port_alloc.release(lane_id)
+            self._active_requests.pop(lane_id, None)
+            self._starting_deadlines.pop(lane_id, None)
             raise
 
         # Success

--- a/logos/logos-workernode/logos_worker_node/model_cache.py
+++ b/logos/logos-workernode/logos_worker_node/model_cache.py
@@ -367,18 +367,25 @@ class ModelRamCache:
         try:
             rsync_available = shutil.which("rsync") is not None
             if rsync_available:
-                proc = await asyncio.create_subprocess_exec(
-                    "rsync", "-aL", "--delete",
+                progress_cmd = [
+                    "rsync", "-aL", "--delete", "--info=progress2",
                     str(src) + "/", str(partial) + "/",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                _stdout, stderr = await proc.communicate()
-                if proc.returncode != 0:
+                ]
+                rc, tail = await self._run_rsync_with_feedback(progress_cmd, model_name, t0)
+                if rc != 0:
+                    logger.warning(
+                        "rsync copy with progress flags failed for %s; retrying without progress flags",
+                        model_name,
+                    )
+                    shutil.rmtree(partial, ignore_errors=True)
+                    fallback_cmd = ["rsync", "-aL", "--delete", str(src) + "/", str(partial) + "/"]
+                    rc, tail = await self._run_rsync_with_feedback(fallback_cmd, model_name, t0)
+                if rc != 0:
                     logger.error(
                         "rsync failed for %s (rc=%d): %s",
-                        model_name, proc.returncode,
-                        stderr.decode(errors="replace")[:500],
+                        model_name,
+                        rc,
+                        tail[:500],
                     )
                     shutil.rmtree(partial, ignore_errors=True)
                     return False
@@ -410,6 +417,65 @@ class ModelRamCache:
             size_mb / elapsed if elapsed > 0 else 0,
         )
         return True
+
+    async def _run_rsync_with_feedback(self, cmd: list[str], model_name: str, started_at: float) -> tuple[int, str]:
+        """Run rsync command while emitting periodic feedback and collecting output tail."""
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        log_interval_s = 30.0
+        last_progress_line = ""
+        output_tail: list[str] = []
+
+        async def _drain_output() -> None:
+            nonlocal last_progress_line
+            if proc.stdout is None:
+                return
+            buffer = ""
+            while True:
+                chunk = await proc.stdout.read(4096)
+                if not chunk:
+                    break
+                buffer += chunk.decode(errors="replace")
+                buffer = buffer.replace("\r", "\n")
+                parts = buffer.split("\n")
+                buffer = parts.pop() if parts else ""
+                for raw in parts:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    output_tail.append(line)
+                    if len(output_tail) > 20:
+                        output_tail.pop(0)
+                    last_progress_line = line
+            trailing = buffer.strip()
+            if trailing:
+                output_tail.append(trailing)
+                if len(output_tail) > 20:
+                    output_tail.pop(0)
+                last_progress_line = trailing
+
+        drain_task = asyncio.create_task(_drain_output())
+        while True:
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=log_interval_s)
+                break
+            except TimeoutError:
+                elapsed_s = time.monotonic() - started_at
+                if last_progress_line:
+                    logger.info("  [RAM cache] %s — %s", model_name, last_progress_line)
+                else:
+                    logger.info(
+                        "  [RAM cache] %s — copy in progress (%.1fs elapsed)",
+                        model_name,
+                        elapsed_s,
+                    )
+
+        await drain_task
+        return proc.returncode or 0, " | ".join(output_tail[-3:])
 
     def _is_stale(self, src: Path, cached: Path) -> bool:
         """Check if source is newer than cached copy by comparing mtimes."""

--- a/logos/logos-workernode/logos_worker_node/model_cache.py
+++ b/logos/logos-workernode/logos_worker_node/model_cache.py
@@ -212,22 +212,35 @@ class ModelRamCache:
         size_mb = self.model_size_bytes(model_name) / (1024 * 1024)
         t0 = time.monotonic()
         logger.info(
-            "Copying %s into RAM cache (%.0f MB) [sync] ...",
-            model_name, size_mb,
+            "Copying %s into RAM cache (%.0f MB, %s -> %s)",
+            model_name, size_mb, src, partial,
         )
 
         try:
             rsync_available = shutil.which("rsync") is not None
             if rsync_available:
-                result = subprocess.run(  # noqa: S603
-                    ["rsync", "-aL", "--delete", str(src) + "/", str(partial) + "/"],
-                    capture_output=True, text=True,
+                proc = subprocess.Popen(  # noqa: S603
+                    ["rsync", "-aL", "--delete", "--info=progress2", "--no-inc-recursive",
+                     str(src) + "/", str(partial) + "/"],
+                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
                 )
-                if result.returncode != 0:
+                _last_log = time.monotonic()
+                _LOG_INTERVAL = 30.0  # log progress every 30s
+                for line in proc.stdout or []:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    now = time.monotonic()
+                    if now - _last_log >= _LOG_INTERVAL:
+                        # rsync --info=progress2 emits lines like:
+                        #   1,234,567,890  42%  123.45MB/s  0:01:23
+                        logger.info("  [RAM cache] %s — %s", model_name, line)
+                        _last_log = now
+                proc.wait()
+                if proc.returncode != 0:
                     logger.error(
-                        "rsync failed for %s (rc=%d): %s",
-                        model_name, result.returncode,
-                        (result.stderr or "")[:500],
+                        "rsync failed for %s (rc=%d)",
+                        model_name, proc.returncode,
                     )
                     shutil.rmtree(partial, ignore_errors=True)
                     return False

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 
 _GPU_DEVICE_LIST_PATTERN = re.compile(r"^\d+(,\d+)*$")
+_DEFAULT_LANE_CONTEXT_LENGTH = 4096
 
 
 def _normalize_gpu_devices(raw: str) -> str:
@@ -236,7 +237,7 @@ class LaneConfig(BaseModel):
     model: str
     vllm: bool = False
     num_parallel: int = Field(default=4, ge=1)
-    context_length: int = Field(default=4096, ge=128)
+    context_length: int = Field(default=_DEFAULT_LANE_CONTEXT_LENGTH, ge=128)
     keep_alive: str = "5m"
     kv_cache_type: str = "q8_0"
     flash_attention: bool = True

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -38,6 +38,7 @@ from logos_worker_node.models import (
     ProcessState,
     ProcessStatus,
     VllmEngineConfig,
+    _DEFAULT_LANE_CONTEXT_LENGTH,
 )
 
 logger = logging.getLogger("logos_worker_node.vllm_process")
@@ -46,7 +47,6 @@ _READY_TIMEOUT = 300  # vLLM startup can be slow (model download + compilation)
 _STOP_TIMEOUT = 15
 _STARTUP_LOG_TAIL_LINES = 8
 _STARTUP_LOG_TAIL_MAX_CHARS = 1200
-_DEFAULT_LANE_CONTEXT_LENGTH = 4096
 _SCRUBBED_ENV_VARS = (
     "LOCAL_RANK",
     "RANK",

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -46,6 +46,7 @@ _READY_TIMEOUT = 300  # vLLM startup can be slow (model download + compilation)
 _STOP_TIMEOUT = 15
 _STARTUP_LOG_TAIL_LINES = 8
 _STARTUP_LOG_TAIL_MAX_CHARS = 1200
+_DEFAULT_LANE_CONTEXT_LENGTH = 4096
 _SCRUBBED_ENV_VARS = (
     "LOCAL_RANK",
     "RANK",
@@ -455,7 +456,10 @@ class VllmProcessHandle:
         # prevents the model weights from loading at all.
         if vc.max_model_len > 0:
             cmd.extend(["--max-model-len", str(vc.max_model_len)])
-        elif lane_config.context_length > 0:
+        # For vLLM lanes, context_length defaults to 4096 from shared lane
+        # schema. Treat that sentinel default as "unset" so vLLM can use the
+        # model's native maximum context unless an explicit override is given.
+        elif lane_config.context_length > 0 and lane_config.context_length != _DEFAULT_LANE_CONTEXT_LENGTH:
             cmd.extend(["--max-model-len", str(lane_config.context_length)])
         if vc.kv_cache_memory_bytes:
             cmd.extend(["--kv-cache-memory-bytes", vc.kv_cache_memory_bytes])

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -493,10 +493,18 @@ def test_auto_calibrate_no_escalation_when_already_max_tp(tmp_path):
 
 
 def test_max_tp_for_plan():
+    # Power-of-2 rounding: 4 GPUs → tp=4, 3 GPUs → tp=2, 5 → 4, 7 → 4
     assert _max_tp_for_plan({"model": "x"}, available_gpus=4) == 4
+    assert _max_tp_for_plan({"model": "x"}, available_gpus=3) == 2
+    assert _max_tp_for_plan({"model": "x"}, available_gpus=5) == 4
+    assert _max_tp_for_plan({"model": "x"}, available_gpus=7) == 4
+    assert _max_tp_for_plan({"model": "x"}, available_gpus=8) == 8
+    assert _max_tp_for_plan({"model": "x"}, available_gpus=1) == 1
     assert _max_tp_for_plan({"model": "x", "gpu_devices": "0,1"}, available_gpus=4) == 2
+    assert _max_tp_for_plan({"model": "x", "gpu_devices": "0,1,2"}, available_gpus=4) == 2
     assert _max_tp_for_plan({"model": "x", "gpu_devices": "0"}, available_gpus=4) == 1
     assert _max_tp_for_plan({"model": "x", "gpu_devices": "all"}, available_gpus=4) == 4
+    assert _max_tp_for_plan({"model": "x", "gpu_devices": "all"}, available_gpus=3) == 2
     assert _max_tp_for_plan({"model": "x", "gpu_devices": ""}, available_gpus=4) == 4
 
 

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -402,8 +402,8 @@ def test_auto_calibrate_models_continues_on_failure(tmp_path):
             ["model-a", "model-b"], config_path, state_dir,
         )
 
-    # model-a: tp=1 fail + tp=2 fail = 2 calls, model-b: tp=1 success = 1 call
-    assert mock_cm.call_count == 3
+    # model-a: tp=2 fail + tp=1 fallback fail = 2, model-b: tp=2 ok + tp=1 search = 2
+    assert mock_cm.call_count == 4
     assert not results["model-a"].success
     assert results["model-b"].success
     # Only model-b should have a persisted profile

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -663,9 +663,19 @@ def _patch_calibration_infra(
         "logos_worker_node.calibration._kill_stale_vllm_workers"
     )
 
-    # _load_failed_commands → always empty (no cross-test contamination)
+    # _load_failed_commands / _load_succeeded_commands → always empty
+    # (no cross-test contamination)
     patches["load_failed"] = patch(
         "logos_worker_node.calibration._load_failed_commands", return_value=set()
+    )
+    patches["load_succeeded"] = patch(
+        "logos_worker_node.calibration._load_succeeded_commands", return_value=set()
+    )
+    patches["record_succeeded"] = patch(
+        "logos_worker_node.calibration._record_succeeded_command"
+    )
+    patches["remove_failed"] = patch(
+        "logos_worker_node.calibration._remove_failed_command"
     )
 
     return patches
@@ -859,9 +869,19 @@ def _patch_search_infra(
         "logos_worker_node.calibration._kill_stale_vllm_workers"
     )
 
-    # _load_failed_commands → always empty (no cross-test contamination)
+    # _load_failed_commands / _load_succeeded_commands → always empty
+    # (no cross-test contamination)
     patches["load_failed"] = patch(
         "logos_worker_node.calibration._load_failed_commands", return_value=set()
+    )
+    patches["load_succeeded"] = patch(
+        "logos_worker_node.calibration._load_succeeded_commands", return_value=set()
+    )
+    patches["record_succeeded"] = patch(
+        "logos_worker_node.calibration._record_succeeded_command"
+    )
+    patches["remove_failed"] = patch(
+        "logos_worker_node.calibration._remove_failed_command"
     )
 
     return patches

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -757,9 +757,11 @@ async def test_stuck_lane_is_automatically_restarted(monkeypatch) -> None:
             return ProcessStatus(state=ProcessState.STOPPED, pid=12345, return_code=0)
 
         async def destroy(self) -> None:
+            await asyncio.sleep(0)
             call_log.append("destroy")
 
         async def close(self) -> None:
+            await asyncio.sleep(0)
             call_log.append("close")
 
     class FakeNewHandle:
@@ -769,9 +771,11 @@ async def test_stuck_lane_is_automatically_restarted(monkeypatch) -> None:
             self.lane_config = None
 
         async def init(self) -> None:
+            await asyncio.sleep(0)
             call_log.append("init")
 
         async def spawn(self, lc: LaneConfig) -> ProcessStatus:
+            await asyncio.sleep(0)
             self.lane_config = lc
             call_log.append("spawn")
             return ProcessStatus(state=ProcessState.RUNNING, pid=99999)
@@ -911,6 +915,77 @@ async def test_stuck_restart_failure_does_not_crash(monkeypatch) -> None:
 
     # Lane should have been removed from handles (restart_lane_unlocked pops on failure)
     assert lane_id not in manager._handles  # noqa: SLF001
+    assert manager._port_alloc.get_port(lane_id) is None
+    assert lane_id not in manager._active_requests  # noqa: SLF001
+    assert lane_id not in manager._starting_deadlines  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_recover_dead_lanes_restarts_stopped_lane(monkeypatch) -> None:
+    lane_id = "planner-Qwen_Qwen3-Embedding-8B"
+    lane_config = LaneConfig(
+        lane_id=lane_id,
+        model="Qwen/Qwen3-Embedding-8B",
+        vllm=True,
+        vllm_config=VllmConfig(),
+    )
+    manager = LaneManager(OllamaConfig(), lane_port_start=15000, lane_port_end=15010)
+    call_log: list[str] = []
+
+    class DeadHandle:
+        def __init__(self) -> None:
+            self.lane_id = lane_id
+            self.port = 15000
+            self.lane_config = lane_config
+
+        def status(self) -> ProcessStatus:
+            return ProcessStatus(state=ProcessState.STOPPED, pid=12345, return_code=1)
+
+        async def destroy(self) -> None:
+            call_log.append("destroy")
+
+        async def close(self) -> None:
+            call_log.append("close")
+
+    class NewHandle:
+        def __init__(self, lid: str, port: int) -> None:
+            self.lane_id = lid
+            self.port = port
+            self.lane_config = None
+
+        async def init(self) -> None:
+            call_log.append("init")
+
+        async def spawn(self, lc: LaneConfig) -> ProcessStatus:
+            self.lane_config = lc
+            call_log.append("spawn")
+            return ProcessStatus(state=ProcessState.RUNNING, pid=99999)
+
+    manager._handles[lane_id] = DeadHandle()  # noqa: SLF001
+    manager._port_alloc._used[lane_id] = 15000  # noqa: SLF001
+
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> NewHandle:
+        return NewHandle(lid, port)
+
+    monkeypatch.setattr("logos_worker_node.lane_manager._create_handle", _fake_create_handle)
+
+    status = LaneStatus(
+        lane_id=lane_id,
+        lane_uid=f"vllm:{lane_id}",
+        model=lane_config.model,
+        port=15000,
+        vllm=True,
+        process=ProcessStatus(state=ProcessState.STOPPED, pid=12345, return_code=1),
+        runtime_state="stopped",
+        lane_config=lane_config,
+    )
+
+    await manager._recover_dead_lanes([status])  # noqa: SLF001
+
+    assert "destroy" in call_log
+    assert "init" in call_log
+    assert "spawn" in call_log
+    assert manager._handles[lane_id].lane_config == lane_config  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -170,6 +170,35 @@ def test_build_cmd_omits_kv_cache_when_empty(monkeypatch) -> None:
     assert "--kv-cache-memory-bytes" not in cmd
 
 
+def test_build_cmd_omits_default_lane_context_cap_for_vllm(monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-Coder-7B-Instruct",
+        vllm=True,
+        context_length=4096,
+        vllm_config=VllmConfig(max_model_len=0),
+    )
+    cmd = handle._build_cmd(lane)
+    assert "--max-model-len" not in cmd
+
+
+def test_build_cmd_keeps_explicit_lane_context_cap_for_vllm(monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-Coder-7B-Instruct",
+        vllm=True,
+        context_length=8192,
+        vllm_config=VllmConfig(max_model_len=0),
+    )
+    cmd = handle._build_cmd(lane)
+    idx = cmd.index("--max-model-len")
+    assert cmd[idx + 1] == "8192"
+
+
 def test_vllm_config_kv_cache_validation() -> None:
     import pytest
 

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -1929,6 +1929,10 @@ class CapacityPlanner:
             reason="Request-time lane preparation",
         )
 
+        # Tracks when we first detected phantom VRAM (lanes=0, VRAM still occupied
+        # by a recently-killed process whose CUDA context hasn't been freed yet).
+        _phantom_wait_started: Optional[float] = None
+
         while True:
             capacity = self._safe_get_capacity(provider_id)
             if capacity is None:
@@ -2037,14 +2041,47 @@ class CapacityPlanner:
                 )
                 return True
 
+            lanes_now = self._safe_get_lanes(provider_id)
             reclaim = self._next_request_reclaim_action(
                 provider_id=provider_id,
                 target=target,
-                lanes=self._safe_get_lanes(provider_id),
+                lanes=lanes_now,
                 profiles=self._safe_get_profiles(provider_id),
                 required_free_mb=shortfall,
             )
             if reclaim is None:
+                # Phantom-VRAM path: no lanes exist but VRAM is still occupied by
+                # a recently-killed process whose CUDA context hasn't been released
+                # by the driver yet.  Wait up to 60 s for the driver to free memory
+                # before giving up — the worker will re-report fresh VRAM numbers
+                # on each heartbeat cycle.
+                total_vram = float(getattr(capacity, "total_vram_mb", 0) or 0)
+                phantom_mb = total_vram - available
+                if (
+                    not lanes_now
+                    and total_vram > 0
+                    and phantom_mb > needed * 0.5
+                ):
+                    if _phantom_wait_started is None:
+                        _phantom_wait_started = time.monotonic()
+                        logger.info(
+                            "ensure_capacity provider=%s model=%s: "
+                            "phantom VRAM detected (%.0f MB occupied, 0 lanes) — "
+                            "waiting up to 60 s for CUDA driver to release contexts",
+                            provider_id, target.model_name, phantom_mb,
+                        )
+                    elapsed = time.monotonic() - _phantom_wait_started
+                    if elapsed < 60.0:
+                        await asyncio.sleep(2.0)
+                        capacity = self._safe_get_capacity(provider_id)
+                        if capacity is None:
+                            return False
+                        continue
+                    logger.info(
+                        "ensure_capacity provider=%s model=%s: "
+                        "phantom VRAM still present after %.0f s — giving up",
+                        provider_id, target.model_name, elapsed,
+                    )
                 logger.info(
                     "No idle reclaim action available for provider=%s model=%s "
                     "(need=%.0fMB available=%.0fMB committed=%.0fMB)",

--- a/logos/src/logos/pipeline/base_scheduler.py
+++ b/logos/src/logos/pipeline/base_scheduler.py
@@ -56,6 +56,7 @@ class BaseScheduler(SchedulerInterface):
             priority = Priority.from_int(priority_int)
             queue_state = self._queue_mgr.get_state(model_id, provider_id)
             queue_depth = queue_state.total
+            tracking_started = False
 
             try:
                 status = self._logosnode.get_model_status(model_id, provider_id)
@@ -65,14 +66,24 @@ class BaseScheduler(SchedulerInterface):
                 utilization = 0.0
                 is_cold_start = True
 
-            self._logosnode.on_request_start(
-                request_id,
-                model_id=model_id,
-                provider_id=provider_id,
-                priority=priority.name.lower(),
-            )
+            try:
+                self._logosnode.on_request_start(
+                    request_id,
+                    model_id=model_id,
+                    provider_id=provider_id,
+                    priority=priority.name.lower(),
+                )
+                tracking_started = True
+            except (KeyError, ValueError) as exc:
+                logger.warning(
+                    "Skipping logosnode request tracking for model=%s provider=%s request=%s: %s",
+                    model_id,
+                    provider_id,
+                    request_id,
+                    exc,
+                )
 
-            if not was_queued:
+            if tracking_started and not was_queued:
                 try:
                     self._logosnode.on_request_begin_processing(
                         request_id,

--- a/logos/tests/unit/pipeline/test_correcting_scheduler.py
+++ b/logos/tests/unit/pipeline/test_correcting_scheduler.py
@@ -74,6 +74,7 @@ class MockLogosNodeFacade:
         self._views = {}  # (model_id, provider_id) -> ModelSchedulerView
         self._reserve_results = {}  # (model_id, provider_id) -> bool
         self._tracking = {}
+        self.raise_on_request_start = False
 
     def set_view(self, model_id, provider_id, view):
         self._views[(model_id, provider_id)] = view
@@ -101,9 +102,12 @@ class MockLogosNodeFacade:
         return self._reserve_results.get((model_id, provider_id), True)
 
     def on_request_start(self, request_id, **kwargs):
+        if self.raise_on_request_start:
+            raise ValueError("Model not registered")
         self._tracking[request_id] = {"started": True, **kwargs}
 
     def on_request_begin_processing(self, request_id, **kwargs):
+        # No-op in tests: scheduling assertions do not require processing bookkeeping.
         pass
 
     def on_request_complete(self, request_id, **kwargs):
@@ -129,6 +133,7 @@ class MockAzureFacade:
         return mock
 
     def update_model_rate_limits(self, model_id, provider_id, headers):
+        # No-op in tests: scheduler selection logic does not mutate Azure rate state.
         pass
 
 
@@ -258,7 +263,7 @@ async def test_no_view_treated_as_cold():
     # Model is now COLD (penalty=20), not UNAVAILABLE — it can be scheduled
     assert result is not None
     assert result.ettft_tier == "cold"
-    assert result.ettft_estimate_ms == 45000.0
+    assert result.ettft_estimate_ms == pytest.approx(45000.0)
 
 
 # ---------------------------------------------------------------------------
@@ -316,7 +321,7 @@ async def test_ettft_fields_in_result():
 
     result = await scheduler.schedule(request)
     assert result is not None
-    assert result.ettft_estimate_ms == 150.0  # 0.15s * 1000
+    assert result.ettft_estimate_ms == pytest.approx(150.0)  # 0.15s * 1000
     assert result.ettft_tier == "warm"
 
 
@@ -396,3 +401,23 @@ async def test_sleeping_beats_cold():
     assert result is not None
     assert result.model_id == 1
     assert result.ettft_tier == "sleeping"
+
+
+@pytest.mark.asyncio
+async def test_transient_tracking_failure_does_not_break_scheduling():
+    """Registration races in on_request_start should not fail scheduling."""
+    logosnode = MockLogosNodeFacade()
+    logosnode.set_view(1, 10, _make_view(model_id=1, provider_id=10, best_lane_state="cold", is_loaded=False))
+    logosnode.set_reserve(1, 10, True)
+    logosnode.raise_on_request_start = True
+
+    scheduler = _make_scheduler(logosnode=logosnode, ettft_enabled=True)
+
+    candidates = [(1, 12.0, 1, 4)]
+    deployments = [{"model_id": 1, "provider_id": 10, "type": "logosnode"}]
+    request = _make_request(candidates, deployments)
+
+    result = await scheduler.schedule(request)
+    assert result is not None
+    assert result.model_id == 1
+    assert result.ettft_tier == "cold"

--- a/logos/tests/unit/sdi/test_ollama_facade.py
+++ b/logos/tests/unit/sdi/test_ollama_facade.py
@@ -107,6 +107,25 @@ def test_logosnode_runtime_parallel_capacity_overrides_static_config(monkeypatch
     assert provider.try_reserve_capacity(101, "req-5") is False
 
 
+def test_logosnode_try_reserve_allows_unregistered_model_for_cold_start(monkeypatch):
+    queue_mgr = PriorityQueueManager()
+    facade = LogosNodeSchedulingDataFacade(queue_mgr)
+
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._load_provider_config",
+        lambda self: {},
+    )
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._fetch_ps_data",
+        lambda self: {"models": []},
+    )
+
+    facade.register_model(101, "logosnode", "http://fake", "llama3.1:latest", 65536, provider_id=12)
+    provider = facade._providers[12]
+
+    assert provider.try_reserve_capacity(999, "req-unknown") is True
+
+
 def test_logosnode_capacity_uses_runtime_free_memory_when_nvidia_metrics_present(monkeypatch):
     class _FakeRegistry:
         @staticmethod


### PR DESCRIPTION
## Summary
- **Calibration logs**: switch from overwrite (`"w"`) to append (`"a"`) mode with timestamped separators — the full binary search history is now preserved in a single file per model, not just the last probe
- **TP fallback**: when `max_tp` (all GPUs) fails during calibration, fall back to the configured `tensor_parallel_size` before giving up — fixes models whose attention-head count is not divisible by the GPU count (e.g. `openai/gpt-oss-120b` with 64 heads on 3 GPUs on deioma)
- **Post-calibration GPU cleanup**: call `_kill_stale_vllm_workers()` after each `calibrate_model()` to kill orphaned TP workers left behind by CUDA/NCCL crashes during the binary search — prevents dirty GPU state from blocking subsequent lane startup
- **Log tail**: increased from 40 to 80 lines for better error visibility in workernode logs

## Context
- On **deioma**: calibration escalated tp from 2→3 (3 GPUs), but `64 % 3 != 0` caused immediate vLLM validation failure, then gave up without trying the configured tp=2
- On **deimama**: repeated CUDA/NCCL crash-restart cycles during KV cache search left GPU 0 in a stuck state (100% util, 0 processes); GPU needs host reboot + blacklist clear

## Test plan
- [x] All 44 calibration tests pass
- [ ] Deploy to deioma — verify `openai/gpt-oss-120b` calibrates at tp=2
- [ ] Reboot deimama, clear blacklist, verify calibration completes with full log history
- [ ] Verify calibration log file shows all probes (not just the last one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker cleanup after calibration failures to prevent orphaned processes.
  * Fixed whitelist/blacklist interactions so skipped probes don't trigger caching or leave stale state.

* **Improvements**
  * Calibration logging appends probe headers and preserves more recent output.
  * Lazy on-demand model caching with streamed copy progress and periodic logs.
  * Parallel-device sizing now rounds down to nearest power-of-two.
  * Capacity checks wait briefly for transient "phantom" VRAM.
  * Recovery cooldowns and cleanup for lane restarts; scheduler tolerates transient tracking errors.
  * Default context-length treated as an unset sentinel for command construction.

* **New Features**
  * Visual search/progress bar and per-probe outcome tracking during calibration.

* **Tests**
  * Expanded tests for calibration retries/fallbacks, TP sizing, lane recovery, vLLM arg behavior, and scheduling resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->