### PR TITLE
`Athena`: Pin Docker build base image in module_text_cofee

### DIFF
--- a/athena/modules/text/module_text_cofee/Dockerfile
+++ b/athena/modules/text/module_text_cofee/Dockerfile
@@ -3,7 +3,7 @@
 # This is the Dockerfile for the module_text_cofee.
 
 # Protobuf build
-FROM golang:alpine AS cofee_protobuf
+FROM golang:alpine3.22 AS cofee_protobuf
 RUN apk update && apk add --no-cache make protobuf-dev
 WORKDIR /proto
 COPY cofee.proto .

--- a/athena/modules/text/module_text_cofee/pyproject.toml
+++ b/athena/modules/text/module_text_cofee/pyproject.toml
@@ -10,7 +10,7 @@ python = "3.11.*"
 # if you have local changes in the common Athena module, use the line below. Otherwise, please use a VCS stable version. Also, a version with tag = "" is possible.
 athena = { path = "../../../athena", develop = true }
 # athena = { git = "https://github.com/ls1intum/Athena.git", rev = "bbb2bb0", subdirectory = "athena" }
-protobuf = "5.29.5" # requires libprotobuf >= 5.29 (provided by alpine protobuf-dev)
+protobuf = "5.29.5" # if this version is updated, you also need to update the used base image (golang:alpine3.22) in the Dockerfile
 requests = "2.32.5"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the docker image of `athena_module_text_cofee` does not work due to this error:
`google.protobuf.runtime_version.VersionError: Detected mismatched Protobuf Gencode/Runtime major versions when loading cofee.proto: gencode 6.31.1 runtime 5.29.5. Same major version is required. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.`

### Description
<!-- Describe your changes in detail -->
This PR pins the used build base image in the Dockerfile, so it contains the same protobuf version as in pyproject.yaml

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image to a more specific Alpine version for improved consistency.
  * Pinned protobuf dependency to a specific version to ensure build stability and alignment with Docker base image requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/552)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->