### PR TITLE
`General`: Switch version scheme from `major.minor.patch` to `major.patch` (bump to `2.2`)

### DIFF
--- a/athena/assessment_module_manager/pyproject.toml
+++ b/athena/assessment_module_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "assessment-module-manager"
-version = "2.0.0"
+version = "2.2"
 description = "The interface between the Athena modules and external systems. It manages, which modules will be used for incoming submissions and feedback."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/athena/pyproject.toml
+++ b/athena/athena/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athena"
-version = "2.0.0"
+version = "2.2"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/docs/package-lock.json
+++ b/athena/docs/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "athena-docs",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "athena-docs",
+      "version": "2.2",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/athena/docs/package-lock.json
+++ b/athena/docs/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "athena-docs",
-  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "athena-docs",
-      "version": "1.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/athena/docs/package.json
+++ b/athena/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "athena-docs",
-  "version": "1.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/athena/docs/package.json
+++ b/athena/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "athena-docs",
+  "version": "2.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/athena/evaluation/pyproject.toml
+++ b/athena/evaluation/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evaluation"
-version = "2.0.0"
+version = "2.2"
 description = ""
 authors = ["Dominik Remo <47261058+DominikRemo@users.noreply.github.com>"]
 package-mode = false

--- a/athena/llm_core/pyproject.toml
+++ b/athena/llm_core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llm_core"
-version = "2.0.0"
+version = "2.2"
 description = "SHared LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/log_viewer/pyproject.toml
+++ b/athena/log_viewer/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "log-viewer"
-version = "2.0.0"
+version = "2.2"
 description = "Shows the logs of the assessment module manager and all modules in a web interface."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/modeling/module_modeling_llm/pyproject.toml
+++ b/athena/modules/modeling/module_modeling_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_modeling_llm"
-version = "2.0.0"
+version = "2.2"
 description = "Modeling assessment LLM module."
 authors = ["Matthias Lehner <ga59bip@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_example/pyproject.toml
+++ b/athena/modules/programming/module_example/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_example"
-version = "2.0.0"
+version = "2.2"
 description = "An example module to demonstrate how to create new modules for Athena."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_apted/pyproject.toml
+++ b/athena/modules/programming/module_programming_apted/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_apted"
-version = "2.0.0"
+version = "2.2"
 description = "Programming assessment AP-TED module."
 authors = ["Marlon Bucciarelli <marlon.bucciarelli@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_llm/pyproject.toml
+++ b/athena/modules/programming/module_programming_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_llm"
-version = "2.0.0"
+version = "2.2"
 description = "Programming assessment LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_quality_llm/pyproject.toml
+++ b/athena/modules/programming/module_programming_quality_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_quality_llm"
-version = "2.0.0"
+version = "2.2"
 description = "Programming quality LLM module."
 authors = ["Aniruddh Zaveri <aniruddh.zaveri@tum.de>", "Konrad Weiß <konrad2002.weiss@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_themisml/pyproject.toml
+++ b/athena/modules/programming/module_programming_themisml/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_themisml"
-version = "2.0.0"
+version = "2.2"
 description = "A module generating feedback suggestions somewhat similar to CoFee, but for programming submissions and by using CodeBERT."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_winnowing/pyproject.toml
+++ b/athena/modules/programming/module_programming_winnowing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_winnowing"
-version = "2.0.0"
+version = "2.2"
 description = "Programming assessment Winnowing module."
 authors = ["Marlon Bucciarelli <marlon.bucciarelli@tum.de>"]
 license = "MIT"

--- a/athena/modules/text/module_text_cofee/pyproject.toml
+++ b/athena/modules/text/module_text_cofee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_text_cofee"
-version = "2.0.0"
+version = "2.2"
 description = "An adapter to the original [Athena](https://github.com/ls1intum/Athena), an implementation of CoFee (text exercise assessment)."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/text/module_text_llm/pyproject.toml
+++ b/athena/modules/text/module_text_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_text_llm"
-version = "2.0.0"
+version = "2.2"
 description = "Text assessment LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/playground/package-lock.json
+++ b/athena/playground/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "playground",
-  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playground",
-      "version": "0.1.0",
       "dependencies": {
         "@blueprintjs/core": "5.5.1",
         "@fortawesome/fontawesome-svg-core": "6.6.0",
@@ -419,7 +417,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
       "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -475,7 +472,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
       "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -609,7 +605,6 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
       "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.6.0"
       },
@@ -1309,7 +1304,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1545,7 +1539,6 @@
       "version": "5.13.2",
       "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.13.2.tgz",
       "integrity": "sha512-iluvCOQDwZkp66RRZdIV3TgJnI+I2xv7Ks+UVqjO9lG8U9ygoWuH85zGPAojqapJUuC+frVRZsEBsTwGegDWIw==",
-      "peer": true,
       "dependencies": {
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
@@ -1785,7 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
       "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1797,7 +1789,6 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2027,7 +2018,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2740,7 +2730,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3360,7 +3349,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3882,7 +3870,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4035,7 +4022,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
       "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.findlastindex": "^1.2.2",
@@ -6665,8 +6651,7 @@
     "node_modules/monaco-editor": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
-      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
-      "peer": true
+      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -7285,7 +7270,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -7483,7 +7467,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7524,7 +7507,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8502,7 +8484,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.7.tgz",
       "integrity": "sha512-pjgQxDZPvyS/nG3ZYkyCvsbONJl7GdOejfm24iMt2ElYQQw8Jc4p0m8RdMp7mznPD0kUhfzwV3zAwa80qI0zmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8822,7 +8803,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/athena/playground/package-lock.json
+++ b/athena/playground/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "playground",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playground",
+      "version": "2.2",
       "dependencies": {
         "@blueprintjs/core": "5.5.1",
         "@fortawesome/fontawesome-svg-core": "6.6.0",

--- a/athena/playground/package.json
+++ b/athena/playground/package.json
@@ -1,6 +1,5 @@
 {
   "name": "playground",
-  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/athena/playground/package.json
+++ b/athena/playground/package.json
@@ -1,5 +1,6 @@
 {
   "name": "playground",
+  "version": "2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/athena/pyproject.toml
+++ b/athena/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Athena"
-version = "2.0.0"
+version = "2.2"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 package-mode = true

--- a/athena/tests/pyproject.toml
+++ b/athena/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athena-tests"
-version = "2.0.0"
+version = "2.2"
 description = "Testing environment for the Athena project, orchestrating tests for all modules."
 license = "MIT"
 package-mode = false

--- a/atlas/AtlasMl/pyproject.toml
+++ b/atlas/AtlasMl/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atlasml"
-version = "2.0.0"
+version = "2.2"
 description = ""
 authors = ["Maximilian Anzinger <anzinger@cit.tum.de>"]
 readme = "README.md"

--- a/atlas/docs/package-lock.json
+++ b/atlas/docs/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "docs-new",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs-new",
+      "version": "2.2",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/atlas/docs/package-lock.json
+++ b/atlas/docs/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "docs-new",
-  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs-new",
-      "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/atlas/docs/package.json
+++ b/atlas/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "docs-new",
+  "version": "2.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/atlas/docs/package.json
+++ b/atlas/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "docs-new",
-  "version": "0.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/iris/docs/package-lock.json
+++ b/iris/docs/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "iris-docs",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-docs",
+      "version": "2.2",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/iris/docs/package-lock.json
+++ b/iris/docs/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "iris-docs",
-  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-docs",
-      "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
@@ -4932,9 +4930,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4950,9 +4945,6 @@
       "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4970,9 +4962,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4988,9 +4977,6 @@
       "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/iris/docs/package.json
+++ b/iris/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "iris-docs",
+  "version": "2.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/iris/docs/package.json
+++ b/iris/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "iris-docs",
-  "version": "0.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/iris/poetry.lock
+++ b/iris/poetry.lock
@@ -2215,7 +2215,7 @@ files = [
 
 [[package]]
 name = "memiris"
-version = "2.0.0"
+version = "2.2"
 description = ""
 optional = false
 python-versions = ">=3.13,<4.0.0"

--- a/iris/pyproject.toml
+++ b/iris/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iris"
-version = "2.0.0"
+version = "2.2"
 description = "An LLM microservice for the learning platform Artemis"
 authors = ["Timor Morrien <timor.morrien@tum.de>", "Patrick Bassner <patrick.bassner@tum.de>"]
 readme = "README.md"

--- a/logos/logos-landing/package-lock.json
+++ b/logos/logos-landing/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "logos-ui",
-  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logos-ui",
-      "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-navigation/bottom-tabs": "^7.3.10",

--- a/logos/logos-landing/package-lock.json
+++ b/logos/logos-landing/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "logos-ui",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logos-ui",
+      "version": "2.2",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-navigation/bottom-tabs": "^7.3.10",

--- a/logos/logos-landing/package.json
+++ b/logos/logos-landing/package.json
@@ -1,5 +1,6 @@
 {
   "name": "logos-ui",
+  "version": "2.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/logos/logos-landing/package.json
+++ b/logos/logos-landing/package.json
@@ -1,7 +1,6 @@
 {
   "name": "logos-ui",
   "main": "expo-router/entry",
-  "version": "1.0.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/logos/logos-ui/package-lock.json
+++ b/logos/logos-ui/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "logos-ui",
+  "version": "2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logos-ui",
+      "version": "2.2",
       "dependencies": {
         "@expo/html-elements": "^0.12.5",
         "@expo/vector-icons": "^15.0.3",

--- a/logos/logos-ui/package-lock.json
+++ b/logos/logos-ui/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "logos-ui",
-  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logos-ui",
-      "version": "1.0.0",
       "dependencies": {
         "@expo/html-elements": "^0.12.5",
         "@expo/vector-icons": "^15.0.3",
@@ -2384,9 +2382,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2406,9 +2401,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2430,9 +2422,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2452,9 +2441,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/logos/logos-ui/package.json
+++ b/logos/logos-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "logos-ui",
+  "version": "2.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/logos/logos-ui/package.json
+++ b/logos/logos-ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "logos-ui",
   "main": "expo-router/entry",
-  "version": "1.0.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/logos/pyproject.toml
+++ b/logos/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logos"
-version = "2.0.0"
+version = "2.2"
 description = "Logos is an LLM Engineering Platform that includes usage logging, billing, central resouce management, policy-based model selection, scheduling, and monitoring."
 authors = [
     {name = "Tobias Wasner",email = "tobias.wasner@tum.de"},

--- a/logos/src/logos/sdi/__init__.py
+++ b/logos/src/logos/sdi/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "RequestMetrics",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.2"

--- a/memiris/pyproject.toml
+++ b/memiris/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "memiris"
-version = "2.0.0"
+version = "2.2"
 description = ""
 authors = ["Timor Morrien <timor.morrien@tum.de>"]
 readme = "README.MD"

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shared"
-version = "2.0.0"
+version = "2.2"
 description = "Shared python library for EduTelligence"
 authors = [
     { name = "Felix T.J. Dietrich", email = "felixtj.dietrich@tum.de" },


### PR DESCRIPTION
## Summary
Adopts a two-part version scheme (`X.Y`) across the monorepo, aligned with the new Artemis convention. All 21 `pyproject.toml` files and `logos/src/logos/sdi/__init__.py` move from `2.0.0` directly to `2.2`. The retro release [`v2.1.0`](https://github.com/ls1intum/edutelligence/releases/tag/v2.1.0) was just published to mark the state shipped alongside Artemis 9.1.

Three-part hotfix versions (`X.Y.Z` where `Z ≥ 1`) remain valid as exceptions — Poetry 2.2.1 / poetry-core 2.2.1 accept both forms cleanly (empirically verified).

## What's in this PR

- **21 `pyproject.toml`** — `version = "2.0.0"` → `version = "2.2"` across iris, memiris, logos, shared, atlas/AtlasMl, athena, and all athena submodules (athena/athena, athena/llm_core, athena/log_viewer, athena/tests, athena/evaluation, athena/assessment_module_manager, athena/modules/modeling/module_modeling_llm, athena/modules/programming/{module_example,module_programming_apted,module_programming_llm,module_programming_quality_llm,module_programming_themisml,module_programming_winnowing}, athena/modules/text/{module_text_cofee,module_text_llm}).
- **`logos/src/logos/sdi/__init__.py:20`** — `__version__ = "2.0.0"` → `"2.2"`.
- **6 docs/UI `package.json` files** — `version` field deleted (all are `"private": true` and unpublished; matches the precedent set in Artemis). Affected: `atlas/docs`, `athena/playground`, `athena/docs`, `iris/docs`, `logos/logos-landing`, `logos/logos-ui`.
- **6 corresponding `package-lock.json` files** — stale top-level `"version"` field stripped (npm leaves it after `package.json` loses the field; this avoids permanent drift).
- **`iris/poetry.lock`** — refreshed for the `memiris` internal-dep version change.

## Test Plan
- [x] All 35 modified files staged explicitly (no `git add -A`).
- [x] Each `package.json` re-validated as parseable JSON after edits.
- [x] `pre-commit run --from-ref origin/main --to-ref HEAD` passes: `iris Passed`, `athena Passed`, `memiris Passed`.
- [x] No project-version `2.0.0` strings remain in the tree (verified with `git grep '"version".*"2\\.0\\.0"'` — only transitive third-party deps in lockfiles and one Apollon schema-version check in `athena/modules/.../schema_converter.py`).
- [ ] Docker images build successfully for iris, logos, atlas, and athena under the new version string (CI will exercise this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions from 2.0.0 to 2.2 across the platform.
  * Removed version fields from select package manifests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/554)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->