### PR TITLE
`Athena`: Improve logging messages to include users AI preference

### DIFF
--- a/athena/modules/modeling/module_modeling_llm/module_modeling_llm/__main__.py
+++ b/athena/modules/modeling/module_modeling_llm/module_modeling_llm/__main__.py
@@ -6,6 +6,7 @@ import tiktoken
 from athena import app, submission_selector, submissions_consumer, feedback_consumer, feedback_provider
 from athena.logger import logger
 from athena.modeling import Exercise, Feedback, Submission
+from athena.schemas import AiSelectionDecision
 from module_modeling_llm.config import Configuration
 from module_modeling_llm.core.filter_feedback import filter_feedback
 from module_modeling_llm.core.generate_suggestions import generate_suggestions
@@ -32,9 +33,19 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-async def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool, module_config: Configuration) -> List[Feedback]:
-    logger.info("suggest_feedback: Suggestions for submission %d of exercise %d were requested", submission.id,
-                exercise.id)
+async def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool,
+    module_config: Configuration,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     
     # First, we convert the incoming exercise and submission to our internal models and textual representations
     exercise_model = get_exercise_model(exercise, submission)

--- a/athena/modules/programming/module_example/module_example/__main__.py
+++ b/athena/modules/programming/module_example/module_example/__main__.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from athena import app, config_schema_provider, submissions_consumer, submission_selector, feedback_consumer, feedback_provider, evaluation_provider, emit_meta
 from athena.programming import Exercise, Submission, Feedback
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from athena.storage import store_exercise, store_submissions, store_feedback
 
 
@@ -70,8 +71,18 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-def suggest_feedback(exercise: Exercise, submission: Submission, module_config: Configuration) -> List[Feedback]:
-    logger.info("suggest_feedback: Suggestions for submission %d of exercise %d were requested", submission.id, exercise.id)
+def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    module_config: Configuration,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     # Do something with the submission and return a list of feedback
 
     # Example use of module config

--- a/athena/modules/programming/module_programming_apted/module_programming_apted/__main__.py
+++ b/athena/modules/programming/module_programming_apted/module_programming_apted/__main__.py
@@ -9,6 +9,7 @@ from module_programming_apted.feedback_suggestions.feedback_suggestions import c
 from athena import (app, config_schema_provider, submissions_consumer, submission_selector, feedback_consumer,
                     feedback_provider, evaluation_provider, emit_meta)
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from athena.storage import store_exercise, store_submissions, store_feedback, store_feedback_suggestions
 from athena.programming import (Exercise, Submission, Feedback, get_stored_feedback_suggestions,
                                 count_stored_submissions, get_stored_submissions)
@@ -121,9 +122,17 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-def suggest_feedback(exercise: Exercise, submission: Submission) -> List[Feedback]:
-    logger.info("suggest_feedback: Suggestions for submission %d of exercise %d were requested", submission.id,
-                exercise.id)
+def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     # Do something with the submission and return a list of feedback
     # ThemisML currently only works with Java
     if exercise.programming_language.lower() != "java" or exercise.programming_language.lower() != "python":

--- a/athena/modules/programming/module_programming_llm/module_programming_llm/__main__.py
+++ b/athena/modules/programming/module_programming_llm/module_programming_llm/__main__.py
@@ -11,6 +11,7 @@ from athena import (
 )
 from athena.programming import Exercise, Submission, Feedback
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from module_programming_llm.config import Configuration
 
 from module_programming_llm.generate_graded_suggestions_by_file import (
@@ -38,9 +39,20 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-async def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool, module_config: Configuration) -> List[Feedback]:
-    logger.info("suggest_feedback: %s suggestions for submission %d of exercise %d were requested",
-                "Graded" if is_graded else "Non-graded", submission.id, exercise.id)
+async def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool,
+    module_config: Configuration,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: %s suggestions for submission %d of exercise %d were requested, with selection: %s",
+        "Graded" if is_graded else "Non-graded",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     if is_graded:
         return await generate_graded_suggestions_by_file(exercise, submission, module_config.graded_approach,
                                                          module_config.debug)

--- a/athena/modules/programming/module_programming_quality_llm/module_programming_quality_llm/__main__.py
+++ b/athena/modules/programming/module_programming_quality_llm/module_programming_quality_llm/__main__.py
@@ -11,6 +11,7 @@ from athena import (
 )
 from athena.programming import Exercise, Submission, Feedback
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from module_programming_quality_llm.config import Configuration
 
 from module_programming_quality_llm.generate_graded_suggestions_by_file import (
@@ -42,9 +43,20 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-async def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool, module_config: Configuration) -> List[Feedback]:
-    logger.info("suggest_feedback: %s suggestions for submission %d of exercise %d were requested",
-                "Graded" if is_graded else "Non-graded", submission.id, exercise.id)
+async def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool,
+    module_config: Configuration,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: %s suggestions for submission %d of exercise %d were requested, with selection: %s",
+        "Graded" if is_graded else "Non-graded",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     if is_graded:
         return await generate_graded_suggestions_by_file(exercise, submission, module_config.graded_approach,
                                                          module_config.debug)

--- a/athena/modules/programming/module_programming_themisml/module_programming_themisml/__main__.py
+++ b/athena/modules/programming/module_programming_themisml/module_programming_themisml/__main__.py
@@ -6,6 +6,7 @@ from typing import List, cast
 from athena import app, submissions_consumer, submission_selector, feedback_consumer, feedback_provider
 from athena.programming import Exercise, Submission, Feedback, get_stored_feedback_suggestions, get_stored_submissions, count_stored_submissions
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from athena.storage import store_feedback
 from athena.storage.feedback_storage import store_feedback_suggestions
 
@@ -81,8 +82,18 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-async def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool = True) -> List[Feedback]:
-    logger.info("suggest_feedback: Suggestions for submission %d of exercise %d were requested", submission.id, exercise.id)
+async def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool = True,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
 
     # ThemisML currently only works with Java
     if exercise.programming_language.lower() != "java":

--- a/athena/modules/programming/module_programming_winnowing/module_programming_winnowing/__main__.py
+++ b/athena/modules/programming/module_programming_winnowing/module_programming_winnowing/__main__.py
@@ -9,6 +9,7 @@ from athena import app, config_schema_provider, submissions_consumer, submission
 from athena.programming import Exercise, Submission, Feedback, get_stored_feedback_suggestions, \
     count_stored_submissions, get_stored_submissions
 from athena.logger import logger
+from athena.schemas import AiSelectionDecision
 from athena.storage import store_exercise, store_submissions, store_feedback, store_feedback_suggestions
 from module_programming_winnowing.convert_code_to_ast.get_feedback_methods import get_feedback_method
 from module_programming_winnowing.feedback_suggestions.feedback_suggestions import create_feedback_suggestions
@@ -120,9 +121,19 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
     logger.debug("Feedbacks processed")
 
 @feedback_provider
-def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool, module_config: Configuration) -> List[Feedback]:
-    logger.info("suggest_feedback: Suggestions for submission %d of exercise %d were requested", submission.id,
-                exercise.id)
+def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool,
+    module_config: Configuration,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
+    logger.info(
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
+    )
     # Do something with the submission and return a list of feedback
     # ThemisML currently only works with Java
     if exercise.programming_language.lower() not in ["java", "python"]:

--- a/athena/modules/text/module_text_cofee/module_text_cofee/__main__.py
+++ b/athena/modules/text/module_text_cofee/module_text_cofee/__main__.py
@@ -5,6 +5,7 @@ from typing import List
 
 from athena import app, submission_selector, submissions_consumer, feedback_consumer, feedback_provider
 from athena.storage import store_feedback
+from athena.schemas import AiSelectionDecision
 from athena.text import Exercise, Submission, Feedback, TextLanguageEnum
 from athena.logger import logger
 
@@ -45,10 +46,17 @@ def process_incoming_feedback(exercise: Exercise, submission: Submission, feedba
 
 
 @feedback_provider
-def suggest_feedback(exercise: Exercise, submission: Submission, is_graded: bool = True) -> List[Feedback]:
+def suggest_feedback(
+    exercise: Exercise,
+    submission: Submission,
+    is_graded: bool = True,
+    selection: AiSelectionDecision | None = None,
+) -> List[Feedback]:
     logger.info(
-        "suggest_feedback: Suggestions for submission %d of exercise %d were requested",
-        submission.id, exercise.id
+        "suggest_feedback: Suggestions for submission %d of exercise %d were requested, with selection: %s",
+        submission.id,
+        exercise.id,
+        selection.value if selection is not None else "None",
     )
     suggestions = suggest_feedback_for_submission(submission)
     logger.info("suggest_feedback: Returning %d suggestions", len(suggestions))

--- a/athena/modules/text/module_text_llm/module_text_llm/__main__.py
+++ b/athena/modules/text/module_text_llm/module_text_llm/__main__.py
@@ -13,7 +13,7 @@ from athena import (
 )
 from athena.text import Exercise, Submission, Feedback
 from athena.logger import logger
-from athena.schemas import LearnerProfile, Competency
+from athena.schemas import AiSelectionDecision, LearnerProfile, Competency
 
 from module_text_llm.config import Configuration
 from module_text_llm.evaluation import get_feedback_statistics, get_llm_statistics
@@ -62,13 +62,15 @@ async def suggest_feedback(
     learner_profile: Optional[LearnerProfile] = None,
     latest_submission: Optional[Submission] = None,
     competencies: Optional[List[Competency]] = None,
+    selection: Optional[AiSelectionDecision] = None,
 ) -> List[Feedback]:
     logger.info(
-        "suggest_feedback: %s suggestions for submission %d of exercise %d were requested, with approach: %s",
+        "suggest_feedback: %s suggestions for submission %d of exercise %d were requested, with approach: %s, selection: %s",
         "Graded" if is_graded else "Non-graded",
         submission.id,
         exercise.id,
         module_config.approach.__class__.__name__,
+        selection.value if selection is not None else "None",
     )
     return await generate_suggestions(
         exercise=exercise,


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the received AI_selection preference is not logged so it is hard to debug issues related to this flag.

### Description
<!-- Describe your changes in detail -->
This PR logs the received AI_Selection preference so it simplifies debugging.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated feedback modules across modeling, programming, and text variants to support optional tracking of AI selection decisions during feedback generation.
  * Enhanced logging now includes AI selection information when processing feedback suggestions.

* **Refactoring**
  * Standardized feedback processing interfaces across modules for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/556)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->