### PR TITLE
`Iris`: Make health-check baseline variant configurable per pipeline

### DIFF
--- a/iris/src/iris/pipeline/pipeline.py
+++ b/iris/src/iris/pipeline/pipeline.py
@@ -43,6 +43,11 @@ class Pipeline(metaclass=ABCMeta):
     ROLES: ClassVar[set[str]] = set()
     VARIANT_DEFS: ClassVar[list[tuple[str, str, str]]] = []
     DEPENDENCIES: ClassVar[list[Dep]] = []
+    # Variant id the health checker treats as the baseline smoke test. Most
+    # pipelines have a literal "default" variant; pipelines whose variants are
+    # content-orthogonal (e.g. faq vs problem_statement in RewritingPipeline)
+    # override this to pick one of their existing variants.
+    HEALTH_BASELINE_VARIANT_ID: ClassVar[str] = "default"
 
     implementation_id: str
     tokens: List[TokenUsageDTO]

--- a/iris/src/iris/pipeline/rewriting_pipeline.py
+++ b/iris/src/iris/pipeline/rewriting_pipeline.py
@@ -51,6 +51,7 @@ class RewritingPipeline(Pipeline):
             "Default Problem statement rewriting variant.",
         ),
     ]
+    HEALTH_BASELINE_VARIANT_ID = "problem_statement"
 
     callback: RewritingCallback
     rewriting_handler: LlmRequestHandler

--- a/iris/src/iris/web/routers/health/Pipelines/checker.py
+++ b/iris/src/iris/web/routers/health/Pipelines/checker.py
@@ -10,16 +10,19 @@ from iris.web.routers.health.Pipelines.features import Features
 from iris.web.routers.health.Pipelines.registery import PIPELINE_BY_FEATURE
 
 
-def _get_default_variant(variants: Iterable) -> AbstractVariant | None:
-    variants = list(variants)
-    return next((v for v in variants if getattr(v, "id", None) == "default"), None)
+def _get_baseline_variant(
+    variants: Iterable[AbstractVariant], baseline_id: str
+) -> AbstractVariant | None:
+    return next((v for v in variants if getattr(v, "id", None) == baseline_id), None)
 
 
-def _get_advanced_required_models(variants: Iterable[AbstractVariant]) -> set[str]:
+def _get_non_baseline_required_models(
+    variants: Iterable[AbstractVariant], baseline_id: str
+) -> set[str]:
     return {
         m
         for v in variants
-        if "default" not in getattr(v, "id", "")
+        if getattr(v, "id", "") != baseline_id
         for m in v.required_models()
     }
 
@@ -72,30 +75,33 @@ def evaluate_feature(feature: Features, available_ids: Set[str]) -> FeatureResul
             feature, wired=True, has_default=False, missing_models=frozenset()
         )
 
-    default = _get_default_variant(variants)
-    if default is None:
-        # No default variant found. Return has_default=False.
-        # Per your request, we don't check advanced models if the default is missing.
+    baseline_id = getattr(pipeline_cls, "HEALTH_BASELINE_VARIANT_ID", "default")
+    baseline = _get_baseline_variant(variants, baseline_id)
+    if baseline is None:
+        # Baseline variant not declared on this pipeline. Skip non-baseline
+        # checks: we can't validate models for a baseline we don't have.
         return FeatureResult(
             feature,
             wired=True,
             has_default=False,
-            missing_models=frozenset({"No default variant found"}),
+            missing_models=frozenset(
+                {f"No baseline variant found (expected variant id: '{baseline_id}')"}
+            ),
         )
-    required_default = default.required_models()
-    required_advanced = _get_advanced_required_models(variants)
+    required_baseline = baseline.required_models()
+    required_non_baseline = _get_non_baseline_required_models(variants, baseline_id)
 
-    all_required = required_default.union(required_advanced)
+    all_required = required_baseline.union(required_non_baseline)
     all_missing = missing_llm_requirements(
         all_required,
         available_ids=set(available_ids),
     )
-    default_missing = missing_llm_requirements(
-        required_default,
+    baseline_missing = missing_llm_requirements(
+        required_baseline,
         available_ids=set(available_ids),
     )
-    default_available = not default_missing
-    if not default_available:
+    baseline_available = not baseline_missing
+    if not baseline_available:
         return FeatureResult(
             feature,
             wired=True,

--- a/iris/tests/test_pipeline_health_checker.py
+++ b/iris/tests/test_pipeline_health_checker.py
@@ -70,7 +70,7 @@ class _FakePipelineBase:
     """Fake pipeline whose get_variants() is controlled by class attributes."""
 
     HEALTH_BASELINE_VARIANT_ID = "default"
-    _VARIANTS: list[Variant] = []
+    _VARIANTS: tuple[Variant, ...] = ()
 
     @classmethod
     def get_variants(cls) -> list[Variant]:
@@ -91,10 +91,10 @@ def _evaluate_with_fake(
 def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("faq", {"m_faq"}),
             _make_variant("problem_statement", {"m_ps"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq", "m_ps"})
     assert result.wired is True
@@ -106,10 +106,10 @@ def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
 def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("faq", {"m_faq"}),
             _make_variant("problem_statement", {"m_ps"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
     assert result.wired is True
@@ -120,10 +120,10 @@ def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
 def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "default"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("default", {"m_default"}),
             _make_variant("advanced", {"m_advanced"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_default"})
     assert result.wired is True
@@ -136,7 +136,7 @@ def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
 def test_evaluate_feature_missing_baseline_variant_reports_expected_id(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [_make_variant("faq", {"m_faq"})]
+        _VARIANTS = (_make_variant("faq", {"m_faq"}),)
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
     assert result.wired is True

--- a/iris/tests/test_pipeline_health_checker.py
+++ b/iris/tests/test_pipeline_health_checker.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+
+from iris.domain.variant.variant import Variant
+from iris.pipeline.rewriting_pipeline import RewritingPipeline
+from iris.web.routers.health.Pipelines import checker
+from iris.web.routers.health.Pipelines.checker import (
+    _get_baseline_variant,
+    _get_non_baseline_required_models,
+    evaluate_feature,
+)
+
+
+def test_rewriting_pipeline_health_baseline_is_problem_statement():
+    # Pin the specific override so accidentally removing it surfaces here
+    # rather than only in the health endpoint at deploy time.
+    assert RewritingPipeline.HEALTH_BASELINE_VARIANT_ID == "problem_statement"
+    declared_variant_ids = {vid for vid, _, _ in RewritingPipeline.VARIANT_DEFS}
+    assert (
+        RewritingPipeline.HEALTH_BASELINE_VARIANT_ID in declared_variant_ids
+    ), "HEALTH_BASELINE_VARIANT_ID must point at a declared variant"
+
+
+def _make_variant(variant_id: str, required: set[str]) -> Variant:
+    return Variant(
+        variant_id=variant_id,
+        name=variant_id,
+        description="",
+        role_models={},
+        required_model_ids=required,
+    )
+
+
+def test_get_baseline_variant_returns_match_for_custom_id():
+    variants = [
+        _make_variant("faq", {"m1"}),
+        _make_variant("problem_statement", {"m2"}),
+    ]
+    baseline = _get_baseline_variant(variants, "problem_statement")
+    assert baseline is not None
+    assert baseline.id == "problem_statement"
+
+
+def test_get_baseline_variant_returns_none_when_id_absent():
+    variants = [_make_variant("faq", {"m1"})]
+    assert _get_baseline_variant(variants, "default") is None
+
+
+def test_get_non_baseline_required_models_exact_equality():
+    # A variant id that *contains* the substring "default" but is not equal
+    # must be treated as non-baseline. The previous substring-based check
+    # would have wrongly excluded "default_v2" from the non-baseline set.
+    variants = [
+        _make_variant("default", {"m_baseline"}),
+        _make_variant("default_v2", {"m_v2"}),
+        _make_variant("advanced", {"m_advanced"}),
+    ]
+    non_baseline = _get_non_baseline_required_models(variants, "default")
+    assert non_baseline == {"m_v2", "m_advanced"}
+
+
+class _FakeFeature(str, Enum):
+    FAKE = "FAKE"
+
+
+class _FakePipelineBase:
+    """Fake pipeline whose get_variants() is controlled by class attributes."""
+
+    HEALTH_BASELINE_VARIANT_ID = "default"
+    _VARIANTS: list[Variant] = []
+
+    @classmethod
+    def get_variants(cls) -> list[Variant]:
+        return list(cls._VARIANTS)
+
+
+def _evaluate_with_fake(
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline_cls: type,
+    available: set[str],
+):
+    monkeypatch.setattr(
+        checker, "PIPELINE_BY_FEATURE", {_FakeFeature.FAKE: pipeline_cls}
+    )
+    return evaluate_feature(_FakeFeature.FAKE, available)
+
+
+def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [
+            _make_variant("faq", {"m_faq"}),
+            _make_variant("problem_statement", {"m_ps"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq", "m_ps"})
+    assert result.wired is True
+    assert result.has_default is True
+    assert result.missing_models == frozenset()
+    assert result.ok is True
+
+
+def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [
+            _make_variant("faq", {"m_faq"}),
+            _make_variant("problem_statement", {"m_ps"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
+    assert result.wired is True
+    assert result.has_default is False
+    assert "m_ps" in result.missing_models
+
+
+def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "default"
+        _VARIANTS = [
+            _make_variant("default", {"m_default"}),
+            _make_variant("advanced", {"m_advanced"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_default"})
+    assert result.wired is True
+    assert result.has_default is True
+    assert result.missing_models == frozenset({"m_advanced"})
+    # has_default is True but missing_models is non-empty → not "ok"
+    assert result.ok is False
+
+
+def test_evaluate_feature_missing_baseline_variant_reports_expected_id(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [_make_variant("faq", {"m_faq"})]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
+    assert result.wired is True
+    assert result.has_default is False
+    assert result.missing_models == frozenset(
+        {"No baseline variant found (expected variant id: 'problem_statement')"}
+    )


### PR DESCRIPTION
## Summary

The pipeline health endpoint reported `RewritingPipeline` as `DOWN` with `No default variant found` because `checker.py` hardcoded a lookup for a variant with id `"default"`, but `RewritingPipeline.VARIANT_DEFS` declares only content-orthogonal variants (`faq`, `problem_statement`). Pipelines whose variants aren't quality-tier (default / advanced) have no semantic *default*, and shouldn't have to invent one.

- Add `Pipeline.HEALTH_BASELINE_VARIANT_ID: ClassVar[str] = "default"`. All existing pipelines keep their current behavior because the base value matches the previous hardcoded id.
- Override on `RewritingPipeline` to `"problem_statement"` — chosen because its declared display name is `"Default Variant"`, while `faq`'s is `"Default FAQ Variant"`.
- Thread the baseline id through the checker. Rename `_get_default_variant` / `_get_advanced_required_models` → `_get_baseline_variant` / `_get_non_baseline_required_models`.
- Replace the fragile substring match `if "default" not in v.id` with exact equality, so a future variant id like `default_v2` isn't silently misclassified as baseline.
- Include the expected variant id in the missing-baseline message: `No baseline variant found (expected variant id: '<id>')`.

After this lands, prod (currently `7/8 DEGRADED`) will go to `8/8 UP` once `:latest` rebuilds and `pyris-app` restarts.

## Out of scope (worth a follow-up)

- `PipelineExecutionSettingsDTO.variant` still defaults to `"default"`. If a caller omits the field for a rewriting request, it will fail at request time because `RewritingPipeline` has no variant by that name. This is preexisting; Artemis always sends an explicit variant today.
- `Pipeline.get_variants()` raises eagerly on missing YAML config for *any* declared variant. The baseline / non-baseline split only differentiates severity when **models** are missing (in `available_ids`), not when the **YAML** is incomplete — a misconfigured non-baseline variant still flips `has_default=False`.

## Test plan

- [x] `poetry run pytest tests/test_pipeline_health_checker.py` — 8 passed
- [x] `poetry run pytest` — 88 passed (full iris suite)
- [x] `poetry run black --check` on all four files — clean
- [x] `poetry run pylint --rcfile=pylintrc` on all four files — 10.00/10
- [x] Multi-turn `codex exec` review on `gpt-5.5` / `xhigh` reasoning — explicit approval
- [ ] After merge: restart `pyris-app` on `pyris-prod` and `pyris-test`, hit `/api/v1/health/`, expect `8/8 pipelines have valid LLM configurations`, `Pipelines: UP`.

## New tests

`iris/tests/test_pipeline_health_checker.py` covers:

- `RewritingPipeline.HEALTH_BASELINE_VARIANT_ID == "problem_statement"` (pinned, plus a check that the id exists in `VARIANT_DEFS`)
- `_get_baseline_variant` returns the match for a custom baseline id, and `None` when absent
- `_get_non_baseline_required_models` uses exact equality (a variant `default_v2` is treated as non-baseline)
- `evaluate_feature` with a custom baseline passes when its model is available
- A missing baseline model flips `has_default` to `False`
- A missing non-baseline model keeps `has_default=True`, populates `missing_models`
- A missing baseline variant reports the expected id in the message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check mechanism to support pipeline-specific baseline variants for health checks
  * Improved health check flexibility by enabling pipelines to define their own baseline variant

* **Tests**
  * Added comprehensive test coverage for health checking logic
  * Verifies baseline variant selection and model requirement detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->