### PR TITLE
Logos: exclude wake target from its own eviction set (fixes self-evic…

### DIFF
--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -239,10 +239,11 @@ class CapacityPlanner:
         ).strip().lower() not in ("0", "false", "no")
         # Phase 3: split Gate 1 (drop scheduler queue from pre-filter), tighten
         # branch A of the proceed check, and gate the per-lane VRAM ledger.
-        # Default off until staging confirms the deimama symptom unblocks
-        # without surprising eviction patterns.
+        # Default ON: production confirmed the deimama/7B-starvation symptom
+        # unblocks without surprising eviction patterns. Set
+        # LOGOS_EVICTION_GATE_V2=false to fall back to the legacy v1 gate.
         self._eviction_gate_v2 = os.environ.get(
-            "LOGOS_EVICTION_GATE_V2", "false"
+            "LOGOS_EVICTION_GATE_V2", "true"
         ).strip().lower() in ("1", "true", "yes")
         # Cross-provider best-first ranking: before iterating providers in a
         # cycle, pre-score every (provider, model) candidate by action cost
@@ -1599,6 +1600,7 @@ class CapacityPlanner:
         profiles: dict[str, "ModelProfile"],
         target_model_name: Optional[str] = None,
         *,
+        target_lane_id: Optional[str] = None,
         replicas_only: bool = False,
         cluster_lanes_by_model: Optional[dict[str, int]] = None,
     ) -> Optional[list[tuple[LaneSchedulerSignals, str, float]]]:
@@ -1623,6 +1625,11 @@ class CapacityPlanner:
         count is decremented so the *last* remaining copy of any model is
         never picked in this pass. Callers should fall back to a normal
         (non-replicas-only) call when this pass cannot cover the deficit.
+
+        ``target_lane_id`` is the lane_id of the lane about to be woken (wake
+        path only; cold load has no existing wakee and passes ``None``). That
+        lane is hard-excluded from the candidate set — it cannot evict itself
+        to make room for itself.
         """
         # Nothing to do if deficit is already met
         if all(d <= 0 for d in per_gpu_deficit.values()):
@@ -1645,6 +1652,17 @@ class CapacityPlanner:
         # empty. Each entry is (lane_id, model_name, reason).
         skipped: list[tuple[str, str, str]] = []
         for lane in lanes:
+            # The lane being woken can never be its own eviction victim:
+            # `stop` destroys the wakee (the follow-up wake then fails with
+            # "Lane '<id>' not found" and the model goes permanently absent),
+            # and `sleep_l1` is a no-op on an already-sleeping lane. Sibling
+            # replicas — the same model_name on a *different* lane_id — are
+            # still valid victims, so filter strictly on lane_id and never on
+            # model_name (the Phase 3.3 self-eviction branches below
+            # intentionally allow same-model siblings through).
+            if target_lane_id is not None and lane.lane_id == target_lane_id:
+                skipped.append((lane.lane_id, lane.model_name, "is-wake-target"))
+                continue
             total_demand = self._get_queue_depth_for_model(provider_id, lane.model_name, lanes)
             # Phase 3.1: under LOGOS_EVICTION_GATE_V2, hard-block only on
             # vLLM-internal busyness (active_requests / queue_waiting). The
@@ -2735,6 +2753,7 @@ class CapacityPlanner:
                     eviction_set = self._find_eviction_set(
                         provider_id, target_gpus, per_gpu_deficit, available_lanes, profiles,
                         target_model_name=model_name,
+                        target_lane_id=target.lane_id,
                         replicas_only=True,
                         cluster_lanes_by_model=cluster_lanes_by_model,
                     )
@@ -2742,6 +2761,7 @@ class CapacityPlanner:
                     eviction_set = self._find_eviction_set(
                         provider_id, target_gpus, per_gpu_deficit, available_lanes, profiles,
                         target_model_name=model_name,
+                        target_lane_id=target.lane_id,
                     )
 
                 if eviction_set is None:
@@ -2820,10 +2840,13 @@ class CapacityPlanner:
                             else f"target_eff={eff:.2f} > victim={max_victim_score:.2f}×{self.WAKE_COMPETITIVE_RATIO}"
                         )
                     if proceed:
+                        target_lane_destroyed = False
                         for vlane, vaction, _ in eviction_set:
                             if vlane.lane_id in claimed_victims:
                                 continue
                             claimed_victims.add(vlane.lane_id)
+                            if vaction == "stop" and vlane.lane_id == target.lane_id:
+                                target_lane_destroyed = True
                             actions.append(CapacityPlanAction(
                                 action=vaction,
                                 provider_id=provider_id,
@@ -2831,13 +2854,32 @@ class CapacityPlanner:
                                 model_name=vlane.model_name,
                                 reason=f"Evicted for {model_name} wake ({gate_reason})",
                             ))
-                        actions.append(CapacityPlanAction(
-                            action="wake",
-                            provider_id=provider_id,
-                            lane_id=target.lane_id,
-                            model_name=model_name,
-                            reason=f"Wake {model_name}: {gate_reason}",
-                        ))
+                        # The is-wake-target pre-filter in _find_eviction_set
+                        # makes this impossible on the wake path, but if any
+                        # other code path ever lets a `stop` of the wakee
+                        # itself slip through, a `wake` would fail with
+                        # "Lane '<id>' not found" — the destroyed lane needs a
+                        # fresh `load`, not a `wake`.
+                        if target_lane_destroyed:
+                            actions.append(CapacityPlanAction(
+                                action="load",
+                                provider_id=provider_id,
+                                lane_id=target.lane_id,
+                                model_name=model_name,
+                                params=self._build_load_params(
+                                    model_name, target.lane_id, profile,
+                                    capacity, provider_id,
+                                ),
+                                reason=f"Load {model_name} (wakee stopped): {gate_reason}",
+                            ))
+                        else:
+                            actions.append(CapacityPlanAction(
+                                action="wake",
+                                provider_id=provider_id,
+                                lane_id=target.lane_id,
+                                model_name=model_name,
+                                reason=f"Wake {model_name}: {gate_reason}",
+                            ))
                         planned_models.add(model_name)
                     else:
                         logger.info(

--- a/logos/tests/unit/capacity/test_best_first_scenarios.py
+++ b/logos/tests/unit/capacity/test_best_first_scenarios.py
@@ -1177,3 +1177,128 @@ class TestSchedulingSanity:
         # Z (lower demand) should be the pick, not Y.
         assert "Z" in picked
         assert "Y" not in picked
+
+
+class TestWakeTargetSelfEviction:
+    """Regression tests for the "self-eviction stops the wakee" bug.
+
+    The eviction picker must never choose the very lane that is about to be
+    woken as its own victim: a `stop` destroys the wakee (the follow-up wake
+    then fails with "Lane '<id>' not found" and the model goes permanently
+    absent). Sibling replicas — same model_name on a *different* lane_id —
+    remain legitimate victims.
+    """
+
+    def test_eviction_excludes_wake_target_same_lane_id(self):
+        """The wake target's own lane is hard-excluded; with no other
+        candidate the deficit is uncoverable → None. Control: without
+        target_lane_id the same lane WOULD be picked (proves the setup is
+        otherwise tempting and the filter is what excludes it)."""
+        provider = _MockProvider(
+            provider_id=1, name="A",
+            lanes=[
+                _lane(lane_id="planner-X", model_name="X",
+                      runtime_state="sleeping", sleep_state="sleeping",
+                      effective_vram_mb=9000, gpu_devices="0"),
+            ],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0,
+                                    sleeping_residual_mb=9000.0)},
+        )
+        planner = _planner([provider])
+        planner._lane_loaded_at = {}
+        planner._demand.get_score = lambda *_: 0.0
+
+        common = dict(
+            provider_id=1,
+            required_gpus=frozenset({0}),
+            per_gpu_deficit={0: 100.0},
+            lanes=provider.lanes,
+            profiles=provider.profiles,
+            target_model_name="X",
+        )
+
+        # Control: self-eviction allowed when we don't identify the wakee.
+        control = planner._find_eviction_set(**common)
+        assert control, "setup must be tempting: lane is picked without the filter"
+        assert any(l.lane_id == "planner-X" for l, _a, _e in control)
+
+        # With the wakee identified by lane_id it must be excluded entirely.
+        guarded = planner._find_eviction_set(target_lane_id="planner-X", **common)
+        assert guarded is None or all(
+            l.lane_id != "planner-X" for l, _a, _e in guarded
+        )
+
+    def test_eviction_allows_sibling_replica_of_same_model(self):
+        """Same model_name, different lane_id → still a valid victim."""
+        provider = _MockProvider(
+            provider_id=1, name="A",
+            lanes=[
+                _lane(lane_id="planner-X", model_name="X",
+                      runtime_state="sleeping", sleep_state="sleeping",
+                      effective_vram_mb=500, gpu_devices="0"),
+                _lane(lane_id="X-sibling", model_name="X",
+                      runtime_state="loaded", sleep_state="awake",
+                      effective_vram_mb=20_000, gpu_devices="0"),
+            ],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0,
+                                    sleeping_residual_mb=500.0)},
+        )
+        planner = _planner([provider])
+        planner._lane_loaded_at = {}
+        planner._stop_dedup_siblings = False
+        planner._demand.get_score = lambda *_: 0.0
+
+        eviction = planner._find_eviction_set(
+            provider_id=1,
+            required_gpus=frozenset({0}),
+            per_gpu_deficit={0: 5000.0},
+            lanes=provider.lanes,
+            profiles=provider.profiles,
+            target_model_name="X",
+            target_lane_id="planner-X",
+        )
+        assert eviction is not None
+        picked = {l.lane_id for l, _a, _e in eviction}
+        assert "X-sibling" in picked          # sibling replica is fair game
+        assert "planner-X" not in picked      # the wakee never is
+
+    def test_self_eviction_followup_uses_load_when_target_stopped(self):
+        """Defensive net: if a `stop` of the wakee ever slips through, the
+        follow-up must be `load` (fresh process), never `wake` (would hit
+        "Lane not found"). Drive _compute_demand_actions with a poisoned
+        eviction set."""
+        target = _lane(lane_id="planner-X", model_name="X",
+                       runtime_state="sleeping", sleep_state="sleeping",
+                       effective_vram_mb=500, gpu_devices="0")
+        provider = _MockProvider(
+            provider_id=1, name="A",
+            lanes=[target],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0,
+                                    sleeping_residual_mb=500.0)},
+            available_vram_mb=0.0,  # force a deficit so eviction is needed
+        )
+        planner = _planner([provider])
+        planner._cross_provider_dedup = False
+        planner._provider_capacity_lock = lambda pid: SimpleNamespace(
+            locked=lambda: False
+        )
+        planner._vram_ledger = SimpleNamespace(
+            get_committed_mb=lambda pid: 0.0,
+            has_overlapping_reservation=lambda *a, **k: False,
+            get_gpu_effective_available_mb=lambda pid, g, f: f,
+        )
+        planner._get_queue_depth_across_deployments = lambda *_: 0
+        planner._build_load_params = lambda *a, **k: {}
+        planner._demand.get_ranked_models.return_value = [("X", 1.0)]
+
+        # Poison: return the wakee itself as a `stop` victim.
+        planner._find_eviction_set = lambda *a, **k: [(target, "stop", 0.0)]
+
+        actions = planner._compute_demand_actions(1, provider.lanes)
+
+        kinds = [(a.action, a.lane_id) for a in actions]
+        assert ("stop", "planner-X") in kinds
+        assert ("load", "planner-X") in kinds
+        assert all(a.action != "wake" for a in actions)
+        # Order: destructive stop before the recovering load.
+        assert kinds.index(("stop", "planner-X")) < kinds.index(("load", "planner-X"))


### PR DESCRIPTION
…tion stop→wake 'Lane not found'); default LOGOS_EVICTION_GATE_V2 on

Please go to the `Preview` tab and select the appropriate sub-template:

* [Athena](?expand=1&template=athena.md)
* [Atlas](?expand=1&template=atlas.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved eviction logic to prevent lanes from being selected as victims during wake operations.
  * Corrected wake action handling to emit load instead of wake when target lane is removed by eviction.

* **Changes**
  * Enabled improved eviction decision-making by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->