### PR TITLE
`Logos`: Raise websocket frame size limits for large multimodal payloads

### DIFF
--- a/logos/Dockerfile
+++ b/logos/Dockerfile
@@ -66,4 +66,4 @@ COPY logos/tests/ ./tests/
 
 EXPOSE 8080 50051
 
-CMD ["uvicorn", "logos.main:app", "--host", "0.0.0.0", "--port", "8080", "--ws-ping-interval", "60", "--ws-ping-timeout", "60"]
+CMD ["uvicorn", "logos.main:app", "--host", "0.0.0.0", "--port", "8080", "--ws-ping-interval", "60", "--ws-ping-timeout", "60", "--ws-max-size", "268435456"]

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -108,7 +108,7 @@ class LogosBridgeClient:
                     ws_url,
                     ping_interval=None,
                     close_timeout=5,
-                    max_size=4 * 1024 * 1024,
+                    max_size=None,
                 ) as ws:
                     self._connected = True
                     self._last_connected_at = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- Remove the 4 MiB cap on the worker bridge inbound websocket (`max_size=None`) so server→worker commands carrying large images aren't rejected with `1009 (message too big)`.
- Raise uvicorn `--ws-max-size` on the Logos server to 256 MiB so worker→server responses can carry image-generation output.

Fixes #565.

## Test plan
- [ ] Send a chat completion request with a >4 MiB image and confirm the worker no longer closes the bridge with code 1009.
- [ ] Verify image-generation responses up to ~256 MiB stream back through the bridge without truncation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket message size configuration to support larger data transfers without size restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->