### PR TITLE
`Logos`: Fix planner crash from missing e2e_latency_p50_seconds

### DIFF
--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -207,11 +207,18 @@ RUN if ! command -v python3.12 >/dev/null 2>&1 \
 # ── CUDA toolchain for Triton / vLLM JIT compilation ─────────────────────────
 # Installed via versioned apt packages (CUDA_VERSION is set by the base image).
 # Package purposes:
-#   cuda-nvcc   — NVIDIA compiler driver (nvcc) for kernel PTX generation
-#   cuda-cudart — CUDA runtime (libcudart.so; needed by torch + vLLM)
-#   cuda-nvrtc  — CUDA runtime compilation library (NVRTC)
-#   libcublas   — cuBLAS (torch GEMM kernels)
-#   libnvvm     — provides libdevice.bc, the PTX standard library used by nvcc
+#   cuda-nvcc       — NVIDIA compiler driver (nvcc) for kernel PTX generation
+#   cuda-cudart     — CUDA runtime (libcudart.so; needed by torch + vLLM)
+#   cuda-nvrtc      — CUDA runtime compilation library (NVRTC)
+#   cuda-nvrtc-dev  — NVRTC headers (nvrtc.h) for FlashInfer JIT compiles
+#   libcublas       — cuBLAS (torch GEMM kernels)
+#   libcublas-dev   — cuBLAS headers (cublasLt.h, cublas_v2.h) required by
+#                     FlashInfer's Blackwell SM 12.0 CUTLASS grouped-GEMM JIT
+#                     path for MoE models (e.g. DeepSeek-OCR-2). Without it the
+#                     JIT fails with "fatal error: cublasLt.h: No such file or
+#                     directory" the first time a MoE model is calibrated on a
+#                     Blackwell host. See vllm-project/vllm#35501.
+#   libnvvm         — provides libdevice.bc, the PTX standard library used by nvcc
 # gcc is the host C compiler Triton uses to compile its ctypes driver module.
 # On non-CUDA base images (CPU builds) only gcc is installed.
 RUN if [ "$INSTALL_VLLM" = "1" ] && [ -n "${CUDA_VERSION}" ]; then \
@@ -222,7 +229,9 @@ RUN if [ "$INSTALL_VLLM" = "1" ] && [ -n "${CUDA_VERSION}" ]; then \
             cuda-nvcc-${CUDA_VER} \
             cuda-cudart-${CUDA_VER} \
             cuda-nvrtc-${CUDA_VER} \
+            cuda-nvrtc-dev-${CUDA_VER} \
             libcublas-${CUDA_VER} \
+            libcublas-dev-${CUDA_VER} \
             libnvvm-${CUDA_VER} \
         && rm -rf /var/lib/apt/lists/*; \
     elif [ "$INSTALL_VLLM" = "1" ]; then \

--- a/logos/logos-workernode/logos_worker_node/model_cache.py
+++ b/logos/logos-workernode/logos_worker_node/model_cache.py
@@ -24,10 +24,67 @@ logger = logging.getLogger(__name__)
 
 _SAFETY_MARGIN_RATIO = 0.10  # keep ≥10% tmpfs free
 
+# A "bulk" file (weight shard) — used to decide whether the source filesystem
+# actually has the model rather than just its manifest files. HF's xet-backed
+# downloads can leave a `models--*/` dir with only config.json + *.index.json
+# (~100 KB total) while the real weights have never been pulled. Caching such
+# a directory and overriding HF_HOME to tmpfs would make vLLM/HF download the
+# multi-GB weights into the small tmpfs and ENOSPC. 10 MB cleanly separates
+# manifests/tokenizers (KB to low-MB) from any real weight shard.
+_BULK_FILE_THRESHOLD_BYTES = 10 * 1024 * 1024
+
 
 def _hf_model_dir_name(model_name: str) -> str:
     """Convert ``org/name`` to ``models--org--name`` (HF cache convention)."""
     return "models--" + model_name.replace("/", "--")
+
+
+def _has_bulk_file(model_dir: Path) -> bool:
+    """Whether any file in ``<model_dir>/snapshots/<rev>/`` is ≥ the bulk threshold.
+
+    Symlinks are followed via ``stat()``, so this works for the standard HF
+    cache layout where snapshot entries point at ``blobs/<sha>``.
+    """
+    snapshots = model_dir / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    try:
+        rev_dirs = [p for p in snapshots.iterdir() if p.is_dir()]
+    except OSError:
+        return False
+    for rev_dir in rev_dirs:
+        try:
+            entries = list(rev_dir.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                size = entry.stat().st_size  # follows symlinks
+            except OSError:
+                continue
+            if size >= _BULK_FILE_THRESHOLD_BYTES:
+                return True
+    return False
+
+
+def _has_valid_refs(model_dir: Path) -> bool:
+    """Whether ``<model_dir>/refs/`` contains at least one non-empty ref file.
+
+    HF writes ``refs/<branch>`` as the final step after a download completes.
+    An ENOSPC mid-write can leave the file present but at 0 bytes — that signals
+    a broken cache entry left behind by a previous crash, and reusing it would
+    just hit ENOSPC again.
+    """
+    refs = model_dir / "refs"
+    if not refs.is_dir():
+        return False
+    try:
+        for ref_file in refs.iterdir():
+            if ref_file.is_file() and ref_file.stat().st_size > 0:
+                return True
+    except OSError:
+        pass
+    return False
 
 
 def _is_tmpfs(path: str) -> bool:
@@ -123,6 +180,15 @@ class ModelRamCache:
                     return str(self._cache_hub.parent)
                 self._cached_models.discard(model_name)
 
+            if not await asyncio.to_thread(self._source_has_bulk_weights, model_name):
+                logger.warning(
+                    "Model %s: source filesystem has no bulk weights (manifest-only / "
+                    "xet-backed not yet downloaded) — loading from source HF_HOME so "
+                    "downloads do not flood tmpfs",
+                    model_name,
+                )
+                return str(self._source_hub.parent)
+
             size = await asyncio.to_thread(self.model_size_bytes, model_name)
             if size <= 0:
                 logger.warning("Model %s not found on source filesystem — loading from disk", model_name)
@@ -161,6 +227,15 @@ class ModelRamCache:
                 logger.info("Model %s: already in tmpfs RAM cache", model_name)
                 return str(self._cache_hub.parent)
             self._cached_models.discard(model_name)
+
+        if not self._source_has_bulk_weights(model_name):
+            logger.warning(
+                "Model %s: source filesystem has no bulk weights (manifest-only / "
+                "xet-backed not yet downloaded) — loading from source HF_HOME so "
+                "downloads do not flood tmpfs",
+                model_name,
+            )
+            return str(self._source_hub.parent)
 
         size = self.model_size_bytes(model_name)
         if size <= 0:
@@ -314,16 +389,48 @@ class ModelRamCache:
             return 0
 
     def _scan_existing(self) -> None:
-        """Detect models already present in tmpfs from a previous run."""
+        """Detect models already present in tmpfs from a previous run.
+
+        Evicts entries that lack a non-empty ``refs/<branch>`` file. An ENOSPC
+        mid-download leaves the blobs and snapshot symlinks in place but the
+        trailing refs write fails, leaving a 0-byte ref. Reusing such an
+        entry just hits ENOSPC again on the next attempt; deleting it now
+        frees tmpfs so a subsequent attempt (with the correct HF_HOME) can
+        succeed.
+        """
         if not self._cache_hub.exists():
             return
         for entry in self._cache_hub.iterdir():
-            if entry.is_dir() and entry.name.startswith("models--"):
-                parts = entry.name.split("--", 1)
-                if len(parts) >= 2:
-                    model_name = parts[1].replace("--", "/")
-                    self._cached_models.add(model_name)
-                    logger.info("Found existing cached model: %s", model_name)
+            if not (entry.is_dir() and entry.name.startswith("models--")):
+                continue
+            parts = entry.name.split("--", 1)
+            if len(parts) < 2:
+                continue
+            model_name = parts[1].replace("--", "/")
+            if not _has_valid_refs(entry):
+                logger.warning(
+                    "Tmpfs entry for %s is incomplete (refs missing or empty — likely "
+                    "from a previous ENOSPC) — evicting %s",
+                    model_name,
+                    entry,
+                )
+                shutil.rmtree(entry, ignore_errors=True)
+                continue
+            self._cached_models.add(model_name)
+            logger.info("Found existing cached model: %s", model_name)
+
+    def _source_has_bulk_weights(self, model_name: str) -> bool:
+        """Whether the source filesystem actually holds this model's weights.
+
+        Returns False for models where ``hub/models--*/`` exists but only
+        contains manifest files (config.json, *.index.json, tokenizer config),
+        which happens for xet-backed models that have never been downloaded.
+        Returning True requires at least one resolved snapshot file ≥ 10 MB.
+        """
+        src = self._source_hub / _hf_model_dir_name(model_name)
+        if not src.exists():
+            return False
+        return _has_bulk_file(src)
 
     async def _get_model_lock(self, model_name: str) -> asyncio.Lock:
         async with self._global_lock:

--- a/logos/logos-workernode/tests/test_model_cache.py
+++ b/logos/logos-workernode/tests/test_model_cache.py
@@ -63,8 +63,12 @@ def ram_cache_env(tmp_path):
     model_dir = source_hf / "models--Qwen--Qwen2.5-7B"
     blobs = model_dir / "blobs"
     blobs.mkdir(parents=True)
-    # Create a fake weight file (1KB)
-    (blobs / "sha256-abc123").write_bytes(b"\x00" * 1024)
+    # Fake weight blob — 12 MB sparse file. The completeness check requires at
+    # least one snapshot entry ≥ 10 MB to treat the source as "real weights".
+    blob_path = blobs / "sha256-abc123"
+    with open(blob_path, "wb") as f:
+        f.seek(12 * 1024 * 1024 - 1)
+        f.write(b"\x00")
     refs = model_dir / "refs"
     refs.mkdir()
     (refs / "main").write_text("abc123")
@@ -77,6 +81,37 @@ def ram_cache_env(tmp_path):
         "source_hf": str(source_hf),
         "tmpfs": str(tmpfs),
         "model_name": "Qwen/Qwen2.5-7B",
+    }
+
+
+@pytest.fixture
+def manifest_only_source(tmp_path):
+    """Source filesystem with a model directory containing only manifest files.
+
+    Mirrors the xet-backed-not-yet-downloaded state that triggered the deioma
+    ENOSPC crash: `models--*/` exists with config.json and *.index.json (small
+    real files) but no weight blobs. RAM cache must refuse this and load from
+    source HF_HOME so the weights download to disk, not tmpfs.
+    """
+    source_hf = tmp_path / "source" / "hub"
+    source_hf.mkdir(parents=True)
+    tmpfs = tmp_path / "ramcache"
+    tmpfs.mkdir()
+
+    model_dir = source_hf / "models--openai--gpt-oss-120b"
+    (model_dir / "blobs").mkdir(parents=True)
+    (model_dir / "refs").mkdir()
+    (model_dir / "refs" / "main").write_text("a" * 40)
+    rev = "b5c939de8f754692c1647ca79fbf85e8c1e70f8a"
+    snap = model_dir / "snapshots" / rev
+    snap.mkdir(parents=True)
+    (snap / "config.json").write_bytes(b"x" * 2089)
+    (snap / "model.safetensors.index.json").write_bytes(b"x" * 54511)
+
+    return {
+        "source_hf": str(source_hf),
+        "tmpfs": str(tmpfs),
+        "model_name": "openai/gpt-oss-120b",
     }
 
 
@@ -199,3 +234,100 @@ async def test_scan_existing_on_init(ram_cache_env):
         source_hf_hub_path=ram_cache_env["source_hf"],
     )
     assert model in cache2.cached_models()
+
+
+@pytest.mark.asyncio
+async def test_ensure_cached_skips_manifest_only_source(manifest_only_source):
+    """A model whose source dir has only manifests (no weights) must not be cached.
+
+    Regression test for the deioma ENOSPC crash: copying the manifest-only
+    directory to tmpfs and pointing HF_HOME at tmpfs made vLLM download the
+    full 60 GB weight set into the 100 GB tmpfs, overflowing it on the
+    trailing refs/main write.
+    """
+    cache = ModelRamCache(
+        tmpfs_path=manifest_only_source["tmpfs"],
+        source_hf_hub_path=manifest_only_source["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+
+    result = await cache.ensure_cached(manifest_only_source["model_name"])
+
+    # Falls back to source HF_HOME (the parent of `hub/`) instead of tmpfs.
+    source_parent = os.path.dirname(manifest_only_source["source_hf"])
+    assert result == source_parent
+    # Model is NOT marked cached.
+    assert manifest_only_source["model_name"] not in cache.cached_models()
+    # Tmpfs hub stays empty for this model.
+    cached_dir = os.path.join(
+        manifest_only_source["tmpfs"], "hub", "models--openai--gpt-oss-120b",
+    )
+    assert not os.path.exists(cached_dir)
+
+
+def test_ensure_cached_sync_skips_manifest_only_source(manifest_only_source):
+    """Sync variant (used by calibration) honors the same completeness check."""
+    cache = ModelRamCache(
+        tmpfs_path=manifest_only_source["tmpfs"],
+        source_hf_hub_path=manifest_only_source["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+
+    result = cache.ensure_cached_sync(manifest_only_source["model_name"])
+
+    source_parent = os.path.dirname(manifest_only_source["source_hf"])
+    assert result == source_parent
+    assert manifest_only_source["model_name"] not in cache.cached_models()
+
+
+def test_scan_existing_evicts_incomplete_cache(tmp_path):
+    """A tmpfs entry with a 0-byte refs/<branch> (ENOSPC mid-download) is evicted.
+
+    Without this, a worker that crashed once would loop forever: scan
+    re-claims the broken directory as 'cached', ensure_cached returns the
+    tmpfs HF_HOME, vLLM tries to use it, fails again on the same ref write.
+    """
+    import os as _os
+
+    source_hf = tmp_path / "source" / "hub"
+    source_hf.mkdir(parents=True)
+    tmpfs = tmp_path / "ramcache"
+    tmpfs.mkdir()
+
+    # Build a broken cached entry: blobs + snapshots present, refs/main empty.
+    broken = tmpfs / "hub" / "models--openai--gpt-oss-120b"
+    (broken / "blobs").mkdir(parents=True)
+    (broken / "blobs" / "deadbeef").write_bytes(b"\x00" * 4096)
+    (broken / "refs").mkdir()
+    (broken / "refs" / "main").write_bytes(b"")  # 0-byte ref = ENOSPC marker
+    (broken / "snapshots" / "rev1").mkdir(parents=True)
+
+    cache = ModelRamCache(
+        tmpfs_path=str(tmpfs),
+        source_hf_hub_path=str(source_hf),
+    )
+
+    assert "openai/gpt-oss-120b" not in cache.cached_models()
+    assert not broken.exists(), "incomplete tmpfs entry should have been evicted on scan"
+
+
+def test_scan_existing_keeps_complete_cache(tmp_path):
+    """A tmpfs entry with a non-empty refs/<branch> is retained."""
+    source_hf = tmp_path / "source" / "hub"
+    source_hf.mkdir(parents=True)
+    tmpfs = tmp_path / "ramcache"
+    tmpfs.mkdir()
+
+    good = tmpfs / "hub" / "models--meta-llama--Llama-3.1-8B"
+    (good / "blobs").mkdir(parents=True)
+    (good / "refs").mkdir()
+    (good / "refs" / "main").write_text("a" * 40)
+    (good / "snapshots" / "rev1").mkdir(parents=True)
+
+    cache = ModelRamCache(
+        tmpfs_path=str(tmpfs),
+        source_hf_hub_path=str(source_hf),
+    )
+
+    assert "meta-llama/Llama-3.1-8B" in cache.cached_models()
+    assert good.exists()

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -942,6 +942,7 @@ class CapacityPlanner:
             requests_running=0.0,
             gpu_cache_usage_percent=None,
             ttft_p95_seconds=0.0,
+            e2e_latency_p50_seconds=0.0,
             effective_vram_mb=0.0,
             num_parallel=0,
         )
@@ -3299,6 +3300,7 @@ class CapacityPlanner:
                     requests_running=0.0,
                     gpu_cache_usage_percent=None,
                     ttft_p95_seconds=0.0,
+                    e2e_latency_p50_seconds=0.0,
                     effective_vram_mb=0.0,
                     num_parallel=0,
                     gpu_devices=sleeping_lane.gpu_devices,


### PR DESCRIPTION
## Summary
Two synthetic `LaneSchedulerSignals` constructions in `capacity_planner.py` omitted the required `e2e_latency_p50_seconds` field, crashing every planner cycle that hit the wake/reclaim path. Added `e2e_latency_p50_seconds=0.0` at both sites to mirror the adjacent (correct) construction.

## Test plan
- [ ] Confirm `planner` no longer logs `TypeError: LaneSchedulerSignals.__init__() missing 1 required positional argument` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Capacity planning signals now include a latency attribute for consistent telemetry.
  * GPU build notes and package selection improved to ensure required CUDA headers are available.

* **Bug Fixes**
  * Prevents temporary in-memory caching of manifest-only model sources and evicts incomplete tmpfs cache entries at startup.

* **Tests**
  * Added regression tests covering manifest-only sources, caching behavior, and startup cache scanning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->