### PR TITLE
`Athena`: Update Athena test URLs to aet.cit.tum.de

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/athena.md
+++ b/.github/PULL_REQUEST_TEMPLATE/athena.md
@@ -14,8 +14,8 @@
 > Green = Currently available, Red = Currently locked
 > Click on the badges to get to the test servers.
 
-[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
-[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)
+[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.aet.cit.tum.de)
+[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.aet.cit.tum.de)
 
 ### Screenshots
 <!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

--- a/.github/workflows/pullrequest-closed.yml
+++ b/.github/workflows/pullrequest-closed.yml
@@ -76,7 +76,7 @@ jobs:
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           name: "athena-test${{ matrix.badge }}"
-          label: "athena-test${{ matrix.badge }}.ase.cit.tum.de"
+          label: "athena-test${{ matrix.badge }}.aet.cit.tum.de"
           status: ${{ github.event.pull_request.head.ref }}
           color: green
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pullrequest-unlabeled.yml
+++ b/.github/workflows/pullrequest-unlabeled.yml
@@ -26,7 +26,7 @@ jobs:
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           name: "athena-test${{ steps.env.outputs.BADGE }}"
-          label: "athena-test${{ steps.env.outputs.BADGE }}.ase.cit.tum.de"
+          label: "athena-test${{ steps.env.outputs.BADGE }}.aet.cit.tum.de"
           status: ${{ github.event.pull_request.head.ref }}
           color: green
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/athena/docs/docs/user/user_guide/setup/setup.md
+++ b/athena/docs/docs/user/user_guide/setup/setup.md
@@ -21,7 +21,7 @@ Playground:
   must request it.
 - Request the Athena Playground secret from the team or find it on the
   team's Confluence.
-- **Playground access:** [https://athena-test1.ase.cit.tum.de/playground](https://athena-test1.ase.cit.tum.de/playground)
+- **Playground access:** [https://athena-test1.aet.cit.tum.de/playground](https://athena-test1.aet.cit.tum.de/playground)
 
 2. **Local setup:**  
 - **Pro:** We cannot access your data this way.
@@ -33,7 +33,7 @@ Playground:
 ## Connect to Athena Instance through the Playground
 
 1. Open the playground  
-- Test-server setup: [https://athena-test1.ase.cit.tum.de/playground](https://athena-test1.ase.cit.tum.de/playground)
+- Test-server setup: [https://athena-test1.aet.cit.tum.de/playground](https://athena-test1.aet.cit.tum.de/playground)
 - Local setup: [http://localhost:3000](http://localhost:3000)
 
 2. Up top you see the **Base Info Header** containing all configuration  


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Updates the remaining occurrences of the old URL to the new oen

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated test server endpoints in configuration files to use new hostnames for test environment access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->