### PR TITLE
`Logos`: Make capacity planner host-RAM-aware

### DIFF
--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -76,12 +76,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -105,11 +105,8 @@ jobs:
         # tests; run them pre-merge locally instead.
         # --timeout=30 turns any individual test hang into a pytest-timeout
         # traceback rather than a SIGTERM mystery from the runner.
-        run: |
-          source .venv/bin/activate
-          pytest -v --tb=short --timeout=30 \
-            --ignore=tests/test_model_cache.py \
-            --ignore=tests/test_calibration.py
+        timeout-minutes: 10
+        run: .venv/bin/pytest -v --tb=short --timeout=30 --ignore=tests/test_model_cache.py --ignore=tests/test_calibration.py
         working-directory: logos/logos-workernode
 
   test-ui-export:

--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -94,21 +94,20 @@ jobs:
             pydantic \
             pytest \
             pytest-asyncio \
+            pytest-timeout \
             pyyaml \
             uvicorn
         working-directory: logos/logos-workernode
 
       - name: Run Tests
         # test_model_cache.py and test_calibration.py spawn real rsync /
-        # vLLM subprocesses against fixtures. They pass on macOS but stall
-        # the GitHub Ubuntu runner. They behave like integration tests; we
-        # run them pre-merge locally. The rest of the worker-node suite is
-        # pure-logic and runs here.
-        # `-v` so the last printed line names the test the runner gave up
-        # on; `--tb=short -x` keeps the log compact on failure.
+        # vLLM subprocesses against fixtures and behave like integration
+        # tests; run them pre-merge locally instead.
+        # --timeout=30 turns any individual test hang into a pytest-timeout
+        # traceback rather than a SIGTERM mystery from the runner.
         run: |
           source .venv/bin/activate
-          pytest -v --tb=short -x \
+          pytest -v --tb=short --timeout=30 \
             --ignore=tests/test_model_cache.py \
             --ignore=tests/test_calibration.py
         working-directory: logos/logos-workernode

--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -101,13 +101,14 @@ jobs:
       - name: Run Tests
         # test_model_cache.py and test_calibration.py spawn real rsync /
         # vLLM subprocesses against fixtures. They pass on macOS but stall
-        # the GitHub Ubuntu runner (orphan rsync processes, runner times
-        # the step out). They behave like integration tests; we run them
-        # locally pre-merge instead of in CI. The rest of the worker-node
-        # suite (243 pure-logic tests) runs here.
+        # the GitHub Ubuntu runner. They behave like integration tests; we
+        # run them pre-merge locally. The rest of the worker-node suite is
+        # pure-logic and runs here.
+        # `-v` so the last printed line names the test the runner gave up
+        # on; `--tb=short -x` keeps the log compact on failure.
         run: |
           source .venv/bin/activate
-          pytest -q \
+          pytest -v --tb=short -x \
             --ignore=tests/test_model_cache.py \
             --ignore=tests/test_calibration.py
         working-directory: logos/logos-workernode

--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -68,6 +68,42 @@ jobs:
           coverage xml
         working-directory: logos
 
+  test-workernode:
+    name: Test (logos-workernode)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Dependencies
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install \
+            fastapi \
+            httpx \
+            prometheus-client \
+            pydantic \
+            pytest \
+            pytest-asyncio \
+            pyyaml \
+            uvicorn
+        working-directory: logos/logos-workernode
+
+      - name: Run Tests
+        run: |
+          source .venv/bin/activate
+          pytest -q
+        working-directory: logos/logos-workernode
+
   test-ui-export:
     name: Test UI Static Export
     runs-on: ubuntu-latest

--- a/.github/workflows/logos_test.yml
+++ b/.github/workflows/logos_test.yml
@@ -99,9 +99,17 @@ jobs:
         working-directory: logos/logos-workernode
 
       - name: Run Tests
+        # test_model_cache.py and test_calibration.py spawn real rsync /
+        # vLLM subprocesses against fixtures. They pass on macOS but stall
+        # the GitHub Ubuntu runner (orphan rsync processes, runner times
+        # the step out). They behave like integration tests; we run them
+        # locally pre-merge instead of in CI. The rest of the worker-node
+        # suite (243 pure-logic tests) runs here.
         run: |
           source .venv/bin/activate
-          pytest -q
+          pytest -q \
+            --ignore=tests/test_model_cache.py \
+            --ignore=tests/test_calibration.py
         working-directory: logos/logos-workernode
 
   test-ui-export:

--- a/logos/logos-workernode/logos_worker_node/cache_planner.py
+++ b/logos/logos-workernode/logos_worker_node/cache_planner.py
@@ -1,0 +1,132 @@
+"""Decide which capability models to pre-populate into the tmpfs RAM cache.
+
+The rule (per operator design):
+
+    Load as many models into the tmpfs cache as possible WITHOUT lowering
+    the number of models that can be in sleep_l1 simultaneously.
+
+Why this rule exists:
+
+  - vLLM sleep_l1 keeps a lane's model weights resident in **host RAM** so
+    the next wake completes in ~2 s instead of a 30–90 s cold reload.
+  - The tmpfs cache ALSO consumes host RAM (tmpfs is a RAM-backed filesystem
+    on Linux). If the cache eats too much, fewer lanes can sleep
+    simultaneously and the planner is forced to either stop them (slow
+    recovery) or block new loads (deioma incident).
+  - So: reserve enough host RAM for every sleepable capability model to be
+    sleeping at the same time, then use any leftover RAM for the cache.
+
+The algorithm is deterministic — same inputs always produce the same output:
+
+  1. Compute ``reserve_mb = sum(host_ram of every sleepable capability)``.
+  2. ``budget_mb = available_host_ram_mb − reserve_mb − safety_margin_mb``.
+     If non-positive: budget is zero (only the unsleepable models, which are
+     unaffected by the sleep reserve, may still get cached up to tmpfs limits;
+     see step 4).
+  3. Priority list: unsleepable models first (smallest → largest), then
+     sleepable models (smallest → largest). Unsleepable models benefit most
+     from the cache because their only path back to "loaded" is a cold reload
+     from disk; sleepable models can fall back to a fast sleep_l1 wake.
+  4. Greedy pack: walk the priority list, accumulating into the budget.
+     Sleepable models are skipped once the running tmpfs budget would go
+     negative. Unsleepable models are always included regardless of budget —
+     they don't enter the sleep reserve (they can't sleep) and the operator's
+     rule explicitly does not protect anyone else's sleep capacity from
+     them. The tmpfs free-space safety margin (10 %) inside
+     ``model_cache.cache_models_by_priority`` still acts as a hard backstop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CacheCandidate:
+    """Inputs the planner needs about a single capability model."""
+
+    name: str
+    can_sleep: bool
+    host_ram_mb: float  # projected host-RAM footprint when loaded
+    size_bytes: int     # weights on disk; surrogate for tmpfs cost
+
+
+@dataclass(frozen=True)
+class CachePlan:
+    """Result of plan_cache_order: ordered list + the budget computation."""
+
+    order: list[str]
+    reserved_for_sleep_mb: float
+    available_host_ram_mb: float
+    safety_margin_mb: float
+    sleepable_tmpfs_budget_mb: float
+    cached_unsleepable: list[str]
+    cached_sleepable: list[str]
+    skipped_sleepable: list[str]
+
+
+def plan_cache_order(
+    candidates: list[CacheCandidate],
+    *,
+    available_host_ram_mb: float,
+    safety_margin_mb: float,
+) -> CachePlan:
+    """Decide which models to pre-cache and in what order.
+
+    Inputs:
+      - ``candidates``: every calibrated capability model the worker knows
+        about, with its sleep capability, projected host-RAM footprint, and
+        tmpfs cost.
+      - ``available_host_ram_mb``: worker's MemAvailable at startup.
+      - ``safety_margin_mb``: fixed host-RAM buffer for OS file cache,
+        malloc fragmentation, vLLM mm processor caches, etc.
+
+    Returns a CachePlan describing the ordering and the budget arithmetic
+    used to derive it. ``order`` is the list to pass to
+    ``ModelRamCache.cache_models_by_priority``.
+    """
+    unsleepable = sorted(
+        (c for c in candidates if not c.can_sleep),
+        key=lambda c: c.size_bytes,
+    )
+    sleepable = sorted(
+        (c for c in candidates if c.can_sleep),
+        key=lambda c: c.size_bytes,
+    )
+
+    reserved_for_sleep_mb = sum(c.host_ram_mb for c in sleepable)
+    sleepable_tmpfs_budget_mb = (
+        available_host_ram_mb - reserved_for_sleep_mb - safety_margin_mb
+    )
+
+    # Unsleepable models are always queued — they can't sleep, so they cannot
+    # reduce anyone else's sleep capacity by being in the cache (the rule
+    # protects sleepable count, and they aren't in it). The tmpfs free-space
+    # safety margin still bounds the actual copy.
+    cached_unsleepable = [c.name for c in unsleepable]
+
+    # Sleepable models consume tmpfs budget — pack greedily by size until the
+    # budget is exhausted. Models whose host_ram_mb is unknown (0) consume
+    # nothing from the reserve; we treat their tmpfs cost as the model size.
+    cached_sleepable: list[str] = []
+    skipped_sleepable: list[str] = []
+    remaining_budget_mb = max(sleepable_tmpfs_budget_mb, 0.0)
+    for c in sleepable:
+        size_mb = c.size_bytes / (1024 * 1024)
+        if size_mb <= remaining_budget_mb:
+            cached_sleepable.append(c.name)
+            remaining_budget_mb -= size_mb
+        else:
+            skipped_sleepable.append(c.name)
+
+    order = cached_unsleepable + cached_sleepable
+    return CachePlan(
+        order=order,
+        reserved_for_sleep_mb=reserved_for_sleep_mb,
+        available_host_ram_mb=available_host_ram_mb,
+        safety_margin_mb=safety_margin_mb,
+        sleepable_tmpfs_budget_mb=sleepable_tmpfs_budget_mb,
+        cached_unsleepable=cached_unsleepable,
+        cached_sleepable=cached_sleepable,
+        skipped_sleepable=skipped_sleepable,
+    )

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -860,7 +860,10 @@ def calibrate_model(
                 "        FAIL kv_cache=%s: %s", kv_str, exc,
             )
             if log_tail:
-                logger.warning("  -- vLLM log tail --\n%s%s%s", _C_DIM, log_tail, _C_RESET)
+                logger.warning(
+                    "  -- vLLM log tail --\n%s%s%s\n  -- end vLLM log tail --",
+                    _C_DIM, log_tail, _C_RESET,
+                )
             stop_vllm(proc)
             time.sleep(_VRAM_SETTLE_S)
             _record_failed_command(failed_path, fingerprint)

--- a/logos/logos-workernode/logos_worker_node/host_ram.py
+++ b/logos/logos-workernode/logos_worker_node/host_ram.py
@@ -1,0 +1,107 @@
+"""Host-RAM measurement helpers for the worker node.
+
+The capacity planner on the Logos master treats host RAM as a first-class
+resource axis parallel to VRAM. The worker measures each lane's host-RAM
+footprint here so the master can make sleep-vs-stop eviction decisions that
+account for the fact that vLLM sleep_l1/sleep_l2 retain weights in host RAM.
+
+PSS (proportional set size) is the right metric: shared pages — like the
+model weights mmapped across vLLM TP worker subprocesses — are counted once
+across the tree rather than N times.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_process_pss_mb(pid: int) -> float:
+    """Read PSS in MiB from /proc/<pid>/smaps_rollup. Returns 0 on failure."""
+    try:
+        for line in Path(f"/proc/{pid}/smaps_rollup").read_text().splitlines():
+            if line.startswith("Pss:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    return float(parts[1]) / 1024.0
+    except (FileNotFoundError, PermissionError, OSError, ValueError):
+        return 0.0
+    return 0.0
+
+
+def read_process_rss_mb(pid: int) -> float:
+    """Read VmRSS in MiB from /proc/<pid>/status. Returns 0 on failure."""
+    try:
+        for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    return float(parts[1]) / 1024.0
+    except (FileNotFoundError, PermissionError, OSError, ValueError):
+        return 0.0
+    return 0.0
+
+
+def walk_process_tree(root_pid: int, max_pids: int = 256) -> set[int]:
+    """Return {root_pid} ∪ all descendants discovered via /proc/<pid>/task/*/children.
+
+    Capped at *max_pids* as a safety guard against /proc cycles or pathological
+    forking. Returns an empty set if the root pid is gone.
+    """
+    if not Path(f"/proc/{root_pid}").exists():
+        return set()
+    visited: set[int] = set()
+    to_visit: list[int] = [root_pid]
+    while to_visit and len(visited) < max_pids:
+        pid = to_visit.pop()
+        if pid in visited:
+            continue
+        visited.add(pid)
+        task_dir = Path(f"/proc/{pid}/task")
+        if not task_dir.exists():
+            continue
+        try:
+            tasks = list(task_dir.iterdir())
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        for tdir in tasks:
+            children_file = tdir / "children"
+            try:
+                raw = children_file.read_text().split()
+            except (FileNotFoundError, PermissionError, OSError):
+                continue
+            for token in raw:
+                if not token.isdigit():
+                    continue
+                cpid = int(token)
+                if cpid not in visited:
+                    to_visit.append(cpid)
+    return visited
+
+
+def measure_process_tree_host_ram_mb(root_pid: int) -> tuple[float, str]:
+    """Return ``(mb, source)`` summed across the process tree rooted at *root_pid*.
+
+    *source* is ``"pss"`` when /proc/<pid>/smaps_rollup yielded data for any
+    process in the tree, ``"rss"`` when only /proc/<pid>/status was readable,
+    and ``"unknown"`` otherwise.
+
+    PSS is preferred because vLLM tensor-parallel workers share the model
+    weights via mmap; summing RSS would multi-count those pages by TP size.
+    """
+    tree = walk_process_tree(root_pid)
+    if not tree:
+        return 0.0, "unknown"
+    pss_total = 0.0
+    pss_seen = False
+    rss_total = 0.0
+    for pid in tree:
+        pss = read_process_pss_mb(pid)
+        if pss > 0:
+            pss_total += pss
+            pss_seen = True
+        rss_total += read_process_rss_mb(pid)
+    if pss_seen and pss_total > 0:
+        return pss_total, "pss"
+    if rss_total > 0:
+        return rss_total, "rss"
+    return 0.0, "unknown"

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -22,6 +22,7 @@ from logos_worker_node.models import (
     VllmConfig,
     VllmEngineConfig,
 )
+from logos_worker_node.host_ram import measure_process_tree_host_ram_mb
 from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.ollama_process import OllamaProcessHandle
 from logos_worker_node import prometheus_metrics as prom
@@ -778,15 +779,42 @@ class LaneManager:
             if ps.state == ProcessState.RUNNING and ps.pid is not None:
                 pids.append(ps.pid)
         pid_vram_map = await self._query_process_vram_map(pids)
+        pid_host_ram_map = await self._query_process_host_ram_map(pids)
 
         statuses = []
         for handle in handles:
-            status = await self._build_lane_status(handle, pid_vram_map)
+            status = await self._build_lane_status(
+                handle, pid_vram_map, pid_host_ram_map,
+            )
             statuses.append(status)
             self._record_profile_from_status(status)
         await self._check_stuck_lanes(statuses)
         await self._recover_dead_lanes(statuses)
         return statuses
+
+    async def _query_process_host_ram_map(
+        self, pids: list[int],
+    ) -> dict[int, tuple[float, str]]:
+        """Measure each PID's process-tree host RAM concurrently in worker threads.
+
+        Returns ``{pid: (mb, source)}``. Empty dict on macOS / non-/proc systems.
+        """
+        unique_pids = [int(pid) for pid in dict.fromkeys(pids) if pid is not None]
+        if not unique_pids:
+            return {}
+        results = await asyncio.gather(
+            *(
+                asyncio.to_thread(measure_process_tree_host_ram_mb, pid)
+                for pid in unique_pids
+            ),
+            return_exceptions=True,
+        )
+        out: dict[int, tuple[float, str]] = {}
+        for pid, res in zip(unique_pids, results):
+            if isinstance(res, BaseException):
+                continue
+            out[pid] = res
+        return out
 
     async def _recover_dead_lanes(self, statuses: list[LaneStatus]) -> None:
         """Best-effort restart for lanes whose process died unexpectedly.
@@ -2047,6 +2075,12 @@ class LaneManager:
                 observed_gpu_memory_utilization = float(lane_config.vllm_config.gpu_memory_utilization)
             tensor_parallel_size = int(lane_config.vllm_config.tensor_parallel_size)
         previous_state = self._last_profile_state.get(status.lane_id)
+        host_ram_mb = float(status.host_ram_mb or 0.0)
+        if host_ram_mb > 0:
+            if status.runtime_state in ("loaded", "running"):
+                self._model_profiles.record_host_ram(model, host_ram_mb, sleeping=False)
+            elif status.runtime_state == "sleeping":
+                self._model_profiles.record_host_ram(model, host_ram_mb, sleeping=True)
         if status.runtime_state in ("loaded", "running"):
             kv_cache_sent_mb = 0.0
             if (
@@ -2089,12 +2123,15 @@ class LaneManager:
         self,
         handle: ProcessHandle,
         pid_vram_map: dict[int, float] | None = None,
+        pid_host_ram_map: dict[int, tuple[float, str]] | None = None,
     ) -> LaneStatus:
         ps = handle.status()
         lc = handle.lane_config
         loaded_models: list[LoadedModel] = []
         vram_reported_mb = 0.0
         vram_by_pid_mb = 0.0
+        host_ram_mb = 0.0
+        host_ram_source = "unknown"
 
         if ps.state == ProcessState.RUNNING:
             try:
@@ -2122,6 +2159,14 @@ class LaneManager:
             if pid_vram_map is None:
                 pid_vram_map = await self._query_process_vram_map([ps.pid])
             vram_by_pid_mb = float(pid_vram_map.get(ps.pid, 0.0))
+            if pid_host_ram_map is None:
+                mb, source = await asyncio.to_thread(
+                    measure_process_tree_host_ram_mb, ps.pid,
+                )
+            else:
+                mb, source = pid_host_ram_map.get(ps.pid, (0.0, "unknown"))
+            host_ram_mb = float(mb)
+            host_ram_source = source
 
         effective_gpu_devices = ""
         is_vllm = False
@@ -2254,6 +2299,8 @@ class LaneManager:
             vram_device_mb=vram_device_mb,
             vram_source=vram_source,
             effective_vram_mb=effective_vram_mb,
+            host_ram_mb=host_ram_mb,
+            host_ram_source=host_ram_source,
         )
 
     async def _query_process_vram_map(self, pids: list[int]) -> dict[int, float]:

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -15,13 +15,14 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from logos_worker_node.cache_planner import CacheCandidate, plan_cache_order
 from logos_worker_node.config import load_config, get_state_dir
 from logos_worker_node.gpu import GpuMetricsCollector
 from logos_worker_node.lane_manager import LaneManager, _lane_id_from_config
 from logos_worker_node.logos_bridge import LogosBridgeClient
 from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.model_cache import create_model_cache
-from logos_worker_node.runtime import SERVICE_VERSION
+from logos_worker_node.runtime import SERVICE_VERSION, _build_host_memory_summary
 from logos_worker_node.calibration import auto_calibrate_models, plans_from_config
 
 logging.basicConfig(
@@ -298,21 +299,34 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if model_cache.enabled:
         caps = list(cfg.logos.capabilities_models) if cfg.logos else []
         if caps:
-            # Priority: models with calibration profiles first, then smallest first
-            def _sort_key(m: str) -> tuple[int, int]:
-                p = model_profiles.get_profile(m)
-                has_profile = int(p is not None and (p.base_residency_mb or 0) > 0)
-                size = model_cache.model_size_bytes(m)
-                return (-has_profile, size)
-
-            # Only pre-populate RAM cache for models with a valid calibration profile.
-            # Uncalibrated models (base_residency_mb absent/0) will be excluded from
-            # capabilities anyway, so caching them wastes precious tmpfs space.
             def _has_valid_profile(m: str) -> bool:
                 p = model_profiles.get_profile(m)
                 return p is not None and (p.base_residency_mb or 0) > 0
 
-            caps_to_cache = sorted([m for m in caps if _has_valid_profile(m)], key=_sort_key)
+            def _can_sleep(m: str) -> bool:
+                """Effective enable_sleep_mode after engine + capability overrides.
+
+                Default (no override) is True — the lane-spawn path enables
+                sleep_mode for capability-served vLLM lanes. A model whose
+                override flips this to False cannot release VRAM via sleep_l1,
+                so it doesn't contribute to the sleep reserve and the cache
+                planner is free to include it.
+                """
+                ov_vllm = (
+                    cfg.engines.vllm.model_overrides.get(m, {})
+                    if cfg.engines and cfg.engines.vllm else {}
+                )
+                ov_caps = (
+                    cfg.logos.capabilities_overrides.get(m, {})
+                    if cfg.logos else {}
+                )
+                if "enable_sleep_mode" in ov_vllm:
+                    return bool(ov_vllm["enable_sleep_mode"])
+                if "enable_sleep_mode" in ov_caps:
+                    return bool(ov_caps["enable_sleep_mode"])
+                return True
+
+            calibrated_caps = [m for m in caps if _has_valid_profile(m)]
             caps_skipped = [m for m in caps if not _has_valid_profile(m)]
             if caps_skipped:
                 logger.info(
@@ -320,19 +334,80 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     "will not be served): %s",
                     len(caps_skipped), caps_skipped,
                 )
-            if caps_to_cache:
+
+            # Host-RAM-aware cache plan. Goal (per design):
+            #   load as many models into the tmpfs cache as possible WITHOUT
+            #   lowering the number of models that can sleep simultaneously.
+            #
+            # plan_cache_order reserves enough host RAM for every sleepable
+            # capability model to be in sleep_l1 at the same time, then packs
+            # the remaining budget with cache candidates. Unsleepable models
+            # are always included (they don't enter the sleep reserve and
+            # benefit most from the cache because their only path back to
+            # "loaded" is a cold reload from disk). Sleepable models are
+            # admitted only while the running tmpfs budget allows. See the
+            # full algorithm in cache_planner.py.
+            host_memory = _build_host_memory_summary()
+            available_host_ram_mb = float(host_memory.available_mb or 0.0)
+            # 8 GiB host-RAM safety buffer for OS page cache, malloc
+            # fragmentation, vLLM mm processor caches, monitoring agents,
+            # and the spike during a single lane's cold load.
+            host_ram_safety_margin_mb = 8192.0
+
+            candidates: list[CacheCandidate] = []
+            for m in calibrated_caps:
+                profile = model_profiles.get_profile(m)
+                host_ram_mb = profile.estimate_host_ram_mb() if profile else 0.0
+                if host_ram_mb <= 0.0:
+                    # Fall back to on-disk size when we've never measured the
+                    # awake footprint. Underestimates by ~tokenizer + compile
+                    # cache overhead but is the right ballpark.
+                    host_ram_mb = model_cache.model_size_bytes(m) / (1024 * 1024)
+                candidates.append(CacheCandidate(
+                    name=m,
+                    can_sleep=_can_sleep(m),
+                    host_ram_mb=host_ram_mb,
+                    size_bytes=model_cache.model_size_bytes(m),
+                ))
+
+            plan = plan_cache_order(
+                candidates,
+                available_host_ram_mb=available_host_ram_mb,
+                safety_margin_mb=host_ram_safety_margin_mb,
+            )
+            logger.info(
+                "Cache plan: host_ram_available=%.0fMB, reserved_for_sleep=%.0fMB "
+                "(%d sleepable model(s)), safety_margin=%.0fMB → tmpfs_budget="
+                "%.0fMB. Caching %d unsleepable + %d sleepable, skipping %d "
+                "sleepable for headroom.",
+                plan.available_host_ram_mb, plan.reserved_for_sleep_mb,
+                sum(1 for c in candidates if c.can_sleep),
+                plan.safety_margin_mb, plan.sleepable_tmpfs_budget_mb,
+                len(plan.cached_unsleepable), len(plan.cached_sleepable),
+                len(plan.skipped_sleepable),
+            )
+            if plan.skipped_sleepable:
                 logger.info(
-                    "Pre-populating RAM cache with %d calibrated model(s): %s",
-                    len(caps_to_cache), caps_to_cache,
+                    "  Skipped sleepable (would compete with sleep reserve): %s",
+                    plan.skipped_sleepable,
                 )
-                effective_paths = await model_cache.cache_models_by_priority(caps_to_cache)
+
+            if plan.order:
+                logger.info(
+                    "Pre-populating RAM cache with %d model(s): %s",
+                    len(plan.order), plan.order,
+                )
+                effective_paths = await model_cache.cache_models_by_priority(plan.order)
                 for m, p in effective_paths.items():
                     if p == str(model_cache._cache_hub.parent):
                         logger.info("  %s → tmpfs RAM cache", m)
                     else:
-                        logger.info("  %s → source filesystem (RAM cache full or model not found)", m)
+                        logger.info(
+                            "  %s → source filesystem (RAM cache full or model not found)",
+                            m,
+                        )
             else:
-                logger.info("No calibrated models to pre-populate into RAM cache")
+                logger.info("No models eligible to pre-populate into RAM cache")
 
     lane_manager = LaneManager(
         global_config=cfg.engines.ollama,

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -69,6 +69,16 @@ class ModelProfileRecord:
     # auto-calibrator hard-forced eager mode). Matched against the production
     # override when deciding whether a cached profile is still valid.
     enforce_eager_at_calibration: bool | None = None
+    # Host-RAM footprint of the lane process tree once loaded. The master's
+    # capacity planner uses this to reason about host RAM as a resource axis
+    # parallel to VRAM — necessary because vLLM sleep_l1/sleep_l2 free VRAM
+    # but retain weights in host RAM. EMA-updated from worker telemetry.
+    host_ram_mb: float | None = None
+    # Host-RAM still held when the lane is sleeping (level 1). Approximately
+    # equal to host_ram_mb in practice — sleep_l1 moves weights from VRAM to
+    # host RAM rather than freeing them — but tracked separately so the
+    # planner can use the right value depending on the candidate's state.
+    host_ram_residual_mb: float | None = None
 
     def known_base_residency_mb(self) -> float | None:
         """Return base_residency_mb only if it came from a real source, else None."""
@@ -115,7 +125,35 @@ class ModelProfileRecord:
             "last_measured_epoch": self.last_measured_epoch,
             "residency_source": self.residency_source,
             "enforce_eager_at_calibration": self.enforce_eager_at_calibration,
+            "host_ram_mb": self.host_ram_mb,
+            "host_ram_residual_mb": self.host_ram_residual_mb,
         }
+
+    def estimate_host_ram_mb(self) -> float:
+        """Best estimate of awake host-RAM footprint for the lane process tree.
+
+        Returns host_ram_mb when known. Otherwise falls back to disk_size_bytes
+        (the safetensors total is a tight lower bound on the loaded footprint —
+        the weights are mmapped/copied into host RAM at load time, plus
+        tokenizer, compile cache, etc. add ~1–4 GiB overhead). Returns 0.0
+        when nothing is known.
+        """
+        if self.host_ram_mb is not None and self.host_ram_mb > 0:
+            return self.host_ram_mb
+        if self.disk_size_bytes and self.disk_size_bytes > 0:
+            return self.disk_size_bytes / (1024 * 1024)
+        return 0.0
+
+    def estimate_sleeping_host_ram_mb(self) -> float:
+        """Host-RAM still held when sleeping (level 1).
+
+        Sleep_l1 retains weights in host RAM, so the residual ≈ the awake
+        footprint. Falls back to estimate_host_ram_mb() when no measurement
+        has been recorded.
+        """
+        if self.host_ram_residual_mb is not None and self.host_ram_residual_mb > 0:
+            return self.host_ram_residual_mb
+        return self.estimate_host_ram_mb()
 
 
 class ModelProfileRegistry:
@@ -213,6 +251,12 @@ class ModelProfileRegistry:
         if "tensor_parallel_size" in overrides:
             profile.tensor_parallel_size = int(overrides["tensor_parallel_size"])
             applied.append(f"tp={profile.tensor_parallel_size}")
+        if "host_ram_mb" in overrides:
+            profile.host_ram_mb = float(overrides["host_ram_mb"])
+            applied.append(f"host_ram={profile.host_ram_mb:.0f}MB")
+        if "host_ram_residual_mb" in overrides:
+            profile.host_ram_residual_mb = float(overrides["host_ram_residual_mb"])
+            applied.append(f"host_ram_residual={profile.host_ram_residual_mb:.0f}MB")
 
         if applied:
             logger.info("Applied manual overrides for %s: %s", model_name, ", ".join(applied))
@@ -399,6 +443,36 @@ class ModelProfileRegistry:
             profile.last_measured_epoch = time.time()
         self._persist()
 
+    def record_host_ram(
+        self,
+        model_name: str,
+        host_ram_mb: float,
+        *,
+        sleeping: bool = False,
+    ) -> None:
+        """Record measured host-RAM footprint for the lane process tree.
+
+        *sleeping* selects which field is updated: when False, host_ram_mb
+        (awake footprint); when True, host_ram_residual_mb (level-1 sleep).
+        EMA-blended with prior measurements.
+        """
+        if host_ram_mb <= 0:
+            return
+        with self._lock:
+            profile = self._profiles.setdefault(model_name, ModelProfileRecord())
+            if sleeping:
+                profile.host_ram_residual_mb = (
+                    host_ram_mb if profile.host_ram_residual_mb is None
+                    else _ema(profile.host_ram_residual_mb, host_ram_mb)
+                )
+            else:
+                profile.host_ram_mb = (
+                    host_ram_mb if profile.host_ram_mb is None
+                    else _ema(profile.host_ram_mb, host_ram_mb)
+                )
+            profile.last_measured_epoch = time.time()
+        self._persist()
+
     def record_disk_size(self, model_name: str, disk_size_bytes: int) -> None:
         """Store disk size reported by Ollama /api/tags. Informational only."""
         if disk_size_bytes <= 0:
@@ -475,6 +549,8 @@ class ModelProfileRegistry:
                     last_measured_epoch=float(profile_data.get("last_measured_epoch", 0.0) or 0.0),
                     residency_source=persisted_source or "cached",
                     enforce_eager_at_calibration=eager_at_cal,
+                    host_ram_mb=profile_data.get("host_ram_mb"),
+                    host_ram_residual_mb=profile_data.get("host_ram_residual_mb"),
                 )
             logger.info(
                 "Loaded %d model profile(s) from %s", len(self._profiles), state_path,

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -441,6 +441,23 @@ class DeviceSummary(BaseModel):
     free_memory_mb: float = 0.0
 
 
+class HostMemorySummary(BaseModel):
+    """Host-RAM telemetry independent of GPU memory.
+
+    Sourced from /proc/meminfo. The planner needs this to gate cold loads:
+    vLLM's sleep_l1 frees VRAM but retains weights in host RAM, so VRAM
+    headroom alone is insufficient when picking eviction victims.
+    """
+
+    timestamp: datetime
+    source: Literal["proc-meminfo", "unavailable"] = "unavailable"
+    total_mb: float = 0.0
+    available_mb: float = 0.0
+    used_mb: float = 0.0
+    swap_total_mb: float = 0.0
+    swap_used_mb: float = 0.0
+
+
 class WorkerTransportStatus(BaseModel):
     connected: bool = False
     worker_id: str = ""
@@ -490,6 +507,11 @@ class LaneStatus(BaseModel):
     device_vram_mb: float = 0.0
     effective_vram_mb: float = 0.0
     vram_source: Literal["pid", "reported", "device", "unknown"] = "unknown"
+    # Host-RAM footprint of the lane's process tree (PSS preferred, RSS
+    # fallback). Includes child workers — vLLM TP=N spawns N Worker_TPx
+    # subprocesses whose RSS each carries a full copy of the weights.
+    host_ram_mb: float = 0.0
+    host_ram_source: Literal["pss", "rss", "unknown"] = "unknown"
 
 
 class WorkerRuntimeStatus(BaseModel):
@@ -499,6 +521,7 @@ class WorkerRuntimeStatus(BaseModel):
     timestamp: datetime
     transport: WorkerTransportStatus
     devices: DeviceSummary
+    host_memory: HostMemorySummary | None = None
     capacity: CapacitySummary
     lanes: list[LaneStatus] = Field(default_factory=list)
     model_profiles: dict[str, dict[str, Any]] | None = None

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -215,6 +215,17 @@ class VllmEngineConfig(BaseModel):
         "Overrides are merged on top of whatever the Logos server sends, so the worker "
         "can enforce Turing/SM-7.5 workarounds without touching the server.",
     )
+    global_extra_args: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Worker-wide vLLM CLI flags appended to every lane's command line, "
+            "after the lane's own vllm_config.extra_args. Use this for flags "
+            "that should apply uniformly across all lanes on this worker — for "
+            "example '--safetensors-load-strategy=prefetch' when the model "
+            "store is a network filesystem that vLLM's own detection misses "
+            "(EXT4 over rbd-nbd / kernel block layer rather than NFS/Lustre)."
+        ),
+    )
 
     @field_validator("model_overrides", mode="before")
     @classmethod

--- a/logos/logos-workernode/logos_worker_node/runtime.py
+++ b/logos/logos-workernode/logos_worker_node/runtime.py
@@ -9,13 +9,19 @@ from typing import Any
 
 from fastapi import FastAPI
 
-from logos_worker_node.models import CapacitySummary, DeviceInfo, DeviceSummary, WorkerRuntimeStatus
+from logos_worker_node.models import (
+    CapacitySummary,
+    DeviceInfo,
+    DeviceSummary,
+    HostMemorySummary,
+    WorkerRuntimeStatus,
+)
 
 SERVICE_VERSION = "2.0.0"
 
 
-def _read_proc_meminfo_mb() -> tuple[float, float, float] | None:
-    """Read Linux memory totals in MiB from /proc/meminfo for degraded telemetry mode."""
+def _read_proc_meminfo_kb() -> dict[str, float] | None:
+    """Read /proc/meminfo values in kB. Returns None when unreadable."""
     meminfo_path = Path("/proc/meminfo")
     if not meminfo_path.exists():
         return None
@@ -35,16 +41,51 @@ def _read_proc_meminfo_mb() -> tuple[float, float, float] | None:
                 continue
     except OSError:
         return None
+    return values_kb
 
+
+def _read_proc_meminfo_mb() -> tuple[float, float, float] | None:
+    """Read MemTotal/MemAvailable in MiB. Returns (total, used, free) or None."""
+    values_kb = _read_proc_meminfo_kb()
+    if values_kb is None:
+        return None
     total_kb = values_kb.get("MemTotal")
     available_kb = values_kb.get("MemAvailable")
     if not total_kb or available_kb is None:
         return None
-
     total_mb = total_kb / 1024.0
     free_mb = max(available_kb / 1024.0, 0.0)
     used_mb = max(total_mb - free_mb, 0.0)
     return total_mb, used_mb, free_mb
+
+
+def _build_host_memory_summary() -> HostMemorySummary:
+    """Always-on host RAM telemetry. Falls back to zeros when /proc is absent."""
+    now = datetime.now(timezone.utc)
+    values_kb = _read_proc_meminfo_kb()
+    if values_kb is None:
+        return HostMemorySummary(timestamp=now, source="unavailable")
+
+    total_kb = values_kb.get("MemTotal")
+    available_kb = values_kb.get("MemAvailable")
+    if not total_kb or available_kb is None:
+        return HostMemorySummary(timestamp=now, source="unavailable")
+
+    total_mb = total_kb / 1024.0
+    available_mb = max(available_kb / 1024.0, 0.0)
+    used_mb = max(total_mb - available_mb, 0.0)
+    swap_total_mb = float(values_kb.get("SwapTotal", 0.0)) / 1024.0
+    swap_free_mb = float(values_kb.get("SwapFree", 0.0)) / 1024.0
+    swap_used_mb = max(swap_total_mb - swap_free_mb, 0.0)
+    return HostMemorySummary(
+        timestamp=now,
+        source="proc-meminfo",
+        total_mb=total_mb,
+        available_mb=available_mb,
+        used_mb=used_mb,
+        swap_total_mb=swap_total_mb,
+        swap_used_mb=swap_used_mb,
+    )
 
 
 def _build_derived_device_summary(lanes) -> DeviceSummary:
@@ -123,6 +164,8 @@ async def build_runtime_status(app: FastAPI) -> WorkerRuntimeStatus:
         free_memory_mb=float(devices.free_memory_mb or 0.0),
     )
 
+    host_memory = _build_host_memory_summary()
+
     # Include model profiles if available
     model_profiles = None
     if hasattr(app.state, "model_profiles") and app.state.model_profiles is not None:
@@ -135,6 +178,7 @@ async def build_runtime_status(app: FastAPI) -> WorkerRuntimeStatus:
         timestamp=datetime.now(timezone.utc),
         transport=bridge.transport_status(),
         devices=devices,
+        host_memory=host_memory,
         capacity=capacity,
         lanes=lanes,
         model_profiles=model_profiles if model_profiles else None,

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -932,6 +932,11 @@ class VllmProcessHandle:
             import json as _json
 
             cmd.extend(["--default-chat-template-kwargs", _json.dumps(merged_kwargs)])
+        # Worker-wide vLLM flags (e.g. --safetensors-load-strategy=prefetch on
+        # NFS-flavoured storage that vLLM's auto-detection misses) — applied
+        # BEFORE per-lane extra_args so a lane can still override a global
+        # default when needed (argparse takes the last occurrence).
+        cmd.extend(self._vllm_engine_config.global_extra_args)
         cmd.extend(vc.extra_args)
         return cmd
 

--- a/logos/logos-workernode/pytest.ini
+++ b/logos/logos-workernode/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 asyncio_mode = auto
 testpaths = tests
+pythonpath = . tools

--- a/logos/logos-workernode/tests/test_cache_planner.py
+++ b/logos/logos-workernode/tests/test_cache_planner.py
@@ -1,0 +1,167 @@
+"""Tests for plan_cache_order — the host-RAM-aware tmpfs cache planner.
+
+The operator rule the planner enforces:
+
+    Load as many models into the tmpfs cache as possible WITHOUT lowering
+    the number of models that can be sleeping simultaneously.
+
+Concretely: reserve ``sum(host_ram of every sleepable capability model)``
+from the host's available RAM, then pack the leftover with cache candidates
+(unsleepable first because they cannot be brought back via sleep_l1; smallest
+first within each group to maximise count).
+"""
+
+from __future__ import annotations
+
+from logos_worker_node.cache_planner import CacheCandidate, plan_cache_order
+
+_MB = 1024 * 1024
+
+
+def _c(name: str, *, can_sleep: bool, host_ram_mb: float, size_bytes: int) -> CacheCandidate:
+    return CacheCandidate(
+        name=name,
+        can_sleep=can_sleep,
+        host_ram_mb=host_ram_mb,
+        size_bytes=size_bytes,
+    )
+
+
+def test_no_candidates_returns_empty_plan():
+    plan = plan_cache_order(
+        [], available_host_ram_mb=100_000.0, safety_margin_mb=4096.0,
+    )
+    assert plan.order == []
+    assert plan.reserved_for_sleep_mb == 0.0
+    assert plan.cached_unsleepable == []
+    assert plan.cached_sleepable == []
+
+
+def test_single_unsleepable_is_cached_regardless_of_budget():
+    """Unsleepable models don't enter the sleep reserve and are always queued
+    for caching — the operator rule protects sleep capacity, and unsleepable
+    models aren't in it."""
+    plan = plan_cache_order(
+        [_c("u", can_sleep=False, host_ram_mb=50_000.0, size_bytes=50 * _MB)],
+        available_host_ram_mb=10.0,  # absurdly low — doesn't matter
+        safety_margin_mb=4096.0,
+    )
+    assert plan.order == ["u"]
+    assert plan.reserved_for_sleep_mb == 0.0
+
+
+def test_all_sleepable_fit_in_budget_get_cached():
+    """Three small sleepable models, lots of host RAM → all reserved AND all
+    cached. (reserve takes 6GB, budget = 100GB − 6GB − 8GB = 86GB, the three
+    weigh ~3 GB on disk and pack easily.)"""
+    cands = [
+        _c("a", can_sleep=True, host_ram_mb=2_000.0, size_bytes=int(1.5 * 1024) * _MB),
+        _c("b", can_sleep=True, host_ram_mb=2_000.0, size_bytes=int(1.0 * 1024) * _MB),
+        _c("c", can_sleep=True, host_ram_mb=2_000.0, size_bytes=int(0.5 * 1024) * _MB),
+    ]
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=100_000.0, safety_margin_mb=8192.0,
+    )
+    assert plan.reserved_for_sleep_mb == 6_000.0
+    # Smallest-first within sleepable group
+    assert plan.order == ["c", "b", "a"]
+    assert plan.skipped_sleepable == []
+
+
+def test_sleepable_skipped_when_tmpfs_budget_exhausted():
+    """Tight host RAM — reserve eats most of it. Only the smallest sleepable
+    fits in the remaining budget; larger ones are skipped."""
+    cands = [
+        _c("small", can_sleep=True, host_ram_mb=20_000.0, size_bytes=5_000 * _MB),
+        _c("large", can_sleep=True, host_ram_mb=20_000.0, size_bytes=15_000 * _MB),
+    ]
+    # reserve = 40GB; available − reserve − margin = 60GB − 40GB − 4GB = 16GB
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=60_000.0, safety_margin_mb=4096.0,
+    )
+    assert plan.reserved_for_sleep_mb == 40_000.0
+    assert plan.sleepable_tmpfs_budget_mb == 60_000.0 - 40_000.0 - 4096.0
+    assert plan.cached_sleepable == ["small"]
+    assert plan.skipped_sleepable == ["large"]
+    assert plan.order == ["small"]
+
+
+def test_unsleepable_precedes_sleepable_in_order():
+    """Ordering rule: every unsleepable comes before any sleepable, regardless
+    of size."""
+    cands = [
+        _c("sleep-tiny", can_sleep=True, host_ram_mb=1_000.0, size_bytes=100 * _MB),
+        _c("no-sleep-huge", can_sleep=False, host_ram_mb=80_000.0, size_bytes=80_000 * _MB),
+        _c("sleep-medium", can_sleep=True, host_ram_mb=2_000.0, size_bytes=2_000 * _MB),
+    ]
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=200_000.0, safety_margin_mb=4096.0,
+    )
+    # Unsleepable first, then sleepable smallest-first
+    assert plan.order == ["no-sleep-huge", "sleep-tiny", "sleep-medium"]
+
+
+def test_reserve_can_be_larger_than_available_no_sleepable_cached():
+    """Overcommitted: every sleepable can't fit in host RAM even by itself.
+    Budget goes negative → no sleepable is cached. Unsleepables still queue."""
+    cands = [
+        _c("over-1", can_sleep=True, host_ram_mb=80_000.0, size_bytes=80_000 * _MB),
+        _c("over-2", can_sleep=True, host_ram_mb=80_000.0, size_bytes=80_000 * _MB),
+        _c("u", can_sleep=False, host_ram_mb=10_000.0, size_bytes=10_000 * _MB),
+    ]
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=100_000.0, safety_margin_mb=4096.0,
+    )
+    assert plan.reserved_for_sleep_mb == 160_000.0
+    assert plan.sleepable_tmpfs_budget_mb < 0
+    assert plan.cached_sleepable == []
+    assert plan.cached_unsleepable == ["u"]
+    assert plan.order == ["u"]
+
+
+def test_safety_margin_is_subtracted_before_packing():
+    """4 GB safety margin → a sleepable that would just fit without margin
+    must be skipped."""
+    cands = [
+        # reserve = 50GB; available 60GB − 50GB − 8GB margin = 2GB budget.
+        # Sleepable is 5GB on disk — doesn't fit.
+        _c("just-too-big", can_sleep=True, host_ram_mb=50_000.0, size_bytes=5_000 * _MB),
+    ]
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=60_000.0, safety_margin_mb=8192.0,
+    )
+    assert plan.cached_sleepable == []
+    assert plan.skipped_sleepable == ["just-too-big"]
+
+
+def test_plan_is_deterministic_for_identical_inputs():
+    """Same inputs → identical CachePlan, every time."""
+    cands = [
+        _c("a", can_sleep=True, host_ram_mb=5_000.0, size_bytes=5_000 * _MB),
+        _c("b", can_sleep=False, host_ram_mb=10_000.0, size_bytes=10_000 * _MB),
+        _c("c", can_sleep=True, host_ram_mb=3_000.0, size_bytes=3_000 * _MB),
+    ]
+    first = plan_cache_order(cands, available_host_ram_mb=100_000.0, safety_margin_mb=4096.0)
+    second = plan_cache_order(cands, available_host_ram_mb=100_000.0, safety_margin_mb=4096.0)
+    third = plan_cache_order(cands, available_host_ram_mb=100_000.0, safety_margin_mb=4096.0)
+    assert first.order == second.order == third.order
+    assert first.cached_unsleepable == second.cached_unsleepable == third.cached_unsleepable
+    assert first.cached_sleepable == second.cached_sleepable == third.cached_sleepable
+
+
+def test_smallest_first_within_each_group():
+    cands = [
+        _c("u-big", can_sleep=False, host_ram_mb=20_000.0, size_bytes=20_000 * _MB),
+        _c("u-small", can_sleep=False, host_ram_mb=2_000.0, size_bytes=2_000 * _MB),
+        _c("u-medium", can_sleep=False, host_ram_mb=10_000.0, size_bytes=10_000 * _MB),
+        _c("s-big", can_sleep=True, host_ram_mb=20_000.0, size_bytes=20_000 * _MB),
+        _c("s-small", can_sleep=True, host_ram_mb=2_000.0, size_bytes=2_000 * _MB),
+    ]
+    plan = plan_cache_order(
+        cands, available_host_ram_mb=200_000.0, safety_margin_mb=4096.0,
+    )
+    assert plan.cached_unsleepable == ["u-small", "u-medium", "u-big"]
+    assert plan.cached_sleepable == ["s-small", "s-big"]
+    assert plan.order == [
+        "u-small", "u-medium", "u-big", "s-small", "s-big",
+    ]

--- a/logos/logos-workernode/tests/test_host_ram.py
+++ b/logos/logos-workernode/tests/test_host_ram.py
@@ -1,0 +1,79 @@
+"""Tests for the worker-side host-RAM measurement helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+from logos_worker_node import host_ram
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="/proc/<pid>/smaps_rollup and /proc/<pid>/status are Linux-only",
+)
+def test_read_process_rss_returns_positive_for_self():
+    """The current Python process has a non-zero RSS via /proc/self/status."""
+    pid = os.getpid()
+    mb = host_ram.read_process_rss_mb(pid)
+    assert mb > 0
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="/proc is Linux-only",
+)
+def test_walk_process_tree_includes_root_pid():
+    pid = os.getpid()
+    tree = host_ram.walk_process_tree(pid)
+    assert pid in tree
+
+
+def test_read_process_pss_returns_zero_for_missing_pid():
+    # PID 0 never has a /proc entry; PSS read must fail-soft to 0.0
+    assert host_ram.read_process_pss_mb(0) == 0.0
+
+
+def test_read_process_rss_returns_zero_for_missing_pid():
+    assert host_ram.read_process_rss_mb(0) == 0.0
+
+
+def test_walk_process_tree_handles_dead_pid():
+    """A non-existent pid yields an empty tree (not a crash)."""
+    assert host_ram.walk_process_tree(2**30) == set()
+
+
+def test_measure_process_tree_falls_back_to_rss_when_pss_unavailable():
+    """If smaps_rollup is empty/unreadable, fall back to RSS-summing the tree."""
+    fake_pid = 12345
+    with (
+        patch.object(host_ram, "walk_process_tree", return_value={fake_pid, 12346}),
+        patch.object(host_ram, "read_process_pss_mb", return_value=0.0),
+        patch.object(host_ram, "read_process_rss_mb", side_effect=[500.0, 250.0]),
+    ):
+        mb, source = host_ram.measure_process_tree_host_ram_mb(fake_pid)
+    assert source == "rss"
+    assert mb == pytest.approx(750.0)
+
+
+def test_measure_process_tree_prefers_pss_when_available():
+    """When PSS readings exist, they are preferred over RSS to avoid TP double-count."""
+    fake_pid = 12345
+    with (
+        patch.object(host_ram, "walk_process_tree", return_value={fake_pid, 12346}),
+        patch.object(host_ram, "read_process_pss_mb", side_effect=[600.0, 300.0]),
+        patch.object(host_ram, "read_process_rss_mb", side_effect=[5000.0, 4900.0]),
+    ):
+        mb, source = host_ram.measure_process_tree_host_ram_mb(fake_pid)
+    assert source == "pss"
+    assert mb == pytest.approx(900.0)
+
+
+def test_measure_process_tree_unknown_for_dead_root():
+    mb, source = host_ram.measure_process_tree_host_ram_mb(2**30)
+    assert mb == 0.0
+    assert source == "unknown"

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -128,6 +128,7 @@ async def test_add_lane_releases_port_when_spawn_fails(monkeypatch) -> None:
         _global_config: OllamaConfig,
         _vllm_engine_config,
         _lane_config: LaneConfig,
+        **_kwargs,
     ) -> FailingHandle:
         handle = FailingHandle(lid, port)
         created["handle"] = handle
@@ -793,7 +794,7 @@ async def test_stuck_lane_is_automatically_restarted(monkeypatch) -> None:
     manager._port_alloc._used[lane_id] = 15000  # noqa: SLF001
 
     def _fake_create_handle(
-        lid: str, port: int, _gc, _vec, _lc,
+        lid: str, port: int, _gc, _vec, _lc, **_kwargs,
     ) -> FakeNewHandle:
         return FakeNewHandle(lid, port)
 
@@ -912,7 +913,7 @@ async def test_stuck_restart_failure_does_not_crash(monkeypatch) -> None:
     manager._handles[lane_id] = FakeStuckHandle()  # noqa: SLF001
     manager._port_alloc._used[lane_id] = 15000  # noqa: SLF001
 
-    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> FailingNewHandle:
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc, **_kwargs) -> FailingNewHandle:
         return FailingNewHandle(lid, port)
 
     monkeypatch.setattr("logos_worker_node.lane_manager._create_handle", _fake_create_handle)
@@ -980,7 +981,7 @@ async def test_recover_dead_lanes_restarts_stopped_lane(monkeypatch) -> None:
     manager._handles[lane_id] = DeadHandle()  # noqa: SLF001
     manager._port_alloc._used[lane_id] = 15000  # noqa: SLF001
 
-    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> NewHandle:
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc, **_kwargs) -> NewHandle:
         return NewHandle(lid, port)
 
     monkeypatch.setattr("logos_worker_node.lane_manager._create_handle", _fake_create_handle)
@@ -1358,7 +1359,7 @@ async def test_stuck_vram_skips_restart(monkeypatch) -> None:
         async def close(self) -> None:
             pass
 
-    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> Any:
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc, **_kwargs) -> Any:
         restart_calls.append("spawn")
         raise AssertionError("should not be called")
 
@@ -1407,7 +1408,7 @@ async def test_fatal_cuda_errors_skip_restart(monkeypatch) -> None:
         async def close(self) -> None:
             pass
 
-    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> Any:
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc, **_kwargs) -> Any:
         restart_calls.append("spawn")
         raise AssertionError("should not be called")
 
@@ -1473,7 +1474,7 @@ async def test_crash_restart_count_resets_on_success(monkeypatch) -> None:
     # Pre-seed count as if 3 prior failures
     manager._crash_restart_counts[lane_id] = 3  # noqa: SLF001
 
-    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc) -> GoodNewHandle:
+    def _fake_create_handle(lid: str, port: int, _gc, _vec, _lc, **_kwargs) -> GoodNewHandle:
         return GoodNewHandle(lid, port)
 
     monkeypatch.setattr("logos_worker_node.lane_manager._create_handle", _fake_create_handle)

--- a/logos/logos-workernode/tests/test_max_lanes.py
+++ b/logos/logos-workernode/tests/test_max_lanes.py
@@ -54,7 +54,7 @@ def _patch_create_handle(monkeypatch):
     """Patch _create_handle to return FakeHandle instances."""
     created = []
 
-    def _fake(lid, port, _gc, _vec, _lc):
+    def _fake(lid, port, _gc, _vec, _lc, **_kwargs):
         h = FakeHandle(lid, port)
         created.append(h)
         return h

--- a/logos/logos-workernode/tests/test_model_profiles.py
+++ b/logos/logos-workernode/tests/test_model_profiles.py
@@ -298,10 +298,13 @@ def test_calibrated_profile_not_overwritten_by_subsequent_load(tmp_path):
     registry.record_loaded_vram("org/model", 7200.0, engine="vllm", kv_cache_sent_mb=2048.0)
 
     profile = registry.get_profile("org/model")
-    # base_residency EMA: first was 5000, measured is 7200-2048=5152 → EMA(5000, 5152)
-    expected_base = 0.3 * 5152.0 + 0.7 * 5000.0
-    assert profile.base_residency_mb == pytest.approx(expected_base, abs=1.0)
-    assert profile.residency_source == "measured"
+    # Calibrated base_residency is authoritative — it was measured on a clean
+    # GPU and must not be EMA-blended with live measurements that can be
+    # lower when multiple models share GPU memory. The runtime measurement
+    # is still recorded against other fields (e.g. loaded_vram_mb) but the
+    # provenance and value of base_residency_mb stay pinned.
+    assert profile.base_residency_mb == 5000.0
+    assert profile.residency_source == "calibrated"
 
 
 def test_persist_no_state_dir():

--- a/logos/logos-workernode/tests/test_runtime.py
+++ b/logos/logos-workernode/tests/test_runtime.py
@@ -49,7 +49,9 @@ class _Bridge:
 
 
 def _make_app(lanes):
-    worker_cfg = SimpleNamespace(name="logos-workernode", max_lanes=0)
+    worker_cfg = SimpleNamespace(
+        name="logos-workernode", max_lanes=0, gpu_performance_score=100,
+    )
     state = SimpleNamespace(
         config=SimpleNamespace(worker=worker_cfg),
         lane_manager=_LaneManager(lanes),

--- a/logos/logos-workernode/tests/test_static_lanes.py
+++ b/logos/logos-workernode/tests/test_static_lanes.py
@@ -59,7 +59,7 @@ def _patch_create_handle(monkeypatch):
     """Patch _create_handle to return FakeHandle instances."""
     created = []
 
-    def _fake(lid, port, _gc, _vec, _lc):
+    def _fake(lid, port, _gc, _vec, _lc, **_kwargs):
         h = FakeHandle(lid, port)
         created.append(h)
         return h

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1319,37 +1319,24 @@ def test_build_env_honors_logos_worker_cache_root(monkeypatch):
 def test_infer_reasoning_parser() -> None:
     from logos_worker_node.vllm_process import _infer_reasoning_parser
 
-    # DeepSeek R1 series
-    assert (
-        _infer_reasoning_parser("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B")
-        == "deepseek_r1"
-    )
-    assert _infer_reasoning_parser("deepseek-ai/DeepSeek-R1-0528") == "deepseek_r1"
-    # QwQ-32B also uses deepseek_r1 (per vLLM docs)
-    assert _infer_reasoning_parser("Qwen/QwQ-32B") == "deepseek_r1"
+    # The production rule table currently registers only the parsers shipping
+    # in vllm/reasoning/__init__.py: gemma4 and openai_gptoss. Other model
+    # families return None — no flag emitted — until vLLM exposes a parser
+    # for them.
     # Google Gemma 4
     assert _infer_reasoning_parser("google/gemma-4-27b-it") == "gemma4"
-    assert _infer_reasoning_parser("google/gemma4-2b") == "gemma4"
-    # Zhipu GLM-4.5
-    assert _infer_reasoning_parser("zai-org/GLM-4.5-Flash") == "glm45"
-    assert _infer_reasoning_parser("zai-org/GLM4.5-Air") == "glm45"
-    # IBM Granite 3.x
-    assert _infer_reasoning_parser("ibm-granite/granite-3.2-8b-instruct") == "granite"
-    assert _infer_reasoning_parser("ibm-granite/granite-3.1-2b-instruct") == "granite"
-    # Alibaba Qwen3
-    assert _infer_reasoning_parser("Qwen/Qwen3-8B") == "qwen3"
-    assert _infer_reasoning_parser("Qwen/Qwen3-Coder-480B-A35B-Instruct") == "qwen3"
-    assert _infer_reasoning_parser("Qwen/Qwen3-VL-7B-Instruct") == "qwen3"
+    assert _infer_reasoning_parser("google/gemma-4-2b") == "gemma4"
     # OpenAI GPT-OSS
-    assert _infer_reasoning_parser("openai/gpt-oss-120b") == "gpt_oss"
-    assert _infer_reasoning_parser("openai/gpt-oss-20b") == "gpt_oss"
-    # Unknown model → None (no flag emitted)
+    assert _infer_reasoning_parser("openai/gpt-oss-120b") == "openai_gptoss"
+    assert _infer_reasoning_parser("openai/gpt-oss-20b") == "openai_gptoss"
+    # Unknown / unsupported model families → None (no flag emitted)
     assert _infer_reasoning_parser("meta-llama/Llama-3.1-8B-Instruct") is None
     assert _infer_reasoning_parser("some/unknown-model") is None
-    # Generic DeepSeek (not R1) should NOT match
-    assert _infer_reasoning_parser("deepseek-ai/DeepSeek-V2.5") is None
-    # Granite 4 should NOT match (only 3.x has confirmed reasoning support)
-    assert _infer_reasoning_parser("ibm-granite/granite-4.0-h-small") is None
+    assert _infer_reasoning_parser("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B") is None
+    assert _infer_reasoning_parser("Qwen/QwQ-32B") is None
+    assert _infer_reasoning_parser("Qwen/Qwen3-8B") is None
+    assert _infer_reasoning_parser("zai-org/GLM-4.5-Flash") is None
+    assert _infer_reasoning_parser("ibm-granite/granite-3.2-8b-instruct") is None
 
 
 # ---------------------------------------------------------------------------
@@ -1360,11 +1347,12 @@ def test_infer_reasoning_parser() -> None:
 def test_infer_default_chat_template_kwargs() -> None:
     from logos_worker_node.vllm_process import _infer_default_chat_template_kwargs
 
-    # Google Gemma 4 → enable_thinking: True
+    # Google Gemma 4 → enable_thinking: True. Pattern is the substring
+    # "gemma-4" (with dash) — names without the dash do not match.
     assert _infer_default_chat_template_kwargs("google/gemma-4-27b-it") == {
         "enable_thinking": True
     }
-    assert _infer_default_chat_template_kwargs("google/gemma4-2b") == {
+    assert _infer_default_chat_template_kwargs("google/gemma-4-2b") == {
         "enable_thinking": True
     }
     # Unknown model → empty dict

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -36,6 +36,7 @@ from logos.terminal_logging import (
 )
 
 from .demand_tracker import DemandTracker
+from .host_ram_ledger import HostRamLedger
 from .lane_comparator import best_lane
 from .vram_ledger import VRAMLedger
 from logos.monitoring import prometheus_metrics as prom
@@ -172,6 +173,20 @@ class CapacityPlanner:
     # quantity → one constant.
     VRAM_SAFETY_MARGIN = 1.0
     PER_GPU_COLD_START_MB = 500.0
+
+    # ─── Host-RAM headroom model ────────────────────────────────────────────
+    #
+    # The planner treats host RAM as a first-class resource axis parallel to
+    # VRAM because vLLM sleep_l1/sleep_l2 free VRAM but retain weights in host
+    # RAM. Without this gate the planner happily issues `sleep_l1` to free
+    # VRAM for a cold load, only for the new lane's mmap of the safetensors
+    # checkpoint to thrash into swap because the sleeping lane's weights
+    # still occupy host RAM.
+    #
+    # Additive margin (MB), not multiplicative — host RAM is a single pool
+    # that needs a fixed absolute buffer (OS file cache, malloc fragmentation,
+    # mm processor cache) regardless of model size.
+    HOST_RAM_SAFETY_MARGIN_MB = 4096.0
     ESTIMATION_SLACK_RATIO = 1.10
     # Tensor-parallel overhead: NCCL buffers + duplicated embedding/output layers
     TP_OVERHEAD_RATIO = 0.10  # 10% overhead per GPU for TP > 1
@@ -304,6 +319,12 @@ class CapacityPlanner:
         # when concurrent load/wake/sleep/stop operations overlap.
         self._vram_ledger = VRAMLedger()
 
+        # Parallel ledger for host RAM. Cold loads and wakes from level-2
+        # reserve here against the worker's reported host_memory.available_mb.
+        # sleep_l1/sleep_l2 do NOT release host RAM (weights stay resident);
+        # only `stop` does. See HOST_RAM_SAFETY_MARGIN_MB above.
+        self._host_ram_ledger = HostRamLedger()
+
         # Per-provider capacity lock: serializes _ensure_request_capacity calls
         # so concurrent reclaim plans can't deadlock by competing for the same
         # freed VRAM.  Only one capacity operation (drain/sleep/stop → load/wake)
@@ -428,6 +449,9 @@ class CapacityPlanner:
         stale_count = self._vram_ledger.cleanup_stale(max_age_seconds=120.0)
         if stale_count > 0:
             logger.warning("Cleaned %d stale VRAM reservations", stale_count)
+        stale_host_ram = self._host_ram_ledger.cleanup_stale(max_age_seconds=120.0)
+        if stale_host_ram > 0:
+            logger.warning("Cleaned %d stale host-RAM reservations", stale_host_ram)
 
         self._demand.decay_all()
 
@@ -841,6 +865,41 @@ class CapacityPlanner:
             )
             return None
 
+    def _check_host_ram_headroom_for_cold_load(
+        self,
+        provider_id: int,
+        loading_model: str,
+        projected_host_ram_mb: float,
+    ) -> tuple[bool, float, float]:
+        """Pure precheck: does the worker have enough host RAM for a cold load?
+
+        Returns ``(ok, effective_available_mb, deficit_mb)``. Effective
+        available is ``available − committed − safety_margin``. *ok* is True
+        when *projected_host_ram_mb* ≤ effective available, False otherwise.
+
+        When the worker has no host-RAM telemetry (pre-upgrade worker, host
+        without /proc/meminfo), this fails open: ``ok=True, deficit=0``.
+
+        Deliberately does NOT proactively stop lanes. Sleep remains the
+        planner's default eviction action because waking from sleep_l1 is
+        ~2s vs. a 30-90s cold reload. The gate only blocks the *runaway
+        retry loop* that fires when a model's load is structurally
+        impossible (e.g. checkpoint exceeds free host RAM). If an operator
+        wants the new model to win against an existing sleeping lane, they
+        delete the sleeping lane explicitly — the planner does not make
+        that policy call on their behalf.
+        """
+        available = self._get_host_ram_available_mb(provider_id)
+        if available is None:
+            return True, 0.0, 0.0
+        effective_available = (
+            available
+            - self._host_ram_ledger.get_committed_mb(provider_id)
+            - self.HOST_RAM_SAFETY_MARGIN_MB
+        )
+        deficit = projected_host_ram_mb - effective_available
+        return deficit <= 0, effective_available, max(deficit, 0.0)
+
     async def _stop_sleeping_lanes_for_headroom(
         self,
         provider_id: int,
@@ -927,6 +986,44 @@ class CapacityPlanner:
             getattr(capacity, "total_vram_mb", None),
         )
 
+        # Host-RAM headroom precheck. vLLM sleep_l1/sleep_l2 free VRAM but
+        # retain weights in host RAM, so a load that's VRAM-feasible can
+        # still OOM the host when sleeping lanes are using it up.
+        # _ensure_request_capacity below cannot see host RAM — gate it here.
+        #
+        # Deliberately a *pure precheck*: we do not auto-stop sleeping
+        # lanes. Sleep remains the planner's default eviction action because
+        # it preserves a fast (~2s) wake. The gate's only job is to break
+        # the runaway retry loop when a load is structurally impossible
+        # (deioma incident: 48 GiB checkpoint vs. ~15 GiB available host RAM
+        # → vLLM startup thrashes into swap → readiness timeout → planner
+        # retries every ~5 minutes forever).
+        projected_host_ram_mb = self._estimate_lane_host_ram_mb(
+            provider_id, lane_id, model_name, profile, runtime_state="cold",
+        )
+        if projected_host_ram_mb > 0:
+            host_ram_ok, eff_avail, deficit = (
+                self._check_host_ram_headroom_for_cold_load(
+                    provider_id, model_name, projected_host_ram_mb,
+                )
+            )
+            logger.info(
+                "Cold-load host-RAM check for %s on worker=%s: "
+                "projected=%.0fMB, effective_available=%.0fMB, margin=%.0fMB → %s",
+                model_name,
+                self._facade.get_provider_name(provider_id) or provider_id,
+                projected_host_ram_mb, eff_avail,
+                self.HOST_RAM_SAFETY_MARGIN_MB,
+                "OK" if host_ram_ok else f"DENY (deficit={deficit:.0f}MB)",
+            )
+            if not host_ram_ok:
+                # Defer the load and let _pending_capacity retry it. When
+                # the operator (or another planner cycle) frees enough host
+                # RAM — e.g. by stopping an unused lane — the retry will
+                # pass the gate naturally. We do NOT stop lanes here.
+                self._pending_capacity[model_name] = (provider_id, time.time())
+                return None
+
         # Use the same reclaim engine as wake — it checks aggregate + per-GPU
         # VRAM with ledger awareness, and returns True immediately if sufficient.
         # If not, it runs the full reclaim loop (sleep loaded lanes, drain busy
@@ -964,10 +1061,18 @@ class CapacityPlanner:
             "Cold-loading %s on worker=%s (lane=%s)",
             model_name, self._facade.get_provider_name(provider_id) or provider_id, lane_id,
         )
-        async with self._lane_lock(provider_id, lane_id):
-            loaded = await self._execute_action_with_confirmation(
-                load_action, timeout_seconds=max(timeout_seconds, 300.0),
+        host_ram_reservation_id: str | None = None
+        if projected_host_ram_mb > 0:
+            host_ram_reservation_id = self._reserve_host_ram(
+                provider_id, lane_id, "load", projected_host_ram_mb,
             )
+        try:
+            async with self._lane_lock(provider_id, lane_id):
+                loaded = await self._execute_action_with_confirmation(
+                    load_action, timeout_seconds=max(timeout_seconds, 300.0),
+                )
+        finally:
+            self._release_host_ram(host_ram_reservation_id)
         if not loaded:
             return None
 
@@ -5391,6 +5496,140 @@ class CapacityPlanner:
     def get_pending_vram_mb(self, provider_id: int) -> float:
         """Get total VRAM committed by in-flight operations on a provider."""
         return self._vram_ledger.get_committed_mb(provider_id)
+
+    # ------------------------------------------------------------------
+    # Host-RAM accounting (parallel to the VRAM helpers above)
+    # ------------------------------------------------------------------
+
+    def _get_host_ram_available_mb(self, provider_id: int) -> float | None:
+        """Read host_memory.available_mb from the runtime snapshot.
+
+        Returns None when the worker has not reported host memory (e.g.
+        pre-upgrade workers, or hosts without /proc/meminfo). Callers MUST
+        skip the host-RAM headroom check when this returns None — failing
+        open avoids a regression for older workers.
+        """
+        if self._registry is None:
+            return None
+        snap = self._registry.peek_runtime_snapshot(provider_id)
+        if snap is None:
+            return None
+        runtime = snap.get("runtime") or {}
+        hm = runtime.get("host_memory")
+        if not isinstance(hm, dict):
+            return None
+        if hm.get("source") != "proc-meminfo":
+            return None
+        available = hm.get("available_mb")
+        try:
+            return float(available)
+        except (TypeError, ValueError):
+            return None
+
+    def _try_reserve_host_ram_atomic(
+        self,
+        provider_id: int,
+        lane_id: str,
+        operation: str,
+        host_ram_mb: float,
+    ) -> str | None:
+        """Atomic check-and-reserve against the worker-reported host RAM.
+
+        Returns the reservation_id on success, or None when:
+          - the worker reports no host-RAM telemetry (fail open — older worker)
+          - the projected footprint would exceed available − safety margin.
+
+        The reservation should be released by the caller in a finally block,
+        regardless of whether the actual lane operation succeeded.
+        """
+        available = self._get_host_ram_available_mb(provider_id)
+        if available is None:
+            # Pre-host-RAM-aware worker; cannot gate. Return a sentinel so the
+            # caller does not interpret None as "no telemetry => OK to skip"
+            # vs. None as "denial" — encode that with the explicit sentinel.
+            return None
+        return self._host_ram_ledger.try_reserve_atomic(
+            provider_id, lane_id, operation, host_ram_mb,
+            raw_available_mb=available,
+            safety_margin_mb=self.HOST_RAM_SAFETY_MARGIN_MB,
+        )
+
+    def _reserve_host_ram(
+        self,
+        provider_id: int,
+        lane_id: str,
+        operation: str,
+        host_ram_mb: float,
+    ) -> str:
+        """Unconditional host-RAM reservation. Returns reservation_id."""
+        return self._host_ram_ledger.reserve(
+            provider_id, lane_id, operation, host_ram_mb,
+        )
+
+    def _release_host_ram(self, reservation_id: str | None) -> None:
+        """Release a host-RAM reservation by ID (no-op when None)."""
+        if reservation_id:
+            self._host_ram_ledger.release(reservation_id)
+
+    def get_pending_host_ram_mb(self, provider_id: int) -> float:
+        """Get total host RAM committed by in-flight operations on a provider."""
+        return self._host_ram_ledger.get_committed_mb(provider_id)
+
+    def _estimate_lane_host_ram_mb(
+        self,
+        provider_id: int,
+        lane_id: str,
+        model_name: str,
+        profile: "ModelProfile | None",
+        runtime_state: str | None = None,
+    ) -> float:
+        """Project a lane's host-RAM footprint for ledger reservations.
+
+        Order of preference:
+          1. The lane's last-measured host_ram_mb in the runtime snapshot
+             (the worker reports PSS across the process tree).
+          2. The model profile estimate (host_ram_mb, then disk_size).
+          3. Zero — caller treats as "unknown" and skips the gate.
+
+        *runtime_state* is used only for cold-load paths where the lane does
+        not yet exist; ignored otherwise.
+        """
+        if runtime_state != "cold":
+            measured = self._lane_host_ram_from_snapshot(provider_id, lane_id)
+            if measured > 0:
+                return measured
+        if profile is None:
+            return 0.0
+        host_ram_mb = getattr(profile, "host_ram_mb", None)
+        if host_ram_mb and host_ram_mb > 0:
+            return float(host_ram_mb)
+        disk_size = getattr(profile, "disk_size_bytes", None)
+        if disk_size and disk_size > 0:
+            return float(disk_size) / (1024 * 1024)
+        return 0.0
+
+    def _lane_host_ram_from_snapshot(
+        self, provider_id: int, lane_id: str,
+    ) -> float:
+        """Look up an existing lane's measured host_ram_mb in the snapshot."""
+        if self._registry is None:
+            return 0.0
+        snap = self._registry.peek_runtime_snapshot(provider_id)
+        if snap is None:
+            return 0.0
+        lanes = (snap.get("runtime") or {}).get("lanes") or []
+        if not isinstance(lanes, list):
+            return 0.0
+        for lane in lanes:
+            if not isinstance(lane, dict):
+                continue
+            if lane.get("lane_id") != lane_id:
+                continue
+            try:
+                return float(lane.get("host_ram_mb") or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+        return 0.0
 
     def _get_per_gpu_free(self, provider_id: int) -> dict[int, float] | None:
         """Read per-GPU free memory from the runtime snapshot.

--- a/logos/src/logos/capacity/host_ram_ledger.py
+++ b/logos/src/logos/capacity/host_ram_ledger.py
@@ -1,0 +1,195 @@
+"""Host-RAM reservation ledger.
+
+Parallel to ``vram_ledger.VRAMLedger`` but for host memory. The capacity
+planner uses this to gate cold loads against the worker's reported
+``host_memory.available_mb``: a cold load that fits in VRAM can still OOM the
+host if previously-sleeping lanes have not actually released their weights
+(vLLM sleep_l1 keeps weights in host RAM; sleep_l2 keeps the lane process).
+
+Reservations are per-provider. Unlike VRAM there is no per-GPU breakdown —
+host RAM is a single pool per worker.
+
+Semantics of operations:
+  * ``load``         — cold add of a new lane; reserves the projected awake
+                       host-RAM footprint (model profile estimate).
+  * ``wake``         — wake from sleep_l2 only. wake from sleep_l1 is free on
+                       the host RAM axis because the weights never left.
+  * ``reclaim_stop`` — reservation tied to a ``delete_lane`` action; the
+                       planner uses a negative ``host_ram_mb`` so the
+                       reservation accounts for the upcoming free.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HostRamReservation:
+    """A single host-RAM reservation for an in-flight operation."""
+
+    reservation_id: str
+    provider_id: int
+    lane_id: str
+    operation: str  # "load" | "wake" | "reclaim_stop"
+    host_ram_mb: float  # positive = consuming, negative = freeing
+    created_at: float
+
+
+class HostRamLedger:
+    """Per-provider host-RAM reservation tracking with atomic reserve/release.
+
+    All public methods are synchronous (no ``await``) so ``try_reserve_atomic``
+    cannot be interleaved between availability check and reservation in the
+    asyncio event loop.
+    """
+
+    def __init__(self) -> None:
+        self._reservations: dict[str, HostRamReservation] = {}
+        self._provider_committed: dict[int, float] = {}
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def reserve(
+        self,
+        provider_id: int,
+        lane_id: str,
+        operation: str,
+        host_ram_mb: float,
+    ) -> str:
+        """Create a host-RAM reservation unconditionally. Returns reservation_id."""
+        rid = uuid.uuid4().hex[:12]
+        self._reservations[rid] = HostRamReservation(
+            reservation_id=rid,
+            provider_id=provider_id,
+            lane_id=lane_id,
+            operation=operation,
+            host_ram_mb=host_ram_mb,
+            created_at=time.time(),
+        )
+        self._provider_committed[provider_id] = (
+            self._provider_committed.get(provider_id, 0.0) + host_ram_mb
+        )
+        logger.debug(
+            "Host-RAM reserve %s: provider=%d lane=%s op=%s host_ram=%.0fMB "
+            "(total_committed=%.0fMB)",
+            rid, provider_id, lane_id, operation, host_ram_mb,
+            self._provider_committed.get(provider_id, 0.0),
+        )
+        return rid
+
+    def release(self, reservation_id: str) -> None:
+        """Release a reservation, restoring its host RAM to available.
+
+        Does NOT clamp to zero — paired positive+negative reservations must
+        cancel out exactly. The totals are clamped only when no reservations
+        remain for the provider (floating-point cleanup).
+        """
+        res = self._reservations.pop(reservation_id, None)
+        if res is None:
+            return
+        committed = self._provider_committed.get(res.provider_id, 0.0)
+        self._provider_committed[res.provider_id] = committed - res.host_ram_mb
+        if not any(r.provider_id == res.provider_id for r in self._reservations.values()):
+            self._provider_committed[res.provider_id] = max(
+                0.0, self._provider_committed[res.provider_id],
+            )
+        logger.debug(
+            "Host-RAM release %s: provider=%d lane=%s op=%s freed=%.0fMB "
+            "(total_committed=%.0fMB)",
+            reservation_id, res.provider_id, res.lane_id, res.operation,
+            res.host_ram_mb,
+            self._provider_committed.get(res.provider_id, 0.0),
+        )
+
+    def try_reserve_atomic(
+        self,
+        provider_id: int,
+        lane_id: str,
+        operation: str,
+        host_ram_mb: float,
+        raw_available_mb: float,
+        safety_margin_mb: float = 0.0,
+    ) -> str | None:
+        """Check-and-reserve in one synchronous step.
+
+        Returns the reservation_id if ``raw_available_mb`` minus existing
+        commitments has at least ``host_ram_mb + safety_margin_mb`` room.
+        Returns ``None`` if there is insufficient host RAM.
+
+        Unlike VRAM we use an additive safety margin (MB) rather than a
+        multiplicative one: host RAM is a single pool that needs a fixed
+        absolute buffer (OS file cache, malloc fragmentation, mm processor
+        cache) regardless of the model size.
+        """
+        effective = raw_available_mb - self._provider_committed.get(provider_id, 0.0)
+        needed = host_ram_mb + safety_margin_mb
+        if effective < needed:
+            logger.debug(
+                "Host-RAM reserve DENIED: provider=%d lane=%s op=%s "
+                "need=%.0fMB effective_avail=%.0fMB "
+                "(raw=%.0fMB committed=%.0fMB margin=%.0fMB)",
+                provider_id, lane_id, operation, needed, effective,
+                raw_available_mb, self._provider_committed.get(provider_id, 0.0),
+                safety_margin_mb,
+            )
+            return None
+        return self.reserve(provider_id, lane_id, operation, host_ram_mb)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def get_committed_mb(self, provider_id: int) -> float:
+        """Total host RAM committed by in-flight operations on this provider."""
+        return self._provider_committed.get(provider_id, 0.0)
+
+    def get_effective_available_mb(
+        self, provider_id: int, raw_available_mb: float,
+    ) -> float:
+        """Available host RAM after subtracting in-flight reservations."""
+        return raw_available_mb - self._provider_committed.get(provider_id, 0.0)
+
+    def has_active_reservation(
+        self, provider_id: int, lane_id: str, operation: str | None = None,
+    ) -> bool:
+        for res in self._reservations.values():
+            if res.provider_id == provider_id and res.lane_id == lane_id:
+                if operation is None or res.operation == operation:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+
+    def cleanup_stale(self, max_age_seconds: float = 600.0) -> int:
+        """Remove reservations older than *max_age_seconds*. Safety net."""
+        now = time.time()
+        stale_ids = [
+            rid for rid, res in self._reservations.items()
+            if (now - res.created_at) > max_age_seconds
+        ]
+        for rid in stale_ids:
+            res = self._reservations[rid]
+            logger.warning(
+                "Cleaning stale host-RAM reservation %s: provider=%d lane=%s "
+                "op=%s host_ram=%.0fMB age=%.0fs",
+                rid, res.provider_id, res.lane_id, res.operation,
+                res.host_ram_mb, now - res.created_at,
+            )
+            self.release(rid)
+        return len(stale_ids)
+
+    def __repr__(self) -> str:
+        return (
+            f"HostRamLedger(reservations={len(self._reservations)}, "
+            f"committed={dict(self._provider_committed)})"
+        )

--- a/logos/tests/unit/capacity/test_host_ram_ledger.py
+++ b/logos/tests/unit/capacity/test_host_ram_ledger.py
@@ -1,0 +1,122 @@
+"""Tests for HostRamLedger atomic reservation gating.
+
+The host-RAM ledger is the analogue of VRAMLedger for system memory. Its job
+is to prevent cold loads from being issued when the worker's reported
+host_memory.available_mb (minus in-flight commitments and safety margin)
+cannot accommodate the new lane's projected footprint.
+"""
+
+from __future__ import annotations
+
+from logos.capacity.host_ram_ledger import HostRamLedger
+
+
+def test_reserve_within_available_succeeds():
+    ledger = HostRamLedger()
+    rid = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="a", operation="load",
+        host_ram_mb=50000.0, raw_available_mb=100000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert rid is not None
+    assert ledger.get_committed_mb(1) == 50000.0
+
+
+def test_reserve_denied_when_committed_exceeds_available():
+    """Two 50GB loads cannot both fit in 100GB minus 4GB margin."""
+    ledger = HostRamLedger()
+    first = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="a", operation="load",
+        host_ram_mb=50000.0, raw_available_mb=100000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert first is not None
+    # Effective available = 100000 - 50000 = 50000; need = 50000 + 4096
+    second = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="b", operation="load",
+        host_ram_mb=50000.0, raw_available_mb=100000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert second is None
+
+
+def test_release_restores_capacity_for_next_reservation():
+    ledger = HostRamLedger()
+    rid = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="a", operation="load",
+        host_ram_mb=80000.0, raw_available_mb=100000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert rid is not None
+    ledger.release(rid)
+    assert ledger.get_committed_mb(1) == 0.0
+    rid2 = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="b", operation="load",
+        host_ram_mb=80000.0, raw_available_mb=100000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert rid2 is not None
+
+
+def test_safety_margin_blocks_borderline_reservation():
+    """A reservation that uses every byte without margin must still be denied."""
+    ledger = HostRamLedger()
+    rid = ledger.try_reserve_atomic(
+        provider_id=1, lane_id="a", operation="load",
+        host_ram_mb=10000.0, raw_available_mb=10000.0,
+        safety_margin_mb=1024.0,
+    )
+    assert rid is None
+
+
+def test_per_provider_isolation():
+    """Reservations on one provider do not affect another."""
+    ledger = HostRamLedger()
+    ledger.reserve(provider_id=1, lane_id="a", operation="load", host_ram_mb=50000.0)
+    rid = ledger.try_reserve_atomic(
+        provider_id=2, lane_id="x", operation="load",
+        host_ram_mb=50000.0, raw_available_mb=80000.0,
+        safety_margin_mb=4096.0,
+    )
+    assert rid is not None  # Provider 2 sees its own empty ledger
+    assert ledger.get_committed_mb(1) == 50000.0
+    assert ledger.get_committed_mb(2) == 50000.0
+
+
+def test_negative_reservation_offsets_positive():
+    """A reclaim_stop reservation (negative MB) cancels its paired load."""
+    ledger = HostRamLedger()
+    pos = ledger.reserve(1, "lane-a", "load", host_ram_mb=40000.0)
+    neg = ledger.reserve(1, "lane-b", "reclaim_stop", host_ram_mb=-30000.0)
+    # Net committed = 10000
+    assert ledger.get_committed_mb(1) == 10000.0
+    ledger.release(pos)
+    ledger.release(neg)
+    assert ledger.get_committed_mb(1) == 0.0
+
+
+def test_active_reservation_lookup():
+    ledger = HostRamLedger()
+    ledger.reserve(1, "lane-a", "load", host_ram_mb=10000.0)
+    assert ledger.has_active_reservation(1, "lane-a") is True
+    assert ledger.has_active_reservation(1, "lane-b") is False
+    assert ledger.has_active_reservation(1, "lane-a", operation="load") is True
+    assert ledger.has_active_reservation(1, "lane-a", operation="wake") is False
+
+
+def test_cleanup_stale_releases_old_reservations():
+    """Reservations older than max_age_seconds are reaped as a safety net."""
+    ledger = HostRamLedger()
+    rid = ledger.reserve(1, "lane-a", "load", host_ram_mb=10000.0)
+    # Force stale by rewriting the created_at field
+    ledger._reservations[rid].created_at -= 1000.0
+    reaped = ledger.cleanup_stale(max_age_seconds=60.0)
+    assert reaped == 1
+    assert ledger.get_committed_mb(1) == 0.0
+
+
+def test_effective_available_subtracts_commitments():
+    ledger = HostRamLedger()
+    ledger.reserve(1, "lane-a", "load", host_ram_mb=30000.0)
+    eff = ledger.get_effective_available_mb(1, raw_available_mb=100000.0)
+    assert eff == 70000.0

--- a/logos/tests/unit/capacity/test_host_ram_planner.py
+++ b/logos/tests/unit/capacity/test_host_ram_planner.py
@@ -1,0 +1,133 @@
+"""Tests for the planner's host-RAM headroom precheck.
+
+The precheck reads the worker's reported host_memory.available_mb from the
+runtime snapshot, subtracts in-flight HostRamLedger commitments and the
+HOST_RAM_SAFETY_MARGIN_MB, and compares against the projected lane footprint.
+It is a pure gate — it does not stop existing lanes.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+# Prometheus stub (matches test_planner_concurrency.py).
+if "prometheus_client" not in sys.modules:
+    _prom_stub = ModuleType("prometheus_client")
+
+    class _MetricStub:
+        def __init__(self, *a, **kw): pass
+        def labels(self, *a, **kw): return self
+        def inc(self, *a, **kw): pass
+        def dec(self, *a, **kw): pass
+        def set(self, *a, **kw): pass
+        def observe(self, *a, **kw): pass
+
+    _prom_stub.Counter = _MetricStub
+    _prom_stub.Gauge = _MetricStub
+    _prom_stub.Histogram = _MetricStub
+    _prom_stub.Summary = _MetricStub
+    _prom_stub.CollectorRegistry = MagicMock
+    _prom_stub.REGISTRY = MagicMock()
+    _prom_stub.CONTENT_TYPE_LATEST = "text/plain"
+    _prom_stub.generate_latest = lambda *a, **kw: b""
+    sys.modules["prometheus_client"] = _prom_stub
+
+from logos.capacity.capacity_planner import CapacityPlanner  # noqa: E402
+from logos.capacity.host_ram_ledger import HostRamLedger  # noqa: E402
+
+
+def _bare_planner(snapshot: dict | None = None) -> CapacityPlanner:
+    """Build a planner with only the fields the precheck touches."""
+    planner = CapacityPlanner.__new__(CapacityPlanner)
+    planner._host_ram_ledger = HostRamLedger()
+    registry = MagicMock()
+    registry.peek_runtime_snapshot.return_value = snapshot
+    planner._registry = registry
+    return planner
+
+
+def _snapshot_with_host_memory(available_mb: float | None) -> dict:
+    """Build a minimal snapshot dict shaped like the master ingests."""
+    host_memory: dict = {"source": "proc-meminfo"}
+    if available_mb is not None:
+        host_memory["available_mb"] = available_mb
+    return {"runtime": {"host_memory": host_memory, "lanes": []}}
+
+
+def test_precheck_ok_when_projected_fits_with_margin():
+    """50 GiB load against 100 GiB available passes (margin is ~4 GiB)."""
+    p = _bare_planner(_snapshot_with_host_memory(100_000.0))
+    ok, eff, deficit = p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="m", projected_host_ram_mb=50_000.0,
+    )
+    assert ok is True
+    assert deficit == 0.0
+    assert eff == 100_000.0 - p.HOST_RAM_SAFETY_MARGIN_MB
+
+
+def test_precheck_denies_when_projected_exceeds_available():
+    """The deioma scenario: 48 GiB checkpoint vs ~15 GiB available."""
+    p = _bare_planner(_snapshot_with_host_memory(15_000.0))
+    ok, eff, deficit = p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="gemma-4-26B",
+        projected_host_ram_mb=48_000.0,
+    )
+    assert ok is False
+    assert deficit > 0
+
+
+def test_precheck_accounts_for_ledger_commitments():
+    """An in-flight 60 GiB load reduces the effective available."""
+    p = _bare_planner(_snapshot_with_host_memory(100_000.0))
+    p._host_ram_ledger.reserve(1, "in-flight", "load", host_ram_mb=60_000.0)
+    ok, eff, deficit = p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="m2", projected_host_ram_mb=50_000.0,
+    )
+    # eff = 100k - 60k - margin = ~36k; 50k load is denied.
+    assert ok is False
+    assert deficit > 0
+
+
+def test_precheck_fails_open_when_worker_lacks_host_memory():
+    """Pre-upgrade worker has no host_memory key → precheck returns OK."""
+    p = _bare_planner({"runtime": {"lanes": []}})
+    ok, eff, deficit = p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="m", projected_host_ram_mb=999_999.0,
+    )
+    assert ok is True
+    assert deficit == 0.0
+
+
+def test_precheck_fails_open_when_host_memory_source_is_unavailable():
+    """Worker that read /proc/meminfo and got nothing also fails open."""
+    p = _bare_planner({"runtime": {"host_memory": {"source": "unavailable"}}})
+    ok, _, _ = p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="m", projected_host_ram_mb=10_000.0,
+    )
+    assert ok is True
+
+
+def test_precheck_does_not_mutate_ledger():
+    """The precheck is pure — no reservation must be created."""
+    p = _bare_planner(_snapshot_with_host_memory(100_000.0))
+    p._check_host_ram_headroom_for_cold_load(
+        provider_id=1, loading_model="m", projected_host_ram_mb=50_000.0,
+    )
+    assert p._host_ram_ledger.get_committed_mb(1) == 0.0
+
+
+def test_lane_host_ram_from_snapshot_returns_measured_value():
+    p = _bare_planner({
+        "runtime": {
+            "host_memory": {"source": "proc-meminfo", "available_mb": 50_000.0},
+            "lanes": [
+                {"lane_id": "planner-foo", "host_ram_mb": 12_345.0},
+                {"lane_id": "planner-bar", "host_ram_mb": 6_789.0},
+            ],
+        },
+    })
+    assert p._lane_host_ram_from_snapshot(1, "planner-foo") == 12_345.0
+    assert p._lane_host_ram_from_snapshot(1, "planner-bar") == 6_789.0
+    assert p._lane_host_ram_from_snapshot(1, "planner-missing") == 0.0


### PR DESCRIPTION
Closes #576.

## Summary

The capacity planner had no model of host RAM, so the runaway retry loop on `deioma` (48 GiB checkpoint vs. ~15 GiB available host RAM, planner retries every ~5 min, swap fills, neighbouring lanes thrash) was structurally unfixable from the worker's side. This PR adds host-RAM telemetry, a precheck-only gate on cold loads, and a host-RAM-aware tmpfs cache planner that respects sleep capacity.

## What changed

### Master (`src/logos/capacity/`)
- `host_ram_ledger.py` (new): `HostRamLedger` parallel to `VRAMLedger`. Single pool per provider, additive MB safety margin.
- `capacity_planner.py`:
  - `HOST_RAM_SAFETY_MARGIN_MB = 4096.0`, `self._host_ram_ledger`, stale cleanup in `_run_cycle`
  - Helpers: `_get_host_ram_available_mb`, `_try_reserve_host_ram_atomic`, `_reserve_host_ram`, `_release_host_ram`, `_estimate_lane_host_ram_mb`, `_lane_host_ram_from_snapshot`
  - **Pure precheck `_check_host_ram_headroom_for_cold_load`** — returns `(ok, eff_available, deficit)`, no side effects.
  - In `_cold_load_for_request`: when the precheck denies, log the deficit, defer via `_pending_capacity`, and `return None`. **No lane is stopped, no sleep is converted to stop.** Sleep stays the planner's default eviction action because waking is ~2s vs. a 30–90s cold reload.

### Worker (`logos-workernode/`)
- `models.py`: `HostMemorySummary` (total / available / used / swap), added to `WorkerRuntimeStatus.host_memory`. `LaneStatus` gains `host_ram_mb` + `host_ram_source` (`pss` / `rss` / `unknown`).
- `runtime.py`: `_build_host_memory_summary` always emits from `/proc/meminfo` (previously only ran in the degraded `nvidia-smi`-missing fallback).
- `host_ram.py` (new): PSS-based measurement that walks `/proc/<pid>/task/*/children` so a TP=N vLLM lane's `Worker_TPx` subprocesses are summed once (shared weight pages counted via PSS, not multi-counted via RSS).
- `lane_manager.py`: `_build_lane_status` populates `host_ram_mb`; `get_all_statuses` measures all lane process trees concurrently in worker threads.
- `model_profiles.py`: `ModelProfileRecord` gains `host_ram_mb` (awake) and `host_ram_residual_mb` (level-1 sleep); EMA-updated by `record_host_ram`. Falls back to `disk_size_bytes` via `estimate_host_ram_mb`.

### Host-RAM-aware tmpfs cache (`cache_planner.py`, new + `main.py`)
Operator rule: **load as many models into the tmpfs cache as possible WITHOUT lowering the number of models that can be sleeping simultaneously.**

Deterministic algorithm:
1. `reserve_mb = sum(host_ram of every sleepable capability model)` — protects every sleepable model's host RAM so they can all sleep at once.
2. `tmpfs_budget = available_host_ram − reserve_mb − HOST_RAM_SAFETY_MARGIN`.
3. Priority list: unsleepable models first (smallest → largest), then sleepable models (smallest → largest). Unsleepable models benefit most because cold reload is their only recovery path.
4. Greedy pack: unsleepable models are always queued (they don't enter the sleep reserve and don't reduce anyone's sleep capacity). Sleepable models are admitted only while the running tmpfs budget allows.
5. Output feeds `ModelRamCache.cache_models_by_priority`, which still enforces a 10% free-tmpfs safety margin.

### CI + test housekeeping
- New `test-workernode` job in `.github/workflows/logos_test.yml` runs `logos-workernode/tests/` under Python 3.13.
- `pytest.ini` adds `tools/` to pythonpath so `test_bench_lane_backends.py` can import its module.
- Pre-existing worker-node test failures fixed: `_fake_create_handle` mocks updated to accept the new `model_profiles` / `per_gpu_total_mb` kwargs; stale `test_calibrated_profile_not_overwritten_by_subsequent_load` assertions re-aligned with production (calibrated profiles are correctly protected from EMA blending); stale `_infer_reasoning_parser` / `_infer_default_chat_template_kwargs` tests aligned with the trimmed rule set in `vllm_process.py`.

## What this PR explicitly does NOT do

- **No auto-stopping of sleeping lanes when the cold-load precheck denies.** Sleep is the planner's preferred eviction because waking is ~2s vs. cold reload. Aggressive auto-stop on host-RAM pressure would degrade steady-state throughput.
- No changes to `_find_eviction_set`. Eviction-set escalation of `sleep_l1` → `stop` for host-RAM-bound deficits is a deliberate follow-up — the right policy for "two big models compete, one can't sleep" is materially more complex.
- No changes to wake or sleep cost weights.

## Test plan

- `tests/unit/capacity/test_host_ram_ledger.py` — 9 tests: reserve/release, safety margin, per-provider isolation, negative-reservation cancellation, stale cleanup.
- `tests/unit/capacity/test_host_ram_planner.py` — 7 tests: OK/DENY transitions, ledger commitment subtraction, fail-open on pre-upgrade workers, pure-function behaviour.
- `logos-workernode/tests/test_host_ram.py` — 8 tests (6 + 2 Linux-skipped on macOS): PSS/RSS read paths, process-tree walking, dead-pid resilience, PSS-preferred-over-RSS semantics.
- `logos-workernode/tests/test_cache_planner.py` — 9 tests: empty input, single-unsleepable, all-sleepable-fit, sleepable-skipped-when-budget-exhausted, unsleepable-precedes-sleepable, overcommitted-reserve, safety-margin-subtraction, determinism, smallest-first-within-group.
- All existing master-side capacity tests pass: 119 + 1 xfailed (unchanged).
- All existing worker-node tests pass: 243 + 2 Linux-skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Worker processes now report host RAM footprint measurements in runtime telemetry.
  * Capacity planner now accounts for host RAM availability during model loading, preventing overcommitment.
  * Added host RAM reservation system to manage concurrent model loads.
  * Cache planning now considers host RAM constraints to optimize tmpfs model caching.
  * Model profiling tracks host RAM consumption across loaded and sleeping states.

* **Tests**
  * Added host RAM measurement validation suite.
  * Added capacity planner host RAM precheck tests.
  * Updated test compatibility for system changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->