### PR TITLE
`Logos`: Bump vLLM to 0.22.0 and auto-purge poisoned compile cache

### DIFF
--- a/.github/workflows/logos_deploy-prod.yml
+++ b/.github/workflows/logos_deploy-prod.yml
@@ -2,9 +2,9 @@ name: Logos - Deploy to Prod
 
 on:
   workflow_run:
-    workflows: [ "Logos - Build" ]
-    branches: [ main ]
-    types: [ completed ]
+    workflows: ["Logos - Build"]
+    branches: [main]
+    types: [completed]
   workflow_dispatch:
     inputs:
       image-tag:
@@ -20,7 +20,7 @@ jobs:
   deploy-logos-server:
     if: ${{ github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos - Prod"
       docker-compose-file: "./logos/docker-compose.yaml"
@@ -32,7 +32,7 @@ jobs:
   deploy-worker-deimama:
     if: ${{ github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos Worker - Prod - deimama"
       docker-compose-file: "./logos/logos-workernode/docker-compose.yml"
@@ -44,7 +44,7 @@ jobs:
   deploy-worker-deipapa:
     if: ${{ github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos Worker - Prod - deipapa"
       docker-compose-file: "./logos/logos-workernode/docker-compose.yml"
@@ -56,7 +56,7 @@ jobs:
   deploy-worker-deioma:
     if: ${{ github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success' }}
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos Worker - Prod - deioma"
       docker-compose-file: "./logos/logos-workernode/docker-compose.yml"

--- a/.github/workflows/logos_deploy-test.yml
+++ b/.github/workflows/logos_deploy-test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy-logos-server:
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos - Test"
       docker-compose-file: "./logos/docker-compose.yaml"
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
 
   deploy-worker-hochbruegge:
-    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@fix/issue-66-ghcr-image-check
+    uses: ls1intum/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
       environment: "Logos Worker - Test - hochbruegge"
       docker-compose-file: "./logos/logos-workernode/docker-compose.yml"

--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -37,7 +37,7 @@
 ARG BASE_IMAGE=python:3.12-slim
 ARG RUNTIME_IMAGE=${BASE_IMAGE}
 ARG INSTALL_VLLM=0
-ARG VLLM_PIP_SPEC="vllm==0.21.0"
+ARG VLLM_PIP_SPEC="vllm==0.22.0"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -345,8 +345,7 @@ class VllmProcessHandle:
                 if not purged:
                     raise
                 logger.warning(
-                    "[%s] vLLM startup failed inside the on-disk compile cache; "
-                    "purged %s and retrying once",
+                    "[%s] vLLM startup failed inside the on-disk compile cache; " "purged %s and retrying once",
                     self.lane_id,
                     purged,
                 )
@@ -597,9 +596,7 @@ class VllmProcessHandle:
         # No cache on disk yet → nothing to do, and writing a stamp ahead of
         # time would be misleading. The stamp gets written after the next
         # successful spawn produces real artifacts.
-        if not any(
-            os.path.isdir(os.path.join(cache_root, sub)) for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS
-        ):
+        if not any(os.path.isdir(os.path.join(cache_root, sub)) for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS):
             return []
         current = self._current_compile_versions()
         if not current:

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -311,7 +311,16 @@ class VllmProcessHandle:
     # ------------------------------------------------------------------
 
     async def spawn(self, lane_config: LaneConfig) -> ProcessStatus:
-        """Spawn the vLLM process for this lane."""
+        """Spawn the vLLM process for this lane.
+
+        Cache safety: before spawning, the on-disk torch.compile and inductor
+        caches are purged if the recorded (vLLM, torch) versions don't match
+        the venv's current versions — a version bump is the most common cause
+        of cache poisoning. If the spawn still fails with a stack trace
+        pointing inside the compile cache directory (e.g. an AOT-compiled
+        graph that was specialized on a stale shape profile), the caches are
+        purged again and the spawn is retried once.
+        """
         if self._process is not None and self._process.returncode is None:
             logger.info(
                 "[%s] Stopping existing process (pid=%d) before spawn",
@@ -320,6 +329,30 @@ class VllmProcessHandle:
             )
             await self._kill_process()
 
+        self._purge_compile_caches_if_versions_changed()
+
+        purged_once = False
+        while True:
+            try:
+                status = await self._spawn_once(lane_config)
+                self._write_compile_cache_stamp()
+                return status
+            except RuntimeError:
+                if purged_once or not self.has_poisoned_compile_cache:
+                    raise
+                purged = self._purge_compile_caches()
+                purged_once = True
+                if not purged:
+                    raise
+                logger.warning(
+                    "[%s] vLLM startup failed inside the on-disk compile cache; "
+                    "purged %s and retrying once",
+                    self.lane_id,
+                    purged,
+                )
+
+    async def _spawn_once(self, lane_config: LaneConfig) -> ProcessStatus:
+        """A single vLLM spawn attempt; raises on startup failure."""
         self._recent_logs.clear()
         self._lane_config = lane_config
         cmd = self._build_cmd(lane_config)
@@ -412,6 +445,184 @@ class VllmProcessHandle:
             "cuda error: out of memory",
         )
         return any(p in log_blob for p in fatal_patterns)
+
+    # Stack-trace path fragments that mean execution is inside a file loaded
+    # from the persistent torch.compile / inductor cache. A failure raised
+    # from these paths means the cached artifact is no longer valid for the
+    # current vLLM/torch build (or the current shape profile of an
+    # AOT-compiled model) and the engine cannot start until the cache is
+    # removed.
+    _POISONED_COMPILE_CACHE_PATH_FRAGMENTS: ClassVar[tuple[str, ...]] = (
+        "/.cache/vllm/torch_compile_cache/",
+        "/.cache/torch_inductor/",
+        "/torch_aot_compile/",
+        "/inductor_cache/",
+    )
+
+    # Subdirectories under <cache_root>/.cache that are safe to wipe when a
+    # compile-cache poisoning is detected. FlashInfer JIT artifacts and the
+    # HuggingFace weights cache are intentionally excluded — they are not
+    # implicated in compile-cache poisoning and are expensive to rebuild.
+    _PURGEABLE_COMPILE_CACHE_SUBDIRS: ClassVar[tuple[str, ...]] = (
+        "vllm",
+        "torch_inductor",
+    )
+
+    _COMPILE_CACHE_STAMP_FILENAME: ClassVar[str] = ".logos_compile_cache_stamp.json"
+
+    @property
+    def has_poisoned_compile_cache(self) -> bool:
+        """True if recent logs implicate the on-disk torch.compile cache.
+
+        Triggered when a stack-trace line references a file under
+        ``VLLM_CACHE_ROOT`` or ``TORCHINDUCTOR_CACHE_DIR``. The originating
+        exception can be anything (``RuntimeError`` on a shape assert,
+        ``ImportError`` on a stale symbol, ``UnpicklingError`` on a stale
+        FX graph) — if execution is reaching into a cached compile artifact
+        and crashing there, the artifact is bad.
+        """
+        if not self._recent_logs:
+            return False
+        log_blob = "\n".join(self._recent_logs)
+        return any(frag in log_blob for frag in self._POISONED_COMPILE_CACHE_PATH_FRAGMENTS)
+
+    def _compile_cache_root(self) -> str | None:
+        """Return ``<persistent_root>/.cache`` or ``None`` if unresolvable."""
+        try:
+            cache_root_dir = self._resolve_persistent_cache_root(self._global_config)
+        except Exception:
+            logger.exception("[%s] Could not resolve cache root", self.lane_id)
+            return None
+        if not cache_root_dir:
+            return None
+        return os.path.join(cache_root_dir, ".cache")
+
+    def _purge_compile_caches(self) -> list[str]:
+        """Remove the torch.compile and inductor caches for this worker.
+
+        Returns the paths actually removed. HuggingFace weights and the
+        FlashInfer JIT cache are left in place — they are not implicated
+        in compile-cache poisoning and are expensive to rebuild. Paths
+        resolve to the persistent cache root which, in the standard
+        docker-compose deployment, is bind-mounted onto host storage
+        (e.g. ``/mnt/ceph``), so the wipe affects the host volume too.
+        """
+        cache_root = self._compile_cache_root()
+        if cache_root is None:
+            return []
+        removed: list[str] = []
+        for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS:
+            path = os.path.join(cache_root, sub)
+            if not os.path.isdir(path):
+                continue
+            try:
+                shutil.rmtree(path)
+                removed.append(path)
+                logger.warning("[%s] Purged compile cache: %s", self.lane_id, path)
+            except OSError:
+                logger.exception("[%s] Failed to purge compile cache: %s", self.lane_id, path)
+        return removed
+
+    @staticmethod
+    def _current_compile_versions() -> dict[str, str]:
+        """Return ``{"vllm": "...", "torch": "..."}`` from the worker venv.
+
+        Missing packages are silently omitted so the resulting dict only
+        contains versions we successfully read; the stamp comparison then
+        compares only on overlapping keys.
+        """
+        import importlib.metadata as md
+
+        versions: dict[str, str] = {}
+        for pkg in ("vllm", "torch"):
+            try:
+                versions[pkg] = md.version(pkg)
+            except md.PackageNotFoundError:
+                continue
+        return versions
+
+    def _compile_cache_stamp_path(self) -> str | None:
+        cache_root = self._compile_cache_root()
+        if cache_root is None:
+            return None
+        return os.path.join(cache_root, self._COMPILE_CACHE_STAMP_FILENAME)
+
+    def _read_compile_cache_stamp(self) -> dict[str, str] | None:
+        path = self._compile_cache_stamp_path()
+        if not path or not os.path.isfile(path):
+            return None
+        import json as _json
+
+        try:
+            with open(path, encoding="utf-8") as fh:
+                data = _json.load(fh)
+        except (OSError, ValueError):
+            logger.debug("[%s] Could not read compile cache stamp at %s", self.lane_id, path, exc_info=True)
+            return None
+        if not isinstance(data, dict):
+            return None
+        return {str(k): str(v) for k, v in data.items()}
+
+    def _write_compile_cache_stamp(self) -> None:
+        """Record the current (vllm, torch) versions next to the compile cache."""
+        path = self._compile_cache_stamp_path()
+        if not path:
+            return
+        versions = self._current_compile_versions()
+        if not versions:
+            return
+        import json as _json
+
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                _json.dump(versions, fh, sort_keys=True)
+        except OSError:
+            logger.debug("[%s] Could not write compile cache stamp at %s", self.lane_id, path, exc_info=True)
+
+    def _purge_compile_caches_if_versions_changed(self) -> list[str]:
+        """Purge compile caches when the recorded versions no longer match.
+
+        Returns the paths actually removed. A version bump of vLLM or torch
+        is the most common cause of compile-cache poisoning: the cached
+        FX graph / inductor ``.so`` artifacts were produced by the previous
+        build and trip the engine when it tries to replay them. Comparing
+        a small stamp file against the venv's current versions on every
+        spawn lets us preempt that failure without waiting for the reactive
+        detector to fire after a crash.
+        """
+        cache_root = self._compile_cache_root()
+        if cache_root is None:
+            return []
+        # No cache on disk yet → nothing to do, and writing a stamp ahead of
+        # time would be misleading. The stamp gets written after the next
+        # successful spawn produces real artifacts.
+        if not any(
+            os.path.isdir(os.path.join(cache_root, sub)) for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS
+        ):
+            return []
+        current = self._current_compile_versions()
+        if not current:
+            return []
+        stamp = self._read_compile_cache_stamp()
+        if stamp is not None:
+            mismatched = {k: (stamp.get(k), current[k]) for k in current if stamp.get(k) != current[k]}
+            if not mismatched:
+                return []
+            logger.warning(
+                "[%s] Compile cache stamp mismatch (%s); purging to avoid poisoning",
+                self.lane_id,
+                ", ".join(f"{k}: {old}→{new}" for k, (old, new) in mismatched.items()),
+            )
+        else:
+            # Cache exists but no stamp — produced by a worker version
+            # that predates the stamping logic. Treat as unknown and purge
+            # so we start from a known-good baseline.
+            logger.warning(
+                "[%s] Compile cache present but no version stamp; purging to avoid poisoning",
+                self.lane_id,
+            )
+        return self._purge_compile_caches()
 
     async def reconfigure(self, lane_config: LaneConfig) -> ProcessStatus:
         """Reconfigure = full restart for vLLM (model/config change)."""
@@ -1575,6 +1786,12 @@ class VllmProcessHandle:
             return (
                 "Detected missing C compiler during vLLM startup. "
                 "Install build-essential (gcc/g++/make) in the runtime image."
+            )
+        if self.has_poisoned_compile_cache:
+            return (
+                "Stack trace points inside the on-disk torch.compile / inductor cache. "
+                "The worker auto-purges and retries once; a repeat failure means the new "
+                "spawn produced fresh artifacts that still crash."
             )
         return ""
 

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1415,3 +1415,267 @@ def test_build_cmd_explicit_chat_template_kwargs_win_over_inferred(monkeypatch) 
     parsed = json.loads(cmd[idx + 1])
     # User explicitly disabled thinking — must win over inferred default True
     assert parsed["enable_thinking"] is False
+
+
+# ---------------------------------------------------------------------------
+# Compile cache poisoning detection & auto-purge
+# ---------------------------------------------------------------------------
+
+
+def _populate_compile_cache(root: Path) -> dict[str, Path]:
+    """Build a realistic <cache_root>/.cache/ subtree and return key paths."""
+    cache_root = root / ".cache"
+    vllm_cache = cache_root / "vllm"
+    inductor_cache = cache_root / "torch_inductor"
+    flashinfer_cache = cache_root / "flashinfer"
+    (vllm_cache / "torch_compile_cache" / "deadbeef" / "inductor_cache" / "ol").mkdir(parents=True)
+    (vllm_cache / "torch_compile_cache" / "deadbeef" / "inductor_cache" / "ol" / "frag.py").write_text("x = 1\n")
+    inductor_cache.mkdir(parents=True)
+    (inductor_cache / "artifact.bin").write_text("blob")
+    flashinfer_cache.mkdir(parents=True)
+    (flashinfer_cache / "keep.so").write_text("preserved")
+    return {
+        "cache_root": cache_root,
+        "vllm": vllm_cache,
+        "inductor": inductor_cache,
+        "flashinfer": flashinfer_cache,
+    }
+
+
+def test_has_poisoned_compile_cache_detects_cache_dir_in_stack(tmp_path: Path) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    # Realistic snippet from a gemma-4 startup failure where the cached
+    # AOT-compiled inductor file is executed and raises.
+    handle._recent_logs.extend(
+        [
+            "(EngineCore) ERROR core.py:1140   File "
+            '"/usr/share/ollama/.ollama/models/.cache/vllm/torch_compile_cache/'
+            'deadbeef/inductor_cache/ol/frag.py", line 664, in call',
+            "(EngineCore) ERROR core.py:1140 RuntimeError: Expected result >= 0",
+        ]
+    )
+    assert handle.has_poisoned_compile_cache is True
+
+
+def test_has_poisoned_compile_cache_ignores_unrelated_errors() -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._recent_logs.extend(
+        [
+            "ValueError: Could not load model weights from HuggingFace hub",
+            "ImportError: No module named 'foo'",
+        ]
+    )
+    assert handle.has_poisoned_compile_cache is False
+
+
+def test_has_poisoned_compile_cache_false_when_no_logs() -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    assert handle.has_poisoned_compile_cache is False
+
+
+def test_purge_compile_caches_removes_vllm_and_inductor_only(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    removed = handle._purge_compile_caches()
+
+    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
+    assert not paths["vllm"].exists()
+    assert not paths["inductor"].exists()
+    # FlashInfer JIT cache + HF weights are not implicated in compile-cache
+    # poisoning and must survive a purge.
+    assert paths["flashinfer"].exists()
+    assert (paths["flashinfer"] / "keep.so").exists()
+
+
+def test_purge_compile_caches_is_noop_when_nothing_to_remove(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    assert handle._purge_compile_caches() == []
+
+
+def test_purge_compile_caches_if_versions_changed_purges_on_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    # Stamp records the previous vLLM version.
+    import json
+
+    stamp_path = paths["cache_root"] / handle._COMPILE_CACHE_STAMP_FILENAME
+    stamp_path.write_text(json.dumps({"vllm": "0.21.0", "torch": "2.11.0"}))
+
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    removed = handle._purge_compile_caches_if_versions_changed()
+    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
+    assert not paths["vllm"].exists()
+    assert paths["flashinfer"].exists()
+
+
+def test_purge_compile_caches_if_versions_changed_noop_when_match(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    import json
+
+    stamp_path = paths["cache_root"] / handle._COMPILE_CACHE_STAMP_FILENAME
+    stamp_path.write_text(json.dumps({"vllm": "0.22.0", "torch": "2.11.0"}))
+
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    assert handle._purge_compile_caches_if_versions_changed() == []
+    assert paths["vllm"].exists()
+    assert paths["inductor"].exists()
+
+
+def test_purge_compile_caches_if_versions_changed_purges_when_no_stamp(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    removed = handle._purge_compile_caches_if_versions_changed()
+    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
+
+
+def test_purge_compile_caches_if_versions_changed_skips_when_no_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0"}),
+    )
+    assert handle._purge_compile_caches_if_versions_changed() == []
+    # And no stamp was created — writing one would be misleading because no
+    # artifacts exist yet.
+    assert not (tmp_path / ".cache" / handle._COMPILE_CACHE_STAMP_FILENAME).exists()
+
+
+def test_write_compile_cache_stamp_records_current_versions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    handle._write_compile_cache_stamp()
+
+    import json
+
+    stamp_path = tmp_path / ".cache" / handle._COMPILE_CACHE_STAMP_FILENAME
+    assert stamp_path.exists()
+    assert json.loads(stamp_path.read_text()) == {"vllm": "0.22.0", "torch": "2.11.0"}
+
+
+@pytest.mark.asyncio
+async def test_spawn_retries_once_on_poisoned_compile_cache(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    # Pretend the stamp matches so the proactive purge stays out of the
+    # way — we want to exercise the reactive purge-then-retry path.
+    import json as _json
+
+    (paths["cache_root"] / handle._COMPILE_CACHE_STAMP_FILENAME).write_text(
+        _json.dumps({"vllm": "0.22.0", "torch": "2.11.0"})
+    )
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="google/gemma-4-27b-it", vllm=True, vllm_config=VllmConfig())
+
+    attempt_calls: list[int] = []
+
+    async def _fake_spawn_once(_lc):  # noqa: ANN001
+        attempt_calls.append(len(attempt_calls) + 1)
+        if len(attempt_calls) == 1:
+            # Simulate the deioma failure: stack trace ends inside the
+            # cached AOT-compiled inductor file.
+            handle._recent_logs.extend(
+                [
+                    '  File "/tmp/x/.cache/vllm/torch_compile_cache/abc/'
+                    'inductor_cache/ol/frag.py", line 1, in call',
+                    "RuntimeError: Expected result >= 0",
+                ]
+            )
+            raise RuntimeError("Engine core init failed")
+        # Successful second attempt.
+        handle._recent_logs.clear()
+        return handle.status()
+
+    monkeypatch.setattr(handle, "_spawn_once", _fake_spawn_once)
+
+    await handle.spawn(lane)
+
+    assert attempt_calls == [1, 2]
+    # The reactive purge wiped vllm + inductor caches between attempts.
+    assert not paths["vllm"].exists()
+    assert not paths["inductor"].exists()
+    assert paths["flashinfer"].exists()
+
+
+@pytest.mark.asyncio
+async def test_spawn_does_not_retry_on_unrelated_startup_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    import json as _json
+
+    (paths["cache_root"] / handle._COMPILE_CACHE_STAMP_FILENAME).write_text(
+        _json.dumps({"vllm": "0.22.0", "torch": "2.11.0"})
+    )
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="google/gemma-4-27b-it", vllm=True, vllm_config=VllmConfig())
+    calls: list[int] = []
+
+    async def _fake_spawn_once(_lc):  # noqa: ANN001
+        calls.append(1)
+        handle._recent_logs.extend(["ValueError: missing HF token"])
+        raise RuntimeError("auth failure")
+
+    monkeypatch.setattr(handle, "_spawn_once", _fake_spawn_once)
+
+    with pytest.raises(RuntimeError, match="auth failure"):
+        await handle.spawn(lane)
+    assert len(calls) == 1
+    # Unrelated failure must not wipe the compile cache.
+    assert paths["vllm"].exists()
+    assert paths["inductor"].exists()

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1495,9 +1495,7 @@ def test_purge_compile_caches_is_noop_when_nothing_to_remove(tmp_path: Path, mon
     assert handle._purge_compile_caches() == []
 
 
-def test_purge_compile_caches_if_versions_changed_purges_on_mismatch(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_purge_compile_caches_if_versions_changed_purges_on_mismatch(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     paths = _populate_compile_cache(tmp_path)
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
@@ -1520,9 +1518,7 @@ def test_purge_compile_caches_if_versions_changed_purges_on_mismatch(
     assert paths["flashinfer"].exists()
 
 
-def test_purge_compile_caches_if_versions_changed_noop_when_match(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_purge_compile_caches_if_versions_changed_noop_when_match(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     paths = _populate_compile_cache(tmp_path)
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
@@ -1543,9 +1539,7 @@ def test_purge_compile_caches_if_versions_changed_noop_when_match(
     assert paths["inductor"].exists()
 
 
-def test_purge_compile_caches_if_versions_changed_purges_when_no_stamp(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_purge_compile_caches_if_versions_changed_purges_when_no_stamp(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     paths = _populate_compile_cache(tmp_path)
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
@@ -1560,9 +1554,7 @@ def test_purge_compile_caches_if_versions_changed_purges_when_no_stamp(
     assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
 
 
-def test_purge_compile_caches_if_versions_changed_skips_when_no_cache(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_purge_compile_caches_if_versions_changed_skips_when_no_cache(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
     monkeypatch.setattr(
@@ -1623,8 +1615,7 @@ async def test_spawn_retries_once_on_poisoned_compile_cache(tmp_path: Path, monk
             # cached AOT-compiled inductor file.
             handle._recent_logs.extend(
                 [
-                    '  File "/tmp/x/.cache/vllm/torch_compile_cache/abc/'
-                    'inductor_cache/ol/frag.py", line 1, in call',
+                    '  File "/tmp/x/.cache/vllm/torch_compile_cache/abc/' 'inductor_cache/ol/frag.py", line 1, in call',
                     "RuntimeError: Expected result >= 0",
                 ]
             )
@@ -1645,9 +1636,7 @@ async def test_spawn_retries_once_on_poisoned_compile_cache(tmp_path: Path, monk
 
 
 @pytest.mark.asyncio
-async def test_spawn_does_not_retry_on_unrelated_startup_failure(
-    tmp_path: Path, monkeypatch
-) -> None:
+async def test_spawn_does_not_retry_on_unrelated_startup_failure(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     paths = _populate_compile_cache(tmp_path)
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())


### PR DESCRIPTION
## Summary
- Bumps vLLM to **0.22.0** in `logos-workernode/Dockerfile`.
- Adds **proactive** + **reactive** auto-purging of the on-disk torch.compile / inductor cache so the worker survives version upgrades and AOT shape-profile mismatches.
- Pins the shared `deploy-docker-compose.yml` workflow back to `@main` now that the GHCR image-check fix is merged.

## Why
gemma 4 on **deioma** has been in a tight startup-failure loop for 16+ hours. Every restart replays the same cached AOT-compiled inductor file and crashes inside it:

```
File ".../models/.cache/vllm/torch_compile_cache/<hash>/inductor_cache/ol/<hash>.py", line 664, in call
    buf3 = empty_strided_cuda((s18, 64), (64, 1), torch.bfloat16)
RuntimeError: Expected result >= 0 to be true, but got false.
```

The lane manager's restart budget (5 attempts) is useless here — the same poisoned artifact crashes every time. Bumping vLLM 0.21 → 0.22 would make this problem worse for every cached model on every host.

## What changed in `vllm_process.py`
1. **Proactive (version stamp).** After a successful spawn, write `<cache_root>/.cache/.logos_compile_cache_stamp.json` containing the installed vllm + torch versions. On the next spawn, if the stamp doesn't match the venv's current versions (or is missing while a cache exists), purge `.cache/vllm` and `.cache/torch_inductor` first.
2. **Reactive (stack-trace detector).** `has_poisoned_compile_cache` returns true when the recent log buffer contains a path under `/.cache/vllm/torch_compile_cache/`, `/.cache/torch_inductor/`, `/torch_aot_compile/`, or `/inductor_cache/`. On a startup failure where the detector fires, `spawn()` purges the caches and retries **once**.
3. `_purge_compile_caches()` removes only `vllm/` and `torch_inductor/` — HF weights and the FlashInfer JIT cache (`.cache/flashinfer/`) are intentionally preserved.

The cache root is the same path the worker already uses (`<persistent_root>/.cache/...`); in the standard deioma/deimama/deipapa deployments this resolves through the `/mnt/ceph → /usr/share/ollama/.ollama/models` bind mount, so the wipe affects the ceph volume on the host.

## Test plan
- [x] `uv run pytest tests/` in `logos-workernode/` — 271 passed, 2 skipped (12 new tests).
- [x] `uv run pytest tests/test_lane_manager.py` — 41 passed.
- [ ] Deploy to prod → confirm `planner-google_gemma-4-26B-A4B-it` on deioma comes up clean on first spawn (proactive purge should fire because the venv jumps to vllm 0.22).
- [ ] Confirm `.logos_compile_cache_stamp.json` is created under `/mnt/ceph/.cache/` after the lane boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added automatic detection and cleanup of corrupted worker compile caches with built-in retry mechanism to improve reliability.

* **Chores**
  * Updated vLLM dependency to version 0.22.0.
  * Updated deployment workflows to reference stable branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/edutelligence/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->