### PR TITLE
`Logos`: Cooldown load failures, RAM-gate sleeps, calibrate sleep transient, quiet tracebacks

### DIFF
--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -29,13 +29,15 @@ import math
 import os
 import signal
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 try:
     import yaml
@@ -630,6 +632,65 @@ class CalibrationResult:
     # the profile so the worker can detect mismatches against production overrides
     # and trigger recalibration when CUDA-graph state would change the footprint.
     enforce_eager: bool = False
+    # Peak transient host-RAM consumption measured during the sleep call
+    # (one of sleep_l1 / sleep_l2 depending on `sleep_level` for this run).
+    # Captured by sampling /proc/meminfo MemAvailable at ~50ms during the
+    # /sleep HTTP call. The other slot stays None — the planner falls back
+    # to a heuristic when missing.
+    sleep_l1_transient_host_ram_mb: float | None = None
+    sleep_l2_transient_host_ram_mb: float | None = None
+
+
+def _sample_host_ram_available_mb() -> float | None:
+    """Read /proc/meminfo MemAvailable, return MB. None when unavailable."""
+    try:
+        with open("/proc/meminfo", "rb") as f:
+            for line in f:
+                if line.startswith(b"MemAvailable:"):
+                    parts = line.split()
+                    return float(parts[1]) / 1024.0  # kB → MB
+    except OSError:
+        return None
+    return None
+
+
+@contextmanager
+def _track_host_ram_transient(interval_s: float = 0.05) -> Iterator[dict[str, float | None]]:
+    """Sample MemAvailable while inside this block; report peak transient delta.
+
+    Yields a dict that will hold ``baseline_mb`` and ``transient_mb`` (peak
+    consumption = baseline_mb − min_available_during_block) once the block
+    exits. Both fields are None when /proc/meminfo is unavailable.
+    """
+    result: dict[str, float | None] = {"baseline_mb": None, "transient_mb": None}
+    baseline = _sample_host_ram_available_mb()
+    if baseline is None:
+        yield result
+        return
+
+    result["baseline_mb"] = baseline
+    stop = threading.Event()
+    min_seen = baseline
+
+    def _poll() -> None:
+        nonlocal min_seen
+        while not stop.wait(interval_s):
+            sample = _sample_host_ram_available_mb()
+            if sample is not None and sample < min_seen:
+                min_seen = sample
+
+    thread = threading.Thread(target=_poll, daemon=True)
+    thread.start()
+    try:
+        yield result
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+        # Final snapshot in case the operation completed before the poller fired
+        final_sample = _sample_host_ram_available_mb()
+        if final_sample is not None and final_sample < min_seen:
+            min_seen = final_sample
+        result["transient_mb"] = max(baseline - min_seen, 0.0)
 
 
 def calibrate_model(
@@ -1138,20 +1199,36 @@ def calibrate_model(
             kv_cache_sent_mb,
         )
 
-        # Phase 4 — Sleep the model
+        # Phase 4 — Sleep the model (with host-RAM transient sampling)
         logger.info("  [4/6] Sleeping model (level=%d)...", sleep_level)
         sleep_url = f"{base_url}/sleep?level={sleep_level}"
-        status, _ = _post(sleep_url, timeout_s=_SLEEP_TIMEOUT_S)
-        if status not in (200, 204):
-            partial.error = f"/sleep returned HTTP {status}"
-            logger.warning("  ERROR: %s", partial.error)
-            return partial
-        try:
-            wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
-        except TimeoutError as exc:
-            partial.error = str(exc)
-            logger.warning("  ERROR: %s", partial.error)
-            return partial
+        with _track_host_ram_transient() as host_ram_probe:
+            status, _ = _post(sleep_url, timeout_s=_SLEEP_TIMEOUT_S)
+            if status not in (200, 204):
+                partial.error = f"/sleep returned HTTP {status}"
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
+            try:
+                wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
+            except TimeoutError as exc:
+                partial.error = str(exc)
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
+
+        sleep_transient_mb = host_ram_probe["transient_mb"]
+        sleep_baseline_mb = host_ram_probe["baseline_mb"]
+        if sleep_transient_mb is not None and sleep_baseline_mb is not None:
+            logger.info(
+                "        sleep_l%d transient host RAM: baseline_available=%.0fMB, " "peak_consumption=%.0fMB",
+                sleep_level,
+                sleep_baseline_mb,
+                sleep_transient_mb,
+            )
+        else:
+            logger.info(
+                "        sleep_l%d transient host RAM: /proc/meminfo unavailable — skipped",
+                sleep_level,
+            )
 
         # Phase 5 — Measure sleeping VRAM. Sample twice with a settle between
         # samples and take the max. CuMemAllocator's release is asynchronous;
@@ -1220,6 +1297,8 @@ def calibrate_model(
             base_residency_mb=base_residency_mb,
             calibrated_at=time.time(),
             enforce_eager=eager_mode,
+            sleep_l1_transient_host_ram_mb=sleep_transient_mb if sleep_level == 1 else None,
+            sleep_l2_transient_host_ram_mb=sleep_transient_mb if sleep_level == 2 else None,
         )
 
     finally:
@@ -1262,6 +1341,12 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
         "last_measured_epoch": r.calibrated_at,
         "residency_source": "calibrated",
         "enforce_eager_at_calibration": r.enforce_eager,
+        "sleep_l1_transient_host_ram_mb": (
+            round(r.sleep_l1_transient_host_ram_mb, 1) if r.sleep_l1_transient_host_ram_mb is not None else None
+        ),
+        "sleep_l2_transient_host_ram_mb": (
+            round(r.sleep_l2_transient_host_ram_mb, 1) if r.sleep_l2_transient_host_ram_mb is not None else None
+        ),
         # Not part of ModelProfileRecord but useful for auditing
         "_calibration_kv_cache_mb": round(r.kv_cache_sent_mb, 1),
         # Discovered KV cache size for use by the lane manager at runtime

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -704,6 +704,7 @@ def calibrate_model(
     nccl_p2p_available: bool = False,
     hf_home: str | None = None,
     model_cache: Any | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> CalibrationResult:
     # Honor the production enforce_eager setting (default False, matching the
     # worker schema). Calibrating in a different mode than production runs
@@ -750,6 +751,10 @@ def calibrate_model(
     # subsequent calibrations to OOM or hang.
     _kill_stale_vllm_workers()
 
+    if cancel_event is not None and cancel_event.is_set():
+        partial.error = "cancelled"
+        return partial
+
     # Phase 1 — Baseline: measure before any model process exists.
     # Retry up to 3 times with a short delay — nvidia-smi can be temporarily
     # sluggish right after a previous heavy calibration run (GPU driver busy).
@@ -773,6 +778,10 @@ def calibrate_model(
         logger.warning("  ERROR: %s", partial.error)
         return partial
     logger.info("        baseline = %.0f MB", baseline_mb)
+
+    if cancel_event is not None and cancel_event.is_set():
+        partial.error = "cancelled"
+        return partial
 
     # Compute VRAM cap for KV cache search.
     # Use per-GPU VRAM × tp so the cap reflects the GPUs actually used,
@@ -1007,6 +1016,10 @@ def calibrate_model(
             best_kv = search_lo
 
             while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info("  Calibration cancelled during KV search.")
+                    partial.error = "cancelled"
+                    return partial
                 mid = _round_up_gb((search_lo + search_hi) / 2.0)
                 if mid <= search_lo:
                     break
@@ -1067,6 +1080,10 @@ def calibrate_model(
                 search_lo = best_kv
                 search_hi = original_ceiling
                 while search_hi - search_lo >= _KV_CACHE_MIN_STEP_MB:
+                    if cancel_event is not None and cancel_event.is_set():
+                        logger.info("  Calibration cancelled during KV search.")
+                        partial.error = "cancelled"
+                        return partial
                     mid = _round_up_gb((search_lo + search_hi) / 2.0)
                     if mid <= search_lo:
                         break
@@ -1147,6 +1164,10 @@ def calibrate_model(
 
     partial.kv_cache_sent_mb = kv_cache_sent_mb
 
+    if cancel_event is not None and cancel_event.is_set():
+        partial.error = "cancelled"
+        return partial
+
     try:
         # Phase 2.5 — Warmup with a 1-token completion. Forces:
         #   • CUDA graph capture (when enforce_eager=False)
@@ -1176,6 +1197,10 @@ def calibrate_model(
             )
 
         # Phase 3 — Measure awake VRAM
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info("  Calibration cancelled before Phase 3.")
+            partial.error = "cancelled"
+            return partial
         logger.info("  [3/6] Measuring awake VRAM (settling %.0fs)...", _VRAM_SETTLE_S)
         time.sleep(_VRAM_SETTLE_S)
         try:
@@ -1200,6 +1225,10 @@ def calibrate_model(
         )
 
         # Phase 4 — Sleep the model (with host-RAM transient sampling)
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info("  Calibration cancelled before Phase 4.")
+            partial.error = "cancelled"
+            return partial
         logger.info("  [4/6] Sleeping model (level=%d)...", sleep_level)
         sleep_url = f"{base_url}/sleep?level={sleep_level}"
         with _track_host_ram_transient() as host_ram_probe:
@@ -1236,6 +1265,10 @@ def calibrate_model(
         # residual (which leads to wake-time OOM when the planner trusts an
         # artificially low value). The first sample is required; the second
         # is a refinement and falls back silently if it fails.
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info("  Calibration cancelled before Phase 5.")
+            partial.error = "cancelled"
+            return partial
         logger.info(
             "  [5/6] Measuring sleeping VRAM (settling %.0fs, double-sample)...",
             _VRAM_SETTLE_S,

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import json
 import logging
-import subprocess
 import threading
 import time
 from datetime import datetime, timezone
@@ -562,13 +561,7 @@ class LogosBridgeClient:
         def _run_calibration() -> None:
             from pathlib import Path
 
-            from logos_worker_node.calibration import (
-                CalibrationResult,
-                auto_calibrate_models,
-                load_existing_profiles,
-                result_to_profile_dict,
-                save_profiles,
-            )
+            from logos_worker_node.calibration import load_existing_profiles, result_to_profile_dict, save_profiles
             from logos_worker_node.config import get_state_dir
 
             state_dir = get_state_dir()
@@ -620,9 +613,19 @@ class LogosBridgeClient:
                 )
 
                 if result.success:
-                    # Persist the new profile to model_profiles.yml and reload
+                    # Persist the new profile to model_profiles.yml and reload.
+                    # Preserve any prior transient measurements that the current
+                    # run did not produce (this calibration only measures one
+                    # sleep level — the other field comes back as None from
+                    # result_to_profile_dict and must not clobber an earlier
+                    # value).
                     existing = load_existing_profiles(profiles_path)
-                    existing[model_name] = result_to_profile_dict(result)
+                    prior = existing.get(model_name) or {}
+                    new_profile = result_to_profile_dict(result)
+                    for _carry in ("sleep_l1_transient_host_ram_mb", "sleep_l2_transient_host_ram_mb"):
+                        if new_profile.get(_carry) is None and prior.get(_carry) is not None:
+                            new_profile[_carry] = prior[_carry]
+                    existing[model_name] = new_profile
                     save_profiles(profiles_path, existing)
                     model_profiles._load_persisted()
                     logger.info(

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -6,6 +6,8 @@ import asyncio
 import base64
 import json
 import logging
+import subprocess
+import threading
 import time
 from datetime import datetime, timezone
 from typing import Any, ClassVar
@@ -58,6 +60,8 @@ class LogosBridgeClient:
         self._last_runtime_payload: dict[str, Any] = {}
         # Resolved by server during auth
         self._resolved_worker_id: str = ""
+        # Active server-orchestrated calibration: (model_name, cancel_event, thread, started_at)
+        self._active_calibration: tuple[str, threading.Event, threading.Thread, float] | None = None
 
     @property
     def worker_id(self) -> str:
@@ -525,7 +529,148 @@ class LogosBridgeClient:
             status = await lane_manager.reconfigure_lane(lane_id, updates)
             return status.model_dump(mode="json")
 
+        if action == "start_calibration":
+            return self._handle_start_calibration(params)
+        if action == "stop_calibration":
+            return self._handle_stop_calibration()
+        if action == "get_calibration_status":
+            return self._handle_get_calibration_status()
+
         raise ValueError(f"Unsupported bridge command '{action}'")
+
+    def _handle_start_calibration(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Start a background calibration for one model (server-orchestrated path)."""
+        model_name = str(params.get("model_name", "")).strip()
+        if not model_name:
+            return {"ok": False, "error": "model_name is required"}
+        sleep_level = int(params.get("sleep_level", 1))
+
+        if self._active_calibration is not None:
+            active_model = self._active_calibration[0]
+            if self._active_calibration[2].is_alive():
+                return {"ok": False, "error": f"calibration already in progress: {active_model}"}
+            # Thread finished — clean up stale entry
+            self._active_calibration = None
+
+        cancel_event = threading.Event()
+        started_at = time.time()
+
+        cfg = self._app.state.config
+        model_profiles = self._app.state.model_profiles
+        model_cache = getattr(self._app.state, "model_cache", None)
+
+        def _run_calibration() -> None:
+            from pathlib import Path
+
+            from logos_worker_node.calibration import (
+                CalibrationResult,
+                auto_calibrate_models,
+                load_existing_profiles,
+                result_to_profile_dict,
+                save_profiles,
+            )
+            from logos_worker_node.config import get_state_dir
+
+            state_dir = get_state_dir()
+            profiles_path = state_dir / "model_profiles.yml"
+            nccl_p2p = cfg.engines.vllm.nccl_p2p_available if cfg.engines else False
+            _mc = model_cache if (model_cache is not None and getattr(model_cache, "enabled", False)) else None
+
+            # Find the config.yml path for plans_from_config
+            import os
+
+            config_path_str = os.environ.get("LOGOS_WORKER_NODE_CONFIG", "").strip()
+            if config_path_str:
+                config_path = Path(config_path_str)
+            else:
+                for candidate in [Path("/app/config.yml"), Path("config.yml")]:
+                    if candidate.resolve().is_file():
+                        config_path = candidate
+                        break
+                else:
+                    config_path = Path("config.yml")
+
+            try:
+                logger.info(
+                    "[Calibration] Starting server-orchestrated calibration: model=%s sleep_level=%d",
+                    model_name,
+                    sleep_level,
+                )
+                from logos_worker_node.calibration import calibrate_model, plans_from_config
+
+                all_plans = plans_from_config(config_path) if config_path.exists() else []
+                plan_by_model = {p["model"]: p for p in all_plans}
+                plan = plan_by_model.get(model_name) or {"model": model_name}
+
+                from logos_worker_node.calibration import _CALIBRATION_PORT, _DEFAULT_VLLM, _READY_TIMEOUT_S
+
+                log_dir = state_dir / "calibration_logs"
+                log_dir.mkdir(parents=True, exist_ok=True)
+
+                result = calibrate_model(
+                    plan,
+                    vllm_binary=cfg.engines.vllm.vllm_binary if cfg.engines and cfg.engines.vllm else _DEFAULT_VLLM,
+                    port=_CALIBRATION_PORT,
+                    log_dir=log_dir,
+                    sleep_level=sleep_level,
+                    ready_timeout_s=_READY_TIMEOUT_S,
+                    nccl_p2p_available=nccl_p2p,
+                    model_cache=_mc,
+                    cancel_event=cancel_event,
+                )
+
+                if result.success:
+                    # Persist the new profile to model_profiles.yml and reload
+                    existing = load_existing_profiles(profiles_path)
+                    existing[model_name] = result_to_profile_dict(result)
+                    save_profiles(profiles_path, existing)
+                    model_profiles._load_persisted()
+                    logger.info(
+                        "[Calibration] Completed successfully: model=%s base_residency=%.0f MB",
+                        model_name,
+                        result.base_residency_mb,
+                    )
+                elif cancel_event.is_set():
+                    logger.info("[Calibration] Cancelled by server: model=%s", model_name)
+                else:
+                    logger.warning(
+                        "[Calibration] Failed: model=%s error=%s",
+                        model_name,
+                        result.error,
+                    )
+            except Exception:
+                logger.exception("[Calibration] Unexpected error for model=%s", model_name)
+            finally:
+                # Clear active state when the thread exits
+                if self._active_calibration is not None and self._active_calibration[0] == model_name:
+                    self._active_calibration = None
+
+        thread = threading.Thread(target=_run_calibration, name=f"calibration-{model_name}", daemon=True)
+        self._active_calibration = (model_name, cancel_event, thread, started_at)
+        thread.start()
+        return {"ok": True, "model_name": model_name, "sleep_level": sleep_level, "started_at": started_at}
+
+    def _handle_stop_calibration(self) -> dict[str, Any]:
+        """Cancel any in-progress calibration (idempotent)."""
+        if self._active_calibration is None:
+            return {"ok": True, "was_active": False}
+
+        model_name, cancel_event, thread, _started_at = self._active_calibration
+        cancel_event.set()
+        thread.join(timeout=10.0)
+        self._active_calibration = None
+        logger.info("[Calibration] stop_calibration received — cancelled model=%s", model_name)
+        return {"ok": True, "was_active": True, "model_name": model_name}
+
+    def _handle_get_calibration_status(self) -> dict[str, Any]:
+        """Return whether a calibration is currently running."""
+        if self._active_calibration is None:
+            return {"active": False, "model_name": None, "started_at": None}
+        model_name, _cancel, thread, started_at = self._active_calibration
+        if not thread.is_alive():
+            self._active_calibration = None
+            return {"active": False, "model_name": None, "started_at": None}
+        return {"active": True, "model_name": model_name, "started_at": started_at}
 
     # vLLM endpoints that must never be reachable through proxied inference
     # requests.  These are internal management endpoints (sleep/wake, cache

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -310,7 +310,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         hf_home=hf_home,
     )
 
-    await _auto_calibrate_if_needed(cfg, model_profiles, get_state_dir(), model_cache=model_cache)
+    # Auto-calibration on startup is disabled — the Logos server now drives
+    # calibration via start_calibration / stop_calibration commands during the
+    # nightly maintenance window.  The _auto_calibrate_if_needed function is
+    # kept for the standalone CLI tool path (tools/calibrate_vram_profiles.py).
 
     if model_cache.enabled:
         caps = list(cfg.logos.capabilities_models) if cfg.logos else []

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -79,6 +79,14 @@ class ModelProfileRecord:
     # host RAM rather than freeing them — but tracked separately so the
     # planner can use the right value depending on the candidate's state.
     host_ram_residual_mb: float | None = None
+    # Peak transient host-RAM allocation observed during the calibrated
+    # sleep call (level 1 / level 2). Distinct from host_ram_residual_mb,
+    # which is steady-state after the sleep settles. The planner uses these
+    # to gate sleep dispatch on swap-saturated workers — without enough
+    # transient headroom vLLM's sleep cancels mid-flight and kills
+    # EngineCore. None on profiles calibrated before this field existed.
+    sleep_l1_transient_host_ram_mb: float | None = None
+    sleep_l2_transient_host_ram_mb: float | None = None
 
     def known_base_residency_mb(self) -> float | None:
         """Return base_residency_mb only if it came from a real source, else None."""
@@ -127,6 +135,8 @@ class ModelProfileRecord:
             "enforce_eager_at_calibration": self.enforce_eager_at_calibration,
             "host_ram_mb": self.host_ram_mb,
             "host_ram_residual_mb": self.host_ram_residual_mb,
+            "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
+            "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
         }
 
     def estimate_host_ram_mb(self) -> float:
@@ -557,6 +567,8 @@ class ModelProfileRegistry:
                     enforce_eager_at_calibration=eager_at_cal,
                     host_ram_mb=profile_data.get("host_ram_mb"),
                     host_ram_residual_mb=profile_data.get("host_ram_residual_mb"),
+                    sleep_l1_transient_host_ram_mb=profile_data.get("sleep_l1_transient_host_ram_mb"),
+                    sleep_l2_transient_host_ram_mb=profile_data.get("sleep_l2_transient_host_ram_mb"),
                 )
             logger.info(
                 "Loaded %d model profile(s) from %s",

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -1,0 +1,353 @@
+"""Server-orchestrated nightly VRAM calibration.
+
+The CalibrationOrchestrator runs a background asyncio loop that, once per
+minute during a configurable time window (default 02:00–05:00 Europe/Berlin),
+picks one uncalibrated model on one idle worker node and drives it through the
+calibration cycle via the existing bridge RPC commands:
+
+  start_calibration  →  { ok, model_name, sleep_level, started_at }
+  get_calibration_status  →  { active, model_name, started_at }
+  stop_calibration  →  { ok, was_active, model_name? }
+
+Design invariants:
+- Only one worker calibrates at a time (sequential, not concurrent).
+- A worker is considered idle if it has no active requests AND its
+  calibration-status reports active=False.
+- A model "needs calibration" if its ModelProfile.base_residency_mb is None
+  on a worker that lists it as a capability.
+- Outside the time window the orchestrator sends stop_calibration to any worker
+  that may be running one (best-effort) and idles until the next window opens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import time
+from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger("logos.capacity.calibration_orchestrator")
+
+if TYPE_CHECKING:
+    from logos.logosnode_registry import LogosNodeRuntimeRegistry
+    from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CalibrationConfig:
+    """Nightly calibration window and behaviour knobs.
+
+    All values can be overridden via environment variables so that
+    operators can tune them without touching YAML.
+
+    LOGOS_CALIB_WINDOW_START  e.g. "02:00" (HH:MM, default 02:00)
+    LOGOS_CALIB_WINDOW_END    e.g. "05:00" (HH:MM, default 05:00)
+    LOGOS_CALIB_TIMEZONE      e.g. "Europe/Berlin" (default Europe/Berlin)
+    LOGOS_CALIB_ENABLED       "true" / "false" (default true)
+    LOGOS_CALIB_SLEEP_LEVEL   "1" or "2" (default 1)
+    LOGOS_CALIB_TICK_SECONDS  poll interval in seconds (default 60)
+    """
+
+    window_start: time = field(default_factory=lambda: time(2, 0))
+    window_end: time = field(default_factory=lambda: time(5, 0))
+    timezone: str = "Europe/Berlin"
+    enabled: bool = True
+    sleep_level: int = 1
+    tick_seconds: float = 60.0
+
+    @classmethod
+    def from_env(cls) -> "CalibrationConfig":
+        """Build a CalibrationConfig from environment variables (with defaults)."""
+
+        def _parse_time(raw: str, default: time) -> time:
+            raw = raw.strip()
+            if not raw:
+                return default
+            try:
+                h, m = raw.split(":", 1)
+                return time(int(h), int(m))
+            except (ValueError, TypeError):
+                logger.warning("CalibrationConfig: invalid time %r — using default %s", raw, default)
+                return default
+
+        def _parse_bool(raw: str, default: bool) -> bool:
+            return raw.strip().lower() in {"1", "true", "yes"} if raw.strip() else default
+
+        def _parse_int(raw: str, default: int) -> int:
+            try:
+                return int(raw.strip()) if raw.strip() else default
+            except ValueError:
+                return default
+
+        def _parse_float(raw: str, default: float) -> float:
+            try:
+                return float(raw.strip()) if raw.strip() else default
+            except ValueError:
+                return default
+
+        return cls(
+            window_start=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_START", ""), time(2, 0)),
+            window_end=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_END", ""), time(5, 0)),
+            timezone=os.getenv("LOGOS_CALIB_TIMEZONE", "Europe/Berlin").strip() or "Europe/Berlin",
+            enabled=_parse_bool(os.getenv("LOGOS_CALIB_ENABLED", ""), True),
+            sleep_level=_parse_int(os.getenv("LOGOS_CALIB_SLEEP_LEVEL", ""), 1),
+            tick_seconds=_parse_float(os.getenv("LOGOS_CALIB_TICK_SECONDS", ""), 60.0),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+class CalibrationOrchestrator:
+    """Drives server-orchestrated nightly VRAM calibration."""
+
+    def __init__(
+        self,
+        registry: "LogosNodeRuntimeRegistry",
+        facade: "LogosNodeSchedulingDataFacade",
+        config: CalibrationConfig | None = None,
+    ) -> None:
+        self._registry = registry
+        self._facade = facade
+        self._config = config or CalibrationConfig.from_env()
+        self._task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        if not self._config.enabled:
+            logger.info("CalibrationOrchestrator: disabled via config — not starting")
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._tick_loop(), name="calibration-orchestrator")
+        logger.info(
+            "CalibrationOrchestrator: started (window %s–%s %s, tick=%.0fs)",
+            self._config.window_start.strftime("%H:%M"),
+            self._config.window_end.strftime("%H:%M"),
+            self._config.timezone,
+            self._config.tick_seconds,
+        )
+
+    async def stop(self) -> None:
+        if self._task is None or self._task.done():
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+        logger.info("CalibrationOrchestrator: stopped")
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    async def _tick_loop(self) -> None:
+        while True:
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("CalibrationOrchestrator: unhandled error in tick — will retry")
+            await asyncio.sleep(self._config.tick_seconds)
+
+    async def _tick(self) -> None:
+        if not self._is_in_window():
+            # Outside window: cancel any running calibration (best-effort).
+            await self._cancel_all_running()
+            return
+
+        # Inside window: pick one idle worker with an uncalibrated model.
+        target = self._pick_calibration_target()
+        if target is None:
+            logger.debug("CalibrationOrchestrator: all models calibrated or no idle worker available")
+            return
+
+        provider_id, model_name = target
+        provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
+
+        # Check if that worker is already calibrating (maybe we triggered it
+        # last tick and the thread started but didn't finish yet).
+        status = await self._get_status(provider_id)
+        if status is not None and status.get("active"):
+            logger.debug(
+                "CalibrationOrchestrator: worker=%s already calibrating model=%s — waiting",
+                provider_name,
+                status.get("model_name"),
+            )
+            return
+
+        logger.info(
+            "CalibrationOrchestrator: starting calibration provider=%s model=%s sleep_level=%d",
+            provider_name,
+            model_name,
+            self._config.sleep_level,
+        )
+        await self._send_start_calibration(provider_id, model_name)
+
+    # ------------------------------------------------------------------
+    # Window check
+    # ------------------------------------------------------------------
+
+    def _is_in_window(self) -> bool:
+        try:
+            from zoneinfo import ZoneInfo  # Python 3.9+
+        except ImportError:
+            try:
+                from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
+            except ImportError:
+                logger.warning(
+                    "CalibrationOrchestrator: zoneinfo not available — assuming inside window"
+                )
+                return True
+        from datetime import datetime
+
+        tz = ZoneInfo(self._config.timezone)
+        now = datetime.now(tz=tz).time().replace(tzinfo=None)
+        start = self._config.window_start
+        end = self._config.window_end
+
+        if start <= end:
+            return start <= now < end
+        # Overnight window (e.g. 23:00–02:00)
+        return now >= start or now < end
+
+    # ------------------------------------------------------------------
+    # Target selection
+    # ------------------------------------------------------------------
+
+    def _pick_calibration_target(self) -> tuple[int, str] | None:
+        """Return (provider_id, model_name) for the first model that needs
+        calibration on an idle, connected worker — or None if none found."""
+        for provider_id in self._facade.provider_ids():
+            # Skip providers that haven't sent their first status yet.
+            if not self._registry.has_received_first_status(provider_id):
+                continue
+
+            # Skip providers with active inference requests.
+            if self._provider_has_active_requests(provider_id):
+                continue
+
+            # Find a model on this provider that lacks a full calibration.
+            model_name = self._find_uncalibrated_model(provider_id)
+            if model_name is not None:
+                return provider_id, model_name
+
+        return None
+
+    def _provider_has_active_requests(self, provider_id: int) -> bool:
+        """Return True if the provider has any active inference requests."""
+        try:
+            capacity = self._facade.get_capacity_info(provider_id)
+            # OllamaCapacity.active_requests counts requests currently running
+            active: int = getattr(capacity, "active_requests", 0) or 0
+            return active > 0
+        except Exception:
+            # If we can't determine, assume busy to avoid interrupting work.
+            return True
+
+    def _find_uncalibrated_model(self, provider_id: int) -> str | None:
+        """Return the first model on this provider that has no calibration data."""
+        capabilities = self._facade.get_worker_capabilities(provider_id)
+        try:
+            profiles = self._facade.get_model_profiles(provider_id)
+        except Exception:
+            profiles = {}
+
+        for model_name in capabilities:
+            profile = profiles.get(model_name)
+            needs_calib = (
+                profile is None
+                or profile.base_residency_mb is None
+                or profile.sleeping_residual_mb is None
+            )
+            if needs_calib:
+                return model_name
+
+        return None
+
+    # ------------------------------------------------------------------
+    # RPC helpers
+    # ------------------------------------------------------------------
+
+    async def _send_start_calibration(self, provider_id: int, model_name: str) -> None:
+        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
+
+        try:
+            await self._registry.send_command(
+                provider_id,
+                "start_calibration",
+                params={"model_name": model_name, "sleep_level": self._config.sleep_level},
+                timeout_seconds=30,
+            )
+        except LogosNodeOfflineError:
+            logger.warning(
+                "CalibrationOrchestrator: provider=%s offline — cannot start calibration for %s",
+                provider_id,
+                model_name,
+            )
+        except LogosNodeCommandError as exc:
+            logger.warning(
+                "CalibrationOrchestrator: start_calibration failed for provider=%s model=%s: %s",
+                provider_id,
+                model_name,
+                exc,
+            )
+        except Exception:
+            logger.exception(
+                "CalibrationOrchestrator: unexpected error starting calibration "
+                "provider=%s model=%s",
+                provider_id,
+                model_name,
+            )
+
+    async def _get_status(self, provider_id: int) -> dict[str, Any] | None:
+        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
+
+        try:
+            return await self._registry.send_command(
+                provider_id,
+                "get_calibration_status",
+                timeout_seconds=10,
+            )
+        except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
+            return None
+
+    async def _cancel_all_running(self) -> None:
+        """Outside the maintenance window: stop any in-progress calibrations."""
+        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
+
+        for provider_id in self._facade.provider_ids():
+            status = await self._get_status(provider_id)
+            if status is None or not status.get("active"):
+                continue
+            provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
+            logger.info(
+                "CalibrationOrchestrator: outside window — stopping calibration on provider=%s",
+                provider_name,
+            )
+            try:
+                await self._registry.send_command(
+                    provider_id,
+                    "stop_calibration",
+                    timeout_seconds=15,
+                )
+            except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
+                logger.debug(
+                    "CalibrationOrchestrator: failed to stop calibration on provider=%s (ignored)",
+                    provider_name,
+                )

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -210,9 +210,7 @@ class CalibrationOrchestrator:
             try:
                 from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
             except ImportError:
-                logger.warning(
-                    "CalibrationOrchestrator: zoneinfo not available — assuming inside window"
-                )
+                logger.warning("CalibrationOrchestrator: zoneinfo not available — assuming inside window")
                 return True
         from datetime import datetime
 
@@ -261,7 +259,21 @@ class CalibrationOrchestrator:
             return True
 
     def _find_uncalibrated_model(self, provider_id: int) -> str | None:
-        """Return the first model on this provider that has no calibration data."""
+        """Return the first model on this provider that needs calibration.
+
+        A model needs calibration when ANY of:
+          - the profile is missing entirely,
+          - core VRAM fields (``base_residency_mb`` / ``sleeping_residual_mb``)
+            are missing,
+          - ``sleep_l1_transient_host_ram_mb`` is missing — this is the field
+            the planner's host-RAM sleep gate relies on. Production runs
+            sleep_l1 on every idle lane after ~2 min, so a missing value
+            forces the planner onto its flat-threshold fallback every time.
+            We only measure level 1 here; level 2 (``sleep_l2_transient_…``)
+            stays unmeasured because production effectively never fires
+            sleep_l2 (``IDLE_SLEEP_L2 = 24h``). The planner gracefully falls
+            back to a disk-size heuristic for sleep_l2 on demand.
+        """
         capabilities = self._facade.get_worker_capabilities(provider_id)
         try:
             profiles = self._facade.get_model_profiles(provider_id)
@@ -274,6 +286,7 @@ class CalibrationOrchestrator:
                 profile is None
                 or profile.base_residency_mb is None
                 or profile.sleeping_residual_mb is None
+                or profile.sleep_l1_transient_host_ram_mb is None
             )
             if needs_calib:
                 return model_name
@@ -309,8 +322,7 @@ class CalibrationOrchestrator:
             )
         except Exception:
             logger.exception(
-                "CalibrationOrchestrator: unexpected error starting calibration "
-                "provider=%s model=%s",
+                "CalibrationOrchestrator: unexpected error starting calibration " "provider=%s model=%s",
                 provider_id,
                 model_name,
             )

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -248,15 +248,25 @@ class CalibrationOrchestrator:
         return None
 
     def _provider_has_active_requests(self, provider_id: int) -> bool:
-        """Return True if the provider has any active inference requests."""
+        """Return True if the provider has any active inference requests.
+
+        `OllamaCapacity` (the only `get_capacity_info` return type) has no
+        `active_requests` field — that data only exists per-lane in the
+        scheduler signals. Sum across all lanes on the provider; treat any
+        non-zero `active_requests` (currently-running) or `queue_waiting`
+        (admitted but pending) as "busy".
+        """
         try:
-            capacity = self._facade.get_capacity_info(provider_id)
-            # OllamaCapacity.active_requests counts requests currently running
-            active: int = getattr(capacity, "active_requests", 0) or 0
-            return active > 0
+            signals = self._facade.get_all_provider_lane_signals(provider_id)
         except Exception:
-            # If we can't determine, assume busy to avoid interrupting work.
+            # Telemetry unavailable — assume busy to avoid interrupting work.
             return True
+        for sig in signals:
+            if int(getattr(sig, "active_requests", 0) or 0) > 0:
+                return True
+            if float(getattr(sig, "queue_waiting", 0.0) or 0.0) > 0.0:
+                return True
+        return False
 
     def _find_uncalibrated_model(self, provider_id: int) -> str | None:
         """Return the first model on this provider that needs calibration.

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -188,6 +188,11 @@ class CapacityPlanner:
     # that needs a fixed absolute buffer (OS file cache, malloc fragmentation,
     # mm processor cache) regardless of model size.
     HOST_RAM_SAFETY_MARGIN_MB = 4096.0
+    # Additional host-RAM headroom required *on top of* the safety margin
+    # before issuing sleep_l1/sleep_l2. vLLM's sleep op needs transient
+    # anonymous allocations (KV cache export, state migration); without this
+    # cushion a system with full swap will fail the sleep and kill EngineCore.
+    HOST_RAM_SLEEP_HEADROOM_MB = 4096.0
     ESTIMATION_SLACK_RATIO = 1.10
     # Tensor-parallel overhead: NCCL buffers + duplicated embedding/output layers
     TP_OVERHEAD_RATIO = 0.10  # 10% overhead per GPU for TP > 1
@@ -927,6 +932,22 @@ class CapacityPlanner:
         )
         deficit = projected_host_ram_mb - effective_available
         return deficit <= 0, effective_available, max(deficit, 0.0)
+
+    def _check_host_ram_headroom_for_sleep(self, provider_id: int) -> tuple[bool, float]:
+        """Is there enough host RAM to safely sleep a lane?
+
+        Returns ``(ok, effective_available_mb)``. *ok* is True when the
+        worker's available host RAM exceeds
+        ``HOST_RAM_SAFETY_MARGIN_MB + HOST_RAM_SLEEP_HEADROOM_MB`` after
+        accounting for in-flight reservations. Fails open if the worker
+        has no host-RAM telemetry.
+        """
+        available = self._get_host_ram_available_mb(provider_id)
+        if available is None:
+            return True, 0.0
+        effective_available = available - self._host_ram_ledger.get_committed_mb(provider_id)
+        required = self.HOST_RAM_SAFETY_MARGIN_MB + self.HOST_RAM_SLEEP_HEADROOM_MB
+        return effective_available >= required, effective_available
 
     async def _stop_sleeping_lanes_for_headroom(
         self,
@@ -6035,6 +6056,37 @@ class CapacityPlanner:
         # per-action `except Exception` handlers and leak the reservation.
         try:
             if action.action in ("sleep_l1", "sleep_l2"):
+                # Host-RAM precheck: vLLM's sleep op needs transient anonymous
+                # allocations. On a swap-saturated worker (deioma incident:
+                # swap 100% used, anonymous pages can't be evicted) sleep
+                # cancels mid-flight and kills EngineCore, leading to a
+                # multi-minute lane restart loop. Escalate to a full stop
+                # instead — stop releases host RAM entirely, breaking the
+                # cycle. The lane will cold-load again on next demand.
+                host_ram_ok, eff_avail = self._check_host_ram_headroom_for_sleep(action.provider_id)
+                if not host_ram_ok:
+                    required_mb = self.HOST_RAM_SAFETY_MARGIN_MB + self.HOST_RAM_SLEEP_HEADROOM_MB
+                    logger.warning(
+                        "Escalating %s → stop for lane %s on worker=%s: "
+                        "host RAM headroom too low (effective_available=%.0fMB, required=%.0fMB)",
+                        action.action,
+                        action.lane_id,
+                        self._facade.get_provider_name(action.provider_id) or action.provider_id,
+                        eff_avail,
+                        required_mb,
+                    )
+                    stop_action = CapacityPlanAction(
+                        action="stop",
+                        provider_id=action.provider_id,
+                        lane_id=action.lane_id,
+                        model_name=action.model_name,
+                        reason=(
+                            f"Escalated from {action.action}: host RAM headroom too low "
+                            f"({eff_avail:.0f}MB < {required_mb:.0f}MB)"
+                        ),
+                    )
+                    return await self._execute_action_with_confirmation(stop_action, timeout_seconds)
+
                 # For request-time reclaim sleeps, mark the lane cold and drain
                 # active requests BEFORE sending the sleep command.  Without this,
                 # new requests can be routed to the lane between the idle check in

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -5067,6 +5067,46 @@ class CapacityPlanner:
         including VRAM freed by sleep/stop actions in the same batch and
         VRAM reserved by in-flight operations.
         """
+        # Pre-pass: drop load actions in load-failure cooldown AND any reclaim
+        # actions paired with them. Without this the planner sleeps/stops a
+        # victim to make room for a load that the cooldown will refuse —
+        # eviction-only churn with no benefit. Paired reclaims are identified
+        # by the convention that reclaim-action reason strings contain the
+        # target's model_name (e.g. "Evicted for {model} load (...)");
+        # idle/drain sleeps don't reference a model name, so they're not
+        # affected.
+        cooldowned_targets: set[tuple[int, str]] = set()
+        for action in actions:
+            if action.action == "load" and self._lane_is_in_load_failure_cooldown(action.provider_id, action.lane_id):
+                cooldowned_targets.add((action.provider_id, action.model_name))
+
+        if cooldowned_targets:
+            kept_actions: List[CapacityPlanAction] = []
+            for action in actions:
+                if (action.action == "load") and (action.provider_id, action.model_name) in cooldowned_targets:
+                    logger.debug(
+                        "Dropping load of %s on worker=%s: lane %s in load-failure cooldown",
+                        action.model_name,
+                        self._facade.get_provider_name(action.provider_id) or action.provider_id,
+                        action.lane_id,
+                    )
+                    continue
+                if action.action in ("sleep_l1", "sleep_l2", "stop") and action.reason:
+                    paired = any(
+                        action.provider_id == pid and mname in action.reason for pid, mname in cooldowned_targets
+                    )
+                    if paired:
+                        logger.debug(
+                            "Dropping paired reclaim %s on worker=%s lane=%s: target in load-failure cooldown (%s)",
+                            action.action,
+                            self._facade.get_provider_name(action.provider_id) or action.provider_id,
+                            action.lane_id,
+                            action.reason,
+                        )
+                        continue
+                kept_actions.append(action)
+            actions = kept_actions
+
         validated_ids: set[int] = set()
         cumulative_vram: dict[int, float] = {}
 
@@ -5093,15 +5133,6 @@ class CapacityPlanner:
         # For consuming actions, check VRAM budget
         for action in consume_actions:
             provider_id = action.provider_id
-
-            if action.action == "load" and self._lane_is_in_load_failure_cooldown(provider_id, action.lane_id):
-                logger.debug(
-                    "Skipping load of %s on worker=%s: lane %s in load-failure cooldown",
-                    action.model_name,
-                    self._facade.get_provider_name(provider_id) or provider_id,
-                    action.lane_id,
-                )
-                continue
 
             try:
                 capacity = self._facade.get_capacity_info(provider_id)

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -6152,6 +6152,10 @@ class CapacityPlanner:
                             f"Escalated from {action.action}: host RAM headroom too low "
                             f"({eff_avail:.0f}MB < {required_mb:.0f}MB)"
                         ),
+                        # Without this, the stop branch's load-cooldown gate would
+                        # reject the escalation on a freshly loaded lane — exactly
+                        # the case the safety valve exists to handle.
+                        bypass_load_cooldown=True,
                     )
                     return await self._execute_action_with_confirmation(stop_action, timeout_seconds)
 
@@ -6403,8 +6407,14 @@ class CapacityPlanner:
                         return False
 
             elif action.action == "stop":
-                # Phase 1c: Reject stop if lane is within load cooldown
-                if self._lane_is_in_load_cooldown(action.provider_id, action.lane_id):
+                # Phase 1c: Reject stop if lane is within load cooldown — unless
+                # the caller explicitly requested a bypass (e.g. forced
+                # sleep→stop escalation under host-RAM pressure, where the
+                # cooldown would just prolong the very thrash we're trying
+                # to break).
+                if not action.bypass_load_cooldown and self._lane_is_in_load_cooldown(
+                    action.provider_id, action.lane_id
+                ):
                     logger.info(
                         "Skipping stop of lane %s on worker=%s: within %.0fs load cooldown",
                         action.lane_id,

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -933,21 +933,54 @@ class CapacityPlanner:
         deficit = projected_host_ram_mb - effective_available
         return deficit <= 0, effective_available, max(deficit, 0.0)
 
-    def _check_host_ram_headroom_for_sleep(self, provider_id: int) -> tuple[bool, float]:
+    def _check_host_ram_headroom_for_sleep(
+        self,
+        provider_id: int,
+        sleep_level: int,
+        profile: ModelProfile | None,
+    ) -> tuple[bool, float, float]:
         """Is there enough host RAM to safely sleep a lane?
 
-        Returns ``(ok, effective_available_mb)``. *ok* is True when the
-        worker's available host RAM exceeds
-        ``HOST_RAM_SAFETY_MARGIN_MB + HOST_RAM_SLEEP_HEADROOM_MB`` after
-        accounting for in-flight reservations. Fails open if the worker
-        has no host-RAM telemetry.
+        Returns ``(ok, effective_available_mb, required_mb)``. *ok* is True
+        when ``effective_available_mb >= required_mb``.
+
+        ``required_mb`` = ``HOST_RAM_SAFETY_MARGIN_MB + transient_estimate``,
+        where ``transient_estimate`` is:
+
+          1. The calibrated ``sleep_l{level}_transient_host_ram_mb`` from
+             the profile when present.
+          2. For sleep_l2 only: a rough estimate from ``disk_size_bytes``
+             (the weight-transfer dominates l2 transient cost) when the
+             calibrated value is missing.
+          3. ``HOST_RAM_SLEEP_HEADROOM_MB`` as a final flat fallback for
+             pre-calibration profiles.
+
+        Fails open if the worker has no host-RAM telemetry.
         """
         available = self._get_host_ram_available_mb(provider_id)
         if available is None:
-            return True, 0.0
+            return True, 0.0, 0.0
         effective_available = available - self._host_ram_ledger.get_committed_mb(provider_id)
-        required = self.HOST_RAM_SAFETY_MARGIN_MB + self.HOST_RAM_SLEEP_HEADROOM_MB
-        return effective_available >= required, effective_available
+
+        transient_mb: float | None = None
+        if profile is not None:
+            if sleep_level == 1:
+                transient_mb = profile.sleep_l1_transient_host_ram_mb
+            elif sleep_level == 2:
+                transient_mb = profile.sleep_l2_transient_host_ram_mb
+
+        if transient_mb is None and sleep_level == 2 and profile is not None:
+            # sleep_l2 transient is dominated by weight transfer to host RAM;
+            # disk size is a tight lower bound on weight footprint.
+            disk_bytes = profile.disk_size_bytes
+            if disk_bytes and disk_bytes > 0:
+                transient_mb = float(disk_bytes) / (1024.0 * 1024.0)
+
+        if transient_mb is None:
+            transient_mb = self.HOST_RAM_SLEEP_HEADROOM_MB
+
+        required = self.HOST_RAM_SAFETY_MARGIN_MB + transient_mb
+        return effective_available >= required, effective_available, required
 
     async def _stop_sleeping_lanes_for_headroom(
         self,
@@ -6063,9 +6096,13 @@ class CapacityPlanner:
                 # multi-minute lane restart loop. Escalate to a full stop
                 # instead — stop releases host RAM entirely, breaking the
                 # cycle. The lane will cold-load again on next demand.
-                host_ram_ok, eff_avail = self._check_host_ram_headroom_for_sleep(action.provider_id)
+                _sleep_level = 1 if action.action == "sleep_l1" else 2
+                host_ram_ok, eff_avail, required_mb = self._check_host_ram_headroom_for_sleep(
+                    action.provider_id,
+                    _sleep_level,
+                    _profile,
+                )
                 if not host_ram_ok:
-                    required_mb = self.HOST_RAM_SAFETY_MARGIN_MB + self.HOST_RAM_SLEEP_HEADROOM_MB
                     logger.warning(
                         "Escalating %s → stop for lane %s on worker=%s: "
                         "host RAM headroom too low (effective_available=%.0fMB, required=%.0fMB)",

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -5975,12 +5975,13 @@ class CapacityPlanner:
                     {"lane_id": action.lane_id, **action.params},
                     timeout_seconds=int(min(timeout_seconds, 120)),
                 )
-            except Exception:
-                logger.exception(
-                    "Failed to send reconfigure_lane for worker=%s model=%s lane=%s",
+            except Exception as exc:
+                logger.error(
+                    "Failed to send reconfigure_lane for worker=%s model=%s lane=%s: %s",
                     self._facade.get_provider_name(action.provider_id) or action.provider_id,
                     action.model_name,
                     action.lane_id,
+                    exc,
                 )
                 self._unmark_lane_cold(action.provider_id, action.lane_id)
                 return False
@@ -6089,11 +6090,12 @@ class CapacityPlanner:
                         command_params,
                         timeout_seconds=int(min(timeout_seconds, 120)),
                     )
-                except Exception:
-                    logger.exception(
-                        "Failed to send %s command for lane %s",
+                except Exception as exc:
+                    logger.error(
+                        "Failed to send %s command for lane %s: %s",
                         action.action,
                         action.lane_id,
+                        exc,
                     )
                     if _is_reclaim_sleep:
                         self._unmark_lane_cold(action.provider_id, action.lane_id)
@@ -6153,11 +6155,12 @@ class CapacityPlanner:
                         action.lane_id,
                         details=str(exc),
                     )
-                    logger.exception(
-                        "Failed to send wake command for worker=%s model=%s lane=%s",
+                    logger.error(
+                        "Failed to send wake command for worker=%s model=%s lane=%s: %s",
                         self._facade.get_provider_name(action.provider_id) or action.provider_id,
                         action.model_name,
                         action.lane_id,
+                        exc,
                     )
                     return False
 
@@ -6268,12 +6271,13 @@ class CapacityPlanner:
                         self._registry.update_desired_lanes(action.provider_id, desired)
                         # Inflight entry now committed to registry — clear it
                         self._clear_inflight_add(action.provider_id, action.lane_id)
-                    except Exception:
-                        logger.exception(
-                            "Failed to send apply_lanes for load on worker=%s model=%s lane=%s",
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to send apply_lanes for load on worker=%s model=%s lane=%s: %s",
                             self._facade.get_provider_name(action.provider_id) or action.provider_id,
                             action.model_name,
                             action.lane_id,
+                            exc,
                         )
                         self._clear_inflight_add(action.provider_id, action.lane_id)
                         return False
@@ -6331,12 +6335,13 @@ class CapacityPlanner:
                             action.provider_id,
                             action.lane_id,
                         )
-                    except Exception:
-                        logger.exception(
-                            "Failed to send delete_lane for worker=%s model=%s lane=%s",
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to send delete_lane for worker=%s model=%s lane=%s: %s",
                             self._facade.get_provider_name(action.provider_id) or action.provider_id,
                             action.model_name,
                             action.lane_id,
+                            exc,
                         )
                         self._unmark_lane_cold(action.provider_id, action.lane_id)
                         return False
@@ -6367,12 +6372,13 @@ class CapacityPlanner:
                             return False
                         self._registry.update_desired_lanes(action.provider_id, desired)
                         self._clear_inflight_removal(action.provider_id, action.lane_id)
-                    except Exception:
-                        logger.exception(
-                            "Failed to send apply_lanes for stop on worker=%s model=%s lane=%s",
+                    except Exception as exc:
+                        logger.error(
+                            "Failed to send apply_lanes for stop on worker=%s model=%s lane=%s: %s",
                             self._facade.get_provider_name(action.provider_id) or action.provider_id,
                             action.model_name,
                             action.lane_id,
+                            exc,
                         )
                         self._clear_inflight_removal(action.provider_id, action.lane_id)
                         self._unmark_lane_cold(action.provider_id, action.lane_id)

--- a/logos/src/logos/capacity/capacity_planner.py
+++ b/logos/src/logos/capacity/capacity_planner.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from itertools import combinations
 from typing import Any, Dict, List, Optional
 
-from logos.logosnode_registry import LogosNodeRuntimeRegistry
+from logos.logosnode_registry import LogosNodeCommandError, LogosNodeRuntimeRegistry
 from logos.monitoring import prometheus_metrics as prom
 from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
 from logos.sdi.models import CapacityPlanAction, LaneSchedulerSignals, ModelProfile
@@ -195,6 +195,11 @@ class CapacityPlanner:
     # Slow-path request preparation
     REQUEST_WAKE_TIMEOUT_SECONDS = 30.0
     WAKE_FAILURE_COOLDOWN_SECONDS = 15.0
+    # Structural load failures (e.g. worker rejects add_lane because no GPU
+    # subset fits) won't be fixed by an immediate retry; suppress new load
+    # attempts for this long so we don't block the planner cycle on the same
+    # lane every 10s.
+    LOAD_FAILURE_COOLDOWN_SECONDS = 120.0
     COOLDOWN_WAIT_BUFFER_SECONDS = 2.0  # extra margin added after load cooldown expires
     BUSY_DRAIN_POLL_SECONDS = 5.0  # poll interval while waiting for a busy lane to drain
     TP_RANK0_VRAM_FRACTION = 0.62  # rank 0 hosts API server, tokenizer, sampling, embedding
@@ -323,6 +328,11 @@ class CapacityPlanner:
         # Re-attempted when any reclaim action confirms (freed VRAM may suffice).
         # Key: model_name → (provider_id, registered_at)
         self._pending_capacity: dict[str, tuple[int, float]] = {}
+
+        # Structural load-failure cooldown: lanes whose add_lane was rejected
+        # by the worker for a non-transient reason (e.g. no feasible GPU
+        # subset). Suppresses new load actions on the lane until expiry.
+        self._lane_load_failure_until: dict[tuple[int, str], float] = {}
 
         # Phase 4b: Atomic VRAM reservation ledger — prevents double-booking
         # when concurrent load/wake/sleep/stop operations overlap.
@@ -990,6 +1000,15 @@ class CapacityPlanner:
             reason="Request-time cold load",
         )
 
+        if self._lane_is_in_load_failure_cooldown(provider_id, lane_id):
+            logger.info(
+                "Skipping cold load of %s on worker=%s: lane %s in load-failure cooldown",
+                model_name,
+                self._facade.get_provider_name(provider_id) or provider_id,
+                lane_id,
+            )
+            return None
+
         estimated = self._estimate_action_vram(load_action, profile, capacity)
         available = float(capacity.available_vram_mb)
 
@@ -1134,6 +1153,7 @@ class CapacityPlanner:
         self._lane_sleep_since.pop(key, None)
         self._lane_sleep_level.pop(key, None)
         self._lane_wake_failure_until.pop(key, None)
+        self._lane_load_failure_until.pop(key, None)
 
     def _mark_wake_failure(
         self,
@@ -1174,6 +1194,45 @@ class CapacityPlanner:
             return False
         return True
 
+    def _mark_load_failure(
+        self,
+        provider_id: int,
+        lane_id: str,
+        *,
+        details: str | None = None,
+        now: float | None = None,
+    ) -> None:
+        key = self._lane_key(provider_id, lane_id)
+        current_time = time.time() if now is None else now
+        self._lane_load_failure_until[key] = current_time + self.LOAD_FAILURE_COOLDOWN_SECONDS
+        logger.warning(
+            "Marked lane %s on worker=%s as load-failed for %.0fs%s",
+            lane_id,
+            self._facade.get_provider_name(provider_id) or provider_id,
+            self.LOAD_FAILURE_COOLDOWN_SECONDS,
+            f": {details}" if details else "",
+        )
+
+    def _clear_load_failure(self, provider_id: int, lane_id: str) -> None:
+        self._lane_load_failure_until.pop(self._lane_key(provider_id, lane_id), None)
+
+    def _lane_is_in_load_failure_cooldown(
+        self,
+        provider_id: int,
+        lane_id: str,
+        *,
+        now: float | None = None,
+    ) -> bool:
+        key = self._lane_key(provider_id, lane_id)
+        retry_at = self._lane_load_failure_until.get(key)
+        if retry_at is None:
+            return False
+        current_time = time.time() if now is None else now
+        if current_time >= retry_at:
+            self._lane_load_failure_until.pop(key, None)
+            return False
+        return True
+
     def _record_confirmed_action_state(self, action: CapacityPlanAction, confirmed_at: float) -> None:
         key = self._lane_key(action.provider_id, action.lane_id)
 
@@ -1195,6 +1254,7 @@ class CapacityPlanner:
 
         if action.action in {"wake", "load"}:
             self._clear_wake_failure(action.provider_id, action.lane_id)
+            self._clear_load_failure(action.provider_id, action.lane_id)
             self._lane_sleep_since.pop(key, None)
             self._lane_sleep_level.pop(key, None)
             self._lane_idle_since[key] = confirmed_at
@@ -4980,6 +5040,15 @@ class CapacityPlanner:
         for action in consume_actions:
             provider_id = action.provider_id
 
+            if action.action == "load" and self._lane_is_in_load_failure_cooldown(provider_id, action.lane_id):
+                logger.debug(
+                    "Skipping load of %s on worker=%s: lane %s in load-failure cooldown",
+                    action.model_name,
+                    self._facade.get_provider_name(provider_id) or provider_id,
+                    action.lane_id,
+                )
+                continue
+
             try:
                 capacity = self._facade.get_capacity_info(provider_id)
                 available = (
@@ -6140,6 +6209,24 @@ class CapacityPlanner:
                             action.provider_id,
                             action.params,
                         )
+                    except LogosNodeCommandError as exc:
+                        # Worker rejected the load (e.g. no feasible GPU subset).
+                        # Suppress retries on this lane until the cooldown
+                        # expires so the planner cycle isn't blocked by the
+                        # same unplaceable lane every tick.
+                        logger.error(
+                            "Failed to send add_lane for worker=%s model=%s lane=%s: %s",
+                            self._facade.get_provider_name(action.provider_id) or action.provider_id,
+                            action.model_name,
+                            action.lane_id,
+                            exc,
+                        )
+                        self._mark_load_failure(
+                            action.provider_id,
+                            action.lane_id,
+                            details=str(exc),
+                        )
+                        return False
                     except Exception as exc:
                         logger.error(
                             "Failed to send add_lane for worker=%s model=%s lane=%s: %s",

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -21,8 +21,8 @@ from sqlalchemy import text
 from grpclocal import model_pb2_grpc
 from grpclocal.grpc_server import LogosServicer
 from logos.auth import authenticate_api_key
-from logos.capacity.capacity_planner import CapacityPlanner
 from logos.capacity.calibration_orchestrator import CalibrationConfig, CalibrationOrchestrator
+from logos.capacity.capacity_planner import CapacityPlanner
 from logos.capacity.demand_tracker import DemandTracker
 from logos.classification.classification_balancer import Balancer
 from logos.classification.classification_manager import ClassificationManager

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -22,6 +22,7 @@ from grpclocal import model_pb2_grpc
 from grpclocal.grpc_server import LogosServicer
 from logos.auth import authenticate_api_key
 from logos.capacity.capacity_planner import CapacityPlanner
+from logos.capacity.calibration_orchestrator import CalibrationConfig, CalibrationOrchestrator
 from logos.capacity.demand_tracker import DemandTracker
 from logos.classification.classification_balancer import Balancer
 from logos.classification.classification_manager import ClassificationManager
@@ -146,6 +147,7 @@ _logosnode_registry = LogosNodeRuntimeRegistry(
 )
 _demand_tracker: Optional[DemandTracker] = None
 _capacity_planner: Optional[CapacityPlanner] = None
+_calibration_orchestrator: Optional[CalibrationOrchestrator] = None
 
 
 def _env_int(name: str, default: int) -> int:
@@ -1143,6 +1145,8 @@ async def lifespan(app: FastAPI):
     _price_updater_task.cancel()
     if _capacity_planner:
         await _capacity_planner.stop()
+    if _calibration_orchestrator:
+        await _calibration_orchestrator.stop()
     if _grpc_server:
         await _grpc_server.stop(0)
 
@@ -1568,6 +1572,18 @@ async def start_pipeline():
     scheduler._on_capacity_needed = _on_capacity_needed
 
     await _capacity_planner.start()
+
+    global _calibration_orchestrator
+    _calibration_orchestrator = CalibrationOrchestrator(
+        registry=_logosnode_registry,
+        facade=_logosnode_facade,
+        config=CalibrationConfig.from_env(),
+    )
+    await _calibration_orchestrator.start()
+    logger.info(
+        "Calibration orchestrator started (enabled=%s)",
+        _calibration_orchestrator._config.enabled,
+    )
 
     logger.info(
         "Request Pipeline Initialized with ClassificationCorrectingScheduler " "(planner=%s, ettft=%s)",

--- a/logos/src/logos/sdi/models.py
+++ b/logos/src/logos/sdi/models.py
@@ -300,6 +300,11 @@ class CapacityPlanAction:
     params: Dict[str, Any] = field(default_factory=dict)
     reason: str = ""
     vram_reservation_id: Optional[str] = None
+    # When True on a `stop` action, the executor skips the
+    # `_lane_is_in_load_cooldown` gate. Used by forced escalations
+    # (e.g. sleep→stop under host-RAM pressure) where the cycle the
+    # cooldown would prolong is precisely the thing we're trying to break.
+    bypass_load_cooldown: bool = False
 
     def to_dict(self) -> dict:
         return {

--- a/logos/src/logos/sdi/models.py
+++ b/logos/src/logos/sdi/models.py
@@ -331,6 +331,13 @@ class ModelProfile:
     measurement_count: int = 0
     last_measured_epoch: float = 0.0
     residency_source: Optional[str] = None
+    # Peak transient host-RAM allocation observed during a calibrated sleep
+    # call. Used by the planner to gate sleep actions on memory-pressured
+    # workers (swap exhaustion → vLLM kills its own EngineCore otherwise).
+    # sleep_l1 is small + workload-dependent; sleep_l2 is dominated by
+    # weight-transfer size and is more predictive.
+    sleep_l1_transient_host_ram_mb: Optional[float] = None
+    sleep_l2_transient_host_ram_mb: Optional[float] = None
 
     def estimate_vram_mb(self) -> float:
         """Best estimate of model footprint (not GPU reservation).
@@ -375,6 +382,8 @@ class ModelProfile:
             "measurement_count": self.measurement_count,
             "last_measured_epoch": self.last_measured_epoch,
             "residency_source": self.residency_source,
+            "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
+            "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
         }
 
 

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -645,6 +645,8 @@ class LogosNodeDataProvider:
                 measurement_count=int(data.get("measurement_count", 0) or 0),
                 last_measured_epoch=float(data.get("last_measured_epoch", 0.0) or 0.0),
                 residency_source=data.get("residency_source"),
+                sleep_l1_transient_host_ram_mb=data.get("sleep_l1_transient_host_ram_mb"),
+                sleep_l2_transient_host_ram_mb=data.get("sleep_l2_transient_host_ram_mb"),
             )
 
         if isinstance(raw_lanes, list):


### PR DESCRIPTION
## Summary

Four related changes addressing the deioma incident where Qwen3-Coder-Next thrashed in a multi-minute restart loop while the logs were buried under traceback storms.

### 1. Load-failure cooldown
`_lane_load_failure_until`, `LOAD_FAILURE_COOLDOWN_SECONDS = 120 s`. When the worker rejects `add_lane` with `LogosNodeCommandError` (e.g. `Auto-placement: no feasible GPU subset`), suppress further load actions on the same lane for two minutes. Mirrors the existing `_lane_wake_failure_until` pattern; cleared on confirmed wake/load success and `_clear_lane_tracking`. Gated at both `_validate_vram_budget` (planner cycle) and `_cold_load_for_request` (request-time).

### 2. Escalate sleep → stop on host-RAM pressure
vLLM's `sleep_l1`/`sleep_l2` needs transient anonymous-memory allocations (KV cache export, state migration). On a swap-saturated worker, those allocs fail → `Call to sleep method failed: cancelled` → `EngineDeadError` → multi-minute lane restart. Pre-check effective available host RAM against `HOST_RAM_SAFETY_MARGIN_MB + transient_estimate`; if insufficient, escalate the action to a `stop` instead. Releases host RAM entirely, breaks the cycle.

### 3. Calibrate sleep transient host RAM (replaces the flat heuristic)
Adds `sleep_l1_transient_host_ram_mb` and `sleep_l2_transient_host_ram_mb` to `ModelProfile` / `ModelProfileRecord`. Calibration runs a background `/proc/meminfo` sampler at ~50 ms during the `/sleep?level=N` HTTP call and captures the peak transient delta. Only the level matching `--sleep-level` is populated per run — re-run with the other level to fill both fields. The planner's precheck picks transient from: (a) calibrated value when present, (b) `disk_size_bytes` as fallback for `sleep_l2` (weight transfer dominates l2), (c) the flat `HOST_RAM_SLEEP_HEADROOM_MB` otherwise.

Caveat: `sleep_l1` is measured on an idle engine, so it's a lower bound — real-world transient scales with KV-cache fill at sleep time. `sleep_l2` is dominated by weight transfer and is much more predictive.

### 4. Quiet five `logger.exception` call sites
`reconfigure_lane`, `sleep_lane`, `wake_lane`, `delete_lane`, `apply_lanes-load`, `apply_lanes-stop` → `logger.error` with `%s` for the exception message. The worker's error already comes back verbatim via `LogosNodeCommandError`; the stack adds nothing. ~50 traceback lines per failed sleep_l1 → one line per failure. Outer per-cycle / per-action catch-alls keep `logger.exception`.

## Rollout

- Existing model profiles work unchanged; new fields stay `None` and the planner falls back as described.
- To populate `sleep_l1_transient_host_ram_mb` for a model: re-run `tools/calibrate_vram_profiles.py --sleep-level 1 --models …`. For `sleep_l2`, re-run with `--sleep-level 2`.

## Test plan

- [ ] Force an unplaceable lane (e.g. tp too large) — first cycle logs `Marked lane … as load-failed for 120s`, subsequent cycles emit one `Skipping load … in load-failure cooldown` line at debug level instead of re-issuing add_lane.
- [ ] On a worker near the RAM threshold, trigger an idle-sleep — planner escalates to `stop` and logs `Escalating sleep_l1 → stop … (effective_available=…, required=…)`.
- [ ] Calibrate a model with `--sleep-level 1` and confirm the profile YAML contains a non-null `sleep_l1_transient_host_ram_mb`. Repeat with `--sleep-level 2`.
- [ ] On a sleep_l1 / vLLM-EngineDeadError storm: each failure is now one log line, not a full traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server-orchestrated nightly model calibration with configurable time windows and timezone support.
  * Transient host-RAM measurement capability during model sleep operations.
  * Calibration process cancellation support for graceful shutdown control.

* **Improvements**
  * Load failure cooldown mechanism prevents repeated failed worker load attempts.
  * Enhanced host-RAM headroom validation before sleep operations escalates actions as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->