### PR TITLE
`Athena`: Allow overriding base LLM model via env var

### DIFF
--- a/athena/llm_core/llm_core/loaders/llm_config_loader.py
+++ b/athena/llm_core/llm_core/loaders/llm_config_loader.py
@@ -1,8 +1,13 @@
-from llm_core.models.llm_config import LLMConfig, LLMConfigModel, RawLLMConfig
-from llm_core.utils.model_factory import create_config_for_model
-import yaml
+import os
 from pathlib import Path
 from typing import Dict, Optional
+
+import yaml
+
+from llm_core.models.llm_config import LLMConfig, LLMConfigModel, RawLLMConfig
+from llm_core.utils.model_factory import create_config_for_model
+
+_DEFAULT_MODEL_ENV = "LLM_DEFAULT_MODEL"
 
 _state: Dict[str, Optional[LLMConfig]] = {"llm_config": None}
 
@@ -28,7 +33,7 @@ def _load_raw_llm_config(path: Optional[str] = None) -> RawLLMConfig:
 
 
 def _materialize_llm_config(raw_config: RawLLMConfig) -> LLMConfig:
-    base_model = raw_config.models.base_model
+    base_model = os.getenv(_DEFAULT_MODEL_ENV) or raw_config.models.base_model
     if not base_model:
         raise ValueError("Missing required 'base_model' in models")
 


### PR DESCRIPTION
Read `LLM_DEFAULT_MODEL` before the configured `base_model` when materializing the LLM config.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.aet.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.aet.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The default LLM model can now be configured using the `LLM_DEFAULT_MODEL` environment variable, allowing flexible model selection without modifying configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->