### PR TITLE
`Logos`: Add GSM8K performance benchmarking suite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,23 @@ repos:
         args: ["-p", "memiris"]
         additional_dependencies: ['click<8.3.0']
         files: "^memiris/.*"
-      - id: sub-pre-commit
-        alias: logos
-        name: "pre-commit for logos"
-        args: ["-p", "logos"]
-        additional_dependencies: ['click<8.3.0']
-        files: "^logos/.*"
-        exclude: "^logos/(shared|logos-ui)/.*"
+
+  # Logos uses a `local` hook instead of sub-pre-commit because logos's own
+  # .pre-commit-config.yaml scopes hooks with `files: '^logos/'`. The wrapper
+  # `cd`s into logos/ and passes paths relative to that dir (e.g.
+  # `src/logos/main.py`), which then don't match `^logos/` — every inner hook
+  # reports "(no files to check) Skipped" and the wrapper exits 0 while CI
+  # (which invokes the logos config directly from the repo root) still finds
+  # real violations. The local hook below mirrors CI's invocation exactly:
+  # paths stay git-root-relative, the `files:` regex matches, and the inner
+  # pre-commit runs the same hooks CI does.
+  - repo: local
+    hooks:
+      - id: logos-pre-commit
+        name: pre-commit for logos
+        language: system
+        files: "^logos/"
+        exclude: "^logos/(shared|logos-ui)/"
+        entry: pre-commit run --config logos/.pre-commit-config.yaml --files
+        pass_filenames: true
+        require_serial: true

--- a/logos/.gitignore
+++ b/logos/.gitignore
@@ -1,2 +1,4 @@
 .test-deploy/
 tests/performance/results/
+benchmarks/benchmark_results/
+benchmarks/workloads/

--- a/logos/.gitignore
+++ b/logos/.gitignore
@@ -2,3 +2,4 @@
 tests/performance/results/
 benchmarks/benchmark_results/
 benchmarks/workloads/
+benchmarks/data/

--- a/logos/benchmarks/Readme.md
+++ b/logos/benchmarks/Readme.md
@@ -1,0 +1,419 @@
+# Logos Benchmark
+
+Misst **TTFT** (Time to First Token), **TTLT** (Time to Last Token) und **GPU-Energieverbrauch** pro Request über drei Szenarien:
+
+| Szenario | Beschreibung |
+|---|---|
+| `logos-sleep` | Logos mit aktiviertem Sleep Mode (Kapazitätsplaner darf Modelle entladen) |
+| `logos-nosleep` | Logos ohne Sleep Mode (Modelle bleiben dauerhaft geladen) |
+| `ollama` | Direkt gegen Ollama ohne Logos-Layer |
+
+Jedes Szenario wird in zwei Konfigurationen getestet:
+- **2-LLM-Config**: Requests verteilen sich auf 2 Modelle
+- **5-LLM-Config**: Requests verteilen sich auf 5 Modelle
+
+---
+
+## Architektur
+
+```
+┌──────────────────────────────────────────┐
+│  Logos-Host  (benchmark läuft hier)      │
+│  ┌──────────────┐   ┌──────────────────┐ │
+│  │ benchmark_   │   │   Logos-Server   │ │
+│  │ logos.py     │   └────────┬─────────┘ │
+│  └──────────────┘            │ HTTP      │
+└─────────────────────────────┼────────────┘
+                               │ vLLM-API
+          ┌────────────────────┼────────────────────┐
+          │  GPU-Node A        │       GPU-Node B   │
+          │  ┌──────────┐  ┌──┴──────┐ ┌─────────┐ │
+          │  │NVML-Poll │  │  vLLM   │ │  vLLM   │ │
+          │  │(via SSH) │  │RTX Ada  │ │RTX Ada  │ │
+          │  └──────────┘  └─────────┘ └─────────┘ │
+          └─────────────────────────────────────────┘
+```
+
+**Wichtig:** Die GPU-Energie wird auf den **GPU-Nodes** gemessen, nicht auf dem Logos-Host. Das Benchmark-Script verbindet sich per SSH zu den GPU-Nodes und startet dort einen NVML-Poller, der kontinuierlich Leistungsaufnahme und Energiezähler streamt.
+
+---
+
+## Voraussetzungen
+
+### Logos-Host (wo das Benchmark-Script läuft)
+
+```bash
+# Alte pynvml entfernen falls vorhanden
+pip uninstall pynvml -y
+
+pip install httpx paramiko numpy matplotlib
+```
+
+### GPU-Nodes (einmalig mit Root-Zugriff einrichten)
+
+```bash
+pip install nvidia-ml-py
+```
+
+Der Remote-Poller (`_REMOTE_POLLER` im Script eingebettet) nutzt dann `nvidia-ml-py` auf den Nodes. Falls `nvidia-ml-py` nicht installiert ist, fällt der Poller automatisch auf `nvidia-smi` zurück — allerdings ohne Hardware-Energiezähler (nur Power-Polling).
+
+### Vorbereitung der Workloads
+
+```bash
+pip install datasets  # nur für prepare_benchmark.py benötigt
+```
+
+---
+
+## Konfiguration
+
+### `benchmark_config.py`
+
+Zentrales Config-File für beide LLM-Konfigurationen und die Ollama-Namens-Übersetzung:
+
+```python
+# Zwei-LLM-Konfiguration
+MODELS_2 = [
+    "Qwen3-30B-A3B",
+    "Llama-3.3-70B",
+]
+
+# Fünf-LLM-Konfiguration
+MODELS_5 = [
+    "Qwen3-30B-A3B",
+    "Llama-3.3-70B",
+    "Gemma3-4B",
+    "microsoft/Phi-4-reasoning",
+    "Gemma4-26b",
+]
+
+# Übersetzung Logos-Modellname → Ollama-Tag
+OLLAMA_MODEL_MAP = {
+    "Qwen3-30B-A3B":             "qwen3:30b-a3b",
+    ...
+}
+```
+
+**Vor dem ersten Lauf die Ollama-Tags überprüfen:**
+```bash
+# Auf dem Ollama-Server:
+ollama list
+```
+
+---
+
+## Schritt 1 — Workloads vorbereiten
+
+`prepare_benchmark.py` lädt den **openai/gsm8k**-Datensatz von HuggingFace herunter und erzeugt pro LLM-Konfiguration eine Workload-CSV-Datei. Die Modelle werden **gleichmäßig per Round-Robin** über alle Requests verteilt.
+
+```bash
+python prepare_benchmark.py [OPTIONEN]
+```
+
+### Optionen
+
+| Option | Standard | Beschreibung |
+|---|---|---|
+| `--split` | `test` | GSM8K-Split: `test` (1 319 Fragen) oder `train` (7 473 Fragen) |
+| `--num-samples N` | alle | Nur die ersten N Beispiele verwenden |
+| `--rps RATE` | `1.0` | Ankunftsrate in Requests/Sekunde (bestimmt `arrival_offset`) |
+| `--max-tokens N` | `512` | `max_tokens` je Request |
+| `--output-dir DIR` | `workloads/` | Zielverzeichnis |
+
+### Beispiele
+
+```bash
+# 100 Test-Fragen, 0.5 req/s Ankunftsrate
+python prepare_benchmark.py --num-samples 100 --rps 0.5
+
+# Alle Test-Fragen, kein Timing (immer mit --sequential verwenden)
+python prepare_benchmark.py --rps 0
+```
+
+### Ausgabe
+
+```
+workloads/
+├── workload_gsm8k_2llm.csv    ← 2-Modell-Konfiguration
+└── workload_gsm8k_5llm.csv    ← 5-Modell-Konfiguration
+```
+
+Jede Zeile enthält:
+
+| Spalte | Bedeutung |
+|---|---|
+| `request_id` | Eindeutige ID (z. B. `gsm8k-0001`) |
+| `arrival_offset` | Geplante Ankunftszeit in ms ab Benchmark-Start |
+| `mode` | `interactive` (Logos-Scheduling-Parameter) |
+| `priority` | `mid` (Logos-Scheduling-Parameter) |
+| `body_json` | Vollständiger OpenAI-Chat-Payload als JSON-String |
+| `question` | Original-GSM8K-Frage (Referenz/Auswertung) |
+| `answer` | Original-GSM8K-Antwort inkl. Lösungsweg (Referenz/Auswertung) |
+| `model_assigned` | Welches Modell diesem Request zugewiesen wurde |
+
+---
+
+## Schritt 2 — Benchmark ausführen
+
+```bash
+python benchmark_logos.py --scenario SZENARIO [OPTIONEN] \
+    --workload PFAD/ZUR/workload.csv
+```
+
+### Optionen
+
+| Option | Standard | Beschreibung |
+|---|---|---|
+| `--scenario` | `logos-sleep` | Szenario: `logos-sleep`, `logos-nosleep`, `ollama` |
+| `--workload CSV` | — | Workload-CSV von `prepare_benchmark.py` |
+| `--logos-url URL` | `http://localhost:8080` | Ziel-URL (Logos oder Ollama) |
+| `--logos-key KEY` | — | Logos API-Key (erforderlich für `logos-*`-Szenarien) |
+| `--sequential` | aus | **Sequentieller Modus** (siehe unten) |
+| `--max-concurrent N` | `64` | Max. parallele Requests (ohne `--sequential`) |
+| `--request-timeout-s S` | `600` | HTTP-Timeout pro Request |
+| `--output-dir DIR` | `benchmark_results/` | Ausgabeverzeichnis |
+
+### GPU-Energie-Optionen
+
+| Option | Standard | Beschreibung |
+|---|---|---|
+| `--gpu-host HOST [HOST...]` | — | Hostnames der GPU-Nodes (SSH). Typischer Fall: Logos-Szenarien |
+| `--gpu-ssh-user USER` | aktueller User | SSH-Benutzername auf den GPU-Nodes |
+| `--gpu-ssh-key PATH` | — | Pfad zum SSH-Private-Key |
+| `--gpu-ssh-port PORT` | `22` | SSH-Port |
+| `--gpu-device-index IDX` | `0` | NVML-GPU-Index auf jedem Remote-Node |
+| `--gpu-indices IDX [IDX...]` | — | Lokale GPU-Indices (nur wenn GPU auf diesem Server liegt) |
+| `--poll-interval-ms MS` | `100` | GPU-Polling-Intervall (ms) |
+
+`--gpu-host` und `--gpu-indices` schließen sich gegenseitig aus.
+
+---
+
+## `--sequential` — was es bewirkt
+
+### Ohne `--sequential` (Concurrent-Modus, Standard)
+
+Der Benchmark liest die `arrival_offset`-Spalte aus der CSV und sendet Requests zu den darin hinterlegten Zeitpunkten. Wenn mehrere Requests gleichzeitig aktiv sind, kann die GPU parallel für sie arbeiten — genau wie in realistischer Produktionslast.
+
+```
+t=0s    Request 1 → [===== vLLM berechnet =====]
+t=1s    Request 2 →      [===== vLLM berechnet ======]
+t=2s    Request 3 →           [===== vLLM berechnet =====]
+                  ↑ Requests überlappen sich auf der GPU
+```
+
+**Konsequenz für die Energiemessung:** Der NVML-Energiezähler misst die **gesamte GPU-Energie im Zeitfenster eines Requests** — unabhängig davon, ob andere Requests gleichzeitig laufen. Bei überlappenden Requests wird die GPU-Energie im gemeinsamen Zeitraum von allen beteiligten Requests beansprucht (Doppelzählung in der Summe). Die Einzelwerte sind trotzdem aussagekräftig als "Energie, die während dieses Requests von der GPU verbraucht wurde".
+
+### Mit `--sequential`
+
+Der Benchmark ignoriert die `arrival_offset`-Spalte vollständig. Er sendet **exakt einen Request**, wartet bis der gesamte Stream abgeschlossen ist, und sendet erst dann den nächsten.
+
+```
+t=0s    Request 1 → [===== vLLM berechnet =====]
+t=5s                                             Request 2 → [===== vLLM berechnet =====]
+t=10s                                                                                     Request 3 → ...
+                  ↑ Keine Überlappung, GPU idle zwischen Requests
+```
+
+**Vorteile:**
+
+- **Exakte Energiezuordnung:** Zwischen zwei Requests ist die GPU (weitgehend) idle. Die Energie zwischen `t_start` und `t_end` stammt vollständig von diesem Request.
+- **Reproduzierbarkeit:** Jeder Request startet unter identischen Bedingungen — kein Einfluss durch parallele GPU-Last.
+- **Sauberste Vergleichsbasis** zwischen Szenarien: Logos-Sleep vs. -NoSleep vs. Ollama sind unter gleichen Isolationsbedingungen messbar.
+
+**Nachteil:** Bildet keine realistische Produktionslast ab. Für Latenz-unter-Last-Tests sollte `--sequential` weggelassen werden.
+
+### Empfehlung
+
+| Messziel | Modus |
+|---|---|
+| Energievergleich zwischen Szenarien | `--sequential` ✓ |
+| TTFT/TTLT im Einzelbetrieb | `--sequential` ✓ |
+| Scheduling-Verhalten unter Last | ohne `--sequential` |
+| Latenz bei realistischem Throughput | ohne `--sequential` |
+
+---
+
+## Vollständige Beispiel-Kommandos (alle 6 Runs)
+
+```bash
+# ── Schritt 1: Workloads vorbereiten (einmalig) ──────────────────────────
+python prepare_benchmark.py --num-samples 200 --rps 0
+
+# ── Szenario 1: Logos mit Sleep Mode ────────────────────────────────────
+# Logos-Server vorher mit aktiviertem Sleep Mode konfigurieren/starten
+
+python benchmark_logos.py \
+    --scenario logos-sleep \
+    --logos-url http://logos.ase.cit.tum.de \
+    --logos-key YOUR_KEY \
+    --workload workloads/workload_gsm8k_2llm.csv \
+    --gpu-host gpu-node-a gpu-node-b \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+
+python benchmark_logos.py \
+    --scenario logos-sleep \
+    --logos-url http://logos.ase.cit.tum.de \
+    --logos-key YOUR_KEY \
+    --workload workloads/workload_gsm8k_5llm.csv \
+    --gpu-host gpu-node-a gpu-node-b \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+
+# ── Szenario 2: Logos ohne Sleep Mode ───────────────────────────────────
+# Logos-Server vorher mit deaktiviertem Sleep Mode neu starten
+
+python benchmark_logos.py \
+    --scenario logos-nosleep \
+    --logos-url http://logos.ase.cit.tum.de \
+    --logos-key YOUR_KEY \
+    --workload workloads/workload_gsm8k_2llm.csv \
+    --gpu-host gpu-node-a gpu-node-b \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+
+python benchmark_logos.py \
+    --scenario logos-nosleep \
+    --logos-url http://logos.ase.cit.tum.de \
+    --logos-key YOUR_KEY \
+    --workload workloads/workload_gsm8k_5llm.csv \
+    --gpu-host gpu-node-a gpu-node-b \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+
+# ── Szenario 3: Ollama direkt ────────────────────────────────────────────
+# Modellnamen werden automatisch via benchmark_config.py übersetzt.
+# --gpu-host zeigt hier auf den Ollama-Server selbst.
+
+python benchmark_logos.py \
+    --scenario ollama \
+    --logos-url http://ollama-host:11434 \
+    --workload workloads/workload_gsm8k_2llm.csv \
+    --gpu-host ollama-host \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+
+python benchmark_logos.py \
+    --scenario ollama \
+    --logos-url http://ollama-host:11434 \
+    --workload workloads/workload_gsm8k_5llm.csv \
+    --gpu-host ollama-host \
+    --gpu-ssh-user ubuntu --gpu-ssh-key ~/.ssh/id_rsa \
+    --sequential --output-dir results
+```
+
+---
+
+## Ausgabe
+
+Jeder Lauf erzeugt einen Unterordner in `--output-dir`:
+
+```
+results/
+└── 20250603_143022_logos-sleep_workload_gsm8k_2llm/
+    ├── results_detailed.csv          ← Ein Eintrag pro Request
+    ├── results_summary.csv           ← Aggregierte Statistiken (mean/p50/p95/p99)
+    ├── run_meta.json                 ← Metadaten (Szenario, GPU-Hosts, Zeitstempel)
+    ├── chart_ttft.png                ← TTFT-Verteilung
+    ├── chart_ttlt.png                ← TTLT-Verteilung
+    ├── chart_energy_per_request.png
+    ├── chart_energy_per_token.png
+    ├── chart_power_timeline.png      ← GPU-Leistungskurve mit Request-Fenstern
+    ├── chart_energy_vs_ttlt.png      ← Scatter: Energie vs. TTLT
+    ├── chart_ttft_by_model.png       ← TTFT aufgeteilt nach Modell (Boxplot)
+    └── chart_energy_by_model.png     ← Energie aufgeteilt nach Modell (Boxplot)
+```
+
+### `results_detailed.csv` — Spalten
+
+| Spalte | Einheit | Beschreibung |
+|---|---|---|
+| `request_id` | — | Request-ID aus der Workload-CSV |
+| `model` | — | Modellname wie vom Server zurückgegeben |
+| `scenario` | — | Benchmark-Szenario |
+| `ttft_ms` | ms | Time to First Token |
+| `ttlt_ms` | ms | Time to Last Token (= Ende des Streams) |
+| `tpot_ms` | ms/Token | Time Per Output Token (Decode-Phase) |
+| `energy_j` | Joule | GPU-Energie während des Request-Fensters (Summe aller Nodes) |
+| `energy_per_token_mj` | mJ/Token | Energie pro Output-Token |
+| `throughput_tok_s` | Token/s | Output-Tokens pro Sekunde |
+| `prompt_tokens` | — | Anzahl Input-Tokens |
+| `completion_tokens` | — | Anzahl Output-Tokens |
+
+---
+
+## Energiemessung — technische Details
+
+### Remote-Poller (SSH)
+
+Bei Verwendung von `--gpu-host` verbindet sich das Script per SSH zu jedem GPU-Node und startet dort einen eingebetteten Python-Poller. Der Poller streamt alle `--poll-interval-ms` Millisekunden eine Zeile:
+
+```
+<unix_timestamp> <power_mW> <energy_mJ>
+```
+
+Der Poller nutzt in dieser Reihenfolge:
+1. `nvmlDeviceGetTotalEnergyConsumption()` — Hardware-Energiezähler (präziseste Methode)
+2. `nvmlDeviceGetPowerUsage()` — Leistungsaufnahme für Trapez-Integration
+3. `nvidia-smi` — Fallback wenn `nvidia-ml-py` nicht installiert ist
+
+### Primäre Methode: Hardware-Energiezähler
+
+Die RTX Ada 6000 unterstützt `nvmlDeviceGetTotalEnergyConsumption()` — einen monoton steigenden Hardware-Counter in Millijoule. Das Script liest ihn unmittelbar vor und nach jedem Request:
+
+```
+E_request = counter_nach_request − counter_vor_request  [mJ → J]
+```
+
+Dieser Wert ist **hardware-genau** — kein Zeitfenster zwischen zwei Polls geht verloren.
+
+Mit `--sequential` liest der Benchmark die aktuellsten gepollten Werte vor/nach dem Request. Der maximale Messfehler entspricht dem halben Poll-Intervall (Standard: ±50 ms). Bei Requests die typischerweise 5–60 Sekunden dauern ist das ein Fehler unter 2 %.
+
+### Uhren-Synchronisation
+
+Der Remote-Poller verwendet `time.time()` auf dem GPU-Node. Das Script korrigiert den Unterschied zur lokalen Uhr über eine NTP-artige SSH-Round-Trip-Messung beim Start (einmalig pro Host). Auf gut konfigurierten LAN-Servern (NTP aktiviert) liegt der verbleibende Fehler typischerweise unter 5 ms.
+
+### Mehrere GPU-Nodes
+
+Mit `--gpu-host gpu-node-a gpu-node-b` wird auf **jedem** Node ein Poller gestartet. Die gemessene Energie ist die **Summe** aller Nodes. Das ist korrekt, solange Logos Requests an alle angegebenen Nodes verteilt und auf keinem anderen Node Inference stattfindet.
+
+---
+
+## Troubleshooting
+
+**`pynvml`-Warning erscheint trotzdem:**
+```bash
+pip show pynvml          # sollte leer sein
+pip uninstall pynvml -y
+pip install nvidia-ml-py
+```
+
+**SSH-Verbindung zu GPU-Node schlägt fehl:**
+```bash
+ssh -i ~/.ssh/id_rsa ubuntu@gpu-node-a "nvidia-smi"
+# Sollte die GPU-Info ausgeben
+```
+
+**Remote-Poller startet nicht (base64/python3 nicht gefunden):**
+```bash
+# Auf dem GPU-Node prüfen:
+which python3
+which base64
+pip show nvidia-ml-py
+```
+
+**Logos antwortet nicht:**
+```bash
+curl -H "logos_key: YOUR_KEY" http://logos.ase.cit.tum.de/v1/models
+```
+
+**Ollama-Modell nicht gefunden (404):**
+```bash
+# Auf dem Ollama-Server:
+ollama list              # exakte Tags prüfen
+ollama pull llama3.3:70b # fehlende Modelle pullen
+```
+
+**Energiemessung zeigt `not measured`:**
+Entweder konnte keine SSH-Verbindung aufgebaut werden, oder `nvidia-ml-py` und `nvidia-smi` sind beide nicht verfügbar. Die detaillierte Fehlermeldung erscheint beim Start des Scripts (Zeilen mit `[gpu]`).

--- a/logos/benchmarks/analyze_workload.py
+++ b/logos/benchmarks/analyze_workload.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Workload-trace analysis for the logos benchmark dataset.
+
+Answers two questions about the last 30 days of production logs that were
+exported into ``logos/benchmarks/data/``:
+
+1. Are request bursts of one model temporally **independent** of bursts of
+   other models, or are they coupled?
+2. Does each API key (= agent) exhibit a **distinctive temporal arrival
+   pattern**, i.e. is the timing distribution correlated with the API-key
+   identity?
+
+Run via uv (no project-level deps required)::
+
+    cd logos/benchmarks
+    uv run --with pandas --with numpy --with scipy \
+           --with matplotlib --with seaborn \
+        ./analyze_workload.py
+
+Outputs land in ``logos/benchmarks/data/analysis_output/``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # must precede pyplot import; the imports below are deliberately after it
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import seaborn as sns  # noqa: E402
+from scipy import stats  # noqa: E402
+from scipy.cluster.hierarchy import fcluster, linkage  # noqa: E402
+from scipy.spatial.distance import squareform  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+DATA = HERE / "data"
+OUT = DATA / "analysis_output"
+OUT.mkdir(parents=True, exist_ok=True)
+
+RNG = np.random.default_rng(20260604)
+
+
+def load() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    log = pd.read_csv(
+        DATA / "log_entry_30d.csv",
+        parse_dates=[
+            "timestamp_request",
+            "timestamp_forwarding",
+            "timestamp_response",
+            "time_at_first_token",
+        ],
+    )
+    models = pd.read_csv(DATA / "models.csv")
+    api_keys = pd.read_csv(DATA / "api_keys.csv")
+    teams = pd.read_csv(DATA / "teams.csv")
+    log["model_name"] = log["model_id"].map(models.set_index("id")["name"])
+    log["api_key_name"] = log["api_key_id"].map(api_keys.set_index("id")["name"])
+    log = log.dropna(subset=["timestamp_request"]).sort_values("timestamp_request")
+    before = len(log)
+    log = log[log["result_status"] == "success"].copy()
+    print(f"  filtered to result_status=success: {len(log):,} / {before:,} rows kept")
+    return log, models, api_keys, teams
+
+
+def model_pivot(log: pd.DataFrame, freq: str) -> pd.DataFrame:
+    pivot = (
+        log.dropna(subset=["model_name"])
+        .set_index("timestamp_request")
+        .groupby([pd.Grouper(freq=freq), "model_name"])
+        .size()
+        .unstack(fill_value=0)
+        .sort_index()
+    )
+    return pivot
+
+
+def model_burst_dependence(log: pd.DataFrame, freq: str = "1h") -> dict:
+    pivot = model_pivot(log, freq)
+    # Restrict to actively-used models (>=50 requests in the 30d window).
+    totals = pivot.sum().sort_values(ascending=False)
+    keep = totals[totals >= 50].index.tolist()
+    if len(keep) < 2:
+        keep = totals.head(8).index.tolist()
+    pivot = pivot[keep]
+
+    # Count correlations.
+    corr_spearman = pivot.corr(method="spearman")
+    corr_pearson = pivot.corr(method="pearson")
+
+    # Burst definition: z-score >= 2 within the per-model time series.
+    mu = pivot.mean()
+    sd = pivot.std().replace(0, np.nan)
+    z = (pivot - mu) / sd
+    bursts = (z >= 2).fillna(False).astype(int)
+
+    cols = bursts.columns.tolist()
+    n = len(cols)
+    jacc = pd.DataFrame(np.eye(n), index=cols, columns=cols, dtype=float)
+    for i, a in enumerate(cols):
+        for j, b in enumerate(cols):
+            if i == j:
+                continue
+            inter = ((bursts[a] == 1) & (bursts[b] == 1)).sum()
+            union = ((bursts[a] == 1) | (bursts[b] == 1)).sum()
+            jacc.iat[i, j] = (inter / union) if union else np.nan
+
+    # Permutation null for the *mean off-diagonal* Jaccard. We circularly
+    # shift each column independently and recompute. Tests the null "bursts
+    # of different models occur independently in time".
+    n_perm = 200
+    null = np.empty(n_perm)
+    arr = bursts.values  # (T, n)
+    T = arr.shape[0]
+    for p in range(n_perm):
+        shifted = np.empty_like(arr)
+        for k in range(n):
+            shifted[:, k] = np.roll(arr[:, k], RNG.integers(1, T))
+        # mean off-diag Jaccard for shifted
+        j_off = []
+        for i in range(n):
+            for j in range(n):
+                if i == j:
+                    continue
+                a, b = shifted[:, i], shifted[:, j]
+                u = ((a == 1) | (b == 1)).sum()
+                if u:
+                    j_off.append(((a == 1) & (b == 1)).sum() / u)
+        null[p] = float(np.mean(j_off)) if j_off else 0.0
+
+    eye = np.eye(n, dtype=bool)
+    observed_jacc = float(jacc.where(~eye).stack().mean())
+    p_value = float((null >= observed_jacc).mean())
+
+    # Cross-correlation at lags +/- 6 bins.
+    lags = list(range(-6, 7))
+    xcorr_rows = []
+    for a in cols:
+        for b in cols:
+            if a >= b:
+                continue
+            vals = [pivot[a].corr(pivot[b].shift(k), method="pearson") for k in lags]
+            best = int(np.nanargmax(np.abs(vals)))
+            xcorr_rows.append(
+                {
+                    "a": a,
+                    "b": b,
+                    "lag_best": lags[best],
+                    "corr_at_best": float(vals[best]),
+                    "corr_at_0": float(vals[lags.index(0)]),
+                }
+            )
+    xcorr_df = pd.DataFrame(xcorr_rows)
+
+    return {
+        "pivot": pivot,
+        "corr_spearman": corr_spearman,
+        "corr_pearson": corr_pearson,
+        "bursts": bursts,
+        "jacc": jacc,
+        "observed_jacc": observed_jacc,
+        "perm_null_mean": float(null.mean()),
+        "perm_null_p": p_value,
+        "xcorr": xcorr_df,
+    }
+
+
+def plot_model_dependence(res: dict) -> None:
+    pivot = res["pivot"]
+    corr = res["corr_spearman"]
+    jacc = res["jacc"]
+
+    plt.figure(figsize=(13, 5))
+    pivot.plot(ax=plt.gca(), legend=True, alpha=0.7)
+    plt.legend(fontsize=7, ncol=2)
+    plt.title("Requests per model over time (hourly bins)")
+    plt.ylabel("Requests / hour")
+    plt.tight_layout()
+    plt.savefig(OUT / "model_timeseries.png", dpi=120)
+    plt.close()
+
+    plt.figure(figsize=(10, 8))
+    sns.heatmap(corr, annot=True, fmt=".2f", cmap="vlag", center=0, vmin=-1, vmax=1)
+    plt.title("Spearman correlation of hourly request counts (model x model)")
+    plt.tight_layout()
+    plt.savefig(OUT / "model_count_correlation.png", dpi=120)
+    plt.close()
+
+    eye = np.eye(len(jacc), dtype=bool)
+    vmax = float(np.nanmax(jacc.values[~eye])) if (~eye).any() else 1.0
+    plt.figure(figsize=(10, 8))
+    sns.heatmap(jacc, annot=True, fmt=".2f", cmap="rocket_r", vmin=0, vmax=max(vmax, 0.05))
+    plt.title("Burst co-occurrence (Jaccard) — bursts = hourly z-score ≥ 2")
+    plt.tight_layout()
+    plt.savefig(OUT / "model_burst_jaccard.png", dpi=120)
+    plt.close()
+
+
+def api_key_temporal(log: pd.DataFrame, api_keys: pd.DataFrame, min_requests: int = 100) -> dict:
+    log = log.dropna(subset=["api_key_id"]).copy()
+    log["api_key_id"] = log["api_key_id"].astype(int)
+    log["hour"] = log["timestamp_request"].dt.hour
+    log["dow"] = log["timestamp_request"].dt.dayofweek
+
+    counts = log["api_key_id"].value_counts()
+    active = counts[counts >= min_requests].index
+    la = log[log["api_key_id"].isin(active)].copy()
+
+    hod = la.groupby(["api_key_id", "hour"]).size().unstack(fill_value=0).reindex(columns=range(24), fill_value=0)
+    hod_norm = hod.div(hod.sum(axis=1), axis=0)
+
+    dow = la.groupby(["api_key_id", "dow"]).size().unstack(fill_value=0).reindex(columns=range(7), fill_value=0)
+    dow_norm = dow.div(dow.sum(axis=1), axis=0)
+
+    overall_hod = log["hour"].value_counts(normalize=True).reindex(range(24), fill_value=0)
+    overall_dow = log["dow"].value_counts(normalize=True).reindex(range(7), fill_value=0)
+
+    def kl(p: np.ndarray, q: np.ndarray, eps: float = 1e-9) -> float:
+        p = np.asarray(p, dtype=float) + eps
+        q = np.asarray(q, dtype=float) + eps
+        p /= p.sum()
+        q /= q.sum()
+        return float((p * np.log(p / q)).sum())
+
+    kl_hod = hod_norm.apply(lambda r: kl(r.values, overall_hod.values), axis=1)
+    kl_dow = dow_norm.apply(lambda r: kl(r.values, overall_dow.values), axis=1)
+
+    # Global chi-square: is the joint (api_key x hour) distribution different
+    # from independence (api_key indep. of hour)?  Pearson chi-square on the
+    # contingency table.  Significant => api-key identity carries timing info.
+    chi2_global, p_global, dof_global, _ = stats.chi2_contingency(hod.values)
+
+    # Per-key chi-square vs the overall expected hour distribution.
+    chi_rows = {}
+    for k, row in hod.iterrows():
+        expected = overall_hod * row.sum()
+        mask = expected > 5
+        if mask.sum() < 5:
+            chi_rows[k] = (np.nan, np.nan)
+            continue
+        obs = row[mask].values.astype(float)
+        exp = expected[mask].values.astype(float)
+        # chisquare requires sum(obs) == sum(exp); after masking they may
+        # differ slightly. Rescale exp to match the kept observed sum.
+        if exp.sum() > 0:
+            exp = exp * (obs.sum() / exp.sum())
+        c2, p = stats.chisquare(obs, f_exp=exp)
+        chi_rows[k] = (float(c2), float(p))
+    chi_df = pd.DataFrame.from_dict(chi_rows, orient="index", columns=["chi2_hod", "p_hod"])
+
+    # Inter-arrival statistics per key.
+    la_sorted = la.sort_values(["api_key_id", "timestamp_request"])
+    la_sorted["ia_s"] = la_sorted.groupby("api_key_id")["timestamp_request"].diff().dt.total_seconds()
+    bs = (
+        la_sorted.groupby("api_key_id")["ia_s"]
+        .agg(["count", "mean", "std", "median"])
+        .rename(columns={"mean": "ia_mean_s", "std": "ia_std_s", "median": "ia_median_s"})
+    )
+    bs["ia_cv"] = bs["ia_std_s"] / bs["ia_mean_s"]
+
+    # Pairwise hourly-count correlation between keys.
+    pivot_hour = (
+        la.set_index("timestamp_request")
+        .groupby([pd.Grouper(freq="1h"), "api_key_id"])
+        .size()
+        .unstack(fill_value=0)
+        .sort_index()
+    )
+    pairs_corr = pivot_hour.corr(method="spearman")
+
+    name_map = api_keys.set_index("id")["name"]
+    summary = (
+        pd.DataFrame(
+            {
+                "requests": counts.loc[active],
+                "kl_hod": kl_hod,
+                "kl_dow": kl_dow,
+            }
+        )
+        .join(bs[["ia_mean_s", "ia_std_s", "ia_median_s", "ia_cv"]])
+        .join(chi_df)
+    )
+    summary["api_key_name"] = summary.index.map(name_map)
+    summary = summary.sort_values("kl_hod", ascending=False)
+
+    return {
+        "hod_norm": hod_norm,
+        "dow_norm": dow_norm,
+        "summary": summary,
+        "pairs_corr": pairs_corr,
+        "chi2_global": float(chi2_global),
+        "p_global": float(p_global),
+        "dof_global": int(dof_global),
+    }
+
+
+def plot_api_key(res: dict, api_keys: pd.DataFrame) -> None:
+    hod_norm = res["hod_norm"].copy()
+    summary = res["summary"]
+    pairs_corr = res["pairs_corr"]
+    name_map = api_keys.set_index("id")["name"]
+    hod_norm.index = [f"{i} ({name_map.get(i, '?')})" for i in hod_norm.index]
+
+    plt.figure(figsize=(14, max(5, len(hod_norm) * 0.35)))
+    sns.heatmap(hod_norm, cmap="mako", cbar_kws={"label": "fraction"})
+    plt.xlabel("Hour of day (UTC)")
+    plt.ylabel("API key")
+    plt.title("Per-API-key hour-of-day distribution (normalized)")
+    plt.tight_layout()
+    plt.savefig(OUT / "apikey_hour_of_day.png", dpi=120)
+    plt.close()
+
+    s = summary.copy()
+    s["label"] = s.index.astype(str) + " " + s["api_key_name"].fillna("?")
+    fig, ax = plt.subplots(1, 2, figsize=(14, max(4, len(s) * 0.32)))
+    sns.barplot(data=s, y="label", x="kl_hod", ax=ax[0], color="steelblue")
+    ax[0].set_title("KL divergence vs. overall hour-of-day distribution")
+    sns.barplot(
+        data=s.sort_values("ia_cv", ascending=False),
+        y="label",
+        x="ia_cv",
+        ax=ax[1],
+        color="indianred",
+    )
+    ax[1].set_title("Inter-arrival CV (burstiness)")
+    plt.tight_layout()
+    plt.savefig(OUT / "apikey_summary_bars.png", dpi=120)
+    plt.close()
+
+    if len(pairs_corr) > 1:
+        pc = pairs_corr.fillna(0).values
+        # symmetric distance for clustering
+        dist = 1 - pc
+        np.fill_diagonal(dist, 0.0)
+        dist = (dist + dist.T) / 2
+        condensed = squareform(dist, checks=False)
+        Z = linkage(condensed, method="average")
+        order = np.argsort(fcluster(Z, t=max(2, len(pairs_corr) // 4), criterion="maxclust"))
+        pcs = pairs_corr.iloc[order, :].iloc[:, order]
+        labels = [f"{i} {name_map.get(i, '?')}" for i in pcs.index]
+        pcs.index = labels
+        pcs.columns = labels
+        plt.figure(figsize=(11, 9))
+        sns.heatmap(pcs, cmap="vlag", center=0, vmin=-1, vmax=1)
+        plt.title("Spearman correlation between API keys (hourly request counts)")
+        plt.tight_layout()
+        plt.savefig(OUT / "apikey_pairwise_corr.png", dpi=120)
+        plt.close()
+
+
+def main() -> None:
+    log, models, api_keys, teams = load()
+    print(f"Loaded {len(log):,} log entries")
+    print(f"  span : {log['timestamp_request'].min()} → {log['timestamp_request'].max()}")
+    print(f"  models in slice  : {log['model_id'].nunique()}")
+    print(f"  api_keys in slice: {log['api_key_id'].nunique()}")
+    print(f"  teams in slice   : {log['team_id'].nunique()}")
+
+    print("\n=== Q1: model-burst dependence ===")
+    res1 = model_burst_dependence(log, freq="1h")
+    plot_model_dependence(res1)
+    res1["corr_spearman"].to_csv(OUT / "model_count_correlation.csv")
+    res1["jacc"].to_csv(OUT / "model_burst_jaccard.csv")
+    res1["xcorr"].to_csv(OUT / "model_xcorr.csv", index=False)
+
+    corr = res1["corr_spearman"]
+    eye = np.eye(len(corr), dtype=bool)
+    off = corr.where(~eye).stack()
+    print(f"models analysed         : {list(corr.columns)}")
+    print(f"mean off-diag Spearman  : {off.mean():.3f}")
+    print(f"median off-diag Spearman: {off.median():.3f}")
+    print(f"|rho| > 0.5 pairs       : {int((off.abs() > 0.5).sum() / 2)}")
+    print(f"|rho| > 0.7 pairs       : {int((off.abs() > 0.7).sum() / 2)}")
+    print(f"observed mean burst Jaccard : {res1['observed_jacc']:.3f}")
+    print(f"null (shift-permuted) mean  : {res1['perm_null_mean']:.3f}")
+    print(f"permutation p-value         : {res1['perm_null_p']:.3f}")
+
+    jacc = res1["jacc"]
+    # Upper triangle only (avoid duplicate (a,b)/(b,a)).
+    upper = pd.DataFrame(np.triu(jacc.values, k=1), index=jacc.index, columns=jacc.columns)
+    off_j = upper.stack().replace(0, np.nan).dropna().sort_values(ascending=False).head(10)
+    print("\nTop burst-coincident model pairs (Jaccard):")
+    print(off_j.round(3).to_string())
+
+    xc = res1["xcorr"].sort_values("corr_at_best", key=lambda s: s.abs(), ascending=False)
+    print("\nStrongest cross-correlations (any lag, hourly):")
+    print(xc.head(10).to_string(index=False))
+
+    print("\n=== Q2: API-key temporal distinctiveness ===")
+    res2 = api_key_temporal(log, api_keys, min_requests=100)
+    plot_api_key(res2, api_keys)
+    res2["summary"].to_csv(OUT / "apikey_temporal_summary.csv")
+    res2["pairs_corr"].to_csv(OUT / "apikey_pairwise_corr.csv")
+
+    print(
+        f"global chi-square (api_key × hour-of-day): "
+        f"chi2={res2['chi2_global']:.1f}, dof={res2['dof_global']}, p={res2['p_global']:.3e}"
+    )
+    s = res2["summary"]
+    print(f"# active keys (≥100 requests): {len(s)}")
+    print(f"keys with chi-square p<0.001 vs overall hour-distribution: " f"{int((s['p_hod'] < 1e-3).sum())} / {len(s)}")
+    print(
+        f"inter-arrival CV: min={s['ia_cv'].min():.2f}, "
+        f"median={s['ia_cv'].median():.2f}, max={s['ia_cv'].max():.2f}"
+    )
+    cols = ["api_key_name", "requests", "kl_hod", "kl_dow", "ia_cv", "p_hod"]
+    print("\nTop-10 keys by KL divergence vs. global hour-of-day distribution:")
+    print(s[cols].head(10).to_string())
+    print("\nBottom-5 (closest to global):")
+    print(s[cols].tail(5).to_string())
+
+    out_json = {
+        "n_logs": int(len(log)),
+        "n_models_in_slice": int(log["model_id"].nunique()),
+        "n_api_keys_in_slice": int(log["api_key_id"].nunique()),
+        "q1_model_pair_mean_spearman": float(off.mean()),
+        "q1_model_pair_median_spearman": float(off.median()),
+        "q1_pairs_abs_rho_gt_0p5": int((off.abs() > 0.5).sum() / 2),
+        "q1_pairs_abs_rho_gt_0p7": int((off.abs() > 0.7).sum() / 2),
+        "q1_observed_burst_jaccard": res1["observed_jacc"],
+        "q1_null_burst_jaccard": res1["perm_null_mean"],
+        "q1_burst_perm_p": res1["perm_null_p"],
+        "q2_chi2_global": res2["chi2_global"],
+        "q2_p_global": res2["p_global"],
+        "q2_dof_global": res2["dof_global"],
+        "q2_n_keys": int(len(s)),
+        "q2_keys_significant_vs_overall": int((s["p_hod"] < 1e-3).sum()),
+    }
+    (OUT / "summary.json").write_text(json.dumps(out_json, indent=2, default=str))
+    print(f"\nWrote outputs to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/logos/benchmarks/benchmark_config.py
+++ b/logos/benchmarks/benchmark_config.py
@@ -1,0 +1,45 @@
+"""
+Benchmark configuration — edit this file to change models and settings.
+
+Used by both prepare_benchmark.py (to assign models to requests) and
+benchmark_logos.py (to translate Logos model names to Ollama tags).
+"""
+
+# ── LLM configurations ────────────────────────────────────────────────────
+# These are the model identifiers as registered inside Logos.
+
+# Two-LLM configuration (small comparison)
+MODELS_2: list[str] = [
+    "Qwen3-30B-A3B",
+    "Llama-3.3-70B",
+]
+
+# Five-LLM configuration (full comparison)
+MODELS_5: list[str] = [
+    "Qwen3-30B-A3B",
+    "Llama-3.3-70B",
+    "Gemma3-4B",
+    "microsoft/Phi-4-reasoning",
+    "Gemma4-26b",
+]
+
+# ── Ollama model name mapping ─────────────────────────────────────────────
+# Maps Logos model identifiers → Ollama pull tags.
+# Verify exact tag names on the target machine with: ollama list
+OLLAMA_MODEL_MAP: dict[str, str] = {
+    "Qwen3-30B-A3B": "qwen3:30b-a3b",
+    "Llama-3.3-70B": "llama3.3:70b",
+    "Gemma3-4B": "gemma3:4b",
+    "microsoft/Phi-4-reasoning": "phi4-reasoning:latest",  # verify tag
+    "Gemma4-26b": "gemma4:27b",  # verify tag
+}
+
+# ── GSM8K prompt settings ─────────────────────────────────────────────────
+
+GSM8K_SYSTEM_PROMPT: str = (
+    "You are a helpful math tutor. "
+    "Solve the given math problem step by step. "
+    "End your response with '#### <number>' where <number> is the final numeric answer."
+)
+
+GSM8K_MAX_TOKENS: int = 512

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -36,10 +36,12 @@ Supports three scenarios via --scenario:
                  tags. No logos_key header is sent.
 
 Requirements (on this machine):
-    pip install httpx paramiko numpy matplotlib
+    pip install httpx numpy matplotlib
+    # SSH uses the system 'ssh' binary — no extra library needed
 
-Requirements (on each GPU node, installed once with root access):
-    pip install nvidia-ml-py
+Requirements (on each GPU node):
+    nvidia-smi is used automatically (always available on NVIDIA systems).
+    Optionally: pip install nvidia-ml-py  (enables hardware energy counter)
 
 Usage — remote GPU nodes (typical setup):
     python benchmark_logos.py \\
@@ -69,24 +71,25 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
 import csv
 import importlib.util
 import json
 import math
+import shlex
+import subprocess
 import sys
 import threading
 import time
-import warnings as _warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import httpx
 
 # ── Optional deps ─────────────────────────────────────────────────────────
 
+import warnings as _warnings
 
 try:
     with _warnings.catch_warnings():
@@ -99,88 +102,20 @@ try:
 except ImportError:
     _NVML = False
 
-try:
-    import paramiko as _paramiko
-
-    _PARAMIKO = True
-except ImportError:
-    _PARAMIKO = False
 
 try:
-    import matplotlib
     import numpy as np
-
+    import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
-
     _PLOT = True
 except ImportError:
     _PLOT = False
 
 
-# ── Remote poller script (embedded, sent to GPU nodes via SSH) ────────────
-#
-# Runs on each GPU node. Continuously streams one line per poll interval:
-#   <unix_timestamp> <power_mw> <energy_mj>
-# energy_mj = -1 when the hardware counter is unavailable (falls back to
-# power-integration only). Uses nvidia-smi as a last resort if pynvml is
-# not installed on the node.
-
-_REMOTE_POLLER = r"""
-import sys, time, warnings, subprocess
-warnings.filterwarnings("ignore", category=FutureWarning)
-
-GPU_INDEX = {gpu_index}
-INTERVAL  = {interval:.3f}
-
-use_nvml   = False
-has_energy = False
-
-try:
-    import pynvml
-    pynvml.nvmlInit()
-    _h = pynvml.nvmlDeviceGetHandleByIndex(GPU_INDEX)
-    use_nvml = True
-    try:
-        pynvml.nvmlDeviceGetTotalEnergyConsumption(_h)
-        has_energy = True
-    except Exception:
-        pass
-except Exception:
-    pass
-
-def _read_nvml():
-    try:
-        p = pynvml.nvmlDeviceGetPowerUsage(_h)
-        e = pynvml.nvmlDeviceGetTotalEnergyConsumption(_h) if has_energy else -1
-        return p, e
-    except Exception:
-        return 0, -1
-
-def _read_smi():
-    try:
-        out = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=power.draw",
-             "--format=csv,noheader,nounits", f"--id={GPU_INDEX}"],
-            text=True, timeout=2.0,
-        )
-        return int(float(out.strip()) * 1000), -1
-    except Exception:
-        return 0, -1
-
-_read = _read_nvml if use_nvml else _read_smi
-
-while True:
-    t = time.time()
-    p_mw, e_mj = _read()
-    sys.stdout.write(f"{t:.6f} {p_mw} {e_mj}\n")
-    sys.stdout.flush()
-    time.sleep(INTERVAL)
-"""
 
 
 # ── Load benchmark_config (optional sibling file) ─────────────────────────
-
 
 def _load_config_attr(attr: str, default):
     config_path = Path(__file__).parent / "benchmark_config.py"
@@ -196,7 +131,6 @@ def _load_config_attr(attr: str, default):
 
 
 # ── Local GPU Tracker (NVML on this machine) ──────────────────────────────
-
 
 class GPUTracker:
     """
@@ -267,7 +201,10 @@ class GPUTracker:
     def _poll_loop(self) -> None:
         while not self._stop.is_set():
             t = time.monotonic()
-            mw = sum(_pynvml.nvmlDeviceGetPowerUsage(h) for h in self._handles if True)  # errors silently ignored below
+            mw = sum(
+                _pynvml.nvmlDeviceGetPowerUsage(h) for h in self._handles
+                if True  # errors silently ignored below
+            )
             with self._lock:
                 self._samples.append((t, mw))
             time.sleep(self._poll_s)
@@ -304,7 +241,7 @@ class GPUTracker:
         window = [(t, p) for t, p in samples if t_start <= t <= t_end]
         if len(window) < 2:
             before = [s for s in samples if s[0] < t_start]
-            after = [s for s in samples if s[0] > t_end]
+            after  = [s for s in samples if s[0] > t_end]
             if before and after and not window:
                 avg_mw = (before[-1][1] + after[0][1]) / 2.0
                 return avg_mw / 1000.0 * (t_end - t_start)
@@ -321,284 +258,160 @@ class GPUTracker:
             return list(self._samples)
 
 
-# ── Remote GPU Tracker (SSH → NVML on GPU nodes) ──────────────────────────
+# ── SSH GPU Tracker (nvidia-smi via persistent SSH) ────────────────────────
+
+def _find_root_ssh_key() -> Optional[str]:
+    """Auto-detect the first available private key in /root/.ssh/."""
+    for name in ("id_ed25519", "id_rsa", "id_ecdsa"):
+        p = Path("/root/.ssh") / name
+        if p.exists():
+            return str(p)
+    return None
 
 
-@dataclass
-class _RSample:
-    """One sample received from the remote poller."""
-
-    remote_wall_t: float  # time.time() on GPU machine
-    power_mw: float
-    energy_mj: float  # -1 if hardware counter not available
-
-
-class RemoteGPUTracker:
+class SshGpuTracker:
     """
-    GPU energy tracking for nodes accessed via SSH.
-    Use when vLLM (and the GPU) is on a different machine from this script.
+    GPU power tracking via a persistent SSH connection to each GPU node.
+    Runs 'nvidia-smi' in a loop remotely — no extra software needed on the node.
 
-    At start-up this class:
-      1. Opens a paramiko SSH session to each GPU host.
-      2. Measures the clock offset between this machine and the GPU node
-         (NTP-style round-trip) so remote timestamps can be mapped to local
-         monotonic time.
-      3. Launches the embedded _REMOTE_POLLER script on the node. The poller
-         streams "timestamp power_mw energy_mj" lines until stop() is called.
-      4. A background thread per host reads those lines into a local buffer.
-
-    snapshot_energy_mj() returns the sum of the latest energy counter values
-    across all hosts. energy_from_samples() integrates power over the request
-    window using the buffered samples (converted to local monotonic time).
+    Connects as 'logos-server' using the private key from /root/.ssh/.
+    This mirrors exactly what 'ssh deimama' does from the logos-test root shell.
     """
 
     def __init__(
         self,
         hosts: list[str],
         ssh_user: str,
-        ssh_key_path: Optional[str],
-        ssh_port: int,
-        gpu_index: int,
+        ssh_key: Optional[str],
         poll_interval_ms: float,
     ):
-        self.hosts = hosts
+        self._hosts = hosts
         self._ssh_user = ssh_user
-        self._ssh_key_path = ssh_key_path
-        self._ssh_port = ssh_port
-        self._gpu_index = gpu_index
+        self._ssh_key = ssh_key
         self._poll_s = poll_interval_ms / 1000.0
-
-        self._clients: list = []
-        self._channels: list = []
-        self._all_samples: list[list[_RSample]] = []
+        self._host_samples: list[list[tuple[float, float]]] = []  # (mono_t, power_mw)
         self._locks: list[threading.Lock] = []
+        self._procs: list[subprocess.Popen] = []
         self._threads: list[threading.Thread] = []
         self._stop = threading.Event()
-
-        # Clock correlation: local_mono = _mono_start + (remote_wall - _wall_start - _offset[i])
-        self._mono_start = 0.0
-        self._wall_start = 0.0
-        self._offsets: list[float] = []  # clock offset per host (remote - local)
-
         self.available = False
         self._use_counter = False
         self.method = "none"
 
-    # ── lifecycle ─────────────────────────────────────────────────────────
+    def _ssh_cmd(self, host: str, remote: str) -> str:
+        parts = ["ssh"]
+        if self._ssh_key:
+            parts += ["-i", shlex.quote(self._ssh_key)]
+        parts.append(f"{self._ssh_user}@{host}")
+        parts.append(shlex.quote(remote))
+        return " ".join(parts)
 
     def start(self) -> None:
-        if not _PARAMIKO:
-            print("  [gpu] paramiko not installed — remote GPU measurement disabled.")
-            print("        Install with: pip install paramiko")
-            return
-
-        self._mono_start = time.monotonic()
-        self._wall_start = time.time()
-
-        # Base64-encode the poller script to avoid all shell quoting issues
-        script = _REMOTE_POLLER.format(gpu_index=self._gpu_index, interval=self._poll_s)
-        encoded = base64.b64encode(script.encode()).decode()
-        cmd = f"echo {encoded} | base64 -d | python3 -u"
-
-        ok_hosts = 0
-        for host in self.hosts:
-            samples: list[_RSample] = []
+        # Query all GPUs, sum their power with awk → one value per cycle.
+        remote_loop = (
+            f"while true; do "
+            f"nvidia-smi --query-gpu=power.draw --format=csv,noheader,nounits 2>/dev/null"
+            f" | awk '{{sum += $1}} END {{print sum+0}}'; "
+            f"sleep {self._poll_s:.3f}; "
+            f"done"
+        )
+        ok = 0
+        for host in self._hosts:
+            samples: list[tuple[float, float]] = []
             lock = threading.Lock()
             try:
-                client = _paramiko.SSHClient()
-                client.set_missing_host_key_policy(_paramiko.AutoAddPolicy())
-                connect_kwargs: dict = dict(
-                    hostname=host,
-                    port=self._ssh_port,
-                    username=self._ssh_user,
-                    timeout=15.0,
-                    banner_timeout=15.0,
+                proc = subprocess.Popen(
+                    self._ssh_cmd(host, remote_loop),
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
                 )
-                if self._ssh_key_path:
-                    connect_kwargs["key_filename"] = self._ssh_key_path
-                client.connect(**connect_kwargs)
-
-                # Measure clock offset (NTP-style single round-trip)
-                offset = self._measure_offset(client)
-                self._offsets.append(offset)
-                print(f"  [gpu] {host}: connected  clock_offset={offset*1000:+.1f} ms")
-
-                # Start remote poller
-                transport = client.get_transport()
-                channel = transport.open_session()
-                channel.exec_command(cmd)
-                channel.setblocking(False)
-
-                self._clients.append(client)
-                self._channels.append(channel)
-                self._all_samples.append(samples)
+                self._procs.append(proc)
+                self._host_samples.append(samples)
                 self._locks.append(lock)
-
                 t = threading.Thread(
-                    target=self._reader,
-                    args=(channel, samples, lock, len(self._threads)),
-                    daemon=True,
-                    name=f"gpu-reader-{host}",
+                    target=self._reader, args=(proc, samples, lock),
+                    daemon=True, name=f"gpu-ssh-{host}",
                 )
                 t.start()
                 self._threads.append(t)
-                ok_hosts += 1
-
+                ok += 1
             except Exception as exc:
-                print(f"  [gpu] {host}: connection failed — {exc}")
-                self._offsets.append(0.0)
+                print(f"  [gpu] {host}: failed to launch — {exc}")
 
-        if ok_hosts == 0:
+        if ok == 0:
             return
 
-        # Wait for first samples to arrive so snapshots are immediately usable
-        deadline = time.monotonic() + 3.0
+        deadline = time.monotonic() + 5.0
         while time.monotonic() < deadline:
-            if all(len(s) > 0 for s in self._all_samples if s is not None):
+            if all(len(s) > 0 for s in self._host_samples):
                 break
             time.sleep(0.05)
 
-        # Determine energy counter availability from first samples
-        for samples, lock in zip(self._all_samples, self._locks):
-            with lock:
-                if samples and samples[0].energy_mj >= 0:
-                    self._use_counter = True
-                    break
+        connected = [h for h, s in zip(self._hosts, self._host_samples) if s]
+        if not connected:
+            print("  [gpu] Warning: no data received — check SSH access and nvidia-smi")
+            return
 
-        self.method = "counter" if self._use_counter else "polling"
-        print(
-            f"  [gpu] Energy method: {'hardware counter' if self._use_counter else 'power-poll integration'} "
-            f"across {ok_hosts} host(s)"
-        )
+        for host, samples in zip(self._hosts, self._host_samples):
+            if samples:
+                print(f"  [gpu] {host}: connected  power={samples[0][1]/1000:.1f} W")
+
+        self.method = "polling"
+        print(f"  [gpu] Energy: power-poll via nvidia-smi  "
+              f"({self._poll_s*1000:.0f} ms, {len(connected)} host(s))")
         self.available = True
+
+    def _reader(self, proc, samples, lock) -> None:
+        for raw in proc.stdout:
+            if self._stop.is_set():
+                break
+            try:
+                p_w = float(raw.decode(errors="ignore").strip())
+                with lock:
+                    samples.append((time.monotonic(), p_w * 1000.0))
+            except ValueError:
+                continue  # skip [N/A] or empty lines
 
     def stop(self) -> None:
         self._stop.set()
-        for ch in self._channels:
+        for proc in self._procs:
             try:
-                ch.close()
+                proc.terminate()
             except Exception:
                 pass
-        for cl in self._clients:
-            try:
-                cl.close()
-            except Exception:
-                pass
-
-    # ── internals ─────────────────────────────────────────────────────────
-
-    @staticmethod
-    def _measure_offset(client) -> float:
-        """Estimate remote_time - local_time via one SSH round-trip."""
-        t1 = time.time()
-        _, stdout, _ = client.exec_command("python3 -c 'import time; print(time.time())'")
-        try:
-            remote_t = float(stdout.read().decode().strip())
-        except Exception:
-            return 0.0
-        t2 = time.time()
-        return remote_t - (t1 + t2) / 2.0
-
-    def _reader(
-        self,
-        channel,
-        samples: list[_RSample],
-        lock: threading.Lock,
-        host_idx: int,
-    ) -> None:
-        buf = b""
-        while not self._stop.is_set():
-            try:
-                chunk = channel.recv(4096)
-                if not chunk:
-                    break
-                buf += chunk
-                while b"\n" in buf:
-                    line_bytes, buf = buf.split(b"\n", 1)
-                    line = line_bytes.decode(errors="ignore").strip()
-                    if not line:
-                        continue
-                    parts = line.split()
-                    if len(parts) != 3:
-                        continue
-                    try:
-                        s = _RSample(
-                            remote_wall_t=float(parts[0]),
-                            power_mw=float(parts[1]),
-                            energy_mj=float(parts[2]),
-                        )
-                        with lock:
-                            samples.append(s)
-                    except ValueError:
-                        continue
-            except Exception:
-                time.sleep(0.01)
-
-    def _to_local_mono(self, remote_wall_t: float, host_idx: int) -> float:
-        """Convert a remote wall-clock timestamp to local monotonic time."""
-        offset = self._offsets[host_idx] if host_idx < len(self._offsets) else 0.0
-        return self._mono_start + (remote_wall_t - offset - self._wall_start)
-
-    # ── public API (same interface as GPUTracker) ─────────────────────────
 
     def snapshot_energy_mj(self) -> Optional[float]:
-        """Sum of the latest energy counter values across all hosts (mJ)."""
-        if not self.available or not self._use_counter:
-            return None
-        total = 0.0
-        for samples, lock in zip(self._all_samples, self._locks):
-            with lock:
-                if not samples:
-                    return None
-                latest = samples[-1]
-                if latest.energy_mj < 0:
-                    return None
-                total += latest.energy_mj
-        return total
+        return None  # nvidia-smi has no cumulative energy counter
 
     def energy_from_counter(self, start_mj: float, end_mj: float) -> float:
         return (end_mj - start_mj) / 1000.0
 
     def energy_from_samples(self, t_start: float, t_end: float) -> Optional[float]:
-        """Trapezoidal integration of total power across all hosts → Joules."""
-        # Build a merged (local_monotonic_t, total_mw) series
         combined: list[tuple[float, float]] = []
-        for idx, (samples, lock) in enumerate(zip(self._all_samples, self._locks)):
+        for samples, lock in zip(self._host_samples, self._locks):
             with lock:
-                snap = list(samples)
-            for s in snap:
-                lt = self._to_local_mono(s.remote_wall_t, idx)
-                combined.append((lt, s.power_mw))
-
-        combined.sort(key=lambda x: x[0])
-        # Sum power from all hosts at each time step
-        # (since polls from multiple hosts arrive at slightly different times,
-        # we keep them as individual points and integrate the aggregated curve)
-        window = [(t, p) for t, p in combined if t_start <= t <= t_end]
-        if len(window) < 2:
+                combined.extend((t, p) for t, p in samples if t_start <= t <= t_end)
+        if len(combined) < 2:
             return None
+        combined.sort()
         energy_j = 0.0
-        for i in range(1, len(window)):
-            t0, p0 = window[i - 1]
-            t1, p1 = window[i]
+        for i in range(1, len(combined)):
+            t0, p0 = combined[i - 1]
+            t1, p1 = combined[i]
             energy_j += (p0 + p1) / 2.0 / 1000.0 * (t1 - t0)
         return energy_j
 
     def power_samples(self) -> list[tuple[float, float]]:
-        """All samples as (local_monotonic_t, total_mW) — for timeline chart."""
         combined: list[tuple[float, float]] = []
-        for idx, (samples, lock) in enumerate(zip(self._all_samples, self._locks)):
+        for samples, lock in zip(self._host_samples, self._locks):
             with lock:
-                snap = list(samples)
-            for s in snap:
-                lt = self._to_local_mono(s.remote_wall_t, idx)
-                combined.append((lt, s.power_mw))
-        combined.sort(key=lambda x: x[0])
+                combined.extend(samples)
+        combined.sort()
         return combined
 
 
 # ── Workload ──────────────────────────────────────────────────────────────
-
 
 @dataclass
 class WorkloadEntry:
@@ -647,7 +460,6 @@ def _load_prompts(path: Path, model: str, max_tokens: int, interval_ms: float) -
 
 
 # ── Request dispatch ──────────────────────────────────────────────────────
-
 
 @dataclass
 class RequestResult:
@@ -702,7 +514,7 @@ async def _dispatch(
     logos_key: Optional[str],
     entry: WorkloadEntry,
     start_mono: float,
-    tracker,  # GPUTracker | RemoteGPUTracker
+    tracker,   # GPUTracker | RemoteGPUTracker
     sequential: bool,
     scenario: str,
     model_map: dict[str, str],
@@ -804,7 +616,6 @@ async def _dispatch(
 
 # ── Runners ───────────────────────────────────────────────────────────────
 
-
 def _result_line(r: RequestResult) -> str:
     parts = [
         f"TTFT={r.ttft_ms:.0f}ms" if r.ttft_ms is not None else "TTFT=—",
@@ -832,15 +643,8 @@ async def run_sequential(
         for i, entry in enumerate(workload):
             print(f"  [{i+1:{width}}/{len(workload)}] {entry.request_id} ... ", end="", flush=True)
             r = await _dispatch(
-                client,
-                base_url,
-                logos_key,
-                entry,
-                0.0,
-                tracker,
-                sequential=True,
-                scenario=scenario,
-                model_map=model_map,
+                client, base_url, logos_key, entry, 0.0,
+                tracker, sequential=True, scenario=scenario, model_map=model_map,
             )
             results.append(r)
             print(_result_line(r), flush=True)
@@ -870,15 +674,8 @@ async def run_concurrent(
             nonlocal completed
             async with sem:
                 r = await _dispatch(
-                    client,
-                    base_url,
-                    logos_key,
-                    entry,
-                    start_mono,
-                    tracker,
-                    sequential=False,
-                    scenario=scenario,
-                    model_map=model_map,
+                    client, base_url, logos_key, entry, start_mono,
+                    tracker, sequential=False, scenario=scenario, model_map=model_map,
                 )
             async with lock:
                 results.append(r)
@@ -892,7 +689,6 @@ async def run_concurrent(
 
 
 # ── Statistics ────────────────────────────────────────────────────────────
-
 
 def _pct(vals: list[float], p: float) -> float:
     if not vals:
@@ -918,12 +714,12 @@ def compute_summary(results: list[RequestResult], scenario: str, energy_method: 
     ok = [r for r in results if r.success]
     fail = len(results) - len(ok)
 
-    ttft = [r.ttft_ms for r in ok if r.ttft_ms is not None]
-    ttlt = [r.ttlt_ms for r in ok if r.ttlt_ms is not None]
-    tpot = [r.tpot_ms for r in ok if r.tpot_ms is not None]
+    ttft   = [r.ttft_ms for r in ok if r.ttft_ms is not None]
+    ttlt   = [r.ttlt_ms for r in ok if r.ttlt_ms is not None]
+    tpot   = [r.tpot_ms for r in ok if r.tpot_ms is not None]
     energy = [r.energy_j for r in ok if r.energy_j is not None]
-    e_tok = [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None]
-    tput = [r.throughput_tok_s for r in ok if r.throughput_tok_s is not None]
+    e_tok  = [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None]
+    tput   = [r.throughput_tok_s for r in ok if r.throughput_tok_s is not None]
 
     return {
         "scenario": scenario,
@@ -946,7 +742,6 @@ def compute_summary(results: list[RequestResult], scenario: str, energy_method: 
 
 # ── Output ────────────────────────────────────────────────────────────────
 
-
 def _f(v) -> str:
     if v is None or (isinstance(v, float) and math.isnan(v)):
         return ""
@@ -954,23 +749,11 @@ def _f(v) -> str:
 
 
 _DETAIL_COLS = [
-    "request_id",
-    "model",
-    "scenario",
-    "mode",
-    "priority",
-    "status_code",
-    "ttft_ms",
-    "ttlt_ms",
-    "tpot_ms",
-    "energy_j",
-    "energy_per_token_mj",
-    "throughput_tok_s",
-    "prompt_tokens",
-    "completion_tokens",
-    "sent_at",
-    "received_at",
-    "error",
+    "request_id", "model", "scenario", "mode", "priority", "status_code",
+    "ttft_ms", "ttlt_ms", "tpot_ms",
+    "energy_j", "energy_per_token_mj", "throughput_tok_s",
+    "prompt_tokens", "completion_tokens",
+    "sent_at", "received_at", "error",
 ]
 
 
@@ -980,27 +763,25 @@ def write_detailed(path: Path, results: list[RequestResult]) -> None:
         w = csv.DictWriter(f, fieldnames=_DETAIL_COLS)
         w.writeheader()
         for r in results:
-            w.writerow(
-                {
-                    "request_id": r.request_id,
-                    "model": r.model,
-                    "scenario": r.scenario,
-                    "mode": r.mode,
-                    "priority": r.priority,
-                    "status_code": r.status_code,
-                    "ttft_ms": _f(r.ttft_ms),
-                    "ttlt_ms": _f(r.ttlt_ms),
-                    "tpot_ms": _f(r.tpot_ms),
-                    "energy_j": _f(r.energy_j),
-                    "energy_per_token_mj": _f(r.energy_per_token_mj),
-                    "throughput_tok_s": _f(r.throughput_tok_s),
-                    "prompt_tokens": _f(r.prompt_tokens),
-                    "completion_tokens": _f(r.completion_tokens),
-                    "sent_at": r.sent_at,
-                    "received_at": r.received_at,
-                    "error": r.error or "",
-                }
-            )
+            w.writerow({
+                "request_id": r.request_id,
+                "model": r.model,
+                "scenario": r.scenario,
+                "mode": r.mode,
+                "priority": r.priority,
+                "status_code": r.status_code,
+                "ttft_ms": _f(r.ttft_ms),
+                "ttlt_ms": _f(r.ttlt_ms),
+                "tpot_ms": _f(r.tpot_ms),
+                "energy_j": _f(r.energy_j),
+                "energy_per_token_mj": _f(r.energy_per_token_mj),
+                "throughput_tok_s": _f(r.throughput_tok_s),
+                "prompt_tokens": _f(r.prompt_tokens),
+                "completion_tokens": _f(r.completion_tokens),
+                "sent_at": r.sent_at,
+                "received_at": r.received_at,
+                "error": r.error or "",
+            })
 
 
 def write_summary(path: Path, summary: dict) -> None:
@@ -1013,7 +794,6 @@ def write_summary(path: Path, summary: dict) -> None:
 
 
 # ── Charts ────────────────────────────────────────────────────────────────
-
 
 def _kde_curve(data: list[float], x_grid: "np.ndarray") -> "np.ndarray":
     n = len(data)
@@ -1030,7 +810,8 @@ def _dist_chart(vals: list[float], title: str, xlabel: str, path: Path) -> None:
         return
     fig, ax = plt.subplots(figsize=(10, 5))
     n_bins = min(60, max(10, len(vals) // 3))
-    ax.hist(vals, bins=n_bins, density=True, alpha=0.6, color="#4C72B0", edgecolor="#1a3a6b", linewidth=0.4)
+    ax.hist(vals, bins=n_bins, density=True, alpha=0.6,
+            color="#4C72B0", edgecolor="#1a3a6b", linewidth=0.4)
     x = np.linspace(min(vals) * 0.9, max(vals) * 1.1, 400)
     ax.plot(x, _kde_curve(vals, x), color="#1a3a6b", linewidth=1.8)
     for p, col, lbl in [(50, "#2ca02c", "P50"), (95, "#d62728", "P95"), (99, "#9467bd", "P99")]:
@@ -1072,14 +853,9 @@ def _power_timeline(
             r.request_id,
             xy=((x0 + x1) / 2, 0),
             xycoords=("data", "axes fraction"),
-            xytext=(0, 2),
-            textcoords="offset points",
-            ha="center",
-            va="bottom",
-            fontsize=5.5,
-            color=col,
-            rotation=90,
-            zorder=4,
+            xytext=(0, 2), textcoords="offset points",
+            ha="center", va="bottom",
+            fontsize=5.5, color=col, rotation=90, zorder=4,
         )
 
     ax.set_xlabel("Elapsed time (s)")
@@ -1118,7 +894,10 @@ def _per_model_chart(results: list[RequestResult], metric: str, ylabel: str, pat
         return
     ok = [r for r in results if r.success]
     models = sorted({r.model for r in ok})
-    data = [[v for r in ok if r.model == m for v in [getattr(r, metric)] if v is not None] for m in models]
+    data = [
+        [v for r in ok if r.model == m for v in [getattr(r, metric)] if v is not None]
+        for m in models
+    ]
     if not any(data):
         return
     fig, ax = plt.subplots(figsize=(max(8, len(models) * 2), 5))
@@ -1149,8 +928,7 @@ def _model_switching_chart(
     color_map = {m: palette[i % len(palette)] for i, m in enumerate(models)}
 
     fig, axes = plt.subplots(
-        2,
-        1,
+        2, 1,
         figsize=(14, 8),
         sharex=True,
         gridspec_kw={"height_ratios": [3, 1]},
@@ -1164,8 +942,7 @@ def _model_switching_chart(
             continue
         xs, ys = zip(*pts)
         ax_scatter.scatter(
-            xs,
-            ys,
+            xs, ys,
             color=color_map[model],
             label=model.split("/")[-1],
             alpha=0.8,
@@ -1182,8 +959,7 @@ def _model_switching_chart(
             continue
         xs, ys = zip(*pts)
         ax_scatter.scatter(
-            xs,
-            ys,
+            xs, ys,
             color=color_map[model],
             marker="+",
             alpha=0.35,
@@ -1226,19 +1002,17 @@ def generate_charts(out_dir: Path, results: list[RequestResult], tracker, t0: fl
         print("  [charts] matplotlib/numpy not available — skipping.")
         return
     ok = [r for r in results if r.success]
-    _dist_chart(
-        [r.ttft_ms for r in ok if r.ttft_ms is not None], "TTFT Distribution", "TTFT (ms)", out_dir / "chart_ttft.png"
-    )
-    _dist_chart(
-        [r.ttlt_ms for r in ok if r.ttlt_ms is not None], "TTLT Distribution", "TTLT (ms)", out_dir / "chart_ttlt.png"
-    )
+    _dist_chart([r.ttft_ms for r in ok if r.ttft_ms is not None],
+                "TTFT Distribution", "TTFT (ms)", out_dir / "chart_ttft.png")
+    _dist_chart([r.ttlt_ms for r in ok if r.ttlt_ms is not None],
+                "TTLT Distribution", "TTLT (ms)", out_dir / "chart_ttlt.png")
     energy = [r.energy_j for r in ok if r.energy_j is not None]
     if energy:
-        _dist_chart(energy, "Energy per Request", "Energy (J)", out_dir / "chart_energy_per_request.png")
+        _dist_chart(energy, "Energy per Request", "Energy (J)",
+                    out_dir / "chart_energy_per_request.png")
         _dist_chart(
             [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None],
-            "Energy per Output Token",
-            "Energy (mJ/token)",
+            "Energy per Output Token", "Energy (mJ/token)",
             out_dir / "chart_energy_per_token.png",
         )
     _power_timeline(tracker.power_samples(), results, t0, out_dir / "chart_power_timeline.png")
@@ -1250,7 +1024,6 @@ def generate_charts(out_dir: Path, results: list[RequestResult], tracker, t0: fl
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────
-
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
@@ -1272,57 +1045,50 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Workload source
     src = p.add_mutually_exclusive_group(required=True)
-    src.add_argument("--workload", type=Path, metavar="CSV", help="Workload CSV from prepare_benchmark.py.")
-    src.add_argument("--prompts", type=Path, metavar="TXT", help="Plain-text file with one prompt per line.")
+    src.add_argument("--workload", type=Path, metavar="CSV",
+                     help="Workload CSV from prepare_benchmark.py.")
+    src.add_argument("--prompts", type=Path, metavar="TXT",
+                     help="Plain-text file with one prompt per line.")
 
     # Connection
-    p.add_argument("--logos-url", default="http://localhost:8080", help="Base URL of Logos or Ollama server.")
-    p.add_argument(
-        "--logos-key", default=None, help="Logos API key. Required for logos-sleep and logos-nosleep scenarios."
-    )
+    p.add_argument("--logos-url", default="http://localhost:8080",
+                   help="Base URL of Logos or Ollama server.")
+    p.add_argument("--logos-key", default=None,
+                   help="Logos API key. Required for logos-sleep and logos-nosleep scenarios.")
 
     # Prompt-mode extras
-    p.add_argument("--model", default="", help="Model name (overrides workload CSV body; required with --prompts).")
+    p.add_argument("--model", default="",
+                   help="Model name (overrides workload CSV body; required with --prompts).")
     p.add_argument("--max-tokens", type=int, default=512)
-    p.add_argument(
-        "--interval-ms", type=float, default=0.0, help="Arrival offset between prompts in ms (--prompts mode)."
-    )
+    p.add_argument("--interval-ms", type=float, default=0.0,
+                   help="Arrival offset between prompts in ms (--prompts mode).")
 
-    # ── GPU source: remote (default) or local ────────────────────────────
+    # ── GPU energy measurement ────────────────────────────────────────────
     gpu_grp = p.add_argument_group(
         "GPU energy measurement",
-        "Use --gpu-host to measure energy on remote vLLM nodes via SSH (typical setup). "
-        "Use --gpu-indices when the GPU is local (e.g. direct Ollama on this machine).",
+        "SSHes into GPU nodes as 'logos-server' and polls nvidia-smi. "
+        "Use --gpu-indices only when the GPU is local (e.g. direct Ollama on this machine).",
     )
     gpu_excl = gpu_grp.add_mutually_exclusive_group()
     gpu_excl.add_argument(
-        "--gpu-host",
-        nargs="+",
-        metavar="HOST",
-        help="Hostnames/IPs of the GPU nodes running vLLM. " "The NVML poller is launched on each node via SSH.",
+        "--gpu-host", nargs="+", metavar="HOST",
+        help="SSH hostname(s) of GPU nodes, e.g. deimama hochbruegge.",
     )
     gpu_excl.add_argument(
-        "--gpu-indices",
-        type=int,
-        nargs="+",
-        default=None,
-        metavar="IDX",
+        "--gpu-indices", type=int, nargs="+", default=None, metavar="IDX",
         help="Local NVML GPU device indices (only when GPU is on this machine).",
     )
-    gpu_grp.add_argument("--gpu-ssh-user", default=None, help="SSH username for GPU nodes (default: current user).")
-    gpu_grp.add_argument("--gpu-ssh-key", default=None, metavar="PATH", help="Path to SSH private key for GPU nodes.")
-    gpu_grp.add_argument("--gpu-ssh-port", type=int, default=22, help="SSH port on GPU nodes.")
-    gpu_grp.add_argument(
-        "--gpu-device-index", type=int, default=0, help="GPU device index on each remote node (passed to NVML)."
-    )
-    gpu_grp.add_argument("--poll-interval-ms", type=float, default=100.0, help="GPU power-poll interval (ms).")
+    gpu_grp.add_argument("--gpu-ssh-user", default="logos-server",
+                         help="SSH username on GPU nodes.")
+    gpu_grp.add_argument("--gpu-ssh-key", default=None, metavar="PATH",
+                         help="SSH private key path (default: auto-detect from /root/.ssh/).")
+    gpu_grp.add_argument("--poll-interval-ms", type=float, default=500.0,
+                         help="nvidia-smi poll interval in ms.")
 
     # Concurrency / timing
-    p.add_argument(
-        "--sequential",
-        action="store_true",
-        help="Send one request at a time (ignores arrival offsets). " "Cleanest per-request energy attribution.",
-    )
+    p.add_argument("--sequential", action="store_true",
+                   help="Send one request at a time (ignores arrival offsets). "
+                        "Cleanest per-request energy attribution.")
     p.add_argument("--max-concurrent", type=int, default=64)
     p.add_argument("--request-timeout-s", type=float, default=600.0)
 
@@ -1364,16 +1130,13 @@ async def _async_main(args: argparse.Namespace) -> None:
 
     # ── Build tracker ─────────────────────────────────────────────────────
     if args.gpu_host:
-        import getpass
-
-        ssh_user = args.gpu_ssh_user or getpass.getuser()
-        print(f"GPU      : remote SSH → {args.gpu_host}  user={ssh_user}  device={args.gpu_device_index}")
-        tracker = RemoteGPUTracker(
+        ssh_key = args.gpu_ssh_key or _find_root_ssh_key()
+        print(f"GPU      : SSH nvidia-smi (all GPUs) → {args.gpu_host}  "
+              f"user={args.gpu_ssh_user}  key={ssh_key or '(none)'}")
+        tracker = SshGpuTracker(
             hosts=args.gpu_host,
-            ssh_user=ssh_user,
-            ssh_key_path=args.gpu_ssh_key,
-            ssh_port=args.gpu_ssh_port,
-            gpu_index=args.gpu_device_index,
+            ssh_user=args.gpu_ssh_user,
+            ssh_key=ssh_key,
             poll_interval_ms=args.poll_interval_ms,
         )
     else:
@@ -1384,29 +1147,18 @@ async def _async_main(args: argparse.Namespace) -> None:
     tracker.start()
 
     # ── Run ───────────────────────────────────────────────────────────────
-    print("\nRunning...")
+    print(f"\nRunning...")
     t_run_start = time.monotonic()
 
     if args.sequential:
         results = await run_sequential(
-            workload,
-            args.logos_url,
-            args.logos_key,
-            tracker,
-            args.request_timeout_s,
-            args.scenario,
-            model_map,
+            workload, args.logos_url, args.logos_key,
+            tracker, args.request_timeout_s, args.scenario, model_map,
         )
     else:
         results = await run_concurrent(
-            workload,
-            args.logos_url,
-            args.logos_key,
-            tracker,
-            args.request_timeout_s,
-            args.max_concurrent,
-            args.scenario,
-            model_map,
+            workload, args.logos_url, args.logos_key,
+            tracker, args.request_timeout_s, args.max_concurrent, args.scenario, model_map,
         )
 
     t_run_end = time.monotonic()
@@ -1425,31 +1177,24 @@ async def _async_main(args: argparse.Namespace) -> None:
     generate_charts(out_dir, results, tracker, t_run_start)
 
     gpu_info = (
-        {
-            "hosts": args.gpu_host,
-            "device_index": args.gpu_device_index,
-            "ssh_user": (args.gpu_ssh_user or ""),
-            "ssh_port": args.gpu_ssh_port,
-        }
-        if args.gpu_host
-        else {"local_indices": args.gpu_indices or [0]}
+        {"hosts": args.gpu_host,
+         "ssh_user": (args.gpu_ssh_user or ""), "ssh_port": 22}
+        if args.gpu_host else
+        {"local_indices": args.gpu_indices or [0]}
     )
     (out_dir / "run_meta.json").write_text(
-        json.dumps(
-            {
-                "scenario": args.scenario,
-                "logos_url": args.logos_url,
-                "workload": str(args.workload or args.prompts),
-                "mode": mode_str,
-                "gpu": gpu_info,
-                "poll_interval_ms": args.poll_interval_ms,
-                "energy_method": tracker.method,
-                "total_wall_time_s": round(wall_s, 3),
-                "request_count": len(results),
-                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            },
-            indent=2,
-        ),
+        json.dumps({
+            "scenario": args.scenario,
+            "logos_url": args.logos_url,
+            "workload": str(args.workload or args.prompts),
+            "mode": mode_str,
+            "gpu": gpu_info,
+            "poll_interval_ms": args.poll_interval_ms,
+            "energy_method": tracker.method,
+            "total_wall_time_s": round(wall_s, 3),
+            "request_count": len(results),
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        }, indent=2),
         encoding="utf-8",
     )
 
@@ -1463,8 +1208,8 @@ async def _async_main(args: argparse.Namespace) -> None:
 
     def _row(label: str, prefix: str, unit: str) -> None:
         mean = summary.get(f"{prefix}_mean", math.nan)
-        p50 = summary.get(f"{prefix}_p50", math.nan)
-        p95 = summary.get(f"{prefix}_p95", math.nan)
+        p50  = summary.get(f"{prefix}_p50",  math.nan)
+        p95  = summary.get(f"{prefix}_p95",  math.nan)
         if math.isnan(mean):
             return
         print(f"  {label:<14}: mean={mean:>8.1f}  p50={p50:>8.1f}  p95={p95:>8.1f}  ({unit})")

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -80,16 +80,16 @@ import subprocess
 import sys
 import threading
 import time
+import warnings as _warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import httpx
 
 # ── Optional deps ─────────────────────────────────────────────────────────
 
-import warnings as _warnings
 
 try:
     with _warnings.catch_warnings():
@@ -104,18 +104,19 @@ except ImportError:
 
 
 try:
-    import numpy as np
     import matplotlib
+    import numpy as np
+
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
+
     _PLOT = True
 except ImportError:
     _PLOT = False
 
 
-
-
 # ── Load benchmark_config (optional sibling file) ─────────────────────────
+
 
 def _load_config_attr(attr: str, default):
     config_path = Path(__file__).parent / "benchmark_config.py"
@@ -131,6 +132,7 @@ def _load_config_attr(attr: str, default):
 
 
 # ── Local GPU Tracker (NVML on this machine) ──────────────────────────────
+
 
 class GPUTracker:
     """
@@ -201,10 +203,7 @@ class GPUTracker:
     def _poll_loop(self) -> None:
         while not self._stop.is_set():
             t = time.monotonic()
-            mw = sum(
-                _pynvml.nvmlDeviceGetPowerUsage(h) for h in self._handles
-                if True  # errors silently ignored below
-            )
+            mw = sum(_pynvml.nvmlDeviceGetPowerUsage(h) for h in self._handles if True)  # errors silently ignored below
             with self._lock:
                 self._samples.append((t, mw))
             time.sleep(self._poll_s)
@@ -241,7 +240,7 @@ class GPUTracker:
         window = [(t, p) for t, p in samples if t_start <= t <= t_end]
         if len(window) < 2:
             before = [s for s in samples if s[0] < t_start]
-            after  = [s for s in samples if s[0] > t_end]
+            after = [s for s in samples if s[0] > t_end]
             if before and after and not window:
                 avg_mw = (before[-1][1] + after[0][1]) / 2.0
                 return avg_mw / 1000.0 * (t_end - t_start)
@@ -259,6 +258,7 @@ class GPUTracker:
 
 
 # ── SSH GPU Tracker (nvidia-smi via persistent SSH) ────────────────────────
+
 
 def _find_root_ssh_key() -> Optional[str]:
     """Auto-detect the first available private key in /root/.ssh/."""
@@ -330,8 +330,10 @@ class SshGpuTracker:
                 self._host_samples.append(samples)
                 self._locks.append(lock)
                 t = threading.Thread(
-                    target=self._reader, args=(proc, samples, lock),
-                    daemon=True, name=f"gpu-ssh-{host}",
+                    target=self._reader,
+                    args=(proc, samples, lock),
+                    daemon=True,
+                    name=f"gpu-ssh-{host}",
                 )
                 t.start()
                 self._threads.append(t)
@@ -358,8 +360,7 @@ class SshGpuTracker:
                 print(f"  [gpu] {host}: connected  power={samples[0][1]/1000:.1f} W")
 
         self.method = "polling"
-        print(f"  [gpu] Energy: power-poll via nvidia-smi  "
-              f"({self._poll_s*1000:.0f} ms, {len(connected)} host(s))")
+        print(f"  [gpu] Energy: power-poll via nvidia-smi  " f"({self._poll_s*1000:.0f} ms, {len(connected)} host(s))")
         self.available = True
 
     def _reader(self, proc, samples, lock) -> None:
@@ -413,6 +414,7 @@ class SshGpuTracker:
 
 # ── Workload ──────────────────────────────────────────────────────────────
 
+
 @dataclass
 class WorkloadEntry:
     request_id: str
@@ -460,6 +462,7 @@ def _load_prompts(path: Path, model: str, max_tokens: int, interval_ms: float) -
 
 
 # ── Request dispatch ──────────────────────────────────────────────────────
+
 
 @dataclass
 class RequestResult:
@@ -514,7 +517,7 @@ async def _dispatch(
     logos_key: Optional[str],
     entry: WorkloadEntry,
     start_mono: float,
-    tracker,   # GPUTracker | RemoteGPUTracker
+    tracker,  # GPUTracker | RemoteGPUTracker
     sequential: bool,
     scenario: str,
     model_map: dict[str, str],
@@ -616,6 +619,7 @@ async def _dispatch(
 
 # ── Runners ───────────────────────────────────────────────────────────────
 
+
 def _result_line(r: RequestResult) -> str:
     parts = [
         f"TTFT={r.ttft_ms:.0f}ms" if r.ttft_ms is not None else "TTFT=—",
@@ -643,8 +647,15 @@ async def run_sequential(
         for i, entry in enumerate(workload):
             print(f"  [{i+1:{width}}/{len(workload)}] {entry.request_id} ... ", end="", flush=True)
             r = await _dispatch(
-                client, base_url, logos_key, entry, 0.0,
-                tracker, sequential=True, scenario=scenario, model_map=model_map,
+                client,
+                base_url,
+                logos_key,
+                entry,
+                0.0,
+                tracker,
+                sequential=True,
+                scenario=scenario,
+                model_map=model_map,
             )
             results.append(r)
             print(_result_line(r), flush=True)
@@ -674,8 +685,15 @@ async def run_concurrent(
             nonlocal completed
             async with sem:
                 r = await _dispatch(
-                    client, base_url, logos_key, entry, start_mono,
-                    tracker, sequential=False, scenario=scenario, model_map=model_map,
+                    client,
+                    base_url,
+                    logos_key,
+                    entry,
+                    start_mono,
+                    tracker,
+                    sequential=False,
+                    scenario=scenario,
+                    model_map=model_map,
                 )
             async with lock:
                 results.append(r)
@@ -689,6 +707,7 @@ async def run_concurrent(
 
 
 # ── Statistics ────────────────────────────────────────────────────────────
+
 
 def _pct(vals: list[float], p: float) -> float:
     if not vals:
@@ -714,12 +733,12 @@ def compute_summary(results: list[RequestResult], scenario: str, energy_method: 
     ok = [r for r in results if r.success]
     fail = len(results) - len(ok)
 
-    ttft   = [r.ttft_ms for r in ok if r.ttft_ms is not None]
-    ttlt   = [r.ttlt_ms for r in ok if r.ttlt_ms is not None]
-    tpot   = [r.tpot_ms for r in ok if r.tpot_ms is not None]
+    ttft = [r.ttft_ms for r in ok if r.ttft_ms is not None]
+    ttlt = [r.ttlt_ms for r in ok if r.ttlt_ms is not None]
+    tpot = [r.tpot_ms for r in ok if r.tpot_ms is not None]
     energy = [r.energy_j for r in ok if r.energy_j is not None]
-    e_tok  = [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None]
-    tput   = [r.throughput_tok_s for r in ok if r.throughput_tok_s is not None]
+    e_tok = [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None]
+    tput = [r.throughput_tok_s for r in ok if r.throughput_tok_s is not None]
 
     return {
         "scenario": scenario,
@@ -742,6 +761,7 @@ def compute_summary(results: list[RequestResult], scenario: str, energy_method: 
 
 # ── Output ────────────────────────────────────────────────────────────────
 
+
 def _f(v) -> str:
     if v is None or (isinstance(v, float) and math.isnan(v)):
         return ""
@@ -749,11 +769,23 @@ def _f(v) -> str:
 
 
 _DETAIL_COLS = [
-    "request_id", "model", "scenario", "mode", "priority", "status_code",
-    "ttft_ms", "ttlt_ms", "tpot_ms",
-    "energy_j", "energy_per_token_mj", "throughput_tok_s",
-    "prompt_tokens", "completion_tokens",
-    "sent_at", "received_at", "error",
+    "request_id",
+    "model",
+    "scenario",
+    "mode",
+    "priority",
+    "status_code",
+    "ttft_ms",
+    "ttlt_ms",
+    "tpot_ms",
+    "energy_j",
+    "energy_per_token_mj",
+    "throughput_tok_s",
+    "prompt_tokens",
+    "completion_tokens",
+    "sent_at",
+    "received_at",
+    "error",
 ]
 
 
@@ -763,25 +795,27 @@ def write_detailed(path: Path, results: list[RequestResult]) -> None:
         w = csv.DictWriter(f, fieldnames=_DETAIL_COLS)
         w.writeheader()
         for r in results:
-            w.writerow({
-                "request_id": r.request_id,
-                "model": r.model,
-                "scenario": r.scenario,
-                "mode": r.mode,
-                "priority": r.priority,
-                "status_code": r.status_code,
-                "ttft_ms": _f(r.ttft_ms),
-                "ttlt_ms": _f(r.ttlt_ms),
-                "tpot_ms": _f(r.tpot_ms),
-                "energy_j": _f(r.energy_j),
-                "energy_per_token_mj": _f(r.energy_per_token_mj),
-                "throughput_tok_s": _f(r.throughput_tok_s),
-                "prompt_tokens": _f(r.prompt_tokens),
-                "completion_tokens": _f(r.completion_tokens),
-                "sent_at": r.sent_at,
-                "received_at": r.received_at,
-                "error": r.error or "",
-            })
+            w.writerow(
+                {
+                    "request_id": r.request_id,
+                    "model": r.model,
+                    "scenario": r.scenario,
+                    "mode": r.mode,
+                    "priority": r.priority,
+                    "status_code": r.status_code,
+                    "ttft_ms": _f(r.ttft_ms),
+                    "ttlt_ms": _f(r.ttlt_ms),
+                    "tpot_ms": _f(r.tpot_ms),
+                    "energy_j": _f(r.energy_j),
+                    "energy_per_token_mj": _f(r.energy_per_token_mj),
+                    "throughput_tok_s": _f(r.throughput_tok_s),
+                    "prompt_tokens": _f(r.prompt_tokens),
+                    "completion_tokens": _f(r.completion_tokens),
+                    "sent_at": r.sent_at,
+                    "received_at": r.received_at,
+                    "error": r.error or "",
+                }
+            )
 
 
 def write_summary(path: Path, summary: dict) -> None:
@@ -794,6 +828,7 @@ def write_summary(path: Path, summary: dict) -> None:
 
 
 # ── Charts ────────────────────────────────────────────────────────────────
+
 
 def _kde_curve(data: list[float], x_grid: "np.ndarray") -> "np.ndarray":
     n = len(data)
@@ -810,8 +845,7 @@ def _dist_chart(vals: list[float], title: str, xlabel: str, path: Path) -> None:
         return
     fig, ax = plt.subplots(figsize=(10, 5))
     n_bins = min(60, max(10, len(vals) // 3))
-    ax.hist(vals, bins=n_bins, density=True, alpha=0.6,
-            color="#4C72B0", edgecolor="#1a3a6b", linewidth=0.4)
+    ax.hist(vals, bins=n_bins, density=True, alpha=0.6, color="#4C72B0", edgecolor="#1a3a6b", linewidth=0.4)
     x = np.linspace(min(vals) * 0.9, max(vals) * 1.1, 400)
     ax.plot(x, _kde_curve(vals, x), color="#1a3a6b", linewidth=1.8)
     for p, col, lbl in [(50, "#2ca02c", "P50"), (95, "#d62728", "P95"), (99, "#9467bd", "P99")]:
@@ -853,9 +887,14 @@ def _power_timeline(
             r.request_id,
             xy=((x0 + x1) / 2, 0),
             xycoords=("data", "axes fraction"),
-            xytext=(0, 2), textcoords="offset points",
-            ha="center", va="bottom",
-            fontsize=5.5, color=col, rotation=90, zorder=4,
+            xytext=(0, 2),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=5.5,
+            color=col,
+            rotation=90,
+            zorder=4,
         )
 
     ax.set_xlabel("Elapsed time (s)")
@@ -894,10 +933,7 @@ def _per_model_chart(results: list[RequestResult], metric: str, ylabel: str, pat
         return
     ok = [r for r in results if r.success]
     models = sorted({r.model for r in ok})
-    data = [
-        [v for r in ok if r.model == m for v in [getattr(r, metric)] if v is not None]
-        for m in models
-    ]
+    data = [[v for r in ok if r.model == m for v in [getattr(r, metric)] if v is not None] for m in models]
     if not any(data):
         return
     fig, ax = plt.subplots(figsize=(max(8, len(models) * 2), 5))
@@ -928,7 +964,8 @@ def _model_switching_chart(
     color_map = {m: palette[i % len(palette)] for i, m in enumerate(models)}
 
     fig, axes = plt.subplots(
-        2, 1,
+        2,
+        1,
         figsize=(14, 8),
         sharex=True,
         gridspec_kw={"height_ratios": [3, 1]},
@@ -942,7 +979,8 @@ def _model_switching_chart(
             continue
         xs, ys = zip(*pts)
         ax_scatter.scatter(
-            xs, ys,
+            xs,
+            ys,
             color=color_map[model],
             label=model.split("/")[-1],
             alpha=0.8,
@@ -959,7 +997,8 @@ def _model_switching_chart(
             continue
         xs, ys = zip(*pts)
         ax_scatter.scatter(
-            xs, ys,
+            xs,
+            ys,
             color=color_map[model],
             marker="+",
             alpha=0.35,
@@ -1002,17 +1041,19 @@ def generate_charts(out_dir: Path, results: list[RequestResult], tracker, t0: fl
         print("  [charts] matplotlib/numpy not available — skipping.")
         return
     ok = [r for r in results if r.success]
-    _dist_chart([r.ttft_ms for r in ok if r.ttft_ms is not None],
-                "TTFT Distribution", "TTFT (ms)", out_dir / "chart_ttft.png")
-    _dist_chart([r.ttlt_ms for r in ok if r.ttlt_ms is not None],
-                "TTLT Distribution", "TTLT (ms)", out_dir / "chart_ttlt.png")
+    _dist_chart(
+        [r.ttft_ms for r in ok if r.ttft_ms is not None], "TTFT Distribution", "TTFT (ms)", out_dir / "chart_ttft.png"
+    )
+    _dist_chart(
+        [r.ttlt_ms for r in ok if r.ttlt_ms is not None], "TTLT Distribution", "TTLT (ms)", out_dir / "chart_ttlt.png"
+    )
     energy = [r.energy_j for r in ok if r.energy_j is not None]
     if energy:
-        _dist_chart(energy, "Energy per Request", "Energy (J)",
-                    out_dir / "chart_energy_per_request.png")
+        _dist_chart(energy, "Energy per Request", "Energy (J)", out_dir / "chart_energy_per_request.png")
         _dist_chart(
             [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None],
-            "Energy per Output Token", "Energy (mJ/token)",
+            "Energy per Output Token",
+            "Energy (mJ/token)",
             out_dir / "chart_energy_per_token.png",
         )
     _power_timeline(tracker.power_samples(), results, t0, out_dir / "chart_power_timeline.png")
@@ -1024,6 +1065,7 @@ def generate_charts(out_dir: Path, results: list[RequestResult], tracker, t0: fl
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────
+
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
@@ -1045,23 +1087,21 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Workload source
     src = p.add_mutually_exclusive_group(required=True)
-    src.add_argument("--workload", type=Path, metavar="CSV",
-                     help="Workload CSV from prepare_benchmark.py.")
-    src.add_argument("--prompts", type=Path, metavar="TXT",
-                     help="Plain-text file with one prompt per line.")
+    src.add_argument("--workload", type=Path, metavar="CSV", help="Workload CSV from prepare_benchmark.py.")
+    src.add_argument("--prompts", type=Path, metavar="TXT", help="Plain-text file with one prompt per line.")
 
     # Connection
-    p.add_argument("--logos-url", default="http://localhost:8080",
-                   help="Base URL of Logos or Ollama server.")
-    p.add_argument("--logos-key", default=None,
-                   help="Logos API key. Required for logos-sleep and logos-nosleep scenarios.")
+    p.add_argument("--logos-url", default="http://localhost:8080", help="Base URL of Logos or Ollama server.")
+    p.add_argument(
+        "--logos-key", default=None, help="Logos API key. Required for logos-sleep and logos-nosleep scenarios."
+    )
 
     # Prompt-mode extras
-    p.add_argument("--model", default="",
-                   help="Model name (overrides workload CSV body; required with --prompts).")
+    p.add_argument("--model", default="", help="Model name (overrides workload CSV body; required with --prompts).")
     p.add_argument("--max-tokens", type=int, default=512)
-    p.add_argument("--interval-ms", type=float, default=0.0,
-                   help="Arrival offset between prompts in ms (--prompts mode).")
+    p.add_argument(
+        "--interval-ms", type=float, default=0.0, help="Arrival offset between prompts in ms (--prompts mode)."
+    )
 
     # ── GPU energy measurement ────────────────────────────────────────────
     gpu_grp = p.add_argument_group(
@@ -1071,24 +1111,34 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     gpu_excl = gpu_grp.add_mutually_exclusive_group()
     gpu_excl.add_argument(
-        "--gpu-host", nargs="+", metavar="HOST",
+        "--gpu-host",
+        nargs="+",
+        metavar="HOST",
         help="SSH hostname(s) of GPU nodes, e.g. deimama hochbruegge.",
     )
     gpu_excl.add_argument(
-        "--gpu-indices", type=int, nargs="+", default=None, metavar="IDX",
+        "--gpu-indices",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="IDX",
         help="Local NVML GPU device indices (only when GPU is on this machine).",
     )
-    gpu_grp.add_argument("--gpu-ssh-user", default="logos-server",
-                         help="SSH username on GPU nodes.")
-    gpu_grp.add_argument("--gpu-ssh-key", default=None, metavar="PATH",
-                         help="SSH private key path (default: auto-detect from /root/.ssh/).")
-    gpu_grp.add_argument("--poll-interval-ms", type=float, default=500.0,
-                         help="nvidia-smi poll interval in ms.")
+    gpu_grp.add_argument("--gpu-ssh-user", default="logos-server", help="SSH username on GPU nodes.")
+    gpu_grp.add_argument(
+        "--gpu-ssh-key",
+        default=None,
+        metavar="PATH",
+        help="SSH private key path (default: auto-detect from /root/.ssh/).",
+    )
+    gpu_grp.add_argument("--poll-interval-ms", type=float, default=500.0, help="nvidia-smi poll interval in ms.")
 
     # Concurrency / timing
-    p.add_argument("--sequential", action="store_true",
-                   help="Send one request at a time (ignores arrival offsets). "
-                        "Cleanest per-request energy attribution.")
+    p.add_argument(
+        "--sequential",
+        action="store_true",
+        help="Send one request at a time (ignores arrival offsets). " "Cleanest per-request energy attribution.",
+    )
     p.add_argument("--max-concurrent", type=int, default=64)
     p.add_argument("--request-timeout-s", type=float, default=600.0)
 
@@ -1131,8 +1181,10 @@ async def _async_main(args: argparse.Namespace) -> None:
     # ── Build tracker ─────────────────────────────────────────────────────
     if args.gpu_host:
         ssh_key = args.gpu_ssh_key or _find_root_ssh_key()
-        print(f"GPU      : SSH nvidia-smi (all GPUs) → {args.gpu_host}  "
-              f"user={args.gpu_ssh_user}  key={ssh_key or '(none)'}")
+        print(
+            f"GPU      : SSH nvidia-smi (all GPUs) → {args.gpu_host}  "
+            f"user={args.gpu_ssh_user}  key={ssh_key or '(none)'}"
+        )
         tracker = SshGpuTracker(
             hosts=args.gpu_host,
             ssh_user=args.gpu_ssh_user,
@@ -1147,18 +1199,29 @@ async def _async_main(args: argparse.Namespace) -> None:
     tracker.start()
 
     # ── Run ───────────────────────────────────────────────────────────────
-    print(f"\nRunning...")
+    print("\nRunning...")
     t_run_start = time.monotonic()
 
     if args.sequential:
         results = await run_sequential(
-            workload, args.logos_url, args.logos_key,
-            tracker, args.request_timeout_s, args.scenario, model_map,
+            workload,
+            args.logos_url,
+            args.logos_key,
+            tracker,
+            args.request_timeout_s,
+            args.scenario,
+            model_map,
         )
     else:
         results = await run_concurrent(
-            workload, args.logos_url, args.logos_key,
-            tracker, args.request_timeout_s, args.max_concurrent, args.scenario, model_map,
+            workload,
+            args.logos_url,
+            args.logos_key,
+            tracker,
+            args.request_timeout_s,
+            args.max_concurrent,
+            args.scenario,
+            model_map,
         )
 
     t_run_end = time.monotonic()
@@ -1177,24 +1240,26 @@ async def _async_main(args: argparse.Namespace) -> None:
     generate_charts(out_dir, results, tracker, t_run_start)
 
     gpu_info = (
-        {"hosts": args.gpu_host,
-         "ssh_user": (args.gpu_ssh_user or ""), "ssh_port": 22}
-        if args.gpu_host else
-        {"local_indices": args.gpu_indices or [0]}
+        {"hosts": args.gpu_host, "ssh_user": (args.gpu_ssh_user or ""), "ssh_port": 22}
+        if args.gpu_host
+        else {"local_indices": args.gpu_indices or [0]}
     )
     (out_dir / "run_meta.json").write_text(
-        json.dumps({
-            "scenario": args.scenario,
-            "logos_url": args.logos_url,
-            "workload": str(args.workload or args.prompts),
-            "mode": mode_str,
-            "gpu": gpu_info,
-            "poll_interval_ms": args.poll_interval_ms,
-            "energy_method": tracker.method,
-            "total_wall_time_s": round(wall_s, 3),
-            "request_count": len(results),
-            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-        }, indent=2),
+        json.dumps(
+            {
+                "scenario": args.scenario,
+                "logos_url": args.logos_url,
+                "workload": str(args.workload or args.prompts),
+                "mode": mode_str,
+                "gpu": gpu_info,
+                "poll_interval_ms": args.poll_interval_ms,
+                "energy_method": tracker.method,
+                "total_wall_time_s": round(wall_s, 3),
+                "request_count": len(results),
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            },
+            indent=2,
+        ),
         encoding="utf-8",
     )
 
@@ -1208,8 +1273,8 @@ async def _async_main(args: argparse.Namespace) -> None:
 
     def _row(label: str, prefix: str, unit: str) -> None:
         mean = summary.get(f"{prefix}_mean", math.nan)
-        p50  = summary.get(f"{prefix}_p50",  math.nan)
-        p95  = summary.get(f"{prefix}_p95",  math.nan)
+        p50 = summary.get(f"{prefix}_p50", math.nan)
+        p95 = summary.get(f"{prefix}_p95", math.nan)
         if math.isnan(mean):
             return
         print(f"  {label:<14}: mean={mean:>8.1f}  p50={p50:>8.1f}  p95={p95:>8.1f}  ({unit})")

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -1,0 +1,1495 @@
+#!/usr/bin/env python3
+"""
+Logos Benchmark — TTFT, TTLT, GPU Energy per Request
+
+Measures per request:
+  TTFT  (Time to First Token)  — client-side, first SSE content delta
+  TTLT  (Time to Last Token)   — client-side, stream closed
+  Energy (Joules)              — NVIDIA NVML energy counter on the GPU nodes
+
+Architecture
+------------
+This script runs on the same machine as the Logos server. The actual GPU
+work is done by vLLM instances on *separate* GPU nodes. Energy is measured
+by SSH-ing into those nodes and running a continuous NVML poller there.
+
+                ┌─────────────────────────────┐
+                │  Logos host (this script)   │
+                │  ┌──────────┐  ┌─────────┐  │
+                │  │ benchmark│  │  Logos  │  │
+                │  └──────────┘  └────┬────┘  │
+                └───────────────────┼─────────┘
+                                    │ HTTP (vLLM API)
+              ┌─────────────────────┼─────────────────────┐
+              │  GPU node A         │         GPU node B   │
+              │  ┌──────────┐   ┌──┴───────┐ ┌──────────┐ │
+              │  │NVML poll │   │  vLLM    │ │  vLLM    │ │
+              │  │(via SSH) │   │RTX Ada   │ │RTX Ada   │ │
+              │  └──────────┘   └──────────┘ └──────────┘ │
+              └─────────────────────────────────────────────┘
+
+Supports three scenarios via --scenario:
+  logos-sleep    Send to Logos (sleep/idle mode enabled server-side).
+  logos-nosleep  Send to Logos (sleep/idle mode disabled server-side).
+  ollama         Send directly to Ollama. Uses OLLAMA_MODEL_MAP from
+                 benchmark_config.py to translate Logos model names to Ollama
+                 tags. No logos_key header is sent.
+
+Requirements (on this machine):
+    pip install httpx paramiko numpy matplotlib
+
+Requirements (on each GPU node, installed once with root access):
+    pip install nvidia-ml-py
+
+Usage — remote GPU nodes (typical setup):
+    python benchmark_logos.py \\
+        --scenario logos-sleep \\
+        --logos-url http://logos.ase.cit.tum.de \\
+        --logos-key YOUR_KEY \\
+        --workload workloads/workload_gsm8k_2llm.csv \\
+        --gpu-host gpu-node-a gpu-node-b \\
+        --gpu-ssh-user ubuntu \\
+        --gpu-ssh-key ~/.ssh/id_rsa \\
+        --sequential --output-dir results
+
+Usage — local GPU (e.g. direct Ollama on same machine as this script):
+    python benchmark_logos.py \\
+        --scenario ollama \\
+        --logos-url http://localhost:11434 \\
+        --workload workloads/workload_gsm8k_2llm.csv \\
+        --gpu-indices 0 --sequential
+
+Energy note for concurrent requests:
+    Each request reports the GPU energy consumed during its [t_start, t_end]
+    window. With concurrent requests the windows overlap — use --sequential
+    for clean, non-overlapping attribution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import csv
+import importlib.util
+import json
+import math
+import sys
+import threading
+import time
+import warnings as _warnings
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+# ── Optional deps ─────────────────────────────────────────────────────────
+
+
+try:
+    with _warnings.catch_warnings():
+        # Both nvidia-ml-py (correct) and the deprecated pynvml package expose
+        # the same pynvml module. The deprecated package emits a FutureWarning
+        # on import. Suppress it here; requirements.txt pins nvidia-ml-py.
+        _warnings.filterwarnings("ignore", category=FutureWarning, message=".*pynvml.*")
+        import pynvml as _pynvml
+    _NVML = True
+except ImportError:
+    _NVML = False
+
+try:
+    import paramiko as _paramiko
+
+    _PARAMIKO = True
+except ImportError:
+    _PARAMIKO = False
+
+try:
+    import matplotlib
+    import numpy as np
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    _PLOT = True
+except ImportError:
+    _PLOT = False
+
+
+# ── Remote poller script (embedded, sent to GPU nodes via SSH) ────────────
+#
+# Runs on each GPU node. Continuously streams one line per poll interval:
+#   <unix_timestamp> <power_mw> <energy_mj>
+# energy_mj = -1 when the hardware counter is unavailable (falls back to
+# power-integration only). Uses nvidia-smi as a last resort if pynvml is
+# not installed on the node.
+
+_REMOTE_POLLER = r"""
+import sys, time, warnings, subprocess
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+GPU_INDEX = {gpu_index}
+INTERVAL  = {interval:.3f}
+
+use_nvml   = False
+has_energy = False
+
+try:
+    import pynvml
+    pynvml.nvmlInit()
+    _h = pynvml.nvmlDeviceGetHandleByIndex(GPU_INDEX)
+    use_nvml = True
+    try:
+        pynvml.nvmlDeviceGetTotalEnergyConsumption(_h)
+        has_energy = True
+    except Exception:
+        pass
+except Exception:
+    pass
+
+def _read_nvml():
+    try:
+        p = pynvml.nvmlDeviceGetPowerUsage(_h)
+        e = pynvml.nvmlDeviceGetTotalEnergyConsumption(_h) if has_energy else -1
+        return p, e
+    except Exception:
+        return 0, -1
+
+def _read_smi():
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=power.draw",
+             "--format=csv,noheader,nounits", f"--id={GPU_INDEX}"],
+            text=True, timeout=2.0,
+        )
+        return int(float(out.strip()) * 1000), -1
+    except Exception:
+        return 0, -1
+
+_read = _read_nvml if use_nvml else _read_smi
+
+while True:
+    t = time.time()
+    p_mw, e_mj = _read()
+    sys.stdout.write(f"{t:.6f} {p_mw} {e_mj}\n")
+    sys.stdout.flush()
+    time.sleep(INTERVAL)
+"""
+
+
+# ── Load benchmark_config (optional sibling file) ─────────────────────────
+
+
+def _load_config_attr(attr: str, default):
+    config_path = Path(__file__).parent / "benchmark_config.py"
+    if not config_path.exists():
+        return default
+    try:
+        spec = importlib.util.spec_from_file_location("benchmark_config", config_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return getattr(mod, attr, default)
+    except Exception:
+        return default
+
+
+# ── Local GPU Tracker (NVML on this machine) ──────────────────────────────
+
+
+class GPUTracker:
+    """
+    GPU energy tracking via local NVML calls.
+    Use when the GPU is on the same machine as this script (e.g. direct Ollama).
+    """
+
+    def __init__(self, device_indices: list[int], poll_interval_ms: float = 100.0):
+        self.device_indices = device_indices
+        self._poll_s = poll_interval_ms / 1000.0
+        self._handles: list = []
+        self._use_counter = False
+        self._samples: list[tuple[float, float]] = []
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.available = False
+        self.method = "none"
+
+    def start(self) -> None:
+        if not _NVML:
+            print("  [gpu] pynvml not installed — energy measurement disabled.")
+            print("        Install with: pip install nvidia-ml-py")
+            return
+        try:
+            _pynvml.nvmlInit()
+        except Exception as exc:
+            print(f"  [gpu] NVML init failed: {exc}")
+            return
+
+        for idx in self.device_indices:
+            try:
+                h = _pynvml.nvmlDeviceGetHandleByIndex(idx)
+                name = _pynvml.nvmlDeviceGetName(h)
+                self._handles.append(h)
+                print(f"  [gpu] GPU {idx}: {name}")
+            except Exception as exc:
+                print(f"  [gpu] Cannot open GPU {idx}: {exc}")
+
+        if not self._handles:
+            return
+
+        try:
+            _pynvml.nvmlDeviceGetTotalEnergyConsumption(self._handles[0])
+            self._use_counter = True
+            self.method = "counter"
+            print("  [gpu] Energy method: hardware counter (nvmlDeviceGetTotalEnergyConsumption)")
+        except Exception:
+            self.method = "polling"
+            print(f"  [gpu] Energy method: power-poll integration ({self._poll_s*1000:.0f} ms interval)")
+
+        self.available = True
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True, name="gpu-poller")
+        self._thread.start()
+
+    def stop(self) -> None:
+        if not self.available:
+            return
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+        try:
+            _pynvml.nvmlShutdown()
+        except Exception:
+            pass
+
+    def _poll_loop(self) -> None:
+        while not self._stop.is_set():
+            t = time.monotonic()
+            mw = sum(_pynvml.nvmlDeviceGetPowerUsage(h) for h in self._handles if True)  # errors silently ignored below
+            with self._lock:
+                self._samples.append((t, mw))
+            time.sleep(self._poll_s)
+
+    def _sum_power_mw(self) -> float:
+        total = 0.0
+        for h in self._handles:
+            try:
+                total += _pynvml.nvmlDeviceGetPowerUsage(h)
+            except Exception:
+                pass
+        return total
+
+    def _sum_energy_mj(self) -> Optional[float]:
+        total = 0.0
+        for h in self._handles:
+            try:
+                total += _pynvml.nvmlDeviceGetTotalEnergyConsumption(h)
+            except Exception:
+                return None
+        return total
+
+    def snapshot_energy_mj(self) -> Optional[float]:
+        if not self.available or not self._use_counter:
+            return None
+        return self._sum_energy_mj()
+
+    def energy_from_counter(self, start_mj: float, end_mj: float) -> float:
+        return (end_mj - start_mj) / 1000.0
+
+    def energy_from_samples(self, t_start: float, t_end: float) -> Optional[float]:
+        with self._lock:
+            samples = list(self._samples)
+        window = [(t, p) for t, p in samples if t_start <= t <= t_end]
+        if len(window) < 2:
+            before = [s for s in samples if s[0] < t_start]
+            after = [s for s in samples if s[0] > t_end]
+            if before and after and not window:
+                avg_mw = (before[-1][1] + after[0][1]) / 2.0
+                return avg_mw / 1000.0 * (t_end - t_start)
+            return None
+        energy_j = 0.0
+        for i in range(1, len(window)):
+            t0, p0 = window[i - 1]
+            t1, p1 = window[i]
+            energy_j += (p0 + p1) / 2.0 / 1000.0 * (t1 - t0)
+        return energy_j
+
+    def power_samples(self) -> list[tuple[float, float]]:
+        with self._lock:
+            return list(self._samples)
+
+
+# ── Remote GPU Tracker (SSH → NVML on GPU nodes) ──────────────────────────
+
+
+@dataclass
+class _RSample:
+    """One sample received from the remote poller."""
+
+    remote_wall_t: float  # time.time() on GPU machine
+    power_mw: float
+    energy_mj: float  # -1 if hardware counter not available
+
+
+class RemoteGPUTracker:
+    """
+    GPU energy tracking for nodes accessed via SSH.
+    Use when vLLM (and the GPU) is on a different machine from this script.
+
+    At start-up this class:
+      1. Opens a paramiko SSH session to each GPU host.
+      2. Measures the clock offset between this machine and the GPU node
+         (NTP-style round-trip) so remote timestamps can be mapped to local
+         monotonic time.
+      3. Launches the embedded _REMOTE_POLLER script on the node. The poller
+         streams "timestamp power_mw energy_mj" lines until stop() is called.
+      4. A background thread per host reads those lines into a local buffer.
+
+    snapshot_energy_mj() returns the sum of the latest energy counter values
+    across all hosts. energy_from_samples() integrates power over the request
+    window using the buffered samples (converted to local monotonic time).
+    """
+
+    def __init__(
+        self,
+        hosts: list[str],
+        ssh_user: str,
+        ssh_key_path: Optional[str],
+        ssh_port: int,
+        gpu_index: int,
+        poll_interval_ms: float,
+    ):
+        self.hosts = hosts
+        self._ssh_user = ssh_user
+        self._ssh_key_path = ssh_key_path
+        self._ssh_port = ssh_port
+        self._gpu_index = gpu_index
+        self._poll_s = poll_interval_ms / 1000.0
+
+        self._clients: list = []
+        self._channels: list = []
+        self._all_samples: list[list[_RSample]] = []
+        self._locks: list[threading.Lock] = []
+        self._threads: list[threading.Thread] = []
+        self._stop = threading.Event()
+
+        # Clock correlation: local_mono = _mono_start + (remote_wall - _wall_start - _offset[i])
+        self._mono_start = 0.0
+        self._wall_start = 0.0
+        self._offsets: list[float] = []  # clock offset per host (remote - local)
+
+        self.available = False
+        self._use_counter = False
+        self.method = "none"
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        if not _PARAMIKO:
+            print("  [gpu] paramiko not installed — remote GPU measurement disabled.")
+            print("        Install with: pip install paramiko")
+            return
+
+        self._mono_start = time.monotonic()
+        self._wall_start = time.time()
+
+        # Base64-encode the poller script to avoid all shell quoting issues
+        script = _REMOTE_POLLER.format(gpu_index=self._gpu_index, interval=self._poll_s)
+        encoded = base64.b64encode(script.encode()).decode()
+        cmd = f"echo {encoded} | base64 -d | python3 -u"
+
+        ok_hosts = 0
+        for host in self.hosts:
+            samples: list[_RSample] = []
+            lock = threading.Lock()
+            try:
+                client = _paramiko.SSHClient()
+                client.set_missing_host_key_policy(_paramiko.AutoAddPolicy())
+                connect_kwargs: dict = dict(
+                    hostname=host,
+                    port=self._ssh_port,
+                    username=self._ssh_user,
+                    timeout=15.0,
+                    banner_timeout=15.0,
+                )
+                if self._ssh_key_path:
+                    connect_kwargs["key_filename"] = self._ssh_key_path
+                client.connect(**connect_kwargs)
+
+                # Measure clock offset (NTP-style single round-trip)
+                offset = self._measure_offset(client)
+                self._offsets.append(offset)
+                print(f"  [gpu] {host}: connected  clock_offset={offset*1000:+.1f} ms")
+
+                # Start remote poller
+                transport = client.get_transport()
+                channel = transport.open_session()
+                channel.exec_command(cmd)
+                channel.setblocking(False)
+
+                self._clients.append(client)
+                self._channels.append(channel)
+                self._all_samples.append(samples)
+                self._locks.append(lock)
+
+                t = threading.Thread(
+                    target=self._reader,
+                    args=(channel, samples, lock, len(self._threads)),
+                    daemon=True,
+                    name=f"gpu-reader-{host}",
+                )
+                t.start()
+                self._threads.append(t)
+                ok_hosts += 1
+
+            except Exception as exc:
+                print(f"  [gpu] {host}: connection failed — {exc}")
+                self._offsets.append(0.0)
+
+        if ok_hosts == 0:
+            return
+
+        # Wait for first samples to arrive so snapshots are immediately usable
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if all(len(s) > 0 for s in self._all_samples if s is not None):
+                break
+            time.sleep(0.05)
+
+        # Determine energy counter availability from first samples
+        for samples, lock in zip(self._all_samples, self._locks):
+            with lock:
+                if samples and samples[0].energy_mj >= 0:
+                    self._use_counter = True
+                    break
+
+        self.method = "counter" if self._use_counter else "polling"
+        print(
+            f"  [gpu] Energy method: {'hardware counter' if self._use_counter else 'power-poll integration'} "
+            f"across {ok_hosts} host(s)"
+        )
+        self.available = True
+
+    def stop(self) -> None:
+        self._stop.set()
+        for ch in self._channels:
+            try:
+                ch.close()
+            except Exception:
+                pass
+        for cl in self._clients:
+            try:
+                cl.close()
+            except Exception:
+                pass
+
+    # ── internals ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _measure_offset(client) -> float:
+        """Estimate remote_time - local_time via one SSH round-trip."""
+        t1 = time.time()
+        _, stdout, _ = client.exec_command("python3 -c 'import time; print(time.time())'")
+        try:
+            remote_t = float(stdout.read().decode().strip())
+        except Exception:
+            return 0.0
+        t2 = time.time()
+        return remote_t - (t1 + t2) / 2.0
+
+    def _reader(
+        self,
+        channel,
+        samples: list[_RSample],
+        lock: threading.Lock,
+        host_idx: int,
+    ) -> None:
+        buf = b""
+        while not self._stop.is_set():
+            try:
+                chunk = channel.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    line_bytes, buf = buf.split(b"\n", 1)
+                    line = line_bytes.decode(errors="ignore").strip()
+                    if not line:
+                        continue
+                    parts = line.split()
+                    if len(parts) != 3:
+                        continue
+                    try:
+                        s = _RSample(
+                            remote_wall_t=float(parts[0]),
+                            power_mw=float(parts[1]),
+                            energy_mj=float(parts[2]),
+                        )
+                        with lock:
+                            samples.append(s)
+                    except ValueError:
+                        continue
+            except Exception:
+                time.sleep(0.01)
+
+    def _to_local_mono(self, remote_wall_t: float, host_idx: int) -> float:
+        """Convert a remote wall-clock timestamp to local monotonic time."""
+        offset = self._offsets[host_idx] if host_idx < len(self._offsets) else 0.0
+        return self._mono_start + (remote_wall_t - offset - self._wall_start)
+
+    # ── public API (same interface as GPUTracker) ─────────────────────────
+
+    def snapshot_energy_mj(self) -> Optional[float]:
+        """Sum of the latest energy counter values across all hosts (mJ)."""
+        if not self.available or not self._use_counter:
+            return None
+        total = 0.0
+        for samples, lock in zip(self._all_samples, self._locks):
+            with lock:
+                if not samples:
+                    return None
+                latest = samples[-1]
+                if latest.energy_mj < 0:
+                    return None
+                total += latest.energy_mj
+        return total
+
+    def energy_from_counter(self, start_mj: float, end_mj: float) -> float:
+        return (end_mj - start_mj) / 1000.0
+
+    def energy_from_samples(self, t_start: float, t_end: float) -> Optional[float]:
+        """Trapezoidal integration of total power across all hosts → Joules."""
+        # Build a merged (local_monotonic_t, total_mw) series
+        combined: list[tuple[float, float]] = []
+        for idx, (samples, lock) in enumerate(zip(self._all_samples, self._locks)):
+            with lock:
+                snap = list(samples)
+            for s in snap:
+                lt = self._to_local_mono(s.remote_wall_t, idx)
+                combined.append((lt, s.power_mw))
+
+        combined.sort(key=lambda x: x[0])
+        # Sum power from all hosts at each time step
+        # (since polls from multiple hosts arrive at slightly different times,
+        # we keep them as individual points and integrate the aggregated curve)
+        window = [(t, p) for t, p in combined if t_start <= t <= t_end]
+        if len(window) < 2:
+            return None
+        energy_j = 0.0
+        for i in range(1, len(window)):
+            t0, p0 = window[i - 1]
+            t1, p1 = window[i]
+            energy_j += (p0 + p1) / 2.0 / 1000.0 * (t1 - t0)
+        return energy_j
+
+    def power_samples(self) -> list[tuple[float, float]]:
+        """All samples as (local_monotonic_t, total_mW) — for timeline chart."""
+        combined: list[tuple[float, float]] = []
+        for idx, (samples, lock) in enumerate(zip(self._all_samples, self._locks)):
+            with lock:
+                snap = list(samples)
+            for s in snap:
+                lt = self._to_local_mono(s.remote_wall_t, idx)
+                combined.append((lt, s.power_mw))
+        combined.sort(key=lambda x: x[0])
+        return combined
+
+
+# ── Workload ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class WorkloadEntry:
+    request_id: str
+    arrival_offset_ms: float
+    body: dict
+    mode: str = "interactive"
+    priority: str = "mid"
+
+
+_PRIORITY_MAP = {"low": 1, "mid": 5, "high": 10}
+
+
+def _load_csv(path: Path, model_override: Optional[str]) -> list[WorkloadEntry]:
+    entries: list[WorkloadEntry] = []
+    with path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        reader.fieldnames = [h.strip().lower() for h in (reader.fieldnames or [])]
+        for idx, row in enumerate(reader, 1):
+            rid = row.get("request_id") or f"req-{idx:04d}"
+            offset = float(row.get("arrival_offset", 0))
+            mode = row.get("mode", "interactive").strip().lower()
+            priority = row.get("priority", "mid").strip().lower()
+            body = json.loads(row.get("body_json", "{}"))
+            if model_override:
+                body["model"] = model_override
+            entries.append(WorkloadEntry(rid, offset, body, mode, priority))
+    entries.sort(key=lambda e: e.arrival_offset_ms)
+    return entries
+
+
+def _load_prompts(path: Path, model: str, max_tokens: int, interval_ms: float) -> list[WorkloadEntry]:
+    lines = [ln.strip() for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    return [
+        WorkloadEntry(
+            request_id=f"req-{i + 1:04d}",
+            arrival_offset_ms=i * interval_ms,
+            body={
+                "model": model,
+                "messages": [{"role": "user", "content": line}],
+                "max_tokens": max_tokens,
+            },
+        )
+        for i, line in enumerate(lines)
+    ]
+
+
+# ── Request dispatch ──────────────────────────────────────────────────────
+
+
+@dataclass
+class RequestResult:
+    request_id: str
+    model: str
+    mode: str
+    priority: str
+    status_code: int
+    ttft_ms: Optional[float]
+    ttlt_ms: Optional[float]
+    energy_j: Optional[float]
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    error: Optional[str]
+    t_start: float
+    t_end: float
+    sent_at: str
+    received_at: str
+    scenario: str = ""
+
+    @property
+    def success(self) -> bool:
+        return bool(self.status_code and 200 <= self.status_code < 400 and not self.error)
+
+    @property
+    def tpot_ms(self) -> Optional[float]:
+        if (
+            self.ttft_ms is not None
+            and self.ttlt_ms is not None
+            and self.completion_tokens
+            and self.completion_tokens > 1
+        ):
+            return (self.ttlt_ms - self.ttft_ms) / (self.completion_tokens - 1)
+        return None
+
+    @property
+    def throughput_tok_s(self) -> Optional[float]:
+        if self.ttlt_ms and self.completion_tokens:
+            return self.completion_tokens / (self.ttlt_ms / 1000.0)
+        return None
+
+    @property
+    def energy_per_token_mj(self) -> Optional[float]:
+        if self.energy_j is not None and self.completion_tokens:
+            return self.energy_j / self.completion_tokens * 1000.0
+        return None
+
+
+async def _dispatch(
+    client: httpx.AsyncClient,
+    base_url: str,
+    logos_key: Optional[str],
+    entry: WorkloadEntry,
+    start_mono: float,
+    tracker,  # GPUTracker | RemoteGPUTracker
+    sequential: bool,
+    scenario: str,
+    model_map: dict[str, str],
+) -> RequestResult:
+    if not sequential:
+        wait = (entry.arrival_offset_ms / 1000.0) - (time.monotonic() - start_mono)
+        if wait > 0:
+            await asyncio.sleep(wait)
+
+    url = f"{base_url.rstrip('/')}/v1/chat/completions"
+    payload = {**entry.body, "stream": True}
+
+    is_ollama = scenario == "ollama"
+    if is_ollama:
+        original_model = str(payload.get("model", ""))
+        payload["model"] = model_map.get(original_model, original_model)
+        headers = {"Content-Type": "application/json"}
+    else:
+        payload["mode"] = entry.mode
+        payload["priority"] = _PRIORITY_MAP.get(entry.priority.lower(), 5)
+        headers = {"Content-Type": "application/json", "logos_key": logos_key or ""}
+
+    ttft_ms: Optional[float] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    error: Optional[str] = None
+    model = str(payload.get("model", ""))
+    status_code = 0
+
+    e_start = tracker.snapshot_energy_mj()
+    t_start = time.monotonic()
+    sent_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    try:
+        async with client.stream("POST", url, json=payload, headers=headers) as resp:
+            status_code = resp.status_code
+            first_token = False
+
+            async for raw in resp.aiter_lines():
+                line = raw.strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if not data or data == "[DONE]":
+                    continue
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+                if not model:
+                    model = chunk.get("model", "")
+
+                if not first_token:
+                    for choice in chunk.get("choices", []):
+                        if choice.get("delta", {}).get("content"):
+                            ttft_ms = (time.monotonic() - t_start) * 1000.0
+                            first_token = True
+                            break
+
+                if usage := chunk.get("usage"):
+                    prompt_tokens = usage.get("prompt_tokens")
+                    completion_tokens = usage.get("completion_tokens")
+
+    except Exception as exc:
+        error = str(exc)[:500]
+
+    t_end = time.monotonic()
+    e_end = tracker.snapshot_energy_mj()
+    received_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    ttlt_ms = (t_end - t_start) * 1000.0
+
+    energy_j: Optional[float] = None
+    if tracker.available:
+        if e_start is not None and e_end is not None and tracker._use_counter:
+            energy_j = tracker.energy_from_counter(e_start, e_end)
+        else:
+            energy_j = tracker.energy_from_samples(t_start, t_end)
+
+    return RequestResult(
+        request_id=entry.request_id,
+        model=model,
+        mode=entry.mode,
+        priority=entry.priority,
+        status_code=status_code,
+        ttft_ms=ttft_ms,
+        ttlt_ms=ttlt_ms,
+        energy_j=energy_j,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        error=error,
+        t_start=t_start,
+        t_end=t_end,
+        sent_at=sent_at,
+        received_at=received_at,
+        scenario=scenario,
+    )
+
+
+# ── Runners ───────────────────────────────────────────────────────────────
+
+
+def _result_line(r: RequestResult) -> str:
+    parts = [
+        f"TTFT={r.ttft_ms:.0f}ms" if r.ttft_ms is not None else "TTFT=—",
+        f"TTLT={r.ttlt_ms:.0f}ms" if r.ttlt_ms is not None else "TTLT=—",
+    ]
+    if r.energy_j is not None:
+        parts.append(f"E={r.energy_j:.3f}J")
+    if not r.success:
+        parts.append(f"ERR={r.status_code} {(r.error or '')[:60]}".rstrip())
+    return "  ".join(parts)
+
+
+async def run_sequential(
+    workload: list[WorkloadEntry],
+    base_url: str,
+    logos_key: Optional[str],
+    tracker,
+    timeout_s: float,
+    scenario: str,
+    model_map: dict[str, str],
+) -> list[RequestResult]:
+    results: list[RequestResult] = []
+    width = len(str(len(workload)))
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        for i, entry in enumerate(workload):
+            print(f"  [{i+1:{width}}/{len(workload)}] {entry.request_id} ... ", end="", flush=True)
+            r = await _dispatch(
+                client,
+                base_url,
+                logos_key,
+                entry,
+                0.0,
+                tracker,
+                sequential=True,
+                scenario=scenario,
+                model_map=model_map,
+            )
+            results.append(r)
+            print(_result_line(r), flush=True)
+    return results
+
+
+async def run_concurrent(
+    workload: list[WorkloadEntry],
+    base_url: str,
+    logos_key: Optional[str],
+    tracker,
+    timeout_s: float,
+    max_concurrent: int,
+    scenario: str,
+    model_map: dict[str, str],
+) -> list[RequestResult]:
+    sem = asyncio.Semaphore(max_concurrent)
+    results: list[RequestResult] = []
+    completed = 0
+    lock = asyncio.Lock()
+    n = len(workload)
+    width = len(str(n))
+
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+
+        async def _run(entry: WorkloadEntry, start_mono: float) -> None:
+            nonlocal completed
+            async with sem:
+                r = await _dispatch(
+                    client,
+                    base_url,
+                    logos_key,
+                    entry,
+                    start_mono,
+                    tracker,
+                    sequential=False,
+                    scenario=scenario,
+                    model_map=model_map,
+                )
+            async with lock:
+                results.append(r)
+                completed += 1
+                print(f"  [{completed:{width}}/{n}] {r.request_id}  {_result_line(r)}", flush=True)
+
+        start_mono = time.monotonic()
+        await asyncio.gather(*[_run(e, start_mono) for e in workload])
+
+    return results
+
+
+# ── Statistics ────────────────────────────────────────────────────────────
+
+
+def _pct(vals: list[float], p: float) -> float:
+    if not vals:
+        return math.nan
+    s = sorted(vals)
+    k = (len(s) - 1) * p / 100.0
+    lo, hi = int(math.floor(k)), int(math.ceil(k))
+    return s[lo] if lo == hi else s[lo] * (hi - k) + s[hi] * (k - lo)
+
+
+def _stats(vals: list[float], prefix: str) -> dict:
+    if not vals:
+        return {f"{prefix}_{s}": math.nan for s in ("mean", "p50", "p95", "p99")}
+    return {
+        f"{prefix}_mean": sum(vals) / len(vals),
+        f"{prefix}_p50": _pct(vals, 50),
+        f"{prefix}_p95": _pct(vals, 95),
+        f"{prefix}_p99": _pct(vals, 99),
+    }
+
+
+def compute_summary(results: list[RequestResult], scenario: str, energy_method: str) -> dict:
+    ok = [r for r in results if r.success]
+    fail = len(results) - len(ok)
+
+    ttft = [r.ttft_ms for r in ok if r.ttft_ms is not None]
+    ttlt = [r.ttlt_ms for r in ok if r.ttlt_ms is not None]
+    tpot = [r.tpot_ms for r in ok if r.tpot_ms is not None]
+    energy = [r.energy_j for r in ok if r.energy_j is not None]
+    e_tok = [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None]
+    tput = [r.throughput_tok_s for r in ok if r.throughput_tok_s is not None]
+
+    return {
+        "scenario": scenario,
+        "energy_method": energy_method,
+        "total_requests": len(results),
+        "successful_requests": len(ok),
+        "failed_requests": fail,
+        "error_rate_pct": fail / len(results) * 100 if results else math.nan,
+        **_stats(ttft, "ttft_ms"),
+        **_stats(ttlt, "ttlt_ms"),
+        **_stats(tpot, "tpot_ms"),
+        **_stats(energy, "energy_j"),
+        **_stats(e_tok, "energy_per_token_mj"),
+        "throughput_tok_s_mean": sum(tput) / len(tput) if tput else math.nan,
+        "total_prompt_tokens": sum(r.prompt_tokens or 0 for r in ok),
+        "total_completion_tokens": sum(r.completion_tokens or 0 for r in ok),
+        "total_energy_j": sum(energy) if energy else math.nan,
+    }
+
+
+# ── Output ────────────────────────────────────────────────────────────────
+
+
+def _f(v) -> str:
+    if v is None or (isinstance(v, float) and math.isnan(v)):
+        return ""
+    return f"{v:.4f}" if isinstance(v, float) else str(v)
+
+
+_DETAIL_COLS = [
+    "request_id",
+    "model",
+    "scenario",
+    "mode",
+    "priority",
+    "status_code",
+    "ttft_ms",
+    "ttlt_ms",
+    "tpot_ms",
+    "energy_j",
+    "energy_per_token_mj",
+    "throughput_tok_s",
+    "prompt_tokens",
+    "completion_tokens",
+    "sent_at",
+    "received_at",
+    "error",
+]
+
+
+def write_detailed(path: Path, results: list[RequestResult]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=_DETAIL_COLS)
+        w.writeheader()
+        for r in results:
+            w.writerow(
+                {
+                    "request_id": r.request_id,
+                    "model": r.model,
+                    "scenario": r.scenario,
+                    "mode": r.mode,
+                    "priority": r.priority,
+                    "status_code": r.status_code,
+                    "ttft_ms": _f(r.ttft_ms),
+                    "ttlt_ms": _f(r.ttlt_ms),
+                    "tpot_ms": _f(r.tpot_ms),
+                    "energy_j": _f(r.energy_j),
+                    "energy_per_token_mj": _f(r.energy_per_token_mj),
+                    "throughput_tok_s": _f(r.throughput_tok_s),
+                    "prompt_tokens": _f(r.prompt_tokens),
+                    "completion_tokens": _f(r.completion_tokens),
+                    "sent_at": r.sent_at,
+                    "received_at": r.received_at,
+                    "error": r.error or "",
+                }
+            )
+
+
+def write_summary(path: Path, summary: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["metric", "value"])
+        for k, v in summary.items():
+            w.writerow([k, _f(v) if isinstance(v, float) else v])
+
+
+# ── Charts ────────────────────────────────────────────────────────────────
+
+
+def _kde_curve(data: list[float], x_grid: "np.ndarray") -> "np.ndarray":
+    n = len(data)
+    std = float(np.std(data)) or 1.0
+    bw = 1.06 * std * n ** (-0.2)
+    out = np.zeros_like(x_grid, dtype=float)
+    for xi in data:
+        out += np.exp(-0.5 * ((x_grid - xi) / bw) ** 2)
+    return out / (n * bw * math.sqrt(2 * math.pi))
+
+
+def _dist_chart(vals: list[float], title: str, xlabel: str, path: Path) -> None:
+    if not vals or not _PLOT:
+        return
+    fig, ax = plt.subplots(figsize=(10, 5))
+    n_bins = min(60, max(10, len(vals) // 3))
+    ax.hist(vals, bins=n_bins, density=True, alpha=0.6, color="#4C72B0", edgecolor="#1a3a6b", linewidth=0.4)
+    x = np.linspace(min(vals) * 0.9, max(vals) * 1.1, 400)
+    ax.plot(x, _kde_curve(vals, x), color="#1a3a6b", linewidth=1.8)
+    for p, col, lbl in [(50, "#2ca02c", "P50"), (95, "#d62728", "P95"), (99, "#9467bd", "P99")]:
+        v = _pct(vals, p)
+        ax.axvline(v, color=col, linestyle="--", linewidth=1.4, label=f"{lbl}: {v:.1f}")
+    mean_v = sum(vals) / len(vals)
+    ax.axvline(mean_v, color="#ff7f0e", linestyle=":", linewidth=1.6, label=f"Mean: {mean_v:.1f}")
+    ax.set_title(title, fontsize=13)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Density")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def _power_timeline(
+    samples: list[tuple[float, float]],
+    results: list[RequestResult],
+    t0: float,
+    path: Path,
+) -> None:
+    if not _PLOT or not samples:
+        return
+    ts = [(t - t0) for t, _ in samples]
+    pw = [p / 1000.0 for _, p in samples]
+
+    fig, ax = plt.subplots(figsize=(14, 5))
+    ax.plot(ts, pw, color="#2255A0", linewidth=1.0, label="GPU power (W)", zorder=3)
+    ax.fill_between(ts, pw, alpha=0.15, color="#2255A0")
+
+    palette = plt.cm.tab20.colors
+    for i, r in enumerate(sorted(results, key=lambda x: x.t_start)):
+        col = palette[i % len(palette)]
+        x0, x1 = r.t_start - t0, r.t_end - t0
+        ax.axvspan(x0, x1, alpha=0.10, color=col, zorder=1)
+        ax.annotate(
+            r.request_id,
+            xy=((x0 + x1) / 2, 0),
+            xycoords=("data", "axes fraction"),
+            xytext=(0, 2),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=5.5,
+            color=col,
+            rotation=90,
+            zorder=4,
+        )
+
+    ax.set_xlabel("Elapsed time (s)")
+    ax.set_ylabel("Power (W)")
+    ax.set_title("GPU Power Timeline with Request Windows")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def _scatter_energy_ttlt(results: list[RequestResult], path: Path) -> None:
+    if not _PLOT:
+        return
+    ok = [r for r in results if r.success and r.energy_j is not None and r.ttlt_ms is not None]
+    if not ok:
+        return
+    x = [r.ttlt_ms for r in ok]
+    y = [r.energy_j for r in ok]
+    tokens = [r.completion_tokens or 1 for r in ok]
+    fig, ax = plt.subplots(figsize=(8, 5))
+    sc = ax.scatter(x, y, c=tokens, cmap="viridis", alpha=0.75, edgecolors="none", s=40)
+    plt.colorbar(sc, ax=ax, label="completion_tokens")
+    ax.set_xlabel("TTLT (ms)")
+    ax.set_ylabel("Energy (J)")
+    ax.set_title("Energy vs TTLT (color = completion tokens)")
+    ax.grid(True, alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def _per_model_chart(results: list[RequestResult], metric: str, ylabel: str, path: Path) -> None:
+    if not _PLOT:
+        return
+    ok = [r for r in results if r.success]
+    models = sorted({r.model for r in ok})
+    data = [[v for r in ok if r.model == m for v in [getattr(r, metric)] if v is not None] for m in models]
+    if not any(data):
+        return
+    fig, ax = plt.subplots(figsize=(max(8, len(models) * 2), 5))
+    ax.boxplot(data, tick_labels=[m.split("/")[-1] for m in models], patch_artist=True)
+    ax.set_ylabel(ylabel)
+    ax.set_title(f"{ylabel} by Model")
+    ax.grid(True, alpha=0.25, axis="y")
+    plt.xticks(rotation=20, ha="right")
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def _model_switching_chart(
+    results: list[RequestResult],
+    t0: float,
+    path: Path,
+) -> None:
+    """Scatter: x = request start time (s since benchmark start), y = TTLT (ms), color = model."""
+    if not _PLOT:
+        return
+    ok = [r for r in results if r.success and r.ttlt_ms is not None]
+    if not ok:
+        return
+
+    models = sorted({r.model for r in ok})
+    palette = plt.cm.tab10.colors if len(models) <= 10 else plt.cm.tab20.colors
+    color_map = {m: palette[i % len(palette)] for i, m in enumerate(models)}
+
+    fig, axes = plt.subplots(
+        2,
+        1,
+        figsize=(14, 8),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1]},
+    )
+    ax_scatter, ax_model = axes
+
+    # ── top panel: TTLT scatter ──────────────────────────────────────────
+    for model in models:
+        pts = [(r.t_start - t0, r.ttlt_ms) for r in ok if r.model == model]
+        if not pts:
+            continue
+        xs, ys = zip(*pts)
+        ax_scatter.scatter(
+            xs,
+            ys,
+            color=color_map[model],
+            label=model.split("/")[-1],
+            alpha=0.8,
+            s=35,
+            edgecolors="none",
+            zorder=3,
+        )
+
+    # optional: also show TTFT as faint crosses
+    ok_ttft = [r for r in ok if r.ttft_ms is not None]
+    for model in models:
+        pts = [(r.t_start - t0, r.ttft_ms) for r in ok_ttft if r.model == model]
+        if not pts:
+            continue
+        xs, ys = zip(*pts)
+        ax_scatter.scatter(
+            xs,
+            ys,
+            color=color_map[model],
+            marker="+",
+            alpha=0.35,
+            s=25,
+            linewidths=0.8,
+            zorder=2,
+        )
+
+    ax_scatter.set_ylabel("Latency (ms)")
+    ax_scatter.set_title("Model-Switching Timeline  (● TTLT  + TTFT)")
+    ax_scatter.legend(
+        title="Model",
+        fontsize=8,
+        title_fontsize=8,
+        loc="upper right",
+        framealpha=0.8,
+    )
+    ax_scatter.grid(True, alpha=0.25)
+
+    # ── bottom panel: which model was active at each request ─────────────
+    model_indices = {m: i for i, m in enumerate(models)}
+    xs_all = [r.t_start - t0 for r in ok]
+    ys_all = [model_indices[r.model] for r in ok]
+    colors_all = [color_map[r.model] for r in ok]
+
+    ax_model.scatter(xs_all, ys_all, c=colors_all, s=20, alpha=0.9, edgecolors="none")
+    ax_model.set_yticks(range(len(models)))
+    ax_model.set_yticklabels([m.split("/")[-1] for m in models], fontsize=7)
+    ax_model.set_xlabel("Elapsed time (s)")
+    ax_model.set_ylabel("Model")
+    ax_model.grid(True, alpha=0.2, axis="x")
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def generate_charts(out_dir: Path, results: list[RequestResult], tracker, t0: float) -> None:
+    if not _PLOT:
+        print("  [charts] matplotlib/numpy not available — skipping.")
+        return
+    ok = [r for r in results if r.success]
+    _dist_chart(
+        [r.ttft_ms for r in ok if r.ttft_ms is not None], "TTFT Distribution", "TTFT (ms)", out_dir / "chart_ttft.png"
+    )
+    _dist_chart(
+        [r.ttlt_ms for r in ok if r.ttlt_ms is not None], "TTLT Distribution", "TTLT (ms)", out_dir / "chart_ttlt.png"
+    )
+    energy = [r.energy_j for r in ok if r.energy_j is not None]
+    if energy:
+        _dist_chart(energy, "Energy per Request", "Energy (J)", out_dir / "chart_energy_per_request.png")
+        _dist_chart(
+            [r.energy_per_token_mj for r in ok if r.energy_per_token_mj is not None],
+            "Energy per Output Token",
+            "Energy (mJ/token)",
+            out_dir / "chart_energy_per_token.png",
+        )
+    _power_timeline(tracker.power_samples(), results, t0, out_dir / "chart_power_timeline.png")
+    _scatter_energy_ttlt(results, out_dir / "chart_energy_vs_ttlt.png")
+    _per_model_chart(results, "ttft_ms", "TTFT (ms)", out_dir / "chart_ttft_by_model.png")
+    _per_model_chart(results, "energy_j", "Energy (J)", out_dir / "chart_energy_by_model.png")
+    _model_switching_chart(results, t0, out_dir / "chart_model_switching.png")
+    print(f"  [charts] Written to {out_dir}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Benchmark Logos (or Ollama): TTFT, TTLT, GPU energy per request.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    p.add_argument(
+        "--scenario",
+        default="logos-sleep",
+        choices=["logos-sleep", "logos-nosleep", "ollama"],
+        help=(
+            "logos-sleep:   Send to Logos; sleep mode enabled server-side. "
+            "logos-nosleep: Send to Logos; sleep mode disabled server-side. "
+            "ollama:        Send directly to Ollama (no logos_key; model names "
+            "translated via benchmark_config.py)."
+        ),
+    )
+
+    # Workload source
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--workload", type=Path, metavar="CSV", help="Workload CSV from prepare_benchmark.py.")
+    src.add_argument("--prompts", type=Path, metavar="TXT", help="Plain-text file with one prompt per line.")
+
+    # Connection
+    p.add_argument("--logos-url", default="http://localhost:8080", help="Base URL of Logos or Ollama server.")
+    p.add_argument(
+        "--logos-key", default=None, help="Logos API key. Required for logos-sleep and logos-nosleep scenarios."
+    )
+
+    # Prompt-mode extras
+    p.add_argument("--model", default="", help="Model name (overrides workload CSV body; required with --prompts).")
+    p.add_argument("--max-tokens", type=int, default=512)
+    p.add_argument(
+        "--interval-ms", type=float, default=0.0, help="Arrival offset between prompts in ms (--prompts mode)."
+    )
+
+    # ── GPU source: remote (default) or local ────────────────────────────
+    gpu_grp = p.add_argument_group(
+        "GPU energy measurement",
+        "Use --gpu-host to measure energy on remote vLLM nodes via SSH (typical setup). "
+        "Use --gpu-indices when the GPU is local (e.g. direct Ollama on this machine).",
+    )
+    gpu_excl = gpu_grp.add_mutually_exclusive_group()
+    gpu_excl.add_argument(
+        "--gpu-host",
+        nargs="+",
+        metavar="HOST",
+        help="Hostnames/IPs of the GPU nodes running vLLM. " "The NVML poller is launched on each node via SSH.",
+    )
+    gpu_excl.add_argument(
+        "--gpu-indices",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="IDX",
+        help="Local NVML GPU device indices (only when GPU is on this machine).",
+    )
+    gpu_grp.add_argument("--gpu-ssh-user", default=None, help="SSH username for GPU nodes (default: current user).")
+    gpu_grp.add_argument("--gpu-ssh-key", default=None, metavar="PATH", help="Path to SSH private key for GPU nodes.")
+    gpu_grp.add_argument("--gpu-ssh-port", type=int, default=22, help="SSH port on GPU nodes.")
+    gpu_grp.add_argument(
+        "--gpu-device-index", type=int, default=0, help="GPU device index on each remote node (passed to NVML)."
+    )
+    gpu_grp.add_argument("--poll-interval-ms", type=float, default=100.0, help="GPU power-poll interval (ms).")
+
+    # Concurrency / timing
+    p.add_argument(
+        "--sequential",
+        action="store_true",
+        help="Send one request at a time (ignores arrival offsets). " "Cleanest per-request energy attribution.",
+    )
+    p.add_argument("--max-concurrent", type=int, default=64)
+    p.add_argument("--request-timeout-s", type=float, default=600.0)
+
+    # Output
+    p.add_argument("--output-dir", type=Path, default=Path("benchmark_results"))
+
+    return p
+
+
+async def _async_main(args: argparse.Namespace) -> None:
+    # ── Validate ──────────────────────────────────────────────────────────
+    if args.scenario != "ollama" and not args.logos_key:
+        print(f"Error: --logos-key is required for scenario '{args.scenario}'.", file=sys.stderr)
+        sys.exit(1)
+
+    # ── Load workload ─────────────────────────────────────────────────────
+    if args.workload:
+        workload = _load_csv(args.workload, model_override=args.model or None)
+        workload_name = args.workload.stem
+    else:
+        if not args.model:
+            print("Error: --model is required when using --prompts.", file=sys.stderr)
+            sys.exit(1)
+        workload = _load_prompts(args.prompts, args.model, args.max_tokens, args.interval_ms)
+        workload_name = args.prompts.stem
+
+    # ── Load model map for Ollama scenario ────────────────────────────────
+    model_map: dict[str, str] = {}
+    if args.scenario == "ollama":
+        model_map = _load_config_attr("OLLAMA_MODEL_MAP", {})
+        if model_map:
+            print(f"  [config] Loaded OLLAMA_MODEL_MAP ({len(model_map)} entries).")
+
+    mode_str = "sequential" if args.sequential else f"concurrent (max {args.max_concurrent})"
+    print(f"Scenario : {args.scenario}")
+    print(f"Workload : {len(workload)} request(s) from '{workload_name}'")
+    print(f"Target   : {args.logos_url}")
+    print(f"Mode     : {mode_str}")
+
+    # ── Build tracker ─────────────────────────────────────────────────────
+    if args.gpu_host:
+        import getpass
+
+        ssh_user = args.gpu_ssh_user or getpass.getuser()
+        print(f"GPU      : remote SSH → {args.gpu_host}  user={ssh_user}  device={args.gpu_device_index}")
+        tracker = RemoteGPUTracker(
+            hosts=args.gpu_host,
+            ssh_user=ssh_user,
+            ssh_key_path=args.gpu_ssh_key,
+            ssh_port=args.gpu_ssh_port,
+            gpu_index=args.gpu_device_index,
+            poll_interval_ms=args.poll_interval_ms,
+        )
+    else:
+        indices = args.gpu_indices if args.gpu_indices is not None else [0]
+        print(f"GPU      : local NVML  indices={indices}")
+        tracker = GPUTracker(indices, args.poll_interval_ms)
+
+    tracker.start()
+
+    # ── Run ───────────────────────────────────────────────────────────────
+    print("\nRunning...")
+    t_run_start = time.monotonic()
+
+    if args.sequential:
+        results = await run_sequential(
+            workload,
+            args.logos_url,
+            args.logos_key,
+            tracker,
+            args.request_timeout_s,
+            args.scenario,
+            model_map,
+        )
+    else:
+        results = await run_concurrent(
+            workload,
+            args.logos_url,
+            args.logos_key,
+            tracker,
+            args.request_timeout_s,
+            args.max_concurrent,
+            args.scenario,
+            model_map,
+        )
+
+    t_run_end = time.monotonic()
+    tracker.stop()
+    wall_s = t_run_end - t_run_start
+
+    # ── Write outputs ─────────────────────────────────────────────────────
+    summary = compute_summary(results, args.scenario, tracker.method)
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = args.output_dir / f"{ts}_{args.scenario}_{workload_name}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    write_detailed(out_dir / "results_detailed.csv", results)
+    write_summary(out_dir / "results_summary.csv", summary)
+    generate_charts(out_dir, results, tracker, t_run_start)
+
+    gpu_info = (
+        {
+            "hosts": args.gpu_host,
+            "device_index": args.gpu_device_index,
+            "ssh_user": (args.gpu_ssh_user or ""),
+            "ssh_port": args.gpu_ssh_port,
+        }
+        if args.gpu_host
+        else {"local_indices": args.gpu_indices or [0]}
+    )
+    (out_dir / "run_meta.json").write_text(
+        json.dumps(
+            {
+                "scenario": args.scenario,
+                "logos_url": args.logos_url,
+                "workload": str(args.workload or args.prompts),
+                "mode": mode_str,
+                "gpu": gpu_info,
+                "poll_interval_ms": args.poll_interval_ms,
+                "energy_method": tracker.method,
+                "total_wall_time_s": round(wall_s, 3),
+                "request_count": len(results),
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    # ── Summary ───────────────────────────────────────────────────────────
+    ok = summary["successful_requests"]
+    fail = summary["failed_requests"]
+    print(f"\n{'='*58}")
+    print(f"  Scenario : {args.scenario}")
+    print(f"  Wall time: {wall_s:.1f}s")
+    print(f"  Requests : {summary['total_requests']} total  {ok} ok  {fail} failed")
+
+    def _row(label: str, prefix: str, unit: str) -> None:
+        mean = summary.get(f"{prefix}_mean", math.nan)
+        p50 = summary.get(f"{prefix}_p50", math.nan)
+        p95 = summary.get(f"{prefix}_p95", math.nan)
+        if math.isnan(mean):
+            return
+        print(f"  {label:<14}: mean={mean:>8.1f}  p50={p50:>8.1f}  p95={p95:>8.1f}  ({unit})")
+
+    _row("TTFT", "ttft_ms", "ms")
+    _row("TTLT", "ttlt_ms", "ms")
+    _row("TPOT", "tpot_ms", "ms/tok")
+
+    if not math.isnan(summary.get("energy_j_mean", math.nan)):
+        _row("Energy/req", "energy_j", "J")
+        _row("Energy/tok", "energy_per_token_mj", "mJ/tok")
+        total_e = summary.get("total_energy_j", math.nan)
+        if not math.isnan(total_e):
+            print(f"  Total GPU energy (sum of per-request windows): {total_e:.2f} J")
+    else:
+        print("  Energy   : not measured (GPU tracker unavailable)")
+
+    print(f"  Results  : {out_dir}")
+    print(f"{'='*58}")
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/logos/benchmarks/prepare_benchmark.py
+++ b/logos/benchmarks/prepare_benchmark.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Prepare GSM8K workload CSVs for the Logos benchmark.
+
+Downloads openai/gsm8k from HuggingFace and produces two workload CSV files —
+one for the 2-LLM configuration and one for the 5-LLM configuration — that
+benchmark_logos.py can consume directly via --workload.
+
+Models are assigned round-robin so each LLM receives an equal (±1) share of
+the requests. The assignment is deterministic (same seed → same assignment).
+
+Requirements:
+    pip install datasets
+
+Usage:
+    # All 1319 test examples, 1 req/s arrival rate:
+    python prepare_benchmark.py
+
+    # First 200 examples, 0.5 req/s:
+    python prepare_benchmark.py --num-samples 200 --rps 0.5
+
+    # Train split, all examples, 2 req/s:
+    python prepare_benchmark.py --split train --rps 2.0
+
+    # No arrival offsets (use --sequential in benchmark_logos.py):
+    python prepare_benchmark.py --rps 0
+
+Output (in --output-dir):
+    workload_gsm8k_2llm.csv   — requests using 2 LLMs
+    workload_gsm8k_5llm.csv   — requests using 5 LLMs
+
+Each CSV row contains:
+    request_id, arrival_offset, mode, priority, body_json,
+    question, answer, model_assigned
+
+The body_json field holds the full OpenAI chat completions payload (with
+model, messages, max_tokens) ready for benchmark_logos.py to send.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+try:
+    from datasets import load_dataset
+except ImportError:
+    print(
+        "Error: 'datasets' library not installed.\n" "       Run: pip install datasets",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Import model config from the sibling file
+try:
+    from benchmark_config import GSM8K_MAX_TOKENS, GSM8K_SYSTEM_PROMPT, MODELS_2, MODELS_5
+except ImportError as exc:
+    print(f"Error: cannot import benchmark_config.py: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Workload construction ─────────────────────────────────────────────────
+
+
+def build_workload(
+    examples: list[dict],
+    models: list[str],
+    rps: float,
+    max_tokens: int,
+) -> list[dict]:
+    """
+    Assign models round-robin and compute uniform arrival offsets.
+
+    rps = 0  →  all arrival offsets are 0 (use --sequential in benchmark).
+    rps > 0  →  offset_i = i * (1000 / rps) ms.
+    """
+    interval_ms = (1000.0 / rps) if rps > 0 else 0.0
+    rows = []
+
+    for i, ex in enumerate(examples):
+        model = models[i % len(models)]
+        body = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": GSM8K_SYSTEM_PROMPT},
+                {"role": "user", "content": ex["question"]},
+            ],
+            "max_tokens": max_tokens,
+        }
+        rows.append(
+            {
+                "request_id": f"gsm8k-{i + 1:04d}",
+                "arrival_offset": round(i * interval_ms, 3),  # ms
+                "mode": "interactive",
+                "priority": "mid",
+                "body_json": json.dumps(body, ensure_ascii=False),
+                # Reference columns (not used by benchmark_logos.py, but useful for
+                # evaluating model accuracy after the benchmark run)
+                "question": ex["question"],
+                "answer": ex["answer"],
+                "model_assigned": model,
+            }
+        )
+    return rows
+
+
+_FIELDNAMES = [
+    "request_id",
+    "arrival_offset",
+    "mode",
+    "priority",
+    "body_json",
+    "question",
+    "answer",
+    "model_assigned",
+]
+
+
+def write_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def print_distribution(rows: list[dict], models: list[str]) -> None:
+    counts: dict[str, int] = {m: 0 for m in models}
+    for r in rows:
+        counts[r["model_assigned"]] += 1
+    total = len(rows)
+    for model, count in counts.items():
+        bar = "█" * int(count / total * 40)
+        print(f"    {model:<40} {count:>5}  ({count / total * 100:.1f}%)  {bar}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare GSM8K workload CSVs for the Logos benchmark.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=["train", "test"],
+        help="GSM8K dataset split to use. 'test' has 1 319 examples, 'train' has 7 473.",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Limit to the first N examples (default: all examples in the split).",
+    )
+    parser.add_argument(
+        "--rps",
+        type=float,
+        default=1.0,
+        metavar="RATE",
+        help=(
+            "Arrival rate in requests per second. "
+            "Determines the arrival_offset column (offset_i = i * 1000/rps ms). "
+            "Set to 0 to give all requests offset=0 and use --sequential in the benchmark."
+        ),
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=GSM8K_MAX_TOKENS,
+        help="max_tokens value written into each request's body_json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("workloads"),
+        help="Directory where the workload CSVs will be written.",
+    )
+    args = parser.parse_args()
+
+    # ── Download ──────────────────────────────────────────────────────────
+    print(f"Downloading openai/gsm8k ({args.split} split) from HuggingFace...")
+    dataset = load_dataset("openai/gsm8k", "main", split=args.split)
+    examples: list[dict] = list(dataset)
+
+    if args.num_samples is not None:
+        examples = examples[: args.num_samples]
+        print(f"  Using first {len(examples)} of {len(dataset)} examples.")
+    else:
+        print(f"  Using all {len(examples)} examples.")
+
+    if args.rps > 0:
+        total_duration_s = (len(examples) - 1) * (1.0 / args.rps)
+        print(f"  Arrival rate: {args.rps} req/s → workload spans {total_duration_s:.0f}s total.")
+    else:
+        print("  Arrival rate: 0 (all offsets = 0 — use --sequential in benchmark_logos.py).")
+
+    print()
+
+    # ── Build & write one CSV per LLM config ──────────────────────────────
+    configs = [
+        ("2llm", MODELS_2),
+        ("5llm", MODELS_5),
+    ]
+
+    for label, models in configs:
+        print(f"Config '{label}': {len(models)} model(s)")
+        for m in models:
+            print(f"    • {m}")
+
+        rows = build_workload(examples, models, args.rps, args.max_tokens)
+        print(f"  Distribution ({len(rows)} requests):")
+        print_distribution(rows, models)
+
+        out_path = args.output_dir / f"workload_gsm8k_{label}.csv"
+        write_csv(out_path, rows)
+        print(f"  → Written: {out_path}")
+        print()
+
+    print("Done. Pass a workload to the benchmark with:")
+    print(f"  python benchmark_logos.py --workload {args.output_dir}/workload_gsm8k_2llm.csv ...")
+    print(f"  python benchmark_logos.py --workload {args.output_dir}/workload_gsm8k_5llm.csv ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/logos/benchmarks/requirements.txt
+++ b/logos/benchmarks/requirements.txt
@@ -1,0 +1,11 @@
+# benchmark_logos.py (Logos host)
+httpx>=0.27
+paramiko>=3.4
+numpy>=1.26
+matplotlib>=3.8
+
+# prepare_benchmark.py only
+datasets>=2.20
+
+# GPU nodes only (install there with: pip install nvidia-ml-py)
+# nvidia-ml-py>=12.0

--- a/logos/logos-ui/app/statistics.tsx
+++ b/logos/logos-ui/app/statistics.tsx
@@ -2657,6 +2657,7 @@ export default function Statistics() {
                         providerMeta={vramProviderMetaByName}
                         lanesByProvider={lanesByProvider}
                         activeProvider={selectedVramProvider}
+                        apiKey={apiKey}
                       />
                     )}
                   </ChartCard>

--- a/logos/logos-ui/components/statistics/worker-gpu-panel.tsx
+++ b/logos/logos-ui/components/statistics/worker-gpu-panel.tsx
@@ -1,14 +1,17 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { View } from "react-native";
 
 import { Text } from "@/components/ui/text";
 import { HStack } from "@/components/ui/hstack";
 import { VStack } from "@/components/ui/vstack";
+import { Button, ButtonText } from "@/components/ui/button";
+import { API_BASE } from "@/components/statistics/constants";
 import EmptyState from "@/components/statistics/empty-state";
 import type { DeviceInfo, LaneSignalData } from "@/components/statistics/types";
 import type { VramV2Sample } from "@/hooks/use-stats-websocket-v2";
 
 type ProviderMeta = {
+  provider_id?: number;
   connected?: boolean;
   connection_state?: string;
 };
@@ -21,7 +24,15 @@ type WorkerGpuPanelProps = {
   // Provider selected by the shared selector in statistics.tsx. If null or not
   // in this panel's providers list, falls back to the first known provider.
   activeProvider: string | null;
+  // Admin API key — when set, surfaces the "Calibrate uncalibrated" action.
+  apiKey?: string | null;
 };
+
+type CalibrateState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string };
 
 function ProgressBar({ pct, color }: { pct: number; color: string }) {
   const w = Math.max(0, Math.min(100, pct));
@@ -181,7 +192,9 @@ export default function WorkerGpuPanel({
   providerMeta,
   lanesByProvider,
   activeProvider: activeProviderProp,
+  apiKey,
 }: WorkerGpuPanelProps) {
+  const [calibrateState, setCalibrateState] = useState<CalibrateState>({ kind: "idle" });
   const providers = useMemo(
     () =>
       Object.keys(providerLatestSamples).sort((a, b) => {
@@ -226,6 +239,41 @@ export default function WorkerGpuPanel({
     (l) => l.runtime_state === "running" || l.active_requests > 0
   ).length;
 
+  const activeProviderId = activeProvider ? providerMeta[activeProvider]?.provider_id ?? null : null;
+  const canCalibrate = !!apiKey && activeProviderId != null && !isOffline;
+
+  const handleCalibrateUncalibrated = async () => {
+    if (!apiKey || activeProviderId == null) return;
+    setCalibrateState({ kind: "loading" });
+    try {
+      const resp = await fetch(`${API_BASE}/logosdb/providers/logosnode/calibrate_uncalibrated`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          logos_key: apiKey,
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ logos_key: apiKey, provider_id: activeProviderId }),
+      });
+      const body = await resp.json().catch(() => ({} as Record<string, unknown>));
+      if (!resp.ok) {
+        const detail = typeof body?.error === "string" ? body.error : `HTTP ${resp.status}`;
+        setCalibrateState({ kind: "error", message: detail });
+        return;
+      }
+      const count = typeof body?.count === "number" ? body.count : 0;
+      const models = Array.isArray(body?.models) ? (body.models as string[]) : [];
+      const message =
+        count === 0
+          ? "No uncalibrated models on this worker."
+          : `Calibrating ${count} model(s): ${models.join(", ")}`;
+      setCalibrateState({ kind: "success", message });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Request failed";
+      setCalibrateState({ kind: "error", message });
+    }
+  };
+
   if (!providers.length) {
     return <EmptyState message="No providers connected." />;
   }
@@ -251,7 +299,30 @@ export default function WorkerGpuPanel({
             </Text>
           </View>
         )}
+        {apiKey && (
+          <Button
+            size="xs"
+            variant="outline"
+            onPress={handleCalibrateUncalibrated}
+            isDisabled={!canCalibrate || calibrateState.kind === "loading"}
+            className="ml-auto"
+          >
+            <ButtonText>
+              {calibrateState.kind === "loading" ? "Calibrating…" : "Calibrate uncalibrated"}
+            </ButtonText>
+          </Button>
+        )}
       </HStack>
+      {calibrateState.kind === "success" && (
+        <View className="rounded-md bg-emerald-500/10 px-3 py-1.5">
+          <Text className="text-xs text-emerald-600">{calibrateState.message}</Text>
+        </View>
+      )}
+      {calibrateState.kind === "error" && (
+        <View className="rounded-md bg-red-500/10 px-3 py-1.5">
+          <Text className="text-xs text-red-500">{calibrateState.message}</Text>
+        </View>
+      )}
 
       {/* GPU cards */}
       <View style={{ opacity: isOffline ? 0.5 : 1 }}>

--- a/logos/logos-workernode/config.yml
+++ b/logos/logos-workernode/config.yml
@@ -42,6 +42,15 @@ engines:
     flashinfer_logdest: stderr
     nccl_debug: WARN
     nccl_debug_subsys: INIT
+    # Node-wide kill switch for vLLM sleep mode. When omitted or false,
+    # individual lanes/models keep their default behaviour (the Logos
+    # server enables sleep_mode for capability-served lanes). When true,
+    # every vLLM lane on this node is forced to enable_sleep_mode=false,
+    # overriding both per-model overrides below and the server's request.
+    # The Logos server is informed via sleep_state="unsupported" on each
+    # lane and via sleep_mode_disabled in WorkerRuntimeStatus, so the
+    # planner falls back to stop/start for VRAM reclamation here.
+    disable_sleep_mode: false
     # Turing (SM 7.5) workaround for AWQ + TP=2 on Quadro RTX 5000:
     # force AWQ path, disable vLLM custom all-reduce kernels (PCIe, no NVLink),
     # disable NCCL P2P transfers, and run in eager mode for SM 7.5 stability.

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -2043,8 +2043,11 @@ def calibrate_with_tp_escalation(
     result = _try_calibrate(current_plan, **cal_kwargs)
 
     # Auto-retry with --trust-remote-code when vLLM demands it.
+    # vLLM phrasings seen in the wild:
+    #   "Please pass the argument `trust_remote_code=True`..."
+    #   "The repository ... contains custom code which must be executed..."
     _err = result.error or ""
-    if not result.success and "trust_remote_code=True" in _err:
+    if not result.success and ("trust_remote_code=True" in _err or "contains custom code" in _err):
         logger.info(
             "  %s requires trust_remote_code — adding flag and retrying",
             model_name,

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -36,6 +36,7 @@ import urllib.parse
 import urllib.request
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -66,6 +67,7 @@ _KV_CACHE_VRAM_CAP_RATIO = 0.8  # fraction of total GPU VRAM used as KV search c
 _FINAL_MEASUREMENT_RETRIES = 3  # retries for the final VRAM measurement startup
 _FAILED_COMMANDS_FILE = "calibration_failed_commands.txt"
 _SUCCEEDED_COMMANDS_FILE = "calibration_succeeded_commands.txt"
+_UNSUPPORTED_MODELS_FILE = "calibration_unsupported_models.txt"
 
 # ---------------------------------------------------------------------------
 # ANSI colours for calibration search visualisation
@@ -225,6 +227,320 @@ def _remove_failed_command(failed_path: Path, fingerprint: str) -> None:
     remaining = [ln for ln in lines if ln.strip() != fingerprint]
     if len(remaining) < len(lines):
         failed_path.write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Model-level "do not retry" blacklist
+#
+# The per-command blacklist above records (model, tp, kv_cache, …) tuples that
+# OOMed. That works for kv-size-sensitive failures: shrink the kv and retry.
+#
+# But some failures are kv-independent and tied to the model identity itself:
+# wrong HuggingFace repo id, missing config.json, gated repo with no token,
+# architecture vLLM doesn't recognise. Probing other kv sizes can't fix them —
+# each probe just produces an identical failure and adds another junk line to
+# the per-command blacklist (and another stuck-GPU recovery to vLLM's restart
+# logic). We need a coarser "do not retry this MODEL at all" record.
+#
+# Adding a pattern: append to ``_FATAL_LOAD_ERROR_PATTERNS`` below. Keep
+# patterns NARROW — only error signatures that prove the failure is (a)
+# deterministic, (b) about the model itself (not the GPU or vLLM version
+# or some transient I/O issue), and (c) unfixable by kv-cache tuning.
+# When in doubt, leave it out — a missed pattern just means we waste one
+# more calibration window; an over-eager one permanently parks a model
+# that would have worked with smaller kv.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FatalLoadErrorPattern:
+    """A vLLM log signature that proves the model can never load on this worker.
+
+    Matched as a substring against the vLLM log tail captured after a probe
+    failure. Case-sensitive — vLLM's own error strings are stable, so
+    fuzzy-matching is unnecessary and just invites false positives.
+    """
+
+    needle: str
+    reason_code: str  # short, kebab-case; surfaced in logs and the persisted file
+    description: str  # human-readable, shown to ops in the file and in error responses
+
+
+_FATAL_LOAD_ERROR_PATTERNS: tuple[FatalLoadErrorPattern, ...] = (
+    FatalLoadErrorPattern(
+        needle="Invalid repository ID or local directory specified",
+        reason_code="invalid-repo-id",
+        description=(
+            "vLLM cannot resolve the model name to either a Hugging Face "
+            "repository or a local directory containing config.json. The "
+            "identifier is misspelled, the repository is private/withdrawn, "
+            "or the local directory is missing config.json / params.json."
+        ),
+    ),
+    FatalLoadErrorPattern(
+        needle="Cannot access gated repo",
+        reason_code="gated-repo-no-token",
+        description=(
+            "Hugging Face flags this repository as gated. The worker has no "
+            "HF token (or the token lacks access). Fix by adding a "
+            "HUGGING_FACE_HUB_TOKEN with read access to the repo before "
+            "removing this entry."
+        ),
+    ),
+    FatalLoadErrorPattern(
+        needle="does not recognize this architecture",
+        reason_code="unsupported-architecture",
+        description=(
+            "The installed vLLM build does not implement this model's "
+            "architecture. Upgrade vLLM (and remove this entry) if support "
+            "has been added since this worker was deployed."
+        ),
+    ),
+)
+
+
+def _classify_fatal_load_error(log_tail: str) -> FatalLoadErrorPattern | None:
+    """Return the first matching :class:`FatalLoadErrorPattern`, or None.
+
+    Conservative by design: only patterns explicitly listed in
+    ``_FATAL_LOAD_ERROR_PATTERNS`` qualify. CUDA OOM, network blips, NCCL
+    handshake failures, and other transient/recoverable issues deliberately
+    don't match — the kv-cache binary search exists to handle those.
+    """
+    if not log_tail:
+        return None
+    for pattern in _FATAL_LOAD_ERROR_PATTERNS:
+        if pattern.needle in log_tail:
+            return pattern
+    return None
+
+
+@dataclass(frozen=True)
+class UnsupportedModelEntry:
+    """One line in ``calibration_unsupported_models.txt``.
+
+    Lines are tab-separated::
+
+        <model_name>\\t<reason_code>\\t<recorded_at>\\t<description>
+
+    Lines starting with '#' or blank lines are treated as comments. Multiple
+    lines for the same model are tolerated on read — the most recent wins.
+    Operators clean up entries by deleting the relevant lines when the
+    underlying issue is fixed (bad model name corrected, gated-repo token
+    added, vLLM upgraded, …).
+    """
+
+    model: str
+    reason_code: str
+    recorded_at: str  # ISO-8601 UTC, e.g. "2026-06-04T19:46:51Z"
+    description: str
+
+    def to_line(self) -> str:
+        # Defensive: strip embedded tabs/newlines so a misformatted
+        # description can never corrupt the file format.
+        def _safe(s: str) -> str:
+            return s.replace("\t", " ").replace("\n", " ").strip()
+
+        return "\t".join(
+            (
+                _safe(self.model),
+                _safe(self.reason_code),
+                _safe(self.recorded_at),
+                _safe(self.description),
+            )
+        )
+
+
+def _load_unsupported_models(path: Path) -> dict[str, UnsupportedModelEntry]:
+    """Read the unsupported-models file, keyed by model name (latest entry wins)."""
+    if not path.exists():
+        return {}
+    entries: dict[str, UnsupportedModelEntry] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 4:
+            # Tolerate older/partial lines — best-effort upgrade in-place.
+            model = parts[0].strip() if parts else ""
+            if not model:
+                continue
+            entries[model] = UnsupportedModelEntry(
+                model=model,
+                reason_code=parts[1].strip() if len(parts) > 1 else "unknown",
+                recorded_at=parts[2].strip() if len(parts) > 2 else "",
+                description=parts[3].strip() if len(parts) > 3 else "",
+            )
+            continue
+        entries[parts[0].strip()] = UnsupportedModelEntry(
+            model=parts[0].strip(),
+            reason_code=parts[1].strip(),
+            recorded_at=parts[2].strip(),
+            description=parts[3].strip(),
+        )
+    return entries
+
+
+_UNSUPPORTED_FILE_HEADER = (
+    "# calibration_unsupported_models.txt — models that calibration will never\n"
+    "# retry on this worker until an operator removes the relevant line.\n"
+    "#\n"
+    "# Format (tab-separated):\n"
+    "#   <model_name>\\t<reason_code>\\t<iso_timestamp>\\t<description>\n"
+    "#\n"
+    "# Reason codes are defined by FatalLoadErrorPattern.reason_code in\n"
+    "# logos_worker_node/calibration.py. Remove a line after fixing the\n"
+    "# underlying issue (e.g. wrong model name corrected in config.yml,\n"
+    "# gated-repo HF token added, vLLM upgraded) to let the next maintenance\n"
+    "# window pick the model up again.\n"
+)
+
+
+def _record_unsupported_model(path: Path, entry: UnsupportedModelEntry) -> None:
+    """Persist *entry*. If the model is already present, leave the existing
+    line in place and append a new one — keeping prior diagnostic context
+    visible to operators without duplicating the read-side dedup logic.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(_UNSUPPORTED_FILE_HEADER, encoding="utf-8")
+    with path.open("a", encoding="utf-8") as f:
+        f.write(entry.to_line() + "\n")
+    logger.warning(
+        "  Recorded model-level unsupported entry → %s  (%s, %s)",
+        path,
+        entry.model,
+        entry.reason_code,
+    )
+
+
+def _remove_unsupported_model(path: Path, model: str) -> int:
+    """Remove all entries for *model* from the file. Returns the number of
+    lines removed. Used when calibration succeeds despite a prior entry
+    (operator manually cleared the underlying issue and re-ran).
+    """
+    if not path.exists():
+        return 0
+    lines = path.read_text(encoding="utf-8").splitlines()
+    remaining: list[str] = []
+    removed = 0
+    for ln in lines:
+        stripped = ln.strip()
+        if not stripped or stripped.startswith("#"):
+            remaining.append(ln)
+            continue
+        head = stripped.split("\t", 1)[0].strip()
+        if head == model:
+            removed += 1
+            continue
+        remaining.append(ln)
+    if removed:
+        path.write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
+    return removed
+
+
+def is_model_unsupported(log_dir: Path, model: str) -> UnsupportedModelEntry | None:
+    """Public helper for callers outside this module (e.g. logos_bridge).
+
+    Returns the most recent :class:`UnsupportedModelEntry` for *model*, or
+    None if the model has no entry on this worker.
+    """
+    path = log_dir / _UNSUPPORTED_MODELS_FILE
+    return _load_unsupported_models(path).get(model)
+
+
+# ---------------------------------------------------------------------------
+# Node-level transient failures (storage EIO, fs read-only, etc.)
+#
+# Unlike _FATAL_LOAD_ERROR_PATTERNS (which marks the *model* permanently
+# unsupported), these patterns indicate the *node* is in a degraded state
+# that affects every model on it. Examples we've actually seen in prod:
+#
+#   - Ceph RBD-backed nbd0 device remounted read-only after a network
+#     blip → every HF cache directory read returns EIO → 86 garbage
+#     entries added to calibration_failed_commands.txt in ~10 minutes
+#     before we caught it (deioma, 2026-06-04).
+#
+# When _try_start sees one of these in the vLLM log tail, it MUST NOT:
+#   - write to the per-command blacklist (calibration_failed_commands.txt)
+#   - write to the per-model unsupported list (calibration_unsupported_models.txt)
+#
+# It SHOULD:
+#   - log loudly (this will surface in worker logs and, via the bridge,
+#     server logs too — feature #3 wires this through the heartbeat to
+#     the master so the orchestrator stops scheduling calibrations on
+#     unhealthy nodes),
+#   - abort the kv-cache search immediately (every probe will fail
+#     identically until the underlying issue is fixed),
+#   - return a CalibrationResult with ``node_unhealthy_reason`` set so
+#     the bridge can update node health state in the runtime status.
+#
+# Adding a pattern: append to ``_NODE_LEVEL_TRANSIENT_PATTERNS`` below.
+# Keep patterns NARROW — only signatures that are unambiguously
+# node-environment-level (storage, kernel, hardware), never a vLLM
+# argument or model identity issue. When in doubt, leave it out.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NodeTransientErrorPattern:
+    """A vLLM (or kernel-surfaced) log signature pointing at node-level
+    degradation that no kv-cache probe can recover from.
+
+    Matched as a substring against the vLLM log tail captured after a
+    probe failure. Case-sensitive.
+    """
+
+    needle: str
+    reason_code: str  # short kebab-case identifier surfaced in worker + master logs
+    description: str  # human-readable, shown to ops
+
+
+_NODE_LEVEL_TRANSIENT_PATTERNS: tuple[NodeTransientErrorPattern, ...] = (
+    NodeTransientErrorPattern(
+        # Kernel reports EIO when the backing device returns hard read errors
+        # (bad disk, network block device that lost its OSD, Ceph PG in
+        # recovery, …). Files exist on the filesystem but reading them
+        # returns Errno 5.
+        needle="Input/output error",
+        reason_code="filesystem-eio",
+        description=(
+            "Filesystem reads are failing with EIO (Errno 5). The backing "
+            "storage is degraded or disconnected. Investigate the device "
+            "(e.g. `dmesg | grep -E 'nbd|EXT4'`, `findmnt`) and restore "
+            "connectivity or reboot the node."
+        ),
+    ),
+    NodeTransientErrorPattern(
+        # Less common — usually reads (EIO) appear before writes. Kept
+        # because it's the unambiguous "kernel remounted r/o" signal.
+        needle="Read-only file system",
+        reason_code="filesystem-readonly",
+        description=(
+            "The kernel remounted the filesystem read-only after I/O "
+            "errors. The node cannot write to its model cache, profile "
+            "store, or calibration logs. Investigate and remount (or "
+            "reboot the node)."
+        ),
+    ),
+)
+
+
+def _classify_node_transient_error(log_tail: str) -> NodeTransientErrorPattern | None:
+    """Return the first matching :class:`NodeTransientErrorPattern`, or None.
+
+    Conservative by design: only patterns explicitly listed above qualify.
+    Real OOM, network blips between vLLM ranks, NCCL handshake failures,
+    etc. are NOT covered — those are recoverable / non-deterministic
+    enough that the kv-cache search is still the right response.
+    """
+    if not log_tail:
+        return None
+    for pattern in _NODE_LEVEL_TRANSIENT_PATTERNS:
+        if pattern.needle in log_tail:
+            return pattern
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -639,6 +955,24 @@ class CalibrationResult:
     # to a heuristic when missing.
     sleep_l1_transient_host_ram_mb: float | None = None
     sleep_l2_transient_host_ram_mb: float | None = None
+    # Set when calibrate_model bails because the model itself can never
+    # load on this worker (bad repo id, gated repo, unsupported architecture).
+    # Caller persists the model into model_profiles.yml so the master's
+    # orchestrator stops scheduling calibration attempts. Distinct from
+    # `success=False` with a generic error — those are still worth retrying
+    # next window. ``unsupported_reason`` is the FatalLoadErrorPattern code.
+    unsupported_reason: str | None = None
+    # Set when calibrate_model bails because the NODE is in a degraded
+    # state (filesystem EIO, read-only mount, etc. — see
+    # ``_NODE_LEVEL_TRANSIENT_PATTERNS``). Distinct from
+    # ``unsupported_reason``: that one marks a single model permanently,
+    # this one marks the whole node as broken until ops intervenes.
+    # The bridge surfaces this into the runtime status so the master's
+    # orchestrator stops sending calibration commands until the node
+    # recovers. Critically: when this is set, NO blacklist entry of any
+    # kind was written — the failure isn't the calibration's fault and
+    # leaving artefacts behind just pollutes things (see deioma 2026-06-04).
+    node_unhealthy_reason: str | None = None
 
 
 def _sample_host_ram_available_mb() -> float | None:
@@ -745,6 +1079,27 @@ def calibrate_model(
         sleep_level,
     )
     logger.info("-" * 60)
+
+    # Phase 0a — Model-level "do not retry" check. A previous calibration
+    # attempt classified this model as permanently unsupported on this
+    # worker (bad repo id, gated repo, missing architecture). Kv-cache
+    # probing cannot fix any of those, so short-circuit before spawning
+    # vLLM. Operators clear the entry by editing the file.
+    unsupported_path = log_dir / _UNSUPPORTED_MODELS_FILE
+    _unsupported = _load_unsupported_models(unsupported_path).get(model)
+    if _unsupported is not None:
+        partial.error = (
+            f"model is on the unsupported list "
+            f"(reason={_unsupported.reason_code}, recorded_at={_unsupported.recorded_at}): "
+            f"{_unsupported.description}"
+        )
+        partial.unsupported_reason = _unsupported.reason_code
+        logger.warning(
+            "  SKIP: %s. To re-attempt after fixing the underlying issue, " "remove the line from %s.",
+            partial.error,
+            unsupported_path,
+        )
+        return partial
 
     # Phase 0 — Kill any orphaned vLLM workers from previous runs.
     # Without this, leaked GPU memory inflates the baseline and can cause
@@ -859,6 +1214,40 @@ def calibrate_model(
     # blacklist-skip write inside _try_start raises NameError.
     _probes: dict[float, str] = {}
 
+    # Single-element box (mutable across closure scope without `nonlocal`)
+    # that latches the FatalLoadErrorPattern detected for this model, if
+    # any. Once set, subsequent _try_start calls short-circuit so the
+    # kv-cache search doesn't spawn vLLM N more times to watch each kv
+    # produce the same identity-level error.
+    _unsupported_box: list[FatalLoadErrorPattern] = []
+
+    # Sibling latch for node-level transient failures (filesystem EIO,
+    # read-only mount, …). When set, the kv-cache search aborts without
+    # writing ANY blacklist artefact — neither the per-command file nor
+    # the per-model unsupported list. The bridge reads the latch via
+    # ``partial.node_unhealthy_reason`` and surfaces it into the runtime
+    # status so the master skips this worker until ops intervenes.
+    _node_unhealthy_box: list[NodeTransientErrorPattern] = []
+
+    def _override_error_if_unsupported() -> None:
+        """If a fatal model-level error was detected mid-search, replace
+        the partial's generic "no working kv" message with the specific
+        reason code so the bridge / orchestrator can persist the model
+        into the unsupported-models registry. Node-level transient
+        failures (filesystem EIO, …) win over model-level fatalities
+        because they invalidate every measurement on this run.
+        """
+        if _node_unhealthy_box:
+            pat = _node_unhealthy_box[0]
+            partial.node_unhealthy_reason = pat.reason_code
+            partial.error = f"node degraded ({pat.reason_code}): {pat.description}"
+            return
+        if not _unsupported_box:
+            return
+        pat = _unsupported_box[0]
+        partial.unsupported_reason = pat.reason_code
+        partial.error = f"unsupported model ({pat.reason_code}): {pat.description}"
+
     def _try_start(kv_mb: float) -> subprocess.Popen[str] | object | None:
         """Try to start vLLM with the given KV cache.
 
@@ -866,9 +1255,16 @@ def calibrate_model(
           - A running ``Popen`` on real success.
           - ``_WHITELIST_HIT`` sentinel if the command is whitelisted
             (known-good from a previous run) — no process spawned.
-          - ``None`` on failure or blacklist skip.
+          - ``None`` on failure, blacklist skip, or when an earlier probe
+            in this calibration already detected a permanent
+            model-identity-level failure (see ``_unsupported_box``) or a
+            node-level transient failure (see ``_node_unhealthy_box``).
         """
         nonlocal hf_home, _ram_cached
+        # Short-circuit: a prior probe already proved this model can't load,
+        # or proved the node itself is degraded.
+        if _unsupported_box or _node_unhealthy_box:
+            return None
         kv_str = _format_kv_mb(kv_mb)
         planned = {**plan, "kv_cache_memory_bytes": kv_str}
         fingerprint = _cmd_fingerprint(_build_vllm_cmd(planned, vllm_binary, host, port, kv_str))
@@ -952,10 +1348,64 @@ def calibrate_model(
                 )
             stop_vllm(proc)
             time.sleep(_VRAM_SETTLE_S)
+
+            # Check node-level transient failures FIRST — these (filesystem
+            # EIO, read-only mount, …) are not the calibration's fault and
+            # must NOT leave any artefact behind. If we recorded per-command
+            # blacklist lines for them we'd accumulate dozens of garbage
+            # entries during a single 10-minute Ceph outage (see deioma
+            # 2026-06-04). Latch the box, log loudly, and abort. The bridge
+            # reads the partial result, surfaces ``node_unhealthy_reason``
+            # into the runtime status, and the master orchestrator skips
+            # this worker until the node recovers.
+            node_pattern = _classify_node_transient_error(log_tail)
+            if node_pattern is not None:
+                if not _node_unhealthy_box:
+                    _node_unhealthy_box.append(node_pattern)
+                    logger.error(
+                        "  %sNODE DEGRADED%s — %s: %s. "
+                        "Aborting calibration on %s — NO blacklist entries "
+                        "written. Operator action required.",
+                        _C_BOLD + _C_RED,
+                        _C_RESET,
+                        node_pattern.reason_code,
+                        node_pattern.description,
+                        model,
+                    )
+                return None
+
+            # Normal recoverable failure (OOM at this kv, NCCL timeout, …):
+            # record the per-command blacklist line so the kv search avoids
+            # re-trying this exact fingerprint on the next pass.
             _record_failed_command(failed_path, fingerprint)
             failed_commands.add(fingerprint)
             # Remove stale whitelist entry — this command no longer works.
             succeeded_commands.discard(fingerprint)
+
+            # Look for fatal, model-identity-level errors in the log tail
+            # (bad repo id, gated repo, unsupported architecture, …). When
+            # one matches, no other kv-cache size will help — every probe
+            # will produce an identical log tail and a fresh blacklist
+            # line. Persist into the model-level unsupported list and
+            # latch ``_unsupported_box`` so the search loops bail without
+            # spawning vLLM again.
+            fatal_pattern = _classify_fatal_load_error(log_tail)
+            if fatal_pattern is not None and not _unsupported_box:
+                _record_unsupported_model(
+                    unsupported_path,
+                    UnsupportedModelEntry(
+                        model=model,
+                        reason_code=fatal_pattern.reason_code,
+                        recorded_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        description=fatal_pattern.description,
+                    ),
+                )
+                logger.warning(
+                    "  %s detected — aborting kv-cache search for model %s.",
+                    fatal_pattern.reason_code,
+                    model,
+                )
+                _unsupported_box.append(fatal_pattern)
             return None
 
     proc: subprocess.Popen[str] | None = None
@@ -1080,6 +1530,7 @@ def calibrate_model(
                         f"{_format_kv_mb(original_ceiling)} on tp={tp}. "
                         f"Model weights likely exceed available GPU VRAM."
                     )
+                    _override_error_if_unsupported()
                     logger.warning("  ERROR: %s", partial.error)
                     return partial
 
@@ -1158,6 +1609,7 @@ def calibrate_model(
                 f"(tried down to {_format_kv_mb(_final_kv + _KV_CACHE_MIN_STEP_MB)}) "
                 f"on tp={tp}"
             )
+            _override_error_if_unsupported()
             logger.warning("  ERROR: %s", partial.error)
             return partial
     else:
@@ -1166,6 +1618,7 @@ def calibrate_model(
         proc = _try_start(kv_cache_sent_mb)
         if proc is None:
             partial.error = f"Model failed to start with KV cache " f"{_format_kv_mb(kv_cache_sent_mb)} on tp={tp}"
+            _override_error_if_unsupported()
             logger.warning("  ERROR: %s", partial.error)
             return partial
 

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -852,6 +852,13 @@ def calibrate_model(
     # to distinguish from a real running process.
     _WHITELIST_HIT = object()
 
+    # Probe-result map keyed by kv_mb. Used by _try_start (blacklist skip) and,
+    # in search mode, also by _record_probe / _render_search_bar. Initialise
+    # unconditionally so the closure cell exists even when an explicit
+    # kv_cache_memory_bytes override skips the search branch — otherwise the
+    # blacklist-skip write inside _try_start raises NameError.
+    _probes: dict[float, str] = {}
+
     def _try_start(kv_mb: float) -> subprocess.Popen[str] | object | None:
         """Try to start vLLM with the given KV cache.
 
@@ -958,9 +965,9 @@ def calibrate_model(
         search_hi = kv_cache_sent_mb  # ceiling (80% of per-GPU VRAM)
         original_ceiling = search_hi
 
-        # Track probe results for the visual search bar.
-        # Key: kv_mb, Value: "ok" | "fail" | "skip" | "whitelist"
-        _probes: dict[float, str] = {}
+        # _probes (Key: kv_mb, Value: "ok"/"fail"/"skip"/"whitelist") is
+        # initialised in the outer scope so _try_start can write to it on
+        # blacklist-skip even in the no-search path.
         _best_kv_viz: float | None = None
 
         def _stop_if_real(result: object) -> None:

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1501,6 +1501,7 @@ def _try_calibrate(
     nccl_p2p_available: bool = False,
     hf_home: str | None = None,
     model_cache: Any | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> CalibrationResult:
     """Call ``calibrate_model`` with exception → failure conversion."""
     model_name = plan["model"]
@@ -1515,6 +1516,7 @@ def _try_calibrate(
             nccl_p2p_available=nccl_p2p_available,
             hf_home=hf_home,
             model_cache=model_cache,
+            cancel_event=cancel_event,
         )
     except Exception as exc:
         logger.warning("Calibration failed for %s: %s", model_name, exc)
@@ -1527,6 +1529,147 @@ def _try_calibrate(
             error=str(exc),
             enforce_eager=bool(plan.get("enforce_eager", False)),
         )
+
+
+def calibrate_with_tp_escalation(
+    plan: dict[str, Any],
+    *,
+    vllm_binary: str,
+    port: int,
+    log_dir: Path,
+    sleep_level: int,
+    ready_timeout_s: float,
+    nccl_p2p_available: bool = False,
+    model_cache: Any | None = None,
+    available_gpus: int | None = None,
+    cancel_event: threading.Event | None = None,
+) -> CalibrationResult:
+    """Calibrate one model using a max-first, search-down TP strategy.
+
+    Shared by ``auto_calibrate_models`` (boot-time) and the server-orchestrated
+    ``start_calibration`` path so both behave identically:
+
+    1. Try ``max_tp`` first (fail fast on models that can't run at all).
+    2. Auto-retry with ``--trust-remote-code`` when vLLM demands it.
+    3. On max-tp failure, fall back to the configured tp (handles head-count
+       divisibility quirks).
+    4. On max-tp success, binary-search down to the smallest tp that still
+       works — saves GPU resources at runtime.
+
+    ``available_gpus`` defaults to the host's current GPU count.
+    """
+    model_name = plan["model"]
+
+    if available_gpus is None:
+        try:
+            available_gpus = len(query_gpu_vram())
+        except Exception:
+            available_gpus = 1
+
+    original_tp = int(plan.get("tensor_parallel_size", 1))
+    max_tp = _max_tp_for_plan(plan, available_gpus)
+
+    # RAM caching is deferred: calibrate_model triggers it on the first
+    # actual vLLM spawn so we don't waste time copying when all probes are
+    # blacklisted.  Pass the cache object through; it will call
+    # ensure_cached_sync only when needed.
+    _mc = model_cache if (model_cache is not None and getattr(model_cache, "enabled", False)) else None
+    cal_kwargs: dict[str, Any] = dict(
+        vllm_binary=vllm_binary,
+        port=port,
+        log_dir=log_dir,
+        sleep_level=sleep_level,
+        ready_timeout_s=ready_timeout_s,
+        nccl_p2p_available=nccl_p2p_available,
+        model_cache=_mc,
+        cancel_event=cancel_event,
+    )
+
+    tp = max_tp
+    current_plan = {**plan, "tensor_parallel_size": tp}
+    result = _try_calibrate(current_plan, **cal_kwargs)
+
+    # Auto-retry with --trust-remote-code when vLLM demands it.
+    _err = result.error or ""
+    if not result.success and "trust_remote_code=True" in _err:
+        logger.info(
+            "  %s requires trust_remote_code — adding flag and retrying",
+            model_name,
+        )
+        extra = list(plan.get("extra_args") or [])
+        if "--trust-remote-code" not in extra:
+            extra.append("--trust-remote-code")
+        plan = {**plan, "extra_args": extra}
+        current_plan = {**plan, "tensor_parallel_size": tp}
+        result = _try_calibrate(current_plan, **cal_kwargs)
+
+    # If max tp fails, try the configured (original) tp before giving up.
+    # Models may have attention-head counts that aren't divisible by max_tp
+    # (e.g. 64 heads on 3 GPUs) but work fine at the configured tp.
+    _fatal = "does not recognize this architecture" in (result.error or "") or "Cannot access gated repo" in (
+        result.error or ""
+    )
+    if not result.success and not _fatal and tp > original_tp:
+        logger.info(
+            "  %s failed at max tp=%d — falling back to configured tp=%d",
+            model_name,
+            tp,
+            original_tp,
+        )
+        tp = original_tp
+        current_plan = {**plan, "tensor_parallel_size": tp}
+        result = _try_calibrate(current_plan, **cal_kwargs)
+
+    if not result.success or _fatal:
+        return result
+
+    # Max tp succeeded — now binary-search down to find minimum tp.
+    if tp > original_tp:
+        logger.info(
+            "  %s works at tp=%d — searching for minimum tp (from %d)",
+            model_name,
+            tp,
+            original_tp,
+        )
+    best_result = result
+    best_tp = tp
+
+    # Binary search: try progressively smaller tp values.
+    # tp must be a power of 2 in vLLM, so we halve each step.
+    low_tp = original_tp
+    high_tp = tp
+    while low_tp < high_tp:
+        if cancel_event is not None and cancel_event.is_set():
+            break
+        mid_tp = high_tp // 2
+        if mid_tp < low_tp:
+            break
+        logger.info(
+            "  %s trying tp=%d (search range %d–%d)",
+            model_name,
+            mid_tp,
+            low_tp,
+            high_tp,
+        )
+        mid_plan = {**plan, "tensor_parallel_size": mid_tp}
+        mid_result = _try_calibrate(mid_plan, **cal_kwargs)
+        if mid_result.success:
+            best_result = mid_result
+            best_tp = mid_tp
+            high_tp = mid_tp
+        else:
+            low_tp = mid_tp * 2
+
+    if best_tp != original_tp:
+        logger.info(
+            "  %s optimal tp=%d (configured=%d, max=%d)",
+            model_name,
+            best_tp,
+            original_tp,
+            max_tp,
+        )
+
+    return best_result
 
 
 def auto_calibrate_models(
@@ -1598,133 +1741,21 @@ def auto_calibrate_models(
             p.get("gpu_devices") or "all",
         )
 
-    cal_kwargs = dict(
-        vllm_binary=vllm_binary,
-        port=port,
-        log_dir=log_dir,
-        sleep_level=sleep_level,
-        ready_timeout_s=ready_timeout_s,
-        nccl_p2p_available=nccl_p2p_available,
-    )
-
     results: dict[str, CalibrationResult] = {}
 
     for plan in plans:
         model_name = plan["model"]
-        original_tp = int(plan.get("tensor_parallel_size", 1))
-        max_tp = _max_tp_for_plan(plan, available_gpus)
-
-        # RAM caching is deferred: calibrate_model triggers it on the first
-        # actual vLLM spawn so we don't waste time copying when all probes are
-        # blacklisted.  Pass the cache object through; it will call
-        # ensure_cached_sync only when needed.
-        _mc = model_cache if (model_cache is not None and getattr(model_cache, "enabled", False)) else None
-        model_cal_kwargs = {**cal_kwargs, "model_cache": _mc}
-
-        # ----------------------------------------------------------
-        # Strategy: "max-first, then search down"
-        #
-        # 1. Try with max tp first to quickly verify whether the
-        #    model can run at all.  A model that cannot even load
-        #    with all GPUs available will never work — fail fast.
-        # 2. If max tp succeeds, binary-search downward to find the
-        #    smallest tp that still works (to save GPU resources at
-        #    runtime).
-        # 3. If max tp == original tp (only one option), just try it.
-        # ----------------------------------------------------------
-
-        tp = max_tp
-        current_plan = {**plan, "tensor_parallel_size": tp}
-        result = _try_calibrate(current_plan, **model_cal_kwargs)
-
-        # Auto-retry with --trust-remote-code when vLLM demands it.
-        _err = result.error or ""
-        if not result.success and "trust_remote_code=True" in _err:
-            logger.info(
-                "  %s requires trust_remote_code — adding flag and retrying",
-                model_name,
-            )
-            extra = list(plan.get("extra_args") or [])
-            if "--trust-remote-code" not in extra:
-                extra.append("--trust-remote-code")
-            plan = {**plan, "extra_args": extra}
-            current_plan = {**plan, "tensor_parallel_size": tp}
-            result = _try_calibrate(current_plan, **model_cal_kwargs)
-
-        # If max tp fails, try the configured (original) tp before giving up.
-        # Models may have attention-head counts that aren't divisible by max_tp
-        # (e.g. 64 heads on 3 GPUs) but work fine at the configured tp.
-        _fatal = "does not recognize this architecture" in (result.error or "") or "Cannot access gated repo" in (
-            result.error or ""
+        result = calibrate_with_tp_escalation(
+            plan,
+            vllm_binary=vllm_binary,
+            port=port,
+            log_dir=log_dir,
+            sleep_level=sleep_level,
+            ready_timeout_s=ready_timeout_s,
+            nccl_p2p_available=nccl_p2p_available,
+            model_cache=model_cache,
+            available_gpus=available_gpus,
         )
-        if not result.success and not _fatal and tp > original_tp:
-            logger.info(
-                "  %s failed at max tp=%d — falling back to configured tp=%d",
-                model_name,
-                tp,
-                original_tp,
-            )
-            tp = original_tp
-            current_plan = {**plan, "tensor_parallel_size": tp}
-            result = _try_calibrate(current_plan, **model_cal_kwargs)
-
-        if not result.success or _fatal:
-            results[model_name] = result
-            if not result.success:
-                logger.warning(
-                    "Calibration unsuccessful for %s: %s",
-                    model_name,
-                    result.error,
-                )
-            continue
-
-        # Max tp succeeded — now binary-search down to find minimum tp.
-        if tp > original_tp:
-            logger.info(
-                "  %s works at tp=%d — searching for minimum tp (from %d)",
-                model_name,
-                tp,
-                original_tp,
-            )
-        best_result = result
-        best_tp = tp
-
-        # Binary search: try progressively smaller tp values.
-        # tp must be a power of 2 in vLLM, so we halve each step.
-        low_tp = original_tp
-        high_tp = tp
-        while low_tp < high_tp:
-            mid_tp = high_tp // 2
-            if mid_tp < low_tp:
-                break
-            logger.info(
-                "  %s trying tp=%d (search range %d–%d)",
-                model_name,
-                mid_tp,
-                low_tp,
-                high_tp,
-            )
-            mid_plan = {**plan, "tensor_parallel_size": mid_tp}
-            mid_result = _try_calibrate(mid_plan, **model_cal_kwargs)
-            if mid_result.success:
-                best_result = mid_result
-                best_tp = mid_tp
-                high_tp = mid_tp
-            else:
-                low_tp = mid_tp * 2
-
-        result = best_result
-        tp = best_tp
-
-        if tp != int(plan.get("tensor_parallel_size", 1)):
-            logger.info(
-                "  %s optimal tp=%d (configured=%d, max=%d)",
-                model_name,
-                tp,
-                original_tp,
-                max_tp,
-            )
-
         results[model_name] = result
 
         if result.success:

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -864,11 +864,17 @@ def wait_ready(
     timeout_s: float,
     proc: subprocess.Popen[str],
     gpu_indices: list[int] | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> None:
     deadline = time.perf_counter() + timeout_s
     t_start = time.perf_counter()
     last_log = t_start - 25.0  # log at ~5 s, then every 30 s
     while time.perf_counter() < deadline:
+        # Honor mid-probe cancellation: the calibration session sets this
+        # when the maintenance window closes (or operator calls stop). Bail
+        # within ~2s instead of waiting out the full ready_timeout.
+        if cancel_event is not None and cancel_event.is_set():
+            raise RuntimeError("cancelled")
         if proc.poll() is not None:
             raise RuntimeError(f"vLLM exited before becoming ready (code={proc.poll()})")
         status, _ = _get(f"{base_url}/health", timeout_s=5.0)
@@ -1316,7 +1322,7 @@ def calibrate_model(
         )
         t0 = time.perf_counter()
         try:
-            wait_ready(base_url, ready_timeout_s, proc, gpu_indices)
+            wait_ready(base_url, ready_timeout_s, proc, gpu_indices, cancel_event=cancel_event)
             logger.info(
                 "        OK kv_cache=%s ready in %.1fs",
                 kv_str,
@@ -1333,6 +1339,14 @@ def calibrate_model(
                 logger.info("        Removed stale blacklist entry for kv_cache=%s", kv_str)
             return proc
         except (RuntimeError, TimeoutError) as exc:
+            # Cancellation path: kill the probe immediately, do not blacklist.
+            # The session-level driver sees cancel_event and bails after this
+            # returns None, so we just need to stop vLLM and leave no trace.
+            if str(exc) == "cancelled":
+                logger.info("        Calibration cancelled mid-probe kv_cache=%s — stopping vLLM", kv_str)
+                stop_vllm(proc)
+                time.sleep(_VRAM_SETTLE_S)
+                return None
             log_tail = _read_log_tail(log_path)
             logger.warning(
                 "        FAIL kv_cache=%s: %s",

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1578,6 +1578,13 @@ class LaneManager:
         # Ensure model is in RAM cache if available
         hf_home_override: str | None = None
         if self._model_cache is not None and getattr(self._model_cache, "enabled", False) and lane_config.vllm:
+            # Startup pre-population runs in the background — if the model
+            # is already being copied (or queued behind others), bump it to
+            # the front and block this lane add until the copy finishes.
+            # Falls through to ensure_cached anyway so on-demand caching
+            # still works for models the startup planner didn't pick.
+            if hasattr(self._model_cache, "wait_for_cached"):
+                await self._model_cache.wait_for_cached(lane_config.model)
             effective = await self._model_cache.ensure_cached(lane_config.model)
             if effective:
                 hf_home_override = effective

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1108,18 +1108,28 @@ class LaneManager:
         entries on top of the lane's vllm_config.  Lets this worker enforce
         SM-specific workarounds (e.g. disable_custom_all_reduce, quantization: awq
         on Turing) without requiring changes to the Logos server.
+
+        The worker-wide engines.vllm.disable_sleep_mode kill switch is applied
+        last so it cannot be re-enabled by a per-model override or by what the
+        Logos server sends.
         """
         if not lane_config.vllm or lane_config.vllm_config is None:
             return lane_config
-        overrides = self._vllm_engine_config.model_overrides.get(lane_config.model)
-        if not overrides:
+        overrides = self._vllm_engine_config.model_overrides.get(lane_config.model) or {}
+        disable_sleep = self._vllm_engine_config.disable_sleep_mode
+        if not overrides and not disable_sleep:
             return lane_config
         merged = {**lane_config.vllm_config.model_dump(), **overrides}
+        if disable_sleep:
+            merged["enable_sleep_mode"] = False
         new_vc = VllmConfig.model_validate(merged)
+        applied = list(overrides)
+        if disable_sleep:
+            applied.append("enable_sleep_mode=false (engines.vllm.disable_sleep_mode)")
         logger.info(
             "Applied local vLLM overrides for %s: %s",
             lane_config.model,
-            list(overrides),
+            applied,
         )
         return lane_config.model_copy(update={"vllm_config": new_vc})
 

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -532,7 +532,7 @@ class LogosBridgeClient:
             return status.model_dump(mode="json")
 
         if action == "start_calibration":
-            return self._handle_start_calibration(params)
+            return await self._handle_start_calibration(params)
         if action == "stop_calibration":
             return self._handle_stop_calibration()
         if action == "get_calibration_status":
@@ -540,7 +540,7 @@ class LogosBridgeClient:
 
         raise ValueError(f"Unsupported bridge command '{action}'")
 
-    def _handle_start_calibration(self, params: dict[str, Any]) -> dict[str, Any]:
+    async def _handle_start_calibration(self, params: dict[str, Any]) -> dict[str, Any]:
         """Start a background calibration for one model (server-orchestrated path)."""
         model_name = str(params.get("model_name", "")).strip()
         if not model_name:
@@ -652,6 +652,27 @@ class LogosBridgeClient:
                 return {"ok": False, "error": f"calibration already in progress: {active_model}"}
             # Thread finished — clean up stale entry
             self._active_calibration = None
+
+        # Free all VRAM before calibration. Otherwise live lanes compete with
+        # the calibration probe for GPU memory: the kv-cache search starts
+        # against an already-loaded model, every probe size OOMs, and the
+        # blacklist fills up with bogus entries even though the model could
+        # have calibrated on a clean GPU (deioma 2026-06-04). The Logos server
+        # will re-spawn lanes via the normal apply_lanes path once calibration
+        # completes.
+        lane_manager = getattr(self._app.state, "lane_manager", None)
+        if lane_manager is not None:
+            try:
+                await lane_manager.destroy_all()
+                logger.info(
+                    "[Calibration] Stopped all lanes to free VRAM before calibrating %s",
+                    model_name,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "[Calibration] destroy_all failed before calibrating %s — continuing anyway",
+                    model_name,
+                )
 
         cancel_event = threading.Event()
         started_at = time.time()

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -199,6 +199,7 @@ class LogosBridgeClient:
         payload = {
             "shared_key": self._cfg.shared_key,
             "capabilities_models": self._cfg.capabilities_models,
+            "configured_models": self._cfg.configured_models,
         }
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(auth_url, json=payload)
@@ -297,6 +298,7 @@ class LogosBridgeClient:
                 "type": "hello",
                 "worker_id": self.worker_id,
                 "capabilities_models": self._cfg.capabilities_models,
+                "configured_models": self._cfg.configured_models,
                 "max_lanes": max_lanes,
                 "static_lane_ids": static_lane_ids,
                 "actions": [
@@ -339,6 +341,7 @@ class LogosBridgeClient:
                 "type": "status",
                 "worker_id": self.worker_id,
                 "capabilities_models": self._cfg.capabilities_models,
+                "configured_models": self._cfg.configured_models,
                 "runtime": payload,
             },
         )

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -25,7 +25,7 @@ except Exception:  # noqa: BLE001
 
 
 from logos_worker_node import prometheus_metrics as prom
-from logos_worker_node.models import LaneConfig, LogosConfig, WorkerTransportStatus
+from logos_worker_node.models import LaneConfig, LogosConfig, WorkerTransportStatus, model_can_sleep
 from logos_worker_node.runtime import build_runtime_status
 
 logger = logging.getLogger("logos_worker_node.logos_bridge")
@@ -547,6 +547,33 @@ class LogosBridgeClient:
             return {"ok": False, "error": "model_name is required"}
         sleep_level = int(params.get("sleep_level", 1))
 
+        cfg = self._app.state.config
+        model_profiles = self._app.state.model_profiles
+
+        # Reject calibration requests that would measure sleep_l<N> transient
+        # host-RAM for a model whose worker config forbids sleeping. The vLLM
+        # lane would be spawned with enable_sleep_mode=False (worker kill
+        # switch or per-model override), the POST /sleep call in Phase 4
+        # would fail, and the orchestrator would keep retrying every
+        # maintenance window. Persist the sleep_mode_disabled flag in the
+        # model profile so the master's calibration orchestrator can stop
+        # asking instead of relying on per-window deduping alone.
+        if sleep_level > 0 and not model_can_sleep(cfg, model_name):
+            model_profiles.mark_sleep_mode_disabled(model_name, True)
+            err = (
+                f"sleep mode disabled for model {model_name!r} on this worker "
+                f"(engines.vllm.disable_sleep_mode or per-model "
+                f"enable_sleep_mode=false override); cannot calibrate "
+                f"sleep_l{sleep_level} transient host RAM"
+            )
+            logger.warning("[Calibration] refusing start_calibration: %s", err)
+            return {"ok": False, "error": err, "sleep_mode_disabled": True}
+        # Config now permits sleep — clear any stale "sleep_mode_disabled"
+        # flag persisted by a prior rejection so a config flip
+        # (false → true) is picked up immediately.
+        if model_can_sleep(cfg, model_name):
+            model_profiles.mark_sleep_mode_disabled(model_name, False)
+
         if self._active_calibration is not None:
             active_model = self._active_calibration[0]
             if self._active_calibration[2].is_alive():
@@ -557,8 +584,6 @@ class LogosBridgeClient:
         cancel_event = threading.Event()
         started_at = time.time()
 
-        cfg = self._app.state.config
-        model_profiles = self._app.state.model_profiles
         model_cache = getattr(self._app.state, "model_cache", None)
 
         def _run_calibration() -> None:

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -25,10 +25,29 @@ except Exception:  # noqa: BLE001
 
 
 from logos_worker_node import prometheus_metrics as prom
-from logos_worker_node.models import LaneConfig, LogosConfig, WorkerTransportStatus, model_can_sleep
+from logos_worker_node.models import LaneConfig, LaneEvent, LogosConfig, WorkerTransportStatus, model_can_sleep
 from logos_worker_node.runtime import build_runtime_status
 
 logger = logging.getLogger("logos_worker_node.logos_bridge")
+
+
+class _CalibrationSession:
+    """Worker-driven calibration loop state.
+
+    The worker owns the model-selection decision and walks its own list of
+    uncalibrated models one at a time. Server only sends start/stop session
+    RPCs and consumes calibration_* events back from the worker.
+    """
+
+    def __init__(self, sleep_level: int) -> None:
+        self.sleep_level: int = sleep_level
+        self.cancel_event: threading.Event = threading.Event()
+        self.task: asyncio.Task | None = None
+        self.started_at: float = time.time()
+        # Updated by the session driver as it walks the model list — surfaced
+        # so a future status RPC could inspect what's running without polling.
+        self.current_model: str | None = None
+
 
 # ANSI color codes for structured log output
 _GREEN = "\033[32m"
@@ -59,8 +78,14 @@ class LogosBridgeClient:
         self._last_runtime_payload: dict[str, Any] = {}
         # Resolved by server during auth
         self._resolved_worker_id: str = ""
-        # Active server-orchestrated calibration: (model_name, cancel_event, thread, started_at)
-        self._active_calibration: tuple[str, threading.Event, threading.Thread, float] | None = None
+        # Active worker-driven calibration session. The session task iterates
+        # uncalibrated configured models and runs each calibration in a
+        # thread executor. The cancel_event is threaded into the calibration
+        # so a stop_calibration_session RPC kills the in-progress vLLM probe
+        # within ~2s (wait_ready polls cancel_event).
+        self._active_calibration_session: _CalibrationSession | None = None
+        # Sequence counter for calibration event_id (independent of lane events).
+        self._calibration_event_seq: int = 0
 
     @property
     def worker_id(self) -> str:
@@ -312,6 +337,8 @@ class LogosBridgeClient:
                     "sleep_lane",
                     "wake_lane",
                     "reconfigure_lane",
+                    "start_calibration_session",
+                    "stop_calibration_session",
                 ],
             },
         )
@@ -531,39 +558,44 @@ class LogosBridgeClient:
             status = await lane_manager.reconfigure_lane(lane_id, updates)
             return status.model_dump(mode="json")
 
-        if action == "start_calibration":
-            return await self._handle_start_calibration(params)
-        if action == "stop_calibration":
-            return self._handle_stop_calibration()
-        if action == "get_calibration_status":
-            return self._handle_get_calibration_status()
+        if action == "start_calibration_session":
+            return await self._handle_start_calibration_session(params)
+        if action == "stop_calibration_session":
+            return await self._handle_stop_calibration_session()
 
         raise ValueError(f"Unsupported bridge command '{action}'")
 
-    async def _handle_start_calibration(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Start a background calibration for one model (server-orchestrated path)."""
-        model_name = str(params.get("model_name", "")).strip()
-        if not model_name:
-            return {"ok": False, "error": "model_name is required"}
+    async def _handle_start_calibration_session(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Start a worker-driven calibration session.
+
+        The worker iterates its own list of uncalibrated configured models,
+        runs each calibration sequentially, and emits ``calibration_*`` events
+        back to the server. The server does not poll status and does not
+        choose models; it only sends start/stop session RPCs.
+        """
         sleep_level = int(params.get("sleep_level", 1))
 
-        cfg = self._app.state.config
-        model_profiles = self._app.state.model_profiles
+        # Refuse start when a session is already running — caller should
+        # have stopped the previous session first. The event channel told
+        # them whether it finished.
+        if self._active_calibration_session is not None:
+            task = self._active_calibration_session.task
+            if task is not None and not task.done():
+                return {"ok": False, "error": "calibration session already in progress"}
+            # Stale entry — drop it.
+            self._active_calibration_session = None
 
-        # Refuse calibration when the node itself is in a degraded state
-        # (GPU ERR/N/A, HF cache EIO, …). The kv-cache search will fail
-        # the same way for every model; better to surface the underlying
-        # problem to the master upfront than spawn vLLM into a broken
-        # environment and let the user discover it via mysterious
-        # blacklist entries (deioma 2026-06-04).
+        # Refuse when the node itself is in a degraded state (GPU ERR/N/A,
+        # HF cache EIO, …). The kv-cache search would fail the same way
+        # for every model in the session; better to bounce the request now
+        # and let ops fix the underlying issue.
         try:
             from logos_worker_node.node_health import evaluate_node_health  # noqa: PLC0415
 
             _health = evaluate_node_health()
             if not _health.healthy:
                 logger.error(
-                    "[Calibration] refusing start_calibration for %s: " "node unhealthy (reason=%s) — %s",
-                    model_name,
+                    "[Calibration] refusing start_calibration_session: node unhealthy (reason=%s) — %s",
                     _health.reason_code,
                     _health.reason_detail,
                 )
@@ -571,8 +603,8 @@ class LogosBridgeClient:
                     "ok": False,
                     "error": (
                         f"node is in a degraded state (reason={_health.reason_code}): "
-                        f"{_health.reason_detail}. Calibration is suspended until the "
-                        f"underlying issue is resolved."
+                        f"{_health.reason_detail}. Calibration is suspended until "
+                        f"the underlying issue is resolved."
                     ),
                     "node_unhealthy": True,
                     "reason_code": _health.reason_code,
@@ -580,120 +612,170 @@ class LogosBridgeClient:
         except Exception:  # noqa: BLE001
             logger.debug("[Calibration] node_health evaluation failed", exc_info=True)
 
-        # Refuse calibration for models already classified as permanently
-        # unsupported on this worker (bad repo id, gated repo, unsupported
-        # architecture, …). Cheap pre-flight check, before starting the
-        # calibration thread or spawning vLLM. Ensures the master gets a
-        # fast structured failure with the reason code so it can update
-        # the persisted model profile and stop asking.
-        #
-        # Best-effort: if the state dir can't be resolved (e.g. tests on a
-        # host without /app/data), skip the pre-flight and let the
-        # calibration itself catch the failure if any.
-        _unsupported = None
-        try:
-            from logos_worker_node.calibration import is_model_unsupported
-            from logos_worker_node.config import get_state_dir
+        session = _CalibrationSession(sleep_level=sleep_level)
+        session.task = asyncio.create_task(
+            self._run_calibration_session(session),
+            name="calibration-session",
+        )
+        self._active_calibration_session = session
+        logger.info(
+            "[Calibration] Session started (sleep_level=%d) — worker drives model selection",
+            sleep_level,
+        )
+        return {"ok": True, "sleep_level": sleep_level, "started_at": session.started_at}
 
-            _log_dir = get_state_dir() / "calibration_logs"
-            _unsupported = is_model_unsupported(_log_dir, model_name)
-        except Exception:  # noqa: BLE001
-            logger.debug("[Calibration] could not consult unsupported-models list", exc_info=True)
-        if _unsupported is not None:
-            model_profiles.mark_calibration_unsupported(model_name, True, _unsupported.reason_code)
-            logger.warning(
-                "[Calibration] refusing start_calibration for %s: on unsupported list "
-                "(reason=%s, recorded_at=%s). Remove the line from %s/%s to re-attempt.",
-                model_name,
-                _unsupported.reason_code,
-                _unsupported.recorded_at,
-                _log_dir,
-                "calibration_unsupported_models.txt",
-            )
-            return {
-                "ok": False,
-                "error": (
-                    f"model {model_name!r} is on the unsupported list "
-                    f"(reason={_unsupported.reason_code}); calibration "
-                    f"cannot succeed until the underlying issue is fixed "
-                    f"and the entry is removed"
-                ),
-                "calibration_unsupported": True,
-                "reason_code": _unsupported.reason_code,
-            }
+    async def _handle_stop_calibration_session(self) -> dict[str, Any]:
+        """Cancel any in-progress calibration session.
 
-        # Reject calibration requests that would measure sleep_l<N> transient
-        # host-RAM for a model whose worker config forbids sleeping. The vLLM
-        # lane would be spawned with enable_sleep_mode=False (worker kill
-        # switch or per-model override), the POST /sleep call in Phase 4
-        # would fail, and the orchestrator would keep retrying every
-        # maintenance window. Persist the sleep_mode_disabled flag in the
-        # model profile so the master's calibration orchestrator can stop
-        # asking instead of relying on per-window deduping alone.
-        if sleep_level > 0 and not model_can_sleep(cfg, model_name):
-            model_profiles.mark_sleep_mode_disabled(model_name, True)
-            err = (
-                f"sleep mode disabled for model {model_name!r} on this worker "
-                f"(engines.vllm.disable_sleep_mode or per-model "
-                f"enable_sleep_mode=false override); cannot calibrate "
-                f"sleep_l{sleep_level} transient host RAM"
-            )
-            logger.warning("[Calibration] refusing start_calibration: %s", err)
-            return {"ok": False, "error": err, "sleep_mode_disabled": True}
-        # Config now permits sleep — clear any stale "sleep_mode_disabled"
-        # flag persisted by a prior rejection so a config flip
-        # (false → true) is picked up immediately.
-        if model_can_sleep(cfg, model_name):
-            model_profiles.mark_sleep_mode_disabled(model_name, False)
+        Sets the cancel_event so the calibration's wait_ready polling kills
+        the running vLLM probe within ~2s, then awaits the session task
+        briefly so the terminal ``calibration_session_cancelled`` event is
+        emitted before the RPC reply.
+        """
+        session = self._active_calibration_session
+        if session is None:
+            return {"ok": True, "was_active": False}
 
-        if self._active_calibration is not None:
-            active_model = self._active_calibration[0]
-            if self._active_calibration[2].is_alive():
-                return {"ok": False, "error": f"calibration already in progress: {active_model}"}
-            # Thread finished — clean up stale entry
-            self._active_calibration = None
-
-        # Free all VRAM before calibration. Otherwise live lanes compete with
-        # the calibration probe for GPU memory: the kv-cache search starts
-        # against an already-loaded model, every probe size OOMs, and the
-        # blacklist fills up with bogus entries even though the model could
-        # have calibrated on a clean GPU (deioma 2026-06-04). The Logos server
-        # will re-spawn lanes via the normal apply_lanes path once calibration
-        # completes.
-        lane_manager = getattr(self._app.state, "lane_manager", None)
-        if lane_manager is not None:
+        session.cancel_event.set()
+        current_model = session.current_model
+        if session.task is not None and not session.task.done():
             try:
-                await lane_manager.destroy_all()
-                logger.info(
-                    "[Calibration] Stopped all lanes to free VRAM before calibrating %s",
-                    model_name,
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "[Calibration] destroy_all failed before calibrating %s — continuing anyway",
-                    model_name,
-                )
+                await asyncio.wait_for(asyncio.shield(session.task), timeout=15.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                # Session is still wrapping up (subprocess teardown). The
+                # terminal event will arrive on the event channel when it
+                # does. Don't block the RPC longer than 15s.
+                pass
+        logger.info(
+            "[Calibration] stop_calibration_session received — cancelled (current_model=%s)",
+            current_model or "<none>",
+        )
+        return {"ok": True, "was_active": True, "current_model": current_model}
 
-        cancel_event = threading.Event()
-        started_at = time.time()
+    # ------------------------------------------------------------------
+    # Calibration session driver
+    # ------------------------------------------------------------------
 
-        model_cache = getattr(self._app.state, "model_cache", None)
+    def _record_calibration_event(self, event: str, model: str = "", details: str = "") -> None:
+        """Append a calibration event onto the lane manager's event log.
 
-        def _run_calibration() -> None:
-            from pathlib import Path
+        Calibration events ride the same channel as lane events so the
+        existing ``_event_loop`` forwards them to the server without any
+        extra plumbing. ``lane_id`` is fixed to ``"calibration"`` so the
+        server can distinguish them from real lane transitions.
+        """
+        lane_manager = getattr(self._app.state, "lane_manager", None)
+        if lane_manager is None:
+            return
+        self._calibration_event_seq += 1
+        lane_manager._event_log.append(  # noqa: SLF001
+            LaneEvent(
+                event_id=f"calib-{self._calibration_event_seq}",
+                timestamp=datetime.now(timezone.utc),
+                lane_id="calibration",
+                event=event,
+                model=model,
+                details=details,
+            )
+        )
+        # Cap log size like _record_event does.
+        max_events = getattr(lane_manager, "_MAX_EVENT_LOG", 500)
+        if len(lane_manager._event_log) > max_events:  # noqa: SLF001
+            lane_manager._event_log = lane_manager._event_log[-max_events:]  # noqa: SLF001
 
-            from logos_worker_node.calibration import load_existing_profiles, result_to_profile_dict, save_profiles
-            from logos_worker_node.config import get_state_dir
+    def _list_uncalibrated_models(self) -> list[str]:
+        """Pick configured models that still need calibration.
+
+        Mirrors the previous server-side selection logic so behaviour is
+        unchanged — only the location of the decision moves to the worker.
+        Skips models with sleep_mode_disabled (only the sleep field would
+        be N/A) only when base_residency is already known, and models
+        flagged calibration_unsupported.
+        """
+        cfg = self._app.state.config
+        model_profiles = self._app.state.model_profiles
+        candidates = list(self._cfg.configured_models) or list(self._cfg.capabilities_models)
+
+        sleep_level = (
+            self._active_calibration_session.sleep_level if self._active_calibration_session is not None else 1
+        )
+
+        ordered: list[str] = []
+        for model_name in candidates:
+            profile = model_profiles.get_profile(model_name)
+            if profile is not None and profile.calibration_unsupported:
+                continue
+            sleep_na = bool(profile is not None and profile.sleep_mode_disabled)
+            # Worker-side knowledge: if config now forbids sleep but profile
+            # still claims it's possible, picking this model is fine — the
+            # session driver re-checks model_can_sleep before each model
+            # and persists the new flag.
+            if sleep_level > 0 and not model_can_sleep(cfg, model_name):
+                sleep_na = True
+            needs_calib = (
+                profile is None
+                or profile.base_residency_mb is None
+                or (not sleep_na and profile.sleeping_residual_mb is None)
+                or (not sleep_na and profile.sleep_l1_transient_host_ram_mb is None)
+            )
+            if needs_calib:
+                ordered.append(model_name)
+        return ordered
+
+    async def _run_calibration_session(self, session: _CalibrationSession) -> None:
+        """Async driver that walks uncalibrated models one at a time.
+
+        Each model's blocking calibration runs on the default thread
+        executor; the cancel_event is wired through to ``wait_ready`` so a
+        stop_calibration_session RPC tears down the in-flight vLLM probe
+        within ~2s instead of waiting out the full ready timeout.
+        """
+        # Emit the session_started event immediately, before anything that
+        # could fail. The orchestrator relies on the terminal event in the
+        # finally block to free its active-provider slot, so we must always
+        # produce a session_started/session_finished pair on a normal start.
+        models = self._list_uncalibrated_models()
+        self._record_calibration_event(
+            "calibration_session_started",
+            details=f"models={len(models)} sleep_level={session.sleep_level}",
+        )
+
+        terminal_event = "calibration_session_finished"
+        lane_manager = getattr(self._app.state, "lane_manager", None)
+        try:
+            from logos_worker_node.calibration import (  # noqa: PLC0415
+                _CALIBRATION_PORT,
+                _DEFAULT_VLLM,
+                _READY_TIMEOUT_S,
+                calibrate_with_tp_escalation,
+                is_model_unsupported,
+                load_existing_profiles,
+                plans_from_config,
+                result_to_profile_dict,
+                save_profiles,
+            )
+            from logos_worker_node.config import get_state_dir  # noqa: PLC0415
+
+            cfg = self._app.state.config
+            model_profiles = self._app.state.model_profiles
+            model_cache = getattr(self._app.state, "model_cache", None)
+
+            if not models:
+                logger.info("[Calibration] No uncalibrated models to process — session is a no-op")
+                return
 
             state_dir = get_state_dir()
             profiles_path = state_dir / "model_profiles.yml"
+            log_dir = state_dir / "calibration_logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
             nccl_p2p = cfg.engines.vllm.nccl_p2p_available if cfg.engines else False
             _mc = model_cache if (model_cache is not None and getattr(model_cache, "enabled", False)) else None
 
-            # Find the config.yml path for plans_from_config
-            import os
+            # Resolve plans once — the kv-cache ceilings come from config.yml.
+            import os as _os  # noqa: PLC0415
+            from pathlib import Path  # noqa: PLC0415
 
-            config_path_str = os.environ.get("LOGOS_WORKER_NODE_CONFIG", "").strip()
+            config_path_str = _os.environ.get("LOGOS_WORKER_NODE_CONFIG", "").strip()
             if config_path_str:
                 config_path = Path(config_path_str)
             else:
@@ -703,43 +785,127 @@ class LogosBridgeClient:
                         break
                 else:
                     config_path = Path("config.yml")
+            all_plans = plans_from_config(config_path) if config_path.exists() else []
+            plan_by_model = {p["model"]: p for p in all_plans}
 
-            try:
-                logger.info(
-                    "[Calibration] Starting server-orchestrated calibration: model=%s sleep_level=%d",
-                    model_name,
-                    sleep_level,
-                )
-                from logos_worker_node.calibration import calibrate_with_tp_escalation, plans_from_config
+            # Free all VRAM up front. Live lanes compete with the calibration
+            # probe for GPU memory: the kv-cache search starts against an
+            # already-loaded model, every probe size OOMs, and the blacklist
+            # fills up with bogus entries even though the model could have
+            # calibrated on a clean GPU. The Logos server re-spawns lanes via
+            # the normal apply_lanes path once the session ends.
+            if lane_manager is not None:
+                try:
+                    await lane_manager.destroy_all()
+                    logger.info("[Calibration] Stopped all lanes to free VRAM for calibration session")
+                except Exception:  # noqa: BLE001
+                    logger.exception("[Calibration] destroy_all failed — continuing anyway")
 
-                all_plans = plans_from_config(config_path) if config_path.exists() else []
-                plan_by_model = {p["model"]: p for p in all_plans}
+            for model_name in models:
+                if session.cancel_event.is_set():
+                    terminal_event = "calibration_session_cancelled"
+                    break
+
+                session.current_model = model_name
+
+                # Pre-flight: persistent unsupported flag.
+                _unsupported = None
+                try:
+                    _unsupported = is_model_unsupported(log_dir, model_name)
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Calibration] unsupported-list lookup failed", exc_info=True)
+                if _unsupported is not None:
+                    model_profiles.mark_calibration_unsupported(model_name, True, _unsupported.reason_code)
+                    logger.warning(
+                        "[Calibration] Skipping %s — on unsupported list (reason=%s)",
+                        model_name,
+                        _unsupported.reason_code,
+                    )
+                    self._record_calibration_event(
+                        "calibration_model_skipped",
+                        model=model_name,
+                        details=f"unsupported reason={_unsupported.reason_code}",
+                    )
+                    continue
+
+                # Pre-flight: sleep gate. If the worker config forbids sleep
+                # for this model (worker kill switch or per-model override)
+                # there is no point spawning a vLLM lane with sleep_level>0 —
+                # the POST /sleep at Phase 4 of calibration will fail and the
+                # whole probe is wasted. Persist the flag and skip; the model
+                # stays uncalibrated on this worker until config or sleep
+                # level changes.
+                if session.sleep_level > 0 and not model_can_sleep(cfg, model_name):
+                    model_profiles.mark_sleep_mode_disabled(model_name, True)
+                    logger.info(
+                        "[Calibration] Skipping %s — sleep mode disabled on this worker",
+                        model_name,
+                    )
+                    self._record_calibration_event(
+                        "calibration_model_skipped",
+                        model=model_name,
+                        details="sleep_mode_disabled",
+                    )
+                    continue
+                if model_can_sleep(cfg, model_name):
+                    # Config now permits sleep — clear any stale flag so a
+                    # config flip (true → false) is picked up immediately.
+                    model_profiles.mark_sleep_mode_disabled(model_name, False)
+
                 plan = plan_by_model.get(model_name) or {"model": model_name}
-
-                from logos_worker_node.calibration import _CALIBRATION_PORT, _DEFAULT_VLLM, _READY_TIMEOUT_S
-
-                log_dir = state_dir / "calibration_logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-
-                result = calibrate_with_tp_escalation(
-                    plan,
-                    vllm_binary=_DEFAULT_VLLM,
-                    port=_CALIBRATION_PORT,
-                    log_dir=log_dir,
-                    sleep_level=sleep_level,
-                    ready_timeout_s=_READY_TIMEOUT_S,
-                    nccl_p2p_available=nccl_p2p,
-                    model_cache=_mc,
-                    cancel_event=cancel_event,
+                self._record_calibration_event(
+                    "calibration_model_started",
+                    model=model_name,
+                    details=f"sleep_level={session.sleep_level}",
                 )
+                logger.info(
+                    "[Calibration] Starting model=%s sleep_level=%d",
+                    model_name,
+                    session.sleep_level,
+                )
+
+                # Blocking calibration runs in the default thread executor so
+                # we keep the bridge's event loop responsive. The cancel_event
+                # is the same instance the stop RPC sets — wait_ready polls
+                # it every 2s and bails immediately.
+                loop = asyncio.get_running_loop()
+                try:
+                    result = await loop.run_in_executor(
+                        None,
+                        lambda p=plan: calibrate_with_tp_escalation(
+                            p,
+                            vllm_binary=_DEFAULT_VLLM,
+                            port=_CALIBRATION_PORT,
+                            log_dir=log_dir,
+                            sleep_level=session.sleep_level,
+                            ready_timeout_s=_READY_TIMEOUT_S,
+                            nccl_p2p_available=nccl_p2p,
+                            model_cache=_mc,
+                            cancel_event=session.cancel_event,
+                        ),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception("[Calibration] Unexpected error for model=%s", model_name)
+                    self._record_calibration_event(
+                        "calibration_model_failed",
+                        model=model_name,
+                        details=f"unexpected: {exc}",
+                    )
+                    continue
+
+                # Cancellation may have fired during the calibration. We emit
+                # the cancelled event and stop iterating; whether the result
+                # is success or failure, we don't persist a half-baked profile.
+                if session.cancel_event.is_set():
+                    logger.info("[Calibration] Cancelled mid-model: %s", model_name)
+                    self._record_calibration_event(
+                        "calibration_model_cancelled",
+                        model=model_name,
+                    )
+                    terminal_event = "calibration_session_cancelled"
+                    break
 
                 if result.success:
-                    # Persist the new profile to model_profiles.yml and reload.
-                    # Preserve any prior transient measurements that the current
-                    # run did not produce (this calibration only measures one
-                    # sleep level — the other field comes back as None from
-                    # result_to_profile_dict and must not clobber an earlier
-                    # value).
                     existing = load_existing_profiles(profiles_path)
                     prior = existing.get(model_name) or {}
                     new_profile = result_to_profile_dict(result)
@@ -748,70 +914,71 @@ class LogosBridgeClient:
                             new_profile[_carry] = prior[_carry]
                     existing[model_name] = new_profile
                     save_profiles(profiles_path, existing)
-                    model_profiles._load_persisted()
+                    model_profiles._load_persisted()  # noqa: SLF001
                     logger.info(
-                        "[Calibration] Completed successfully: model=%s base_residency=%.0f MB",
+                        "[Calibration] Completed model=%s base_residency=%.0f MB",
                         model_name,
                         result.base_residency_mb,
                     )
-                elif cancel_event.is_set():
-                    logger.info("[Calibration] Cancelled by server: model=%s", model_name)
-                else:
-                    logger.warning(
-                        "[Calibration] Failed: model=%s error=%s",
-                        model_name,
-                        result.error,
+                    self._record_calibration_event(
+                        "calibration_model_completed",
+                        model=model_name,
+                        details=f"base_residency_mb={result.base_residency_mb:.0f}",
                     )
-                    # When calibrate_model identified a permanent
-                    # model-identity-level failure (bad repo id, gated
-                    # repo, unsupported architecture), persist the flag in
-                    # the profile so the master's orchestrator stops
-                    # scheduling this model. Also persisted is the reason
-                    # code, for ops visibility. Recoverable failures
-                    # (kv-cache too high, transient I/O, etc.) carry no
-                    # ``unsupported_reason`` and remain eligible for
-                    # retry on the next maintenance window.
+                    # Dirty the lane manager's status revision so the next
+                    # status push includes the updated model_profiles right
+                    # away (instead of waiting the full status_refresh
+                    # interval). Safe to call from the asyncio task because
+                    # we're on the event loop.
+                    if lane_manager is not None:
+                        try:
+                            lane_manager._mark_status_dirty()  # noqa: SLF001
+                        except Exception:  # noqa: BLE001
+                            logger.debug("[Calibration] _mark_status_dirty failed", exc_info=True)
+                else:
+                    logger.warning("[Calibration] Failed model=%s error=%s", model_name, result.error)
                     if getattr(result, "unsupported_reason", None):
                         model_profiles.mark_calibration_unsupported(model_name, True, result.unsupported_reason)
                         logger.warning(
-                            "[Calibration] %s marked calibration_unsupported "
-                            "(reason=%s) — master will skip future windows.",
+                            "[Calibration] %s marked calibration_unsupported (reason=%s)",
                             model_name,
                             result.unsupported_reason,
                         )
-            except Exception:
-                logger.exception("[Calibration] Unexpected error for model=%s", model_name)
-            finally:
-                # Clear active state when the thread exits
-                if self._active_calibration is not None and self._active_calibration[0] == model_name:
-                    self._active_calibration = None
+                    self._record_calibration_event(
+                        "calibration_model_failed",
+                        model=model_name,
+                        details=f"error={result.error}"
+                        + (
+                            f" unsupported={result.unsupported_reason}"
+                            if getattr(result, "unsupported_reason", None)
+                            else ""
+                        ),
+                    )
 
-        thread = threading.Thread(target=_run_calibration, name=f"calibration-{model_name}", daemon=True)
-        self._active_calibration = (model_name, cancel_event, thread, started_at)
-        thread.start()
-        return {"ok": True, "model_name": model_name, "sleep_level": sleep_level, "started_at": started_at}
-
-    def _handle_stop_calibration(self) -> dict[str, Any]:
-        """Cancel any in-progress calibration (idempotent)."""
-        if self._active_calibration is None:
-            return {"ok": True, "was_active": False}
-
-        model_name, cancel_event, thread, _started_at = self._active_calibration
-        cancel_event.set()
-        thread.join(timeout=10.0)
-        self._active_calibration = None
-        logger.info("[Calibration] stop_calibration received — cancelled model=%s", model_name)
-        return {"ok": True, "was_active": True, "model_name": model_name}
-
-    def _handle_get_calibration_status(self) -> dict[str, Any]:
-        """Return whether a calibration is currently running."""
-        if self._active_calibration is None:
-            return {"active": False, "model_name": None, "started_at": None}
-        model_name, _cancel, thread, started_at = self._active_calibration
-        if not thread.is_alive():
-            self._active_calibration = None
-            return {"active": False, "model_name": None, "started_at": None}
-        return {"active": True, "model_name": model_name, "started_at": started_at}
+                session.current_model = None
+        except asyncio.CancelledError:
+            terminal_event = "calibration_session_cancelled"
+            raise
+        except Exception:  # noqa: BLE001
+            # Anything else — bad state dir, bad config — must not escape
+            # silently because we still need to emit the terminal event so
+            # the orchestrator frees its active-provider slot.
+            logger.exception("[Calibration] Session aborted with unexpected error")
+            terminal_event = "calibration_session_cancelled"
+        finally:
+            session.current_model = None
+            self._record_calibration_event(
+                terminal_event,
+                details=f"sleep_level={session.sleep_level}",
+            )
+            if lane_manager is not None:
+                try:
+                    lane_manager._mark_status_dirty()  # noqa: SLF001
+                except Exception:  # noqa: BLE001
+                    pass
+            if self._active_calibration_session is session:
+                self._active_calibration_session = None
+            logger.info("[Calibration] Session ended (%s)", terminal_event)
 
     # vLLM endpoints that must never be reachable through proxied inference
     # requests.  These are internal management endpoints (sleep/wake, cache

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -592,7 +592,7 @@ class LogosBridgeClient:
                     model_name,
                     sleep_level,
                 )
-                from logos_worker_node.calibration import calibrate_model, plans_from_config
+                from logos_worker_node.calibration import calibrate_with_tp_escalation, plans_from_config
 
                 all_plans = plans_from_config(config_path) if config_path.exists() else []
                 plan_by_model = {p["model"]: p for p in all_plans}
@@ -603,7 +603,7 @@ class LogosBridgeClient:
                 log_dir = state_dir / "calibration_logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
 
-                result = calibrate_model(
+                result = calibrate_with_tp_escalation(
                     plan,
                     vllm_binary=_DEFAULT_VLLM,
                     port=_CALIBRATION_PORT,

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -550,6 +550,78 @@ class LogosBridgeClient:
         cfg = self._app.state.config
         model_profiles = self._app.state.model_profiles
 
+        # Refuse calibration when the node itself is in a degraded state
+        # (GPU ERR/N/A, HF cache EIO, …). The kv-cache search will fail
+        # the same way for every model; better to surface the underlying
+        # problem to the master upfront than spawn vLLM into a broken
+        # environment and let the user discover it via mysterious
+        # blacklist entries (deioma 2026-06-04).
+        try:
+            from logos_worker_node.node_health import evaluate_node_health  # noqa: PLC0415
+
+            _health = evaluate_node_health()
+            if not _health.healthy:
+                logger.error(
+                    "[Calibration] refusing start_calibration for %s: " "node unhealthy (reason=%s) — %s",
+                    model_name,
+                    _health.reason_code,
+                    _health.reason_detail,
+                )
+                return {
+                    "ok": False,
+                    "error": (
+                        f"node is in a degraded state (reason={_health.reason_code}): "
+                        f"{_health.reason_detail}. Calibration is suspended until the "
+                        f"underlying issue is resolved."
+                    ),
+                    "node_unhealthy": True,
+                    "reason_code": _health.reason_code,
+                }
+        except Exception:  # noqa: BLE001
+            logger.debug("[Calibration] node_health evaluation failed", exc_info=True)
+
+        # Refuse calibration for models already classified as permanently
+        # unsupported on this worker (bad repo id, gated repo, unsupported
+        # architecture, …). Cheap pre-flight check, before starting the
+        # calibration thread or spawning vLLM. Ensures the master gets a
+        # fast structured failure with the reason code so it can update
+        # the persisted model profile and stop asking.
+        #
+        # Best-effort: if the state dir can't be resolved (e.g. tests on a
+        # host without /app/data), skip the pre-flight and let the
+        # calibration itself catch the failure if any.
+        _unsupported = None
+        try:
+            from logos_worker_node.calibration import is_model_unsupported
+            from logos_worker_node.config import get_state_dir
+
+            _log_dir = get_state_dir() / "calibration_logs"
+            _unsupported = is_model_unsupported(_log_dir, model_name)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Calibration] could not consult unsupported-models list", exc_info=True)
+        if _unsupported is not None:
+            model_profiles.mark_calibration_unsupported(model_name, True, _unsupported.reason_code)
+            logger.warning(
+                "[Calibration] refusing start_calibration for %s: on unsupported list "
+                "(reason=%s, recorded_at=%s). Remove the line from %s/%s to re-attempt.",
+                model_name,
+                _unsupported.reason_code,
+                _unsupported.recorded_at,
+                _log_dir,
+                "calibration_unsupported_models.txt",
+            )
+            return {
+                "ok": False,
+                "error": (
+                    f"model {model_name!r} is on the unsupported list "
+                    f"(reason={_unsupported.reason_code}); calibration "
+                    f"cannot succeed until the underlying issue is fixed "
+                    f"and the entry is removed"
+                ),
+                "calibration_unsupported": True,
+                "reason_code": _unsupported.reason_code,
+            }
+
         # Reject calibration requests that would measure sleep_l<N> transient
         # host-RAM for a model whose worker config forbids sleeping. The vLLM
         # lane would be spawned with enable_sleep_mode=False (worker kill
@@ -669,6 +741,23 @@ class LogosBridgeClient:
                         model_name,
                         result.error,
                     )
+                    # When calibrate_model identified a permanent
+                    # model-identity-level failure (bad repo id, gated
+                    # repo, unsupported architecture), persist the flag in
+                    # the profile so the master's orchestrator stops
+                    # scheduling this model. Also persisted is the reason
+                    # code, for ops visibility. Recoverable failures
+                    # (kv-cache too high, transient I/O, etc.) carry no
+                    # ``unsupported_reason`` and remain eligible for
+                    # retry on the next maintenance window.
+                    if getattr(result, "unsupported_reason", None):
+                        model_profiles.mark_calibration_unsupported(model_name, True, result.unsupported_reason)
+                        logger.warning(
+                            "[Calibration] %s marked calibration_unsupported "
+                            "(reason=%s) — master will skip future windows.",
+                            model_name,
+                            result.unsupported_reason,
+                        )
             except Exception:
                 logger.exception("[Calibration] Unexpected error for model=%s", model_name)
             finally:

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -330,8 +330,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 sleep_mode for capability-served vLLM lanes. A model whose
                 override flips this to False cannot release VRAM via sleep_l1,
                 so it doesn't contribute to the sleep reserve and the cache
-                planner is free to include it.
+                planner is free to include it. The worker-wide
+                engines.vllm.disable_sleep_mode kill switch takes precedence
+                over any per-model override.
                 """
+                if cfg.engines and cfg.engines.vllm and cfg.engines.vllm.disable_sleep_mode:
+                    return False
                 ov_vllm = cfg.engines.vllm.model_overrides.get(m, {}) if cfg.engines and cfg.engines.vllm else {}
                 ov_caps = cfg.logos.capabilities_overrides.get(m, {}) if cfg.logos else {}
                 if "enable_sleep_mode" in ov_vllm:

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -25,6 +25,7 @@ from logos_worker_node.lane_manager import LaneManager, _lane_id_from_config
 from logos_worker_node.logos_bridge import LogosBridgeClient
 from logos_worker_node.model_cache import create_model_cache
 from logos_worker_node.model_profiles import ModelProfileRegistry
+from logos_worker_node.models import model_can_sleep
 from logos_worker_node.runtime import SERVICE_VERSION, _build_host_memory_summary
 
 logging.basicConfig(
@@ -324,25 +325,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 return p is not None and (p.base_residency_mb or 0) > 0
 
             def _can_sleep(m: str) -> bool:
-                """Effective enable_sleep_mode after engine + capability overrides.
-
-                Default (no override) is True — the lane-spawn path enables
-                sleep_mode for capability-served vLLM lanes. A model whose
-                override flips this to False cannot release VRAM via sleep_l1,
-                so it doesn't contribute to the sleep reserve and the cache
-                planner is free to include it. The worker-wide
-                engines.vllm.disable_sleep_mode kill switch takes precedence
-                over any per-model override.
-                """
-                if cfg.engines and cfg.engines.vllm and cfg.engines.vllm.disable_sleep_mode:
-                    return False
-                ov_vllm = cfg.engines.vllm.model_overrides.get(m, {}) if cfg.engines and cfg.engines.vllm else {}
-                ov_caps = cfg.logos.capabilities_overrides.get(m, {}) if cfg.logos else {}
-                if "enable_sleep_mode" in ov_vllm:
-                    return bool(ov_vllm["enable_sleep_mode"])
-                if "enable_sleep_mode" in ov_caps:
-                    return bool(ov_caps["enable_sleep_mode"])
-                return True
+                return model_can_sleep(cfg, m)
 
             calibrated_caps = [m for m in caps if _has_valid_profile(m)]
             caps_skipped = [m for m in caps if not _has_valid_profile(m)]

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -400,19 +400,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
             if plan.order:
                 logger.info(
-                    "Pre-populating RAM cache with %d model(s): %s",
+                    "Pre-populating RAM cache with %d model(s) in the BACKGROUND: %s. "
+                    "Startup continues immediately; apply_lanes for these models "
+                    "will block on their cache copy only if it's not finished yet.",
                     len(plan.order),
                     plan.order,
                 )
-                effective_paths = await model_cache.cache_models_by_priority(plan.order)
-                for m, p in effective_paths.items():
-                    if p == str(model_cache._cache_hub.parent):
-                        logger.info("  %s → tmpfs RAM cache", m)
-                    else:
-                        logger.info(
-                            "  %s → source filesystem (RAM cache full or model not found)",
-                            m,
-                        )
+                # Fire-and-forget: lane requests that arrive while the
+                # worker is still copying will bump their model to the
+                # front via LaneManager → ModelRamCache.wait_for_cached.
+                model_cache.start_background_caching(plan.order)
             else:
                 logger.info("No models eligible to pre-populate into RAM cache")
 
@@ -565,6 +562,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.warning("Error destroying lanes", exc_info=True)
     await lane_manager.close()
     await gpu_collector.stop()
+    # Cancel any pending background RAM cache copies. Won't roll back an
+    # rsync that's already in flight, but stops the worker from queueing
+    # more after shutdown was requested.
+    try:
+        await model_cache.stop_background_caching()
+    except Exception:  # noqa: BLE001
+        logger.debug("model_cache.stop_background_caching failed", exc_info=True)
 
 
 def create_app() -> FastAPI:

--- a/logos/logos-workernode/logos_worker_node/model_cache.py
+++ b/logos/logos-workernode/logos_worker_node/model_cache.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import subprocess
 import time
+from collections import deque
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,17 @@ class ModelRamCache:
         self._locks: dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
         self._cached_models: set[str] = set()
+
+        # Background-caching state. Caching one model at a time is intentional:
+        # parallel rsyncs to the same tmpfs thrash the source filesystem and
+        # don't speed anything up. ``_cache_queue`` holds the pending models;
+        # ``_completion_events`` lets callers await a specific model finishing.
+        # Lane requests bump their model to the front via ``wait_for_cached``.
+        self._cache_queue: deque[str] = deque()
+        self._cache_queue_event: asyncio.Event | None = None
+        self._completion_events: dict[str, asyncio.Event] = {}
+        self._caching_now: str | None = None
+        self._caching_task: asyncio.Task | None = None
 
         self._cache_hub.mkdir(parents=True, exist_ok=True)
         self._scan_existing()
@@ -372,12 +384,160 @@ class ModelRamCache:
 
         Stops when tmpfs is full.  Returns ``model_name -> effective_hf_home``
         mapping.
+
+        Kept for backwards compatibility and for tools that want to block
+        until everything is cached. New callers should prefer
+        :meth:`start_background_caching` + :meth:`wait_for_cached` to avoid
+        blocking startup on a multi-minute rsync sweep.
         """
         result: dict[str, str] = {}
         for model_name in models:
             effective = await self.ensure_cached(model_name)
             result[model_name] = effective
         return result
+
+    # ------------------------------------------------------------------
+    # Background caching — kick off at startup, prioritize on lane add
+    # ------------------------------------------------------------------
+
+    def _ensure_completion_event(self, model_name: str) -> asyncio.Event:
+        ev = self._completion_events.get(model_name)
+        if ev is None:
+            ev = asyncio.Event()
+            self._completion_events[model_name] = ev
+        return ev
+
+    def is_cached(self, model_name: str) -> bool:
+        """Return True when the model is fully copied into tmpfs and
+        the directory still exists. Cheap and lock-free."""
+        if model_name not in self._cached_models:
+            return False
+        return (self._cache_hub / _hf_model_dir_name(model_name)).exists()
+
+    def start_background_caching(self, models: list[str]) -> None:
+        """Begin caching *models* in the background (sequentially, in the
+        given order). Called once at startup so the worker can accept
+        ``apply_lanes`` immediately instead of blocking the lifespan
+        startup hook on a multi-minute rsync sweep.
+
+        Subsequent calls extend the queue rather than replacing it — safe
+        to invoke from anywhere once the worker is running.
+        """
+        # Coerce to a fresh list because the caller may reuse the input.
+        wanted = [m for m in models if isinstance(m, str) and m.strip()]
+        if self._cache_queue_event is None:
+            self._cache_queue_event = asyncio.Event()
+        for m in wanted:
+            self._enqueue(m, priority=False)
+        if self._caching_task is None or self._caching_task.done():
+            self._caching_task = asyncio.create_task(self._cache_worker_loop(), name="ram-cache-worker")
+            logger.info(
+                "RAM cache: background worker started (queue depth=%d)",
+                len(self._cache_queue),
+            )
+
+    def _enqueue(self, model_name: str, *, priority: bool) -> asyncio.Event:
+        """Internal: place *model_name* on the queue (or bump to front when
+        ``priority=True``) and return the completion event."""
+        event = self._ensure_completion_event(model_name)
+        # Already cached → event is already set; nothing to enqueue.
+        if self.is_cached(model_name):
+            if not event.is_set():
+                event.set()
+            return event
+        # Currently being copied — just await; don't disturb the worker.
+        if self._caching_now == model_name:
+            return event
+        # Already queued: only act if we need to bump priority.
+        if model_name in self._cache_queue:
+            if priority:
+                self._cache_queue.remove(model_name)
+                self._cache_queue.appendleft(model_name)
+                logger.info("RAM cache: bumped %s to front of queue", model_name)
+            return event
+        # Fresh enqueue.
+        if priority:
+            self._cache_queue.appendleft(model_name)
+        else:
+            self._cache_queue.append(model_name)
+        if self._cache_queue_event is not None:
+            self._cache_queue_event.set()
+        return event
+
+    async def wait_for_cached(self, model_name: str, *, timeout: float | None = None) -> bool:
+        """Wait until *model_name* is cached (or its caching attempt has
+        completed with failure). Bumps the model to the front of the
+        queue. Returns True if the model is in tmpfs when this returns,
+        False otherwise.
+
+        ``timeout`` is for callers that need to bound how long a lane add
+        will wait on a slow rsync. ``None`` means wait indefinitely.
+
+        Safe to call before :meth:`start_background_caching` — in that
+        case a one-off worker task is started just for this request.
+        """
+        if self.is_cached(model_name):
+            return True
+        if self._cache_queue_event is None:
+            self._cache_queue_event = asyncio.Event()
+        event = self._enqueue(model_name, priority=True)
+        if self._caching_task is None or self._caching_task.done():
+            # No background worker was started yet (or it exited): spin one
+            # up so the event we just enqueued actually gets processed.
+            self._caching_task = asyncio.create_task(self._cache_worker_loop(), name="ram-cache-worker")
+        logger.info("Lane request waiting on RAM cache for %s", model_name)
+        try:
+            if timeout is None:
+                await event.wait()
+            else:
+                await asyncio.wait_for(event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Lane request timed out waiting %.0fs for %s to cache — proceeding from disk",
+                timeout,
+                model_name,
+            )
+            return False
+        return self.is_cached(model_name)
+
+    async def _cache_worker_loop(self) -> None:
+        """Drain the queue sequentially. Exits cleanly on CancelledError."""
+        try:
+            while True:
+                while not self._cache_queue:
+                    if self._cache_queue_event is not None:
+                        self._cache_queue_event.clear()
+                        await self._cache_queue_event.wait()
+                model = self._cache_queue.popleft()
+                self._caching_now = model
+                try:
+                    if self.is_cached(model):
+                        # Raced with another path that completed it; just
+                        # fire the event for any waiter and move on.
+                        pass
+                    else:
+                        await self.ensure_cached(model)
+                except Exception:
+                    logger.exception("RAM cache: background copy failed for %s", model)
+                finally:
+                    self._caching_now = None
+                    event = self._completion_events.get(model)
+                    if event is not None:
+                        event.set()
+        except asyncio.CancelledError:
+            logger.info("RAM cache worker cancelled (queue=%s, caching=%s)", list(self._cache_queue), self._caching_now)
+            raise
+
+    async def stop_background_caching(self) -> None:
+        """Cancel the background worker task. Call from app shutdown."""
+        if self._caching_task is None or self._caching_task.done():
+            return
+        self._caching_task.cancel()
+        try:
+            await self._caching_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        self._caching_task = None
 
     def evict(self, model_name: str) -> None:
         """Remove a model from the cache to free space."""
@@ -671,6 +831,18 @@ class _DisabledModelRamCache:
 
     async def cache_models_by_priority(self, models: list[str]) -> dict[str, str]:
         return {}
+
+    def is_cached(self, model_name: str) -> bool:  # noqa: ARG002
+        return False
+
+    def start_background_caching(self, models: list[str]) -> None:  # noqa: ARG002
+        pass
+
+    async def wait_for_cached(self, model_name: str, *, timeout: float | None = None) -> bool:  # noqa: ARG002
+        return False
+
+    async def stop_background_caching(self) -> None:
+        pass
 
     def evict(self, model_name: str) -> None:  # noqa: ARG002
         pass

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -96,6 +96,19 @@ class ModelProfileRecord:
     # be measured here. None on legacy profiles written before this flag
     # existed (interpret as "unknown — assume sleep is possible").
     sleep_mode_disabled: bool | None = None
+    # True when calibration has classified this model as permanently
+    # unsupported on this worker — bad repo id, gated repo without token,
+    # vLLM architecture mismatch, etc. (see FatalLoadErrorPattern in
+    # calibration.py). The master's calibration orchestrator skips models
+    # flagged this way so it doesn't burn a maintenance window each night
+    # watching the same identity-level error reproduce. Cleared by an
+    # operator (delete the entry from calibration_unsupported_models.txt
+    # and restart, or set this flag to False) after fixing the underlying
+    # cause. None on profiles written before this flag existed.
+    calibration_unsupported: bool | None = None
+    # Reason code matching FatalLoadErrorPattern.reason_code, for diagnostics.
+    # Surfaced to ops in master logs alongside `calibration_unsupported=True`.
+    calibration_unsupported_reason: str | None = None
 
     def known_base_residency_mb(self) -> float | None:
         """Return base_residency_mb only if it came from a real source, else None."""
@@ -147,6 +160,8 @@ class ModelProfileRecord:
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
             "sleep_mode_disabled": self.sleep_mode_disabled,
+            "calibration_unsupported": self.calibration_unsupported,
+            "calibration_unsupported_reason": self.calibration_unsupported_reason,
         }
 
     def estimate_host_ram_mb(self) -> float:
@@ -532,6 +547,34 @@ class ModelProfileRegistry:
         self._persist()
         return True
 
+    def mark_calibration_unsupported(self, model_name: str, unsupported: bool, reason_code: str | None = None) -> bool:
+        """Persist whether this model is permanently uncalibratable on this worker.
+
+        Returns True when the stored value changed. Used by the
+        server-orchestrated calibration path to tell the master "stop
+        scheduling this model for calibration — it cannot succeed here
+        until an operator removes the matching line from
+        ``calibration_unsupported_models.txt``."
+
+        Setting ``unsupported=False`` is treated as a clearing operation:
+        it never creates a new profile entry, only updates an existing
+        one — same convention as :meth:`mark_sleep_mode_disabled`. When
+        clearing, ``reason_code`` is also nulled out.
+        """
+        with self._lock:
+            if not unsupported and model_name not in self._profiles:
+                return False
+            profile = self._profiles.setdefault(model_name, ModelProfileRecord())
+            changed = profile.calibration_unsupported != unsupported or profile.calibration_unsupported_reason != (
+                reason_code if unsupported else None
+            )
+            if not changed:
+                return False
+            profile.calibration_unsupported = unsupported
+            profile.calibration_unsupported_reason = reason_code if unsupported else None
+        self._persist()
+        return True
+
     def get_profile(self, model_name: str) -> ModelProfileRecord | None:
         with self._lock:
             return self._profiles.get(model_name)
@@ -603,6 +646,8 @@ class ModelProfileRegistry:
                     sleep_l1_transient_host_ram_mb=profile_data.get("sleep_l1_transient_host_ram_mb"),
                     sleep_l2_transient_host_ram_mb=profile_data.get("sleep_l2_transient_host_ram_mb"),
                     sleep_mode_disabled=profile_data.get("sleep_mode_disabled"),
+                    calibration_unsupported=profile_data.get("calibration_unsupported"),
+                    calibration_unsupported_reason=profile_data.get("calibration_unsupported_reason"),
                 )
             logger.info(
                 "Loaded %d model profile(s) from %s",

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -87,6 +87,15 @@ class ModelProfileRecord:
     # EngineCore. None on profiles calibrated before this field existed.
     sleep_l1_transient_host_ram_mb: float | None = None
     sleep_l2_transient_host_ram_mb: float | None = None
+    # True when this worker's effective config forbids sleep mode for this
+    # model (engines.vllm.disable_sleep_mode worker kill switch, or a
+    # per-model enable_sleep_mode=false override under engines.vllm or
+    # logos.capabilities). The server's nightly calibration orchestrator
+    # treats this as "sleep_l1_transient_host_ram_mb is N/A by design" so
+    # it stops re-requesting calibration of a sleep field that can never
+    # be measured here. None on legacy profiles written before this flag
+    # existed (interpret as "unknown — assume sleep is possible").
+    sleep_mode_disabled: bool | None = None
 
     def known_base_residency_mb(self) -> float | None:
         """Return base_residency_mb only if it came from a real source, else None."""
@@ -137,6 +146,7 @@ class ModelProfileRecord:
             "host_ram_residual_mb": self.host_ram_residual_mb,
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
+            "sleep_mode_disabled": self.sleep_mode_disabled,
         }
 
     def estimate_host_ram_mb(self) -> float:
@@ -499,6 +509,29 @@ class ModelProfileRegistry:
             profile.disk_size_bytes = disk_size_bytes
         self._persist()
 
+    def mark_sleep_mode_disabled(self, model_name: str, disabled: bool) -> bool:
+        """Persist whether sleep mode is forbidden for this model on this worker.
+
+        Returns True when the stored value changed. Used by the
+        server-orchestrated calibration path to tell the master "stop
+        asking — sleep_l1_transient_host_ram_mb is N/A for this model
+        because the worker config forbids sleeping it."
+
+        Setting ``disabled=False`` is treated as a clearing operation:
+        it never creates a new profile entry, only updates an existing
+        one. This keeps the registry from filling up with empty stubs
+        for models that were never calibrated.
+        """
+        with self._lock:
+            if not disabled and model_name not in self._profiles:
+                return False
+            profile = self._profiles.setdefault(model_name, ModelProfileRecord())
+            if profile.sleep_mode_disabled == disabled:
+                return False
+            profile.sleep_mode_disabled = disabled
+        self._persist()
+        return True
+
     def get_profile(self, model_name: str) -> ModelProfileRecord | None:
         with self._lock:
             return self._profiles.get(model_name)
@@ -569,6 +602,7 @@ class ModelProfileRegistry:
                     host_ram_residual_mb=profile_data.get("host_ram_residual_mb"),
                     sleep_l1_transient_host_ram_mb=profile_data.get("sleep_l1_transient_host_ram_mb"),
                     sleep_l2_transient_host_ram_mb=profile_data.get("sleep_l2_transient_host_ram_mb"),
+                    sleep_mode_disabled=profile_data.get("sleep_mode_disabled"),
                 )
             logger.info(
                 "Loaded %d model profile(s) from %s",

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -210,6 +210,17 @@ class VllmEngineConfig(BaseModel):
         "Overrides are merged on top of whatever the Logos server sends, so the worker "
         "can enforce Turing/SM-7.5 workarounds without touching the server.",
     )
+    disable_sleep_mode: bool = Field(
+        default=False,
+        description="Worker-wide kill switch for vLLM sleep mode. When true, every "
+        "vLLM lane spawned on this node is forced to enable_sleep_mode=False "
+        "regardless of what the Logos server requests or what per-model "
+        "overrides specify. The server learns about the limitation via the "
+        "lane's reported sleep_state='unsupported' and via the worker-level "
+        "sleep_mode_disabled flag in WorkerRuntimeStatus, so it falls back to "
+        "stop/start cycles for VRAM reclamation. Default false preserves the "
+        "current behaviour (server decides per lane).",
+    )
     global_extra_args: list[str] = Field(
         default_factory=list,
         description=(
@@ -547,6 +558,11 @@ class WorkerRuntimeStatus(BaseModel):
     # Logos request scheduler for weighted round-robin tie-breaks among
     # workers with the same model loaded warm.
     gpu_performance_score: int = 100
+    # Mirrors engines.vllm.disable_sleep_mode so the Logos server can see the
+    # node-wide limitation without inspecting individual lanes. When true,
+    # every vLLM lane on this worker is forced to enable_sleep_mode=False;
+    # the planner therefore cannot rely on sleep_l1 for VRAM reclamation here.
+    sleep_mode_disabled: bool = False
 
 
 class LaneSetRequest(BaseModel):

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -424,6 +424,31 @@ class AppConfig(BaseModel):
     )
 
 
+def model_can_sleep(cfg: AppConfig, model_name: str) -> bool:
+    """Effective enable_sleep_mode for a model on this worker.
+
+    Mirrors the lane-spawn decision: the worker-wide
+    ``engines.vllm.disable_sleep_mode`` kill switch wins over any per-model
+    override; otherwise a per-model ``enable_sleep_mode`` setting under
+    ``engines.vllm.model_overrides`` or ``logos.capabilities_overrides``
+    wins over the default. Default (no override) is True — capability
+    lanes are spawned with sleep_mode enabled.
+
+    Centralized here so both the startup cache planner (main.py) and the
+    server-orchestrated calibration path (logos_bridge.py) compute the
+    same answer.
+    """
+    if cfg.engines and cfg.engines.vllm and cfg.engines.vllm.disable_sleep_mode:
+        return False
+    ov_vllm = cfg.engines.vllm.model_overrides.get(model_name, {}) if cfg.engines and cfg.engines.vllm else {}
+    ov_caps = cfg.logos.capabilities_overrides.get(model_name, {}) if cfg.logos else {}
+    if "enable_sleep_mode" in ov_vllm:
+        return bool(ov_vllm["enable_sleep_mode"])
+    if "enable_sleep_mode" in ov_caps:
+        return bool(ov_caps["enable_sleep_mode"])
+    return True
+
+
 class ProcessState(str, enum.Enum):
     STARTING = "starting"
     RUNNING = "running"

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -315,6 +315,12 @@ class LogosConfig(BaseModel):
     allow_insecure_http: bool = False
     shared_key: str = ""
     capabilities_models: list[str] = Field(default_factory=list)
+    # Unfiltered list of every model declared in worker config. Mirrors
+    # capabilities_models at config-load time, but the runtime later strips
+    # uncalibrated entries from capabilities_models (so the server doesn't
+    # route requests to them); configured_models retains the originals so the
+    # server-side calibration orchestrator can still discover and target them.
+    configured_models: list[str] = Field(default_factory=list)
     capabilities_overrides: dict[str, dict] = Field(default_factory=dict)
     heartbeat_interval_seconds: int = Field(default=5, ge=1)
     reconnect_backoff_seconds: int = Field(default=3, ge=1)
@@ -346,6 +352,7 @@ class LogosConfig(BaseModel):
                     overrides[model_name] = ov
         values["capabilities_models"] = names
         values["capabilities_overrides"] = overrides
+        values["configured_models"] = list(names)
         return values
 
 

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -588,6 +588,12 @@ class WorkerRuntimeStatus(BaseModel):
     # every vLLM lane on this worker is forced to enable_sleep_mode=False;
     # the planner therefore cannot rely on sleep_l1 for VRAM reclamation here.
     sleep_mode_disabled: bool = False
+    # Node-level health snapshot. None on legacy workers that don't report it
+    # yet. When present, ``healthy=False`` means at least one sensor (GPU
+    # ERR/N/A, HF cache EIO, …) flagged the node as degraded. The master
+    # orchestrator MUST skip calibration scheduling on unhealthy workers and
+    # log the condition so an operator can intervene (usually reboot).
+    node_health: dict[str, Any] | None = None
 
 
 class LaneSetRequest(BaseModel):

--- a/logos/logos-workernode/logos_worker_node/node_health.py
+++ b/logos/logos-workernode/logos_worker_node/node_health.py
@@ -1,0 +1,259 @@
+"""Node-level health sensors for the LogosWorkerNode.
+
+Two distinct failure axes that the kv-cache binary search and the
+per-command / per-model blacklists cannot recover from:
+
+  1. GPU sensor — ``nvidia-smi`` reports ``[Error]`` or ``N/A`` for any
+     queried memory field. This usually means a card has fallen off the
+     PCIe bus, ECC is in an unrecoverable state, or the driver lost track
+     of it. The fix is always operator action (reseat the card, reboot).
+
+  2. Storage sensor — the HuggingFace cache directory returns ``EIO`` /
+     ``EROFS`` on ``listdir``/``stat``. Caused by network-block-device
+     hiccups, Ceph PG recovery, dying disks, etc. Until ops intervenes,
+     every vLLM spawn that needs to read a model from cache will fail —
+     and previously (before this module) each failure was misclassified
+     as a per-command OOM, polluting the blacklist with up to a hundred
+     junk lines during a single multi-minute outage (deioma 2026-06-04).
+
+The bridge calls :func:`evaluate_node_health` at heartbeat time and
+includes the result in :class:`WorkerRuntimeStatus`. The server logs
+loudly on any transition into ``healthy=False`` and the calibration
+orchestrator stops scheduling work on unhealthy nodes.
+
+Recovery is automatic: the sensors are stateless and re-checked each
+heartbeat. As soon as the underlying issue clears (e.g. operator
+remounts ``/mnt/ceph`` after a Ceph reconnect), the next heartbeat will
+flip the node back to healthy and the orchestrator resumes scheduling.
+No worker restart required.
+
+Adding a sensor: append a ``_check_<name>`` function returning a
+``SensorResult`` and register it in :data:`_SENSORS`. Keep each sensor
+cheap (≤ a few hundred ms) — the heartbeat path runs them every cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SensorResult:
+    """One sensor's read. ``state="ok"`` means healthy; anything else
+    is a short kebab-case reason code surfaced to ops."""
+
+    state: str  # "ok" | "<kebab-case-reason>"
+    detail: str = ""  # human-readable diagnosis (paths, error messages, …)
+
+
+@dataclass
+class NodeHealthStatus:
+    """Aggregated health snapshot for one heartbeat tick."""
+
+    healthy: bool
+    checked_at: str  # ISO-8601 UTC timestamp
+    sensors: dict[str, dict[str, str]] = field(default_factory=dict)
+    # Top-level reason — first failing sensor's reason code. Convenient
+    # for callers that just want one string to log / display without
+    # walking the per-sensor dict.
+    reason_code: str | None = None
+    reason_detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "healthy": self.healthy,
+            "checked_at": self.checked_at,
+            "sensors": dict(self.sensors),
+            "reason_code": self.reason_code,
+            "reason_detail": self.reason_detail,
+        }
+
+
+# ---------------------------------------------------------------------------
+# GPU sensor — nvidia-smi ERR / N/A
+# ---------------------------------------------------------------------------
+
+
+def _check_gpu() -> SensorResult:
+    """Return ``state="ok"`` when nvidia-smi reports clean values for
+    every visible GPU; otherwise ``"gpu-error"`` (the field is literally
+    ``"[Error]"``) or ``"gpu-na"`` (the field is ``"N/A"``).
+
+    Both are non-recoverable from the worker's side. ``[Error]`` usually
+    means the card fell off the PCIe bus (xid error, RmInitAdapter
+    failed, etc.). ``N/A`` typically means the driver lost track of the
+    device entirely. In both cases the fix is operator action.
+
+    Misses nvidia-smi being absent / non-executable entirely — that's
+    expected on dev machines and not what this sensor is for.
+    """
+    try:
+        raw = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,memory.total,memory.used,memory.free",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return SensorResult(state="ok", detail="nvidia-smi not installed (dev host)")
+    except subprocess.CalledProcessError as exc:
+        return SensorResult(
+            state="gpu-query-failed",
+            detail=f"nvidia-smi exited {exc.returncode}: {exc.output!r}",
+        )
+    except subprocess.TimeoutExpired:
+        # nvidia-smi hanging usually means the driver is stuck — worth
+        # surfacing as unhealthy because it'll block calibration too.
+        return SensorResult(state="gpu-query-timeout", detail="nvidia-smi did not respond within 10s")
+
+    bad_gpus: list[str] = []
+    for line in raw.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 4:
+            continue
+        idx = parts[0]
+        for field_name, value in zip(("total", "used", "free"), parts[1:4]):
+            if value == "[Error]" or value.upper() == "N/A" or value == "Unknown Error":
+                bad_gpus.append(f"GPU{idx}.{field_name}={value!r}")
+    if bad_gpus:
+        return SensorResult(
+            state="gpu-error" if any("Error" in b for b in bad_gpus) else "gpu-na",
+            detail=(
+                f"nvidia-smi reported unreadable fields for {len(bad_gpus)} entry(s): "
+                + ", ".join(bad_gpus[:10])
+                + ("…" if len(bad_gpus) > 10 else "")
+                + ". Card likely fell off the PCIe bus / driver lost track — reboot required."
+            ),
+        )
+    return SensorResult(state="ok")
+
+
+# ---------------------------------------------------------------------------
+# Storage sensor — HF cache readability
+# ---------------------------------------------------------------------------
+
+
+# Paths probed for read access. The first one that actually exists is
+# the one we validate; missing paths are skipped (a worker without an HF
+# cache is just one without that sensor — not unhealthy).
+_STORAGE_PATHS_TO_PROBE: tuple[Path, ...] = (
+    Path("/usr/share/ollama/.ollama/models/.hf_cache/hub"),  # production container path
+    Path("/usr/share/ollama/.ollama/models/.hf_cache"),
+    Path(os.environ.get("HF_HOME", "")) if os.environ.get("HF_HOME") else Path(),
+    Path(os.environ.get("HF_HUB_CACHE", "")) if os.environ.get("HF_HUB_CACHE") else Path(),
+)
+
+
+def _check_storage() -> SensorResult:
+    """Return ``state="ok"`` when the HF cache directory is readable;
+    otherwise ``"filesystem-eio"`` (EIO on read), ``"filesystem-readonly"``
+    (the mount is read-only), or ``"filesystem-missing"`` (none of the
+    expected paths exist — usually a misconfigured worker).
+
+    Cheap: a single ``os.listdir`` call against the first existing
+    candidate path. The HF cache is the most failure-prone storage
+    dependency in production because it's typically backed by a network
+    block device (Ceph RBD via nbd).
+    """
+    probed: list[Path] = [p for p in _STORAGE_PATHS_TO_PROBE if str(p) and p.exists()]
+    if not probed:
+        # No HF cache configured on this host — not a failure. Workers
+        # without a model cache (e.g. ollama-only) are healthy.
+        return SensorResult(state="ok", detail="no HF cache path configured")
+
+    target = probed[0]
+    try:
+        # listdir touches the directory inode and the dirent block — same
+        # I/O path that triggered the deioma EIO storm. Bounded cost
+        # because we don't read file contents.
+        os.listdir(target)
+        return SensorResult(state="ok")
+    except OSError as exc:
+        if exc.errno == 5:  # EIO
+            return SensorResult(
+                state="filesystem-eio",
+                detail=(
+                    f"listdir({target}) failed with EIO (Errno 5). "
+                    "The backing storage is degraded. Check `dmesg | grep -E 'nbd|EXT4'` "
+                    "and either restore the device or reboot the node."
+                ),
+            )
+        if exc.errno == 30:  # EROFS
+            return SensorResult(
+                state="filesystem-readonly",
+                detail=(
+                    f"listdir({target}) failed because the filesystem is read-only. "
+                    "The kernel likely remounted it after I/O errors — investigate the "
+                    "backing device or reboot."
+                ),
+            )
+        # Other OSErrors (ENOENT for the leaf only, EACCES, …) shouldn't
+        # mark the node as unhealthy. We already short-circuited on
+        # ENOENT for the parent above; any remaining error here is
+        # surfaced as a generic but non-fatal warning.
+        return SensorResult(
+            state="ok",
+            detail=f"storage probe noise (errno={exc.errno}): {exc}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry + entry point
+# ---------------------------------------------------------------------------
+
+
+_SENSORS: tuple[tuple[str, Callable[[], SensorResult]], ...] = (
+    ("gpu", _check_gpu),
+    ("storage", _check_storage),
+)
+
+
+def evaluate_node_health() -> NodeHealthStatus:
+    """Run every registered sensor and produce a fresh aggregated status.
+
+    Stateless — call each heartbeat. The first failing sensor's reason
+    code becomes the top-level ``reason_code`` for convenience; the full
+    per-sensor breakdown is preserved in ``sensors``.
+    """
+    sensors: dict[str, dict[str, str]] = {}
+    reason_code: str | None = None
+    reason_detail: str | None = None
+    healthy = True
+
+    for name, check in _SENSORS:
+        t0 = time.perf_counter()
+        try:
+            result = check()
+        except Exception as exc:  # noqa: BLE001
+            # A sensor that throws shouldn't kill heartbeat — log and
+            # treat as a soft 'sensor-error' state.
+            logger.warning("node_health: sensor %r raised: %s", name, exc)
+            result = SensorResult(state="sensor-error", detail=str(exc))
+        sensors[name] = {"state": result.state, "detail": result.detail}
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        if elapsed_ms > 500:
+            logger.warning("node_health: sensor %r took %.0fms — investigate", name, elapsed_ms)
+        if result.state != "ok" and healthy:
+            healthy = False
+            reason_code = result.state
+            reason_detail = result.detail
+
+    return NodeHealthStatus(
+        healthy=healthy,
+        checked_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        sensors=sensors,
+        reason_code=reason_code,
+        reason_detail=reason_detail,
+    )

--- a/logos/logos-workernode/logos_worker_node/runtime.py
+++ b/logos/logos-workernode/logos_worker_node/runtime.py
@@ -176,4 +176,5 @@ async def build_runtime_status(app: FastAPI) -> WorkerRuntimeStatus:
         model_profiles=model_profiles if model_profiles else None,
         max_lanes=cfg.worker.max_lanes,
         gpu_performance_score=cfg.worker.gpu_performance_score,
+        sleep_mode_disabled=cfg.engines.vllm.disable_sleep_mode,
     )

--- a/logos/logos-workernode/logos_worker_node/runtime.py
+++ b/logos/logos-workernode/logos_worker_node/runtime.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import FastAPI
 from logos_worker_node.models import CapacitySummary, DeviceInfo, DeviceSummary, HostMemorySummary, WorkerRuntimeStatus
+
+logger = logging.getLogger(__name__)
 
 SERVICE_VERSION = "2.0.0"
 
@@ -158,10 +161,63 @@ async def build_runtime_status(app: FastAPI) -> WorkerRuntimeStatus:
 
     host_memory = _build_host_memory_summary()
 
+    # Sample node-level health (GPU ERR/N/A, HF cache EIO/EROFS, …).
+    # Stateless — re-evaluated each heartbeat so recovery is automatic
+    # once ops fixes the underlying issue. When unhealthy, the bridge
+    # surfaces the reason into WorkerRuntimeStatus.node_health and the
+    # master orchestrator skips this worker.
+    node_health_dict: dict | None = None
+    try:
+        from logos_worker_node.node_health import evaluate_node_health  # noqa: PLC0415
+
+        _nh = evaluate_node_health()
+        node_health_dict = _nh.to_dict()
+        if not _nh.healthy:
+            # Log loudly so the worker journal shows it too — the master
+            # logs once on transition, but the worker should always show
+            # the current state on every heartbeat for context.
+            from logos_worker_node import logos_bridge as _lb  # noqa: PLC0415
+
+            logger.error(
+                "%sNODE UNHEALTHY%s reason=%s detail=%s",
+                _lb._RED + _lb._BOLD,  # noqa: SLF001
+                _lb._RESET,  # noqa: SLF001
+                _nh.reason_code,
+                _nh.reason_detail,
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("node_health evaluation failed", exc_info=True)
+
     # Include model profiles if available
     model_profiles = None
     if hasattr(app.state, "model_profiles") and app.state.model_profiles is not None:
         model_profiles = app.state.model_profiles.get_all_profiles()
+        # Reconcile each profile's calibration_unsupported flag against the
+        # current state of calibration_unsupported_models.txt — that file is
+        # operator-editable, so deleting a line should immediately let the
+        # master's orchestrator re-schedule the model without requiring a
+        # worker restart or a separate clear-flag RPC. Best-effort: ignore
+        # any I/O error and leave the persisted flag in place.
+        try:
+            from logos_worker_node.calibration import _load_unsupported_models  # noqa: PLC0415
+            from logos_worker_node.config import get_state_dir  # noqa: PLC0415
+
+            _file_state = _load_unsupported_models(
+                get_state_dir() / "calibration_logs" / "calibration_unsupported_models.txt"
+            )
+            for _name, _prof in model_profiles.items():
+                if _name in _file_state:
+                    _prof["calibration_unsupported"] = True
+                    _prof["calibration_unsupported_reason"] = _file_state[_name].reason_code
+                elif _prof.get("calibration_unsupported"):
+                    # File no longer mentions this model — clear the flag
+                    # both on the wire and in the in-memory registry so the
+                    # next persist drops the stale value.
+                    _prof["calibration_unsupported"] = None
+                    _prof["calibration_unsupported_reason"] = None
+                    app.state.model_profiles.mark_calibration_unsupported(_name, False)
+        except Exception:  # noqa: BLE001
+            pass
 
     return WorkerRuntimeStatus(
         worker_name=cfg.worker.name,
@@ -177,4 +233,5 @@ async def build_runtime_status(app: FastAPI) -> WorkerRuntimeStatus:
         max_lanes=cfg.worker.max_lanes,
         gpu_performance_score=cfg.worker.gpu_performance_score,
         sleep_mode_disabled=cfg.engines.vllm.disable_sleep_mode,
+        node_health=node_health_dict,
     )

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -850,6 +850,35 @@ def test_first_attempt_succeeds():
     assert mocks["spawn"].call_count == 1
 
 
+def test_explicit_kv_blacklisted_returns_failure_without_nameerror():
+    """Regression for deimama 2026-06-04: when a model has an explicit
+    kv_cache_memory_bytes override AND the resulting command fingerprint is
+    already blacklisted, calibrate_model used to crash with
+    ``NameError: cannot access free variable '_probes' …`` because the
+    ``_probes`` dict was only initialised inside the ``if kv_search:`` branch
+    while ``_try_start`` (defined outside it) still wrote to ``_probes`` on
+    blacklist-skip. _probes is now initialised in the outer scope; this test
+    asserts the blacklist-skip path returns a failure result cleanly instead
+    of raising.
+    """
+    patches = _patch_calibration_infra()
+    # Inject a blacklist hit for whatever fingerprint _try_start computes.
+    patches["load_failed"] = patch(
+        "logos_worker_node.calibration._load_failed_commands",
+        return_value={"<blacklisted>"},
+    )
+    patches["fingerprint"] = patch(
+        "logos_worker_node.calibration._cmd_fingerprint",
+        return_value="<blacklisted>",
+    )
+
+    result, mocks = _run_calibrate(patches)
+
+    assert not result.success
+    # No vLLM spawn should happen — _try_start short-circuits on blacklist.
+    assert mocks["spawn"].call_count == 0
+
+
 def test_timeout_not_retried():
     """TimeoutError (vLLM loaded but warmup slow) should NOT trigger retry."""
     patches = _patch_calibration_infra(

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import logos_worker_node.main as worker_main
 import pytest
@@ -638,66 +638,7 @@ def test_max_tp_for_plan():
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Group 6 — Startup integration (mock everything)
-# ═══════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.asyncio
-async def test_lifespan_calls_auto_calibrate(tmp_path):
-    """Verify that the lifespan context manager calls _auto_calibrate_if_needed."""
-    cfg = _make_cfg(["model-a"])
-
-    mock_gpu = AsyncMock()
-    mock_gpu.available = True
-    mock_gpu.device_count = 1
-    mock_gpu.per_gpu_vram_mb = 24000.0
-    mock_gpu.get_snapshot = MagicMock(return_value={})
-    mock_gpu.force_poll = AsyncMock()
-    mock_gpu.start = AsyncMock()
-    mock_gpu.stop = AsyncMock()
-
-    mock_bridge = AsyncMock()
-    mock_bridge.start = AsyncMock()
-    mock_bridge.stop = AsyncMock()
-
-    mock_cache = MagicMock()
-    mock_cache.enabled = False
-
-    with (
-        patch("logos_worker_node.main.load_config", return_value=cfg),
-        patch("logos_worker_node.main.get_state_dir", return_value=tmp_path),
-        patch("logos_worker_node.main.GpuMetricsCollector", return_value=mock_gpu),
-        patch("logos_worker_node.main.ModelProfileRegistry") as mock_reg_cls,
-        patch("logos_worker_node.main._auto_calibrate_if_needed", new_callable=AsyncMock) as mock_autocal,
-        patch("logos_worker_node.main.create_model_cache", return_value=mock_cache),
-        patch("logos_worker_node.main.LaneManager") as mock_lm_cls,
-        patch("logos_worker_node.main.LogosBridgeClient", return_value=mock_bridge),
-        patch.dict("sys.modules", {"logos_worker_node.flashinfer_warmup": MagicMock()}),
-    ):
-
-        mock_reg = MagicMock()
-        mock_reg.get_profile.return_value = None
-        mock_reg_cls.return_value = mock_reg
-
-        mock_lm = AsyncMock()
-        mock_lm.close = AsyncMock()
-        mock_lm.destroy_all = AsyncMock()
-        mock_lm.validate_capabilities = MagicMock()
-        mock_lm_cls.return_value = mock_lm
-
-        app = worker_main.app
-        async with worker_main.lifespan(app):
-            pass
-
-    mock_autocal.assert_called_once()
-    call_args = mock_autocal.call_args
-    assert call_args[0][0] is cfg  # first arg = config
-    assert call_args[0][1] is mock_reg  # second arg = profile registry
-    assert call_args[0][2] == tmp_path  # third arg = state_dir
-
-
-# ═══════════════════════════════════════════════════════════════════════
-# Group 7 — _format_kv_mb helper
+# Group 6 — _format_kv_mb helper
 # ═══════════════════════════════════════════════════════════════════════
 
 

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -19,13 +19,23 @@ import logos_worker_node.main as worker_main
 import pytest
 import yaml
 from logos_worker_node.calibration import (
+    _FATAL_LOAD_ERROR_PATTERNS,
     _KV_CACHE_MIN_STEP_MB,
+    _NODE_LEVEL_TRANSIENT_PATTERNS,
+    _UNSUPPORTED_MODELS_FILE,
     CalibrationResult,
+    UnsupportedModelEntry,
+    _classify_fatal_load_error,
+    _classify_node_transient_error,
     _format_kv_mb,
+    _load_unsupported_models,
     _max_tp_for_plan,
     _parse_kv_to_mb,
+    _record_unsupported_model,
+    _remove_unsupported_model,
     auto_calibrate_models,
     calibrate_model,
+    is_model_unsupported,
     load_existing_profiles,
     parse_gpu_indices,
     plans_from_config,
@@ -1216,3 +1226,299 @@ def test_search_direction_never_probes_ceiling_first():
     # First probe must be the floor (1024 MB), not the ceiling
     assert kv_calls[0] == pytest.approx(_KV_CACHE_MIN_STEP_MB)
     assert kv_calls[0] != pytest.approx(ceiling)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Model-level "do not retry" blacklist
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_fatal_classifier_matches_invalid_repo_id():
+    """The classifier picks up vLLM's exact 'Invalid repository ID' string."""
+    tail = (
+        "(APIServer pid=572249)   Value error, "
+        "Invalid repository ID or local directory specified: 'Qwen/Bogus-Model'.\n"
+        "(APIServer pid=572249) Please verify the following requirements:\n"
+    )
+    pat = _classify_fatal_load_error(tail)
+    assert pat is not None
+    assert pat.reason_code == "invalid-repo-id"
+
+
+def test_fatal_classifier_matches_gated_repo():
+    pat = _classify_fatal_load_error("HTTPError: Cannot access gated repo for url https://...")
+    assert pat is not None
+    assert pat.reason_code == "gated-repo-no-token"
+
+
+def test_fatal_classifier_matches_unsupported_arch():
+    pat = _classify_fatal_load_error("ValueError: vLLM does not recognize this architecture: FooNet")
+    assert pat is not None
+    assert pat.reason_code == "unsupported-architecture"
+
+
+def test_fatal_classifier_ignores_oom():
+    """CUDA OOM is recoverable via a smaller kv-cache — must NOT match."""
+    tail = (
+        "torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.16 GiB. "
+        "GPU 0 has a total capacity of 15.56 GiB of which 867.50 MiB is free."
+    )
+    assert _classify_fatal_load_error(tail) is None
+
+
+def test_fatal_classifier_ignores_empty_and_irrelevant():
+    assert _classify_fatal_load_error("") is None
+    assert _classify_fatal_load_error(None) is None  # type: ignore[arg-type]
+    assert _classify_fatal_load_error("nothing to see here") is None
+
+
+def test_fatal_classifier_registry_has_expected_codes():
+    """Guard against accidental pattern deletion. Add codes here when you add new patterns."""
+    codes = {p.reason_code for p in _FATAL_LOAD_ERROR_PATTERNS}
+    assert {"invalid-repo-id", "gated-repo-no-token", "unsupported-architecture"} <= codes
+
+
+def test_unsupported_file_roundtrip(tmp_path: Path):
+    """Record → load → remove preserves contents and round-trips cleanly."""
+    path = tmp_path / _UNSUPPORTED_MODELS_FILE
+    entry = UnsupportedModelEntry(
+        model="Qwen/Bogus-Model",
+        reason_code="invalid-repo-id",
+        recorded_at="2026-06-04T19:46:51Z",
+        description="vLLM cannot resolve the model name to a repository.",
+    )
+    _record_unsupported_model(path, entry)
+    loaded = _load_unsupported_models(path)
+    assert "Qwen/Bogus-Model" in loaded
+    assert loaded["Qwen/Bogus-Model"].reason_code == "invalid-repo-id"
+    assert loaded["Qwen/Bogus-Model"].recorded_at == "2026-06-04T19:46:51Z"
+
+    removed = _remove_unsupported_model(path, "Qwen/Bogus-Model")
+    assert removed == 1
+    assert _load_unsupported_models(path) == {}
+
+
+def test_unsupported_file_ignores_comments_and_blank_lines(tmp_path: Path):
+    path = tmp_path / _UNSUPPORTED_MODELS_FILE
+    path.write_text(
+        "# comment line\n"
+        "\n"
+        "Qwen/A\tinvalid-repo-id\t2026-06-04T00:00:00Z\tdescription A\n"
+        "\n"
+        "# another comment\n"
+        "Qwen/B\tgated-repo-no-token\t2026-06-04T01:00:00Z\tdescription B\n",
+        encoding="utf-8",
+    )
+    loaded = _load_unsupported_models(path)
+    assert set(loaded.keys()) == {"Qwen/A", "Qwen/B"}
+    assert loaded["Qwen/B"].reason_code == "gated-repo-no-token"
+
+
+def test_unsupported_file_last_entry_wins_for_same_model(tmp_path: Path):
+    """When operator appends a fresher entry, the loader returns the most recent."""
+    path = tmp_path / _UNSUPPORTED_MODELS_FILE
+    older = UnsupportedModelEntry(
+        model="Qwen/X", reason_code="invalid-repo-id", recorded_at="2026-06-01T00:00:00Z", description="old"
+    )
+    newer = UnsupportedModelEntry(
+        model="Qwen/X", reason_code="gated-repo-no-token", recorded_at="2026-06-04T00:00:00Z", description="new"
+    )
+    _record_unsupported_model(path, older)
+    _record_unsupported_model(path, newer)
+    loaded = _load_unsupported_models(path)
+    assert loaded["Qwen/X"].reason_code == "gated-repo-no-token"
+
+
+def test_is_model_unsupported_returns_none_when_file_missing(tmp_path: Path):
+    assert is_model_unsupported(tmp_path / "nope", "any/model") is None
+
+
+def test_unsupported_entry_with_tabs_in_description_does_not_corrupt_format(tmp_path: Path):
+    """A description that contains tab characters is sanitized at write time."""
+    path = tmp_path / _UNSUPPORTED_MODELS_FILE
+    entry = UnsupportedModelEntry(
+        model="Qwen/Z",
+        reason_code="invalid-repo-id",
+        recorded_at="2026-06-04T00:00:00Z",
+        description="line one\twith embedded\ttabs and\nnewlines",
+    )
+    _record_unsupported_model(path, entry)
+    # Should round-trip without splitting the description into extra columns.
+    loaded = _load_unsupported_models(path)
+    assert loaded["Qwen/Z"].reason_code == "invalid-repo-id"
+    assert "\t" not in loaded["Qwen/Z"].description
+    assert "\n" not in loaded["Qwen/Z"].description
+
+
+def test_calibrate_model_skips_when_on_unsupported_list(tmp_path: Path):
+    """calibrate_model short-circuits if the model is on the unsupported list."""
+    log_dir = tmp_path / "calibration_logs"
+    log_dir.mkdir()
+    _record_unsupported_model(
+        log_dir / _UNSUPPORTED_MODELS_FILE,
+        UnsupportedModelEntry(
+            model="Qwen/Bogus",
+            reason_code="invalid-repo-id",
+            recorded_at="2026-06-04T19:46:51Z",
+            description="bad repo",
+        ),
+    )
+
+    patches = _patch_calibration_infra()
+
+    plan = _make_plan(model="Qwen/Bogus")
+    managers = {k: p.__enter__() for k, p in patches.items()}
+    try:
+        result = calibrate_model(
+            plan,
+            vllm_binary="vllm",
+            port=11499,
+            log_dir=log_dir,
+            sleep_level=1,
+            ready_timeout_s=60.0,
+        )
+    finally:
+        for p in patches.values():
+            p.__exit__(None, None, None)
+
+    assert not result.success
+    assert result.unsupported_reason == "invalid-repo-id"
+    # No vLLM should have been spawned: the check fires before Phase 0.
+    assert managers["spawn"].call_count == 0
+
+
+def test_node_transient_classifier_matches_eio():
+    """The classifier picks up the kernel/python EIO signature from the
+    deioma 2026-06-04 storage outage."""
+    tail = (
+        "(APIServer pid=611559) FileNotFoundError: [Errno 2] No such file ...\n"
+        "(APIServer pid=611559) OSError: [Errno 5] Input/output error: "
+        "'/usr/share/ollama/.ollama/models/.hf_cache/hub/models--zai-org--GLM-Image'"
+    )
+    pat = _classify_node_transient_error(tail)
+    assert pat is not None
+    assert pat.reason_code == "filesystem-eio"
+
+
+def test_node_transient_classifier_matches_readonly_filesystem():
+    pat = _classify_node_transient_error("PermissionError: [Errno 30] Read-only file system: '/app/data/...'")
+    assert pat is not None
+    assert pat.reason_code == "filesystem-readonly"
+
+
+def test_node_transient_classifier_does_not_match_model_or_oom_errors():
+    """Storage classifier must not steal recoverable failures from the kv search."""
+    assert _classify_node_transient_error("CUDA out of memory") is None
+    assert _classify_node_transient_error("Invalid repository ID or local directory specified") is None
+    assert _classify_node_transient_error("does not recognize this architecture") is None
+    assert _classify_node_transient_error("") is None
+    assert _classify_node_transient_error(None) is None  # type: ignore[arg-type]
+
+
+def test_node_transient_classifier_registry_has_expected_codes():
+    """Guard against accidental pattern deletion. Add codes here when extending."""
+    codes = {p.reason_code for p in _NODE_LEVEL_TRANSIENT_PATTERNS}
+    assert {"filesystem-eio", "filesystem-readonly"} <= codes
+
+
+def test_try_start_with_node_eio_writes_no_blacklist_artifacts(tmp_path: Path):
+    """The critical guarantee: when a probe fails because the node's storage
+    is broken (EIO), calibrate_model must NOT pollute either the per-command
+    blacklist or the per-model unsupported list. Regression for deioma
+    2026-06-04, where a 10-minute Ceph outage added 86 garbage lines to
+    calibration_failed_commands.txt before we caught it.
+    """
+    log_dir = tmp_path / "calibration_logs"
+    log_dir.mkdir()
+    # Pre-seed the per-model log file with an EIO tail.
+    log_path = log_dir / "Qwen__SomeModel.log"
+    log_path.write_text(
+        "(APIServer pid=611559) OSError: [Errno 5] Input/output error: "
+        "'/usr/share/ollama/.ollama/models/.hf_cache/hub/models--Qwen--SomeModel'\n",
+        encoding="utf-8",
+    )
+
+    patches = _patch_calibration_infra(
+        wait_ready_side_effect=RuntimeError("vLLM exited (code=1)"),
+    )
+    # Make sure _record_failed_command and _record_unsupported_model are real
+    # (not pre-patched out) so we can detect any accidental writes.
+    patches["load_failed"].kwargs.pop("return_value", None)
+    patches["load_failed"] = patch(
+        "logos_worker_node.calibration._load_failed_commands",
+        return_value=set(),
+    )
+
+    plan = _make_plan(model="Qwen/SomeModel")
+    managers = {k: p.__enter__() for k, p in patches.items()}
+    try:
+        result = calibrate_model(
+            plan,
+            vllm_binary="vllm",
+            port=11499,
+            log_dir=log_dir,
+            sleep_level=1,
+            ready_timeout_s=60.0,
+        )
+    finally:
+        for p in patches.values():
+            p.__exit__(None, None, None)
+
+    assert not result.success
+    # The two key guarantees:
+    assert result.node_unhealthy_reason == "filesystem-eio"
+    failed_path = log_dir / "calibration_failed_commands.txt"
+    unsupported_path = log_dir / _UNSUPPORTED_MODELS_FILE
+    assert not failed_path.exists(), "node-level transient failure must NOT add per-command blacklist lines"
+    assert not unsupported_path.exists(), "node-level transient failure must NOT add per-model unsupported entries"
+    # Only one spawn — the floor probe latched _node_unhealthy_box; the
+    # ceiling / middle / final probes short-circuit.
+    assert managers["spawn"].call_count == 1
+
+
+def test_try_start_failure_with_fatal_tail_records_unsupported_and_aborts_search(tmp_path: Path):
+    """A first-probe failure whose log tail matches a fatal pattern must:
+
+    (a) write a model-level unsupported entry,
+    (b) populate ``result.unsupported_reason`` so the bridge can mark the profile,
+    (c) NOT spawn vLLM N more times for each subsequent kv-cache size.
+    """
+    log_dir = tmp_path / "calibration_logs"
+    log_dir.mkdir()
+    # Pre-seed the per-model log file with a fatal-pattern tail so the
+    # classifier matches when _try_start reads the log after the simulated
+    # spawn failure.
+    log_path = log_dir / "Qwen__Bogus.log"
+    log_path.write_text(
+        "(APIServer pid=572249)   Value error, " "Invalid repository ID or local directory specified: 'Qwen/Bogus'.\n",
+        encoding="utf-8",
+    )
+
+    # Patch the kv search to fail on every probe (RuntimeError = vLLM exited).
+    patches = _patch_calibration_infra(
+        wait_ready_side_effect=RuntimeError("vLLM exited (code=1)"),
+    )
+
+    plan = _make_plan(model="Qwen/Bogus")
+    managers = {k: p.__enter__() for k, p in patches.items()}
+    try:
+        result = calibrate_model(
+            plan,
+            vllm_binary="vllm",
+            port=11499,
+            log_dir=log_dir,
+            sleep_level=1,
+            ready_timeout_s=60.0,
+        )
+    finally:
+        for p in patches.values():
+            p.__exit__(None, None, None)
+
+    assert not result.success
+    assert result.unsupported_reason == "invalid-repo-id"
+    # Exactly one spawn — the floor probe. Subsequent probes short-circuit
+    # via the _unsupported_box latch instead of spawning again.
+    assert managers["spawn"].call_count == 1
+    # The file on disk now lists the model — restart-safe.
+    loaded = _load_unsupported_models(log_dir / _UNSUPPORTED_MODELS_FILE)
+    assert loaded["Qwen/Bogus"].reason_code == "invalid-repo-id"

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -485,7 +485,7 @@ def test_runtime_has_transient_lanes_uses_last_payload():
 
 
 def _make_app_for_calibration(tmp_path, *, vllm_disable_sleep=False, per_model_overrides=None):
-    """Build a fake app.state for _handle_start_calibration tests."""
+    """Build a fake app.state for calibration-session tests."""
     from logos_worker_node.model_profiles import ModelProfileRegistry
     from logos_worker_node.models import AppConfig
 
@@ -502,138 +502,328 @@ def _make_app_for_calibration(tmp_path, *, vllm_disable_sleep=False, per_model_o
     app.state.config = cfg
     app.state.model_profiles = ModelProfileRegistry(state_dir=tmp_path)
     app.state.model_cache = None
+    # Minimal lane_manager stub: event_log + destroy_all + _mark_status_dirty.
+    # The session driver records calibration_* events onto event_log directly
+    # and marks status dirty after each model completes.
+    lane_manager = type("LaneMgr", (), {})()
+    lane_manager._event_log = []
+    lane_manager._MAX_EVENT_LOG = 500
+    lane_manager._mark_status_dirty = lambda: None
+    lane_manager.destroy_all = AsyncMock(return_value=None)
+    app.state.lane_manager = lane_manager
     return app
 
 
-@pytest.mark.asyncio
-async def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_path):
-    """Regression for prod 2026-06-04: when engines.vllm.disable_sleep_mode is
-    True, lanes spawn with enable_sleep_mode=False and cannot satisfy a
-    sleep_l<N> calibration. The worker must refuse the request immediately
-    instead of spawning a vLLM lane that will fail at Phase 4 (POST /sleep).
-    """
-    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
-    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
-    client = LogosBridgeClient(app, cfg)
-
-    response = await client._handle_start_calibration(
-        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
-    )  # noqa: SLF001
-
-    assert response["ok"] is False
-    assert response.get("sleep_mode_disabled") is True
-    assert "sleep mode disabled" in response["error"]
-    assert client._active_calibration is None  # noqa: SLF001
-    # Flag persisted so the master orchestrator stops asking
-    profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
-    assert profile is not None
-    assert profile.sleep_mode_disabled is True
-
-
-@pytest.mark.asyncio
-async def test_start_calibration_rejected_for_per_model_override(tmp_path):
-    """Per-model enable_sleep_mode=false override under
-    engines.vllm.model_overrides must also block sleep_l<N> calibration."""
-    app = _make_app_for_calibration(
-        tmp_path,
-        per_model_overrides={"openai/gpt-oss-120b": {"enable_sleep_mode": False}},
-    )
-    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
-    client = LogosBridgeClient(app, cfg)
-
-    response = await client._handle_start_calibration(
-        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
-    )  # noqa: SLF001
-
-    assert response["ok"] is False
-    assert response.get("sleep_mode_disabled") is True
-    profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
-    assert profile is not None and profile.sleep_mode_disabled is True
-
-
-@pytest.mark.asyncio
-async def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
-    """sleep_level=0 means "no sleep phase" — the gate must not refuse on
-    enable_sleep_mode=False because no sleep call will happen."""
-    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
-    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
-    client = LogosBridgeClient(app, cfg)
-
-    # Block the background thread from actually starting by pre-claiming the
-    # active-calibration slot — this lets us exercise the gate without
-    # depending on vLLM being available.
-    import threading
-
-    sentinel_event = threading.Event()
-    sentinel_thread = threading.Thread(target=sentinel_event.wait, daemon=True)
-    sentinel_thread.start()
+async def _drain_session(client) -> None:
+    """Await the active session task, swallowing any cleanup exceptions."""
+    session = client._active_calibration_session  # noqa: SLF001
+    if session is None or session.task is None:
+        return
     try:
-        client._active_calibration = (  # noqa: SLF001
-            "sentinel-model",
-            sentinel_event,
-            sentinel_thread,
-            0.0,
-        )
+        await session.task
+    except Exception:
+        pass
 
-        response = await client._handle_start_calibration(
-            {"model_name": "openai/gpt-oss-120b", "sleep_level": 0}
-        )  # noqa: SLF001
-    finally:
-        sentinel_event.set()
-        sentinel_thread.join(timeout=1.0)
 
-    # Gate did not fire (no sleep_mode_disabled marker), but we got the
-    # "calibration already in progress" message from the sentinel block.
+@pytest.mark.asyncio
+async def test_start_calibration_session_returns_ok_and_runs_in_background(tmp_path, monkeypatch):
+    """A normal session start: refuse only on node-unhealthy, otherwise
+    return ok=True and let the background task walk the model list."""
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=[],  # empty list → session finishes as a no-op
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    response = await client._handle_start_calibration_session({"sleep_level": 1})  # noqa: SLF001
+    assert response["ok"] is True
+    assert response["sleep_level"] == 1
+    assert "started_at" in response
+    await _drain_session(client)
+
+    events = [e.event for e in app.state.lane_manager._event_log]
+    assert "calibration_session_started" in events
+    assert "calibration_session_finished" in events
+    # destroy_all is only called when there is at least one model to calibrate;
+    # an empty configured_models list ends the session before that step.
+    app.state.lane_manager.destroy_all.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_calibration_session_refuses_when_node_unhealthy(tmp_path, monkeypatch):
+    """Node-level degradation (GPU ERR, HF cache EIO, …) must bounce the
+    session start RPC. The kv-cache search would fail the same way for
+    every model in the session."""
+    from logos_worker_node import node_health as _nh
+
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    monkeypatch.setattr(
+        _nh,
+        "evaluate_node_health",
+        lambda: _nh.NodeHealthStatus(
+            healthy=False,
+            checked_at="2026-06-05T00:00:00Z",
+            reason_code="filesystem-eio",
+            reason_detail="HF cache returned EIO",
+        ),
+    )
+
+    response = await client._handle_start_calibration_session({"sleep_level": 1})  # noqa: SLF001
     assert response["ok"] is False
-    assert response.get("sleep_mode_disabled") is None
+    assert response.get("node_unhealthy") is True
+    assert response.get("reason_code") == "filesystem-eio"
+    assert client._active_calibration_session is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_start_calibration_session_refuses_when_one_in_progress(tmp_path):
+    """A second start_calibration_session while the first is still running
+    must be rejected. Caller is expected to stop_calibration_session first
+    or wait for the terminal session event."""
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=[],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    # Pre-claim the slot with a never-completing task so the second call
+    # sees an active session.
+    sentinel = asyncio.create_task(asyncio.sleep(60))
+    from logos_worker_node.logos_bridge import _CalibrationSession
+
+    session = _CalibrationSession(sleep_level=1)
+    session.task = sentinel
+    client._active_calibration_session = session  # noqa: SLF001
+    try:
+        response = await client._handle_start_calibration_session({"sleep_level": 1})  # noqa: SLF001
+    finally:
+        sentinel.cancel()
+        try:
+            await sentinel
+        except asyncio.CancelledError:
+            pass
+
+    assert response["ok"] is False
     assert "already in progress" in response["error"]
 
 
 @pytest.mark.asyncio
-async def test_start_calibration_stops_all_lanes_before_spawning(tmp_path, monkeypatch):
-    """Live lanes hold VRAM. Calibration must free everything first or the
-    kv-cache search OOMs and blacklists every probe size (deioma 2026-06-04)."""
+async def test_stop_calibration_session_sets_cancel_event(tmp_path):
+    """stop_calibration_session must set the shared cancel_event so the
+    calibration's wait_ready bails within ~2s instead of waiting out the
+    full ready_timeout."""
     app = _make_app_for_calibration(tmp_path)
-    lane_manager = type("LaneMgr", (), {})()
-    lane_manager.destroy_all = AsyncMock(return_value=None)
-    app.state.lane_manager = lane_manager
-    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=[],
+    )
     client = LogosBridgeClient(app, cfg)
 
-    # Prevent the calibration thread from actually starting vLLM — we only
-    # care that destroy_all ran by the time start_calibration returns.
-    import threading as _threading
+    from logos_worker_node.logos_bridge import _CalibrationSession
 
-    real_thread_cls = _threading.Thread
+    session = _CalibrationSession(sleep_level=1)
+    session.current_model = "test/model"
 
-    class _NoopThread(real_thread_cls):
-        def start(self) -> None:  # noqa: D401
-            return  # don't actually run _run_calibration
+    # The stop handler awaits the task with a 15s timeout. Use a task that
+    # finishes immediately on cancel so the stop returns fast.
+    async def _wait_then_finish():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            raise
 
-    monkeypatch.setattr("logos_worker_node.logos_bridge.threading.Thread", _NoopThread)
+    session.task = asyncio.create_task(_wait_then_finish())
+    client._active_calibration_session = session  # noqa: SLF001
 
-    response = await client._handle_start_calibration(  # noqa: SLF001
-        {"model_name": "openai/gpt-oss-120b", "sleep_level": 0}
-    )
+    # We don't want to wait 15s for the test — cancel the task right after
+    # the stop handler reads cancel_event, so wait_for returns.
+    async def _force_complete():
+        await asyncio.sleep(0.05)
+        if not session.task.done():
+            session.task.cancel()
+
+    forcer = asyncio.create_task(_force_complete())
+    response = await client._handle_stop_calibration_session()  # noqa: SLF001
+    await forcer
+    try:
+        await session.task
+    except (asyncio.CancelledError, Exception):
+        pass
 
     assert response["ok"] is True
-    lane_manager.destroy_all.assert_awaited_once()
+    assert response["was_active"] is True
+    assert response["current_model"] == "test/model"
+    assert session.cancel_event.is_set()
 
 
 @pytest.mark.asyncio
-async def test_start_calibration_does_not_stop_lanes_on_rejection(tmp_path):
-    """Rejection paths (sleep-mode-disabled, etc.) must return before destroy_all
-    so we don't kill live lanes just to refuse the request seconds later."""
-    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
-    lane_manager = type("LaneMgr", (), {})()
-    lane_manager.destroy_all = AsyncMock(return_value=None)
-    app.state.lane_manager = lane_manager
+async def test_stop_calibration_session_idempotent_when_no_session(tmp_path):
+    """A stop with no active session is a no-op — important so the master
+    can fire it on window close without worrying whether a session is
+    actually running."""
+    app = _make_app_for_calibration(tmp_path)
     cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
     client = LogosBridgeClient(app, cfg)
 
-    response = await client._handle_start_calibration(  # noqa: SLF001
-        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
+    response = await client._handle_stop_calibration_session()  # noqa: SLF001
+    assert response["ok"] is True
+    assert response["was_active"] is False
+
+
+def test_list_uncalibrated_skips_calibration_unsupported(tmp_path):
+    """Models classified as permanently unsupported on this worker must not
+    appear in the session's work list — every probe would fail the same
+    way until ops removes the flag."""
+    from logos_worker_node.model_profiles import ModelProfileRecord
+
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["bad/repo", "good/model"],
+    )
+    client = LogosBridgeClient(app, cfg)
+    app.state.model_profiles._profiles["bad/repo"] = ModelProfileRecord(
+        calibration_unsupported=True,
+        calibration_unsupported_reason="invalid-repo-id",
     )
 
-    assert response["ok"] is False
-    lane_manager.destroy_all.assert_not_awaited()
+    assert client._list_uncalibrated_models() == ["good/model"]  # noqa: SLF001
+
+
+def test_list_uncalibrated_skips_sleep_disabled_models_already_measured(tmp_path):
+    """A model whose worker config forbids sleep and that already has
+    base_residency measured has nothing more to calibrate — the sleep
+    fields are N/A by design."""
+    from logos_worker_node.model_profiles import ModelProfileRecord
+
+    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["openai/gpt-oss-120b"],
+    )
+    client = LogosBridgeClient(app, cfg)
+    app.state.model_profiles._profiles["openai/gpt-oss-120b"] = ModelProfileRecord(
+        base_residency_mb=91203.0,
+        sleep_mode_disabled=True,
+    )
+
+    assert client._list_uncalibrated_models() == []  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_session_skips_sleep_disabled_model_and_continues(tmp_path, monkeypatch):
+    """Inside the session loop, a model that can't be slept on this worker
+    is recorded as skipped (with sleep_mode_disabled persisted on the
+    profile) and the loop moves on to the next model. The session must
+    not refuse the whole batch over one bad model."""
+    from logos_worker_node import config as _wcfg
+    from logos_worker_node.calibration import CalibrationResult
+
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(
+        tmp_path,
+        per_model_overrides={"openai/gpt-oss-120b": {"enable_sleep_mode": False}},
+    )
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["openai/gpt-oss-120b", "microsoft/Phi-4-reasoning"],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    # Mock the actual calibration so we don't spawn vLLM.
+    def _fake_calibrate(plan, **kwargs):
+        return CalibrationResult(
+            model=plan["model"],
+            tensor_parallel_size=1,
+            gpu_devices="0",
+            kv_cache_sent_mb=2048.0,
+            success=True,
+            base_residency_mb=12345.0,
+            sleeping_residual_mb=512.0,
+            sleep_l1_transient_host_ram_mb=4096.0,
+        )
+
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.calibrate_with_tp_escalation",
+        _fake_calibrate,
+    )
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.plans_from_config",
+        lambda _p: [],
+    )
+
+    response = await client._handle_start_calibration_session({"sleep_level": 1})  # noqa: SLF001
+    assert response["ok"] is True
+    await _drain_session(client)
+
+    events = [(e.event, e.model) for e in app.state.lane_manager._event_log]
+    # gpt-oss skipped, phi-4 attempted and completed.
+    assert ("calibration_model_skipped", "openai/gpt-oss-120b") in events
+    assert ("calibration_model_completed", "microsoft/Phi-4-reasoning") in events
+    assert ("calibration_session_finished", "") in events
+    # sleep_mode_disabled persisted for the skipped model.
+    skipped_profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
+    assert skipped_profile is not None
+    assert skipped_profile.sleep_mode_disabled is True
+
+
+@pytest.mark.asyncio
+async def test_session_destroys_lanes_before_calibrating(tmp_path, monkeypatch):
+    """Live lanes hold VRAM. The session must free everything up front or
+    the kv-cache search OOMs and blacklists every probe size."""
+    from logos_worker_node import config as _wcfg
+    from logos_worker_node.calibration import CalibrationResult
+
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["some/model"],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    def _fake_calibrate(plan, **kwargs):
+        return CalibrationResult(
+            model=plan["model"],
+            tensor_parallel_size=1,
+            gpu_devices="0",
+            kv_cache_sent_mb=2048.0,
+            success=True,
+            base_residency_mb=12345.0,
+            sleeping_residual_mb=512.0,
+            sleep_l1_transient_host_ram_mb=4096.0,
+        )
+
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.calibrate_with_tp_escalation",
+        _fake_calibrate,
+    )
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.plans_from_config",
+        lambda _p: [],
+    )
+
+    response = await client._handle_start_calibration_session({"sleep_level": 1})  # noqa: SLF001
+    assert response["ok"] is True
+    await _drain_session(client)
+
+    app.state.lane_manager.destroy_all.assert_awaited_once()

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -505,7 +505,8 @@ def _make_app_for_calibration(tmp_path, *, vllm_disable_sleep=False, per_model_o
     return app
 
 
-def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_path):
+@pytest.mark.asyncio
+async def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_path):
     """Regression for prod 2026-06-04: when engines.vllm.disable_sleep_mode is
     True, lanes spawn with enable_sleep_mode=False and cannot satisfy a
     sleep_l<N> calibration. The worker must refuse the request immediately
@@ -515,7 +516,9 @@ def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_p
     cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
     client = LogosBridgeClient(app, cfg)
 
-    response = client._handle_start_calibration({"model_name": "openai/gpt-oss-120b", "sleep_level": 1})  # noqa: SLF001
+    response = await client._handle_start_calibration(
+        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
+    )  # noqa: SLF001
 
     assert response["ok"] is False
     assert response.get("sleep_mode_disabled") is True
@@ -527,7 +530,8 @@ def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_p
     assert profile.sleep_mode_disabled is True
 
 
-def test_start_calibration_rejected_for_per_model_override(tmp_path):
+@pytest.mark.asyncio
+async def test_start_calibration_rejected_for_per_model_override(tmp_path):
     """Per-model enable_sleep_mode=false override under
     engines.vllm.model_overrides must also block sleep_l<N> calibration."""
     app = _make_app_for_calibration(
@@ -537,7 +541,9 @@ def test_start_calibration_rejected_for_per_model_override(tmp_path):
     cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
     client = LogosBridgeClient(app, cfg)
 
-    response = client._handle_start_calibration({"model_name": "openai/gpt-oss-120b", "sleep_level": 1})  # noqa: SLF001
+    response = await client._handle_start_calibration(
+        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
+    )  # noqa: SLF001
 
     assert response["ok"] is False
     assert response.get("sleep_mode_disabled") is True
@@ -545,7 +551,8 @@ def test_start_calibration_rejected_for_per_model_override(tmp_path):
     assert profile is not None and profile.sleep_mode_disabled is True
 
 
-def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
+@pytest.mark.asyncio
+async def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
     """sleep_level=0 means "no sleep phase" — the gate must not refuse on
     enable_sleep_mode=False because no sleep call will happen."""
     app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
@@ -568,7 +575,7 @@ def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
             0.0,
         )
 
-        response = client._handle_start_calibration(
+        response = await client._handle_start_calibration(
             {"model_name": "openai/gpt-oss-120b", "sleep_level": 0}
         )  # noqa: SLF001
     finally:
@@ -580,3 +587,53 @@ def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
     assert response["ok"] is False
     assert response.get("sleep_mode_disabled") is None
     assert "already in progress" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_start_calibration_stops_all_lanes_before_spawning(tmp_path, monkeypatch):
+    """Live lanes hold VRAM. Calibration must free everything first or the
+    kv-cache search OOMs and blacklists every probe size (deioma 2026-06-04)."""
+    app = _make_app_for_calibration(tmp_path)
+    lane_manager = type("LaneMgr", (), {})()
+    lane_manager.destroy_all = AsyncMock(return_value=None)
+    app.state.lane_manager = lane_manager
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    # Prevent the calibration thread from actually starting vLLM — we only
+    # care that destroy_all ran by the time start_calibration returns.
+    import threading as _threading
+
+    real_thread_cls = _threading.Thread
+
+    class _NoopThread(real_thread_cls):
+        def start(self) -> None:  # noqa: D401
+            return  # don't actually run _run_calibration
+
+    monkeypatch.setattr("logos_worker_node.logos_bridge.threading.Thread", _NoopThread)
+
+    response = await client._handle_start_calibration(  # noqa: SLF001
+        {"model_name": "openai/gpt-oss-120b", "sleep_level": 0}
+    )
+
+    assert response["ok"] is True
+    lane_manager.destroy_all.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_calibration_does_not_stop_lanes_on_rejection(tmp_path):
+    """Rejection paths (sleep-mode-disabled, etc.) must return before destroy_all
+    so we don't kill live lanes just to refuse the request seconds later."""
+    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
+    lane_manager = type("LaneMgr", (), {})()
+    lane_manager.destroy_all = AsyncMock(return_value=None)
+    app.state.lane_manager = lane_manager
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    response = await client._handle_start_calibration(  # noqa: SLF001
+        {"model_name": "openai/gpt-oss-120b", "sleep_level": 1}
+    )
+
+    assert response["ok"] is False
+    lane_manager.destroy_all.assert_not_awaited()

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -482,3 +482,101 @@ def test_runtime_has_transient_lanes_uses_last_payload():
 
     client._last_runtime_payload = {"lanes": [{"lane_id": "lane-a", "runtime_state": "starting"}]}  # noqa: SLF001
     assert client._runtime_has_transient_lanes() is True  # noqa: SLF001
+
+
+def _make_app_for_calibration(tmp_path, *, vllm_disable_sleep=False, per_model_overrides=None):
+    """Build a fake app.state for _handle_start_calibration tests."""
+    from logos_worker_node.model_profiles import ModelProfileRegistry
+    from logos_worker_node.models import AppConfig
+
+    cfg_dict = {
+        "engines": {
+            "vllm": {
+                "disable_sleep_mode": vllm_disable_sleep,
+                "model_overrides": per_model_overrides or {},
+            }
+        },
+    }
+    cfg = AppConfig(**cfg_dict)
+    app = _DummyApp()
+    app.state.config = cfg
+    app.state.model_profiles = ModelProfileRegistry(state_dir=tmp_path)
+    app.state.model_cache = None
+    return app
+
+
+def test_start_calibration_rejected_when_worker_kill_switch_disables_sleep(tmp_path):
+    """Regression for prod 2026-06-04: when engines.vllm.disable_sleep_mode is
+    True, lanes spawn with enable_sleep_mode=False and cannot satisfy a
+    sleep_l<N> calibration. The worker must refuse the request immediately
+    instead of spawning a vLLM lane that will fail at Phase 4 (POST /sleep).
+    """
+    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    response = client._handle_start_calibration({"model_name": "openai/gpt-oss-120b", "sleep_level": 1})  # noqa: SLF001
+
+    assert response["ok"] is False
+    assert response.get("sleep_mode_disabled") is True
+    assert "sleep mode disabled" in response["error"]
+    assert client._active_calibration is None  # noqa: SLF001
+    # Flag persisted so the master orchestrator stops asking
+    profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
+    assert profile is not None
+    assert profile.sleep_mode_disabled is True
+
+
+def test_start_calibration_rejected_for_per_model_override(tmp_path):
+    """Per-model enable_sleep_mode=false override under
+    engines.vllm.model_overrides must also block sleep_l<N> calibration."""
+    app = _make_app_for_calibration(
+        tmp_path,
+        per_model_overrides={"openai/gpt-oss-120b": {"enable_sleep_mode": False}},
+    )
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    response = client._handle_start_calibration({"model_name": "openai/gpt-oss-120b", "sleep_level": 1})  # noqa: SLF001
+
+    assert response["ok"] is False
+    assert response.get("sleep_mode_disabled") is True
+    profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
+    assert profile is not None and profile.sleep_mode_disabled is True
+
+
+def test_start_calibration_sleep_level_zero_skips_sleep_gate(tmp_path):
+    """sleep_level=0 means "no sleep phase" — the gate must not refuse on
+    enable_sleep_mode=False because no sleep call will happen."""
+    app = _make_app_for_calibration(tmp_path, vllm_disable_sleep=True)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    # Block the background thread from actually starting by pre-claiming the
+    # active-calibration slot — this lets us exercise the gate without
+    # depending on vLLM being available.
+    import threading
+
+    sentinel_event = threading.Event()
+    sentinel_thread = threading.Thread(target=sentinel_event.wait, daemon=True)
+    sentinel_thread.start()
+    try:
+        client._active_calibration = (  # noqa: SLF001
+            "sentinel-model",
+            sentinel_event,
+            sentinel_thread,
+            0.0,
+        )
+
+        response = client._handle_start_calibration(
+            {"model_name": "openai/gpt-oss-120b", "sleep_level": 0}
+        )  # noqa: SLF001
+    finally:
+        sentinel_event.set()
+        sentinel_thread.join(timeout=1.0)
+
+    # Gate did not fire (no sleep_mode_disabled marker), but we got the
+    # "calibration already in progress" message from the sentinel block.
+    assert response["ok"] is False
+    assert response.get("sleep_mode_disabled") is None
+    assert "already in progress" in response["error"]

--- a/logos/logos-workernode/tests/test_model_cache.py
+++ b/logos/logos-workernode/tests/test_model_cache.py
@@ -324,3 +324,140 @@ def test_scan_existing_keeps_complete_cache(tmp_path):
 
     assert "meta-llama/Llama-3.1-8B" in cache.cached_models()
     assert good.exists()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Background caching (start_background_caching / wait_for_cached)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_background_caching_does_not_block_startup(ram_cache_env):
+    """Startup must return immediately even when the queue has work to do.
+    Previously cache_models_by_priority blocked the lifespan hook for
+    multi-minute rsync sweeps; the new entry point spins up a task and
+    returns synchronously."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    model = ram_cache_env["model_name"]
+
+    cache.start_background_caching([model])
+    # The worker task should be running but caching may not have completed yet.
+    assert cache._caching_task is not None
+    # Drain it for cleanup.
+    await cache.wait_for_cached(model)
+    assert cache.is_cached(model)
+    await cache.stop_background_caching()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cached_returns_immediately_when_already_cached(ram_cache_env):
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    model = ram_cache_env["model_name"]
+
+    await cache.ensure_cached(model)
+    assert cache.is_cached(model)
+    # wait_for_cached on an already-cached model should be a no-op (and fast)
+    import asyncio as _asyncio
+
+    got = await _asyncio.wait_for(cache.wait_for_cached(model), timeout=1.0)
+    assert got is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cached_bumps_priority_when_queued_behind_others(ram_cache_env, tmp_path):
+    """A lane add for a queued-but-not-yet-cached model should bump it to
+    the front of the queue so the lane doesn't wait behind models it
+    doesn't need."""
+    # Build a second model on the source so we can enqueue two and bump one.
+    source_hf = tmp_path / "source" / "hub"
+    other_dir = source_hf / "models--Qwen--Other"
+    other_blobs = other_dir / "blobs"
+    other_blobs.mkdir(parents=True)
+    with open(other_blobs / "sha256-other", "wb") as f:
+        f.seek(12 * 1024 * 1024 - 1)
+        f.write(b"\x00")
+    (other_dir / "refs").mkdir()
+    (other_dir / "refs" / "main").write_text("other")
+    snap = other_dir / "snapshots" / "other"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").symlink_to("../../blobs/sha256-other")
+
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+
+    # Stop the worker before it does anything so we can inspect the queue.
+    cache._cache_queue_event = __import__("asyncio").Event()
+    cache._enqueue("Qwen/Qwen2.5-7B", priority=False)
+    cache._enqueue("Qwen/Other", priority=False)
+    assert list(cache._cache_queue) == ["Qwen/Qwen2.5-7B", "Qwen/Other"]
+
+    # A lane add for the second model bumps it to the front.
+    cache._enqueue("Qwen/Other", priority=True)
+    assert list(cache._cache_queue) == ["Qwen/Other", "Qwen/Qwen2.5-7B"]
+
+
+@pytest.mark.asyncio
+async def test_stop_background_caching_cancels_worker(ram_cache_env):
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    # Empty queue → worker will park on the event.
+    cache.start_background_caching([])
+    task = cache._caching_task
+    assert task is not None and not task.done()
+    await cache.stop_background_caching()
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cached_starts_worker_when_none_running(ram_cache_env):
+    """A lane request that arrives before start_background_caching was
+    ever called (e.g. ad-hoc lane add for a model not in the plan) must
+    still trigger caching."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    assert cache._caching_task is None
+
+    got = await cache.wait_for_cached(ram_cache_env["model_name"])
+    assert got is True
+    assert cache.is_cached(ram_cache_env["model_name"])
+    await cache.stop_background_caching()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_cached_respects_timeout(ram_cache_env, monkeypatch):
+    """When the rsync takes longer than the timeout, wait_for_cached
+    returns False so the caller can fall back to loading from disk."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+
+    # Make the underlying ensure_cached block forever so timeout triggers.
+    import asyncio as _asyncio
+
+    async def _hang(_model_name: str) -> str:
+        await _asyncio.sleep(60)
+        return ""
+
+    monkeypatch.setattr(cache, "ensure_cached", _hang)
+
+    got = await cache.wait_for_cached(ram_cache_env["model_name"], timeout=0.1)
+    assert got is False
+    await cache.stop_background_caching()

--- a/logos/logos-workernode/tests/test_node_health.py
+++ b/logos/logos-workernode/tests/test_node_health.py
@@ -1,0 +1,144 @@
+"""Tests for the node-level health sensors (GPU + storage)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from logos_worker_node import node_health
+
+
+def test_evaluate_node_health_returns_healthy_when_all_sensors_pass(tmp_path: Path, monkeypatch):
+    """No GPU configured (no nvidia-smi) + a fresh tmp dir for HF cache
+    is the dev-machine default. Must report healthy."""
+    monkeypatch.setattr(
+        node_health,
+        "_STORAGE_PATHS_TO_PROBE",
+        (tmp_path,),
+    )
+    with patch.object(
+        subprocess,
+        "check_output",
+        side_effect=FileNotFoundError("nvidia-smi"),
+    ):
+        status = node_health.evaluate_node_health()
+
+    assert status.healthy is True
+    assert status.reason_code is None
+    assert status.sensors["gpu"]["state"] == "ok"
+    assert status.sensors["storage"]["state"] == "ok"
+
+
+def test_evaluate_node_health_flags_gpu_error_field():
+    """nvidia-smi reports [Error] for a memory field — must classify
+    as gpu-error and overall healthy=False."""
+    csv_output = "0, 81920, 12345, 70000\n" "1, [Error], [Error], [Error]\n" "2, 81920, 100, 81820\n"
+    with patch.object(subprocess, "check_output", return_value=csv_output):
+        result = node_health._check_gpu()
+
+    assert result.state == "gpu-error"
+    assert "GPU1" in result.detail
+
+
+def test_evaluate_node_health_flags_gpu_na_field():
+    csv_output = "0, N/A, N/A, N/A\n1, 81920, 100, 81820\n"
+    with patch.object(subprocess, "check_output", return_value=csv_output):
+        result = node_health._check_gpu()
+    # 'N/A' alone (no 'Error' substring) triggers gpu-na, not gpu-error.
+    assert result.state == "gpu-na"
+    assert "GPU0" in result.detail
+
+
+def test_evaluate_node_health_clean_gpu_csv_is_ok():
+    csv_output = "0, 81920, 12345, 70000\n1, 81920, 1, 81920\n"
+    with patch.object(subprocess, "check_output", return_value=csv_output):
+        result = node_health._check_gpu()
+    assert result.state == "ok"
+
+
+def test_evaluate_node_health_storage_eio(tmp_path: Path, monkeypatch):
+    """Regression for deioma 2026-06-04: HF cache directory returns EIO
+    on listdir → must classify as filesystem-eio."""
+    target = tmp_path / "hf_cache"
+    target.mkdir()
+    monkeypatch.setattr(node_health, "_STORAGE_PATHS_TO_PROBE", (target,))
+
+    def _raise_eio(_path):
+        raise OSError(5, "Input/output error", str(target))
+
+    with patch("os.listdir", side_effect=_raise_eio):
+        result = node_health._check_storage()
+    assert result.state == "filesystem-eio"
+    assert "EIO" in result.detail
+
+
+def test_evaluate_node_health_storage_readonly(tmp_path: Path, monkeypatch):
+    target = tmp_path / "hf_cache"
+    target.mkdir()
+    monkeypatch.setattr(node_health, "_STORAGE_PATHS_TO_PROBE", (target,))
+
+    def _raise_erofs(_path):
+        raise OSError(30, "Read-only file system", str(target))
+
+    with patch("os.listdir", side_effect=_raise_erofs):
+        result = node_health._check_storage()
+    assert result.state == "filesystem-readonly"
+
+
+def test_evaluate_node_health_storage_missing_path_is_ok(tmp_path: Path, monkeypatch):
+    """A worker without any HF cache path configured is healthy — not unhealthy."""
+    monkeypatch.setattr(
+        node_health,
+        "_STORAGE_PATHS_TO_PROBE",
+        (tmp_path / "definitely-does-not-exist",),
+    )
+    result = node_health._check_storage()
+    assert result.state == "ok"
+    assert "no HF cache path configured" in result.detail
+
+
+def test_evaluate_node_health_aggregates_first_failing_sensor(tmp_path: Path, monkeypatch):
+    """When multiple sensors fail, NodeHealthStatus.reason_code reflects
+    the first one (deterministic — GPU is registered before storage)."""
+    target = tmp_path / "hf_cache"
+    target.mkdir()
+    monkeypatch.setattr(node_health, "_STORAGE_PATHS_TO_PROBE", (target,))
+
+    def _eio(_path):
+        raise OSError(5, "Input/output error")
+
+    csv_output = "0, [Error], [Error], [Error]\n"
+    with patch.object(subprocess, "check_output", return_value=csv_output), patch("os.listdir", side_effect=_eio):
+        status = node_health.evaluate_node_health()
+
+    assert status.healthy is False
+    # GPU is the first sensor in _SENSORS, so its reason wins.
+    assert status.reason_code == "gpu-error"
+    assert status.sensors["gpu"]["state"] == "gpu-error"
+    assert status.sensors["storage"]["state"] == "filesystem-eio"
+
+
+def test_evaluate_node_health_handles_nvidia_smi_timeout():
+    with patch.object(
+        subprocess,
+        "check_output",
+        side_effect=subprocess.TimeoutExpired(cmd=["nvidia-smi"], timeout=10),
+    ):
+        result = node_health._check_gpu()
+    assert result.state == "gpu-query-timeout"
+
+
+def test_evaluate_node_health_sensor_exception_is_caught(tmp_path: Path, monkeypatch):
+    """A sensor that throws unexpectedly must not crash the heartbeat —
+    it gets surfaced as 'sensor-error' and the node is flagged unhealthy."""
+    monkeypatch.setattr(node_health, "_STORAGE_PATHS_TO_PROBE", (tmp_path,))
+
+    def _boom() -> node_health.SensorResult:
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(node_health, "_SENSORS", (("synthetic", _boom),))
+    status = node_health.evaluate_node_health()
+    assert status.healthy is False
+    assert status.sensors["synthetic"]["state"] == "sensor-error"
+    assert "synthetic" in status.sensors["synthetic"]["detail"]

--- a/logos/logos-workernode/tests/test_runtime.py
+++ b/logos/logos-workernode/tests/test_runtime.py
@@ -53,8 +53,11 @@ def _make_app(lanes):
         max_lanes=0,
         gpu_performance_score=100,
     )
+    # build_runtime_status reads engines.vllm.disable_sleep_mode for the
+    # worker-wide sleep-mode kill switch reported in WorkerRuntimeStatus.
+    engines_cfg = SimpleNamespace(vllm=SimpleNamespace(disable_sleep_mode=False))
     state = SimpleNamespace(
-        config=SimpleNamespace(worker=worker_cfg),
+        config=SimpleNamespace(worker=worker_cfg, engines=engines_cfg),
         lane_manager=_LaneManager(lanes),
         gpu_collector=_GpuCollector(),
         logos_bridge=_Bridge(),

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -306,6 +306,12 @@ class CalibrationOrchestrator:
             sleep_l2 (``IDLE_SLEEP_L2 = 24h``). The planner gracefully falls
             back to a disk-size heuristic for sleep_l2 on demand.
 
+        Exception: when the worker reports ``sleep_mode_disabled=True`` for
+        a model (worker-wide kill switch or per-model
+        enable_sleep_mode=false override), the sleep fields are N/A — the
+        vLLM lane refuses /sleep there. Only ``base_residency_mb`` matters
+        in that case.
+
         Models we have already tried this window are skipped — a successful
         run will have populated the profile and removed them from the
         uncalibrated set anyway, so seeing one here again means the previous
@@ -332,11 +338,19 @@ class CalibrationOrchestrator:
 
         for model_name in candidates:
             profile = profiles.get(model_name)
+            # A worker that forbids sleep for this model (worker-wide
+            # disable_sleep_mode kill switch, or per-model
+            # enable_sleep_mode=false override) cannot produce
+            # sleeping_residual_mb / sleep_l1_transient_host_ram_mb — the
+            # vLLM lane refuses /sleep. Treat those fields as N/A in that
+            # case instead of "uncalibrated"; otherwise the orchestrator
+            # would retry every maintenance window forever.
+            sleep_na = bool(profile is not None and profile.sleep_mode_disabled)
             needs_calib = (
                 profile is None
                 or profile.base_residency_mb is None
-                or profile.sleeping_residual_mb is None
-                or profile.sleep_l1_transient_host_ram_mb is None
+                or (not sleep_na and profile.sleeping_residual_mb is None)
+                or (not sleep_na and profile.sleep_l1_transient_host_ram_mb is None)
             )
             if not needs_calib:
                 continue

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -1,22 +1,25 @@
-"""Server-orchestrated nightly VRAM calibration.
+"""Server-side trigger for worker-driven VRAM calibration.
 
-The CalibrationOrchestrator runs a background asyncio loop that, once per
-minute during a configurable time window (default 02:00–05:00 Europe/Berlin),
-picks one uncalibrated model on one idle worker node and drives it through the
-calibration cycle via the existing bridge RPC commands:
+The CalibrationOrchestrator is now a thin gatekeeper. The worker owns the
+calibration loop: it picks which uncalibrated model runs next, walks its own
+model list, and emits ``calibration_*`` events back to the server when each
+model completes. The orchestrator only:
 
-  start_calibration  →  { ok, model_name, sleep_level, started_at }
-  get_calibration_status  →  { active, model_name, started_at }
-  stop_calibration  →  { ok, was_active, model_name? }
+  * Watches the maintenance window (default 02:00–05:00 Europe/Berlin).
+  * When inside the window and no other worker has a session in progress,
+    picks one idle, healthy worker that still has uncalibrated models and
+    sends ``start_calibration_session``.
+  * When outside the window, sends ``stop_calibration_session`` to the
+    provider that holds the active session — the worker tears the in-flight
+    vLLM probe down inside ~2s.
+  * Reacts to ``calibration_session_finished`` / ``_cancelled`` events to
+    free the active-provider slot so the next tick can pick someone else.
 
-Design invariants:
-- Only one worker calibrates at a time (sequential, not concurrent).
-- A worker is considered idle if it has no active requests AND its
-  calibration-status reports active=False.
-- A model "needs calibration" if its ModelProfile.base_residency_mb is None
-  on a worker that lists it as a capability.
-- Outside the time window the orchestrator sends stop_calibration to any worker
-  that may be running one (best-effort) and idles until the next window opens.
+Design invariants (unchanged from the previous design):
+- Only one worker calibrates at a time across the cluster.
+- A worker is considered idle if it has no active inference requests AND is
+  not already running a calibration session.
+- The orchestrator never polls calibration status. The worker speaks first.
 """
 
 from __future__ import annotations
@@ -26,13 +29,17 @@ import logging
 import os
 from dataclasses import dataclass, field
 from datetime import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 logger = logging.getLogger("logos.capacity.calibration_orchestrator")
 
 if TYPE_CHECKING:
     from logos.logosnode_registry import LogosNodeRuntimeRegistry
     from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
+
+
+# Terminal session events that free the active-provider slot.
+_TERMINAL_SESSION_EVENTS = frozenset({"calibration_session_finished", "calibration_session_cancelled"})
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +59,7 @@ class CalibrationConfig:
     LOGOS_CALIB_TIMEZONE      e.g. "Europe/Berlin" (default Europe/Berlin)
     LOGOS_CALIB_ENABLED       "true" / "false" (default true)
     LOGOS_CALIB_SLEEP_LEVEL   "1" or "2" (default 1)
-    LOGOS_CALIB_TICK_SECONDS  poll interval in seconds (default 60)
+    LOGOS_CALIB_TICK_SECONDS  trigger-loop tick interval in seconds (default 60)
     """
 
     window_start: time = field(default_factory=lambda: time(2, 0))
@@ -108,7 +115,7 @@ class CalibrationConfig:
 
 
 class CalibrationOrchestrator:
-    """Drives server-orchestrated nightly VRAM calibration."""
+    """Triggers worker-driven calibration sessions inside the nightly window."""
 
     def __init__(
         self,
@@ -120,18 +127,17 @@ class CalibrationOrchestrator:
         self._facade = facade
         self._config = config or CalibrationConfig.from_env()
         self._task: asyncio.Task[None] | None = None
-        # Providers confirmed idle since the most recent window close. We skip
-        # polling them on subsequent outside-window ticks so the cleanup pass
-        # doesn't generate one get_calibration_status RPC per provider per
-        # minute, all day long. Cleared whenever the window re-opens.
-        self._outside_window_idle: set[int] = set()
+        # The single provider currently running a session, or None when no
+        # session is in flight anywhere in the cluster. Updated when we
+        # send start_calibration_session and cleared by on_event() when the
+        # worker emits a terminal session event.
+        self._active_provider_id: int | None = None
+        # Providers we have already kicked off this window. A worker that
+        # finishes its session is not asked again until the next window —
+        # whatever models it couldn't calibrate (failures, unsupported)
+        # would loop the same way on a retry. Cleared on window edge.
+        self._completed_this_window: set[int] = set()
         self._was_in_window: bool = False
-        # (provider_id, model_name) pairs we've already issued
-        # start_calibration for in the current window. Successful calibrations
-        # leave the model with a profile so it stops being picked anyway;
-        # failures stay in this set so we don't keep retrying a deterministic
-        # failure mode all night. Cleared on window edge.
-        self._attempted_this_window: set[tuple[int, str]] = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -143,6 +149,15 @@ class CalibrationOrchestrator:
             return
         if self._task is not None and not self._task.done():
             return
+        # Subscribe to worker events so we react to terminal session events
+        # without polling. If the registry does not expose subscription
+        # (older builds), we still function — the next tick would just
+        # try to start another session on an idle provider while the
+        # current one still runs, and the worker would refuse it. The
+        # subscribe path is the fast path.
+        subscribe = getattr(self._registry, "subscribe_to_events", None)
+        if callable(subscribe):
+            subscribe(self._on_provider_event)
         self._task = asyncio.create_task(self._tick_loop(), name="calibration-orchestrator")
         logger.info(
             "CalibrationOrchestrator: started (window %s–%s %s, tick=%.0fs)",
@@ -161,6 +176,9 @@ class CalibrationOrchestrator:
         except asyncio.CancelledError:
             pass
         self._task = None
+        unsubscribe = getattr(self._registry, "unsubscribe_from_events", None)
+        if callable(unsubscribe):
+            unsubscribe(self._on_provider_event)
         logger.info("CalibrationOrchestrator: stopped")
 
     # ------------------------------------------------------------------
@@ -180,46 +198,25 @@ class CalibrationOrchestrator:
     async def _tick(self) -> None:
         in_window = self._is_in_window()
         if in_window != self._was_in_window:
-            # Window edge: forget any prior outside-window idle bookkeeping
-            # and clear per-window attempt records so the next window starts
-            # with a clean slate.
-            self._outside_window_idle.clear()
-            self._attempted_this_window.clear()
+            # Window edge: reset per-window bookkeeping so the next window
+            # gets a clean slate.
+            self._completed_this_window.clear()
             self._was_in_window = in_window
 
         if not in_window:
-            # Outside window: cancel any running calibration (best-effort).
-            await self._cancel_all_running()
+            await self._stop_active_session_if_any("outside-window")
             return
 
-        # Inside window: pick one idle worker with an uncalibrated model.
-        target = self._pick_calibration_target()
-        if target is None:
-            logger.debug("CalibrationOrchestrator: all models calibrated or no idle worker available")
+        # Inside window: do nothing if a session is already running.
+        if self._active_provider_id is not None:
             return
 
-        provider_id, model_name = target
-        provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
-
-        # Check if that worker is already calibrating (maybe we triggered it
-        # last tick and the thread started but didn't finish yet).
-        status = await self._get_status(provider_id)
-        if status is not None and status.get("active"):
-            logger.debug(
-                "CalibrationOrchestrator: worker=%s already calibrating model=%s — waiting",
-                provider_name,
-                status.get("model_name"),
-            )
+        target_provider_id = self._pick_next_provider()
+        if target_provider_id is None:
+            logger.debug("CalibrationOrchestrator: no idle worker with uncalibrated models — waiting for next tick")
             return
 
-        self._attempted_this_window.add((provider_id, model_name))
-        logger.info(
-            "CalibrationOrchestrator: starting calibration provider=%s model=%s sleep_level=%d",
-            provider_name,
-            model_name,
-            self._config.sleep_level,
-        )
-        await self._send_start_calibration(provider_id, model_name)
+        await self._start_session_on(target_provider_id)
 
     # ------------------------------------------------------------------
     # Window check
@@ -247,41 +244,31 @@ class CalibrationOrchestrator:
         return now >= start or now < end
 
     # ------------------------------------------------------------------
-    # Target selection
+    # Provider selection
     # ------------------------------------------------------------------
 
-    def _pick_calibration_target(self) -> tuple[int, str] | None:
-        """Return (provider_id, model_name) for the first model that needs
-        calibration on an idle, connected worker — or None if none found."""
+    def _pick_next_provider(self) -> int | None:
+        """Return the first eligible provider that still has uncalibrated models."""
         for provider_id in self._facade.provider_ids():
-            # Skip providers that haven't sent their first status yet.
+            if provider_id in self._completed_this_window:
+                continue
             if not self._registry.has_received_first_status(provider_id):
                 continue
-
-            # Skip providers reporting node-level degradation (GPU
-            # ERR/N/A, HF cache EIO, …). The worker would refuse the
-            # start_calibration RPC anyway; checking here avoids the
-            # round-trip and the noisy refusal log line every minute.
-            # The registry's update_runtime hook already logged the
-            # transition once on receipt, so quiet skip is fine.
             if self._provider_is_unhealthy(provider_id):
                 continue
-
-            # Skip providers with active inference requests.
             if self._provider_has_active_requests(provider_id):
                 continue
-
-            # Find a model on this provider that lacks a full calibration.
-            model_name = self._find_uncalibrated_model(provider_id)
-            if model_name is not None:
-                return provider_id, model_name
-
+            if not self._provider_has_uncalibrated_models(provider_id):
+                # Whole worker is calibrated — mark done for this window so
+                # we don't re-evaluate it every tick.
+                self._completed_this_window.add(provider_id)
+                continue
+            return provider_id
         return None
 
     def _provider_is_unhealthy(self, provider_id: int) -> bool:
         """Return True if the worker's latest runtime status reports
-        ``node_health.healthy=False``. Legacy workers (no node_health
-        field) and providers without a session are treated as healthy.
+        ``node_health.healthy=False``.
         """
         try:
             snap = self._registry.peek_runtime_snapshot(provider_id)
@@ -298,14 +285,7 @@ class CalibrationOrchestrator:
         return not bool(node_health.get("healthy", True))
 
     def _provider_has_active_requests(self, provider_id: int) -> bool:
-        """Return True if the provider has any active inference requests.
-
-        `OllamaCapacity` (the only `get_capacity_info` return type) has no
-        `active_requests` field — that data only exists per-lane in the
-        scheduler signals. Sum across all lanes on the provider; treat any
-        non-zero `active_requests` (currently-running) or `queue_waiting`
-        (admitted but pending) as "busy".
-        """
+        """Return True if the provider has any active inference requests."""
         try:
             signals = self._facade.get_all_provider_lane_signals(provider_id)
         except Exception:
@@ -318,55 +298,13 @@ class CalibrationOrchestrator:
                 return True
         return False
 
-    def _find_uncalibrated_model(self, provider_id: int) -> str | None:
-        """Return the first model on this provider that needs calibration.
-
-        A model needs calibration when ANY of:
-          - the profile is missing entirely,
-          - core VRAM fields (``base_residency_mb`` / ``sleeping_residual_mb``)
-            are missing,
-          - ``sleep_l1_transient_host_ram_mb`` is missing — this is the field
-            the planner's host-RAM sleep gate relies on. Production runs
-            sleep_l1 on every idle lane after ~2 min, so a missing value
-            forces the planner onto its flat-threshold fallback every time.
-            We only measure level 1 here; level 2 (``sleep_l2_transient_…``)
-            stays unmeasured because production effectively never fires
-            sleep_l2 (``IDLE_SLEEP_L2 = 24h``). The planner gracefully falls
-            back to a disk-size heuristic for sleep_l2 on demand.
-
-        Exception: when the worker reports ``sleep_mode_disabled=True`` for
-        a model (worker-wide kill switch or per-model
-        enable_sleep_mode=false override), the sleep fields are N/A — the
-        vLLM lane refuses /sleep there. Only ``base_residency_mb`` matters
-        in that case.
-
-        Second exception: when the worker reports
-        ``calibration_unsupported=True`` for a model, calibration is known
-        to fail deterministically on this worker (bad repo id, gated repo,
-        vLLM architecture mismatch, …). Skip — retrying would just burn a
-        maintenance window watching the same identity-level error
-        reproduce. Operators clear this by editing
-        ``calibration_unsupported_models.txt`` on the worker after fixing
-        the underlying cause.
-
-        Models we have already tried this window are skipped — a successful
-        run will have populated the profile and removed them from the
-        uncalibrated set anyway, so seeing one here again means the previous
-        attempt failed and is likely to keep failing the same way until
-        something (config, hardware, code) changes.
-
-        We iterate ``get_configured_models`` rather than
-        ``get_worker_capabilities`` because the worker strips uncalibrated
-        models from its capabilities list before advertising it. Without
-        configured_models the orchestrator would never see — and never
-        target — any model that has never been calibrated.
+    def _provider_has_uncalibrated_models(self, provider_id: int) -> bool:
+        """Return True when the worker still has at least one model that needs
+        calibration. Mirrors the worker's own selection logic so we don't fire
+        a session that immediately ends as a no-op.
         """
         candidates = self._facade.get_configured_models(provider_id)
         if not candidates:
-            # Backwards compat: a worker that hasn't been updated to send
-            # configured_models still exposes its calibrated set via
-            # capabilities. The orchestrator can still keep those calibrated
-            # but nothing new will surface until the worker is updated.
             candidates = self._facade.get_worker_capabilities(provider_id)
         try:
             profiles = self._facade.get_model_profiles(provider_id)
@@ -375,17 +313,8 @@ class CalibrationOrchestrator:
 
         for model_name in candidates:
             profile = profiles.get(model_name)
-            # Worker has classified this model as permanently unsupported
-            # — every calibration attempt fails the same way. Skip.
             if profile is not None and profile.calibration_unsupported:
                 continue
-            # A worker that forbids sleep for this model (worker-wide
-            # disable_sleep_mode kill switch, or per-model
-            # enable_sleep_mode=false override) cannot produce
-            # sleeping_residual_mb / sleep_l1_transient_host_ram_mb — the
-            # vLLM lane refuses /sleep. Treat those fields as N/A in that
-            # case instead of "uncalibrated"; otherwise the orchestrator
-            # would retry every maintenance window forever.
             sleep_na = bool(profile is not None and profile.sleep_mode_disabled)
             needs_calib = (
                 profile is None
@@ -393,93 +322,118 @@ class CalibrationOrchestrator:
                 or (not sleep_na and profile.sleeping_residual_mb is None)
                 or (not sleep_na and profile.sleep_l1_transient_host_ram_mb is None)
             )
-            if not needs_calib:
-                continue
-            if (provider_id, model_name) in self._attempted_this_window:
-                continue
-            return model_name
-
-        return None
+            if needs_calib:
+                return True
+        return False
 
     # ------------------------------------------------------------------
-    # RPC helpers
+    # RPC drivers
     # ------------------------------------------------------------------
 
-    async def _send_start_calibration(self, provider_id: int, model_name: str) -> None:
+    async def _start_session_on(self, provider_id: int) -> None:
         from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
 
+        provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
+        # Mark active before sending so a concurrent terminal-event handler
+        # (e.g. from a duplicate connect) can clear it cleanly without us
+        # also firing the same start a second time on the next tick.
+        self._active_provider_id = provider_id
         try:
             await self._registry.send_command(
                 provider_id,
-                "start_calibration",
-                params={"model_name": model_name, "sleep_level": self._config.sleep_level},
+                "start_calibration_session",
+                params={"sleep_level": self._config.sleep_level},
                 timeout_seconds=30,
+            )
+            logger.info(
+                "CalibrationOrchestrator: session started on provider=%s sleep_level=%d",
+                provider_name,
+                self._config.sleep_level,
             )
         except LogosNodeOfflineError:
             logger.warning(
-                "CalibrationOrchestrator: provider=%s offline — cannot start calibration for %s",
-                provider_id,
-                model_name,
-            )
-        except LogosNodeCommandError as exc:
-            logger.warning(
-                "CalibrationOrchestrator: start_calibration failed for provider=%s model=%s: %s",
-                provider_id,
-                model_name,
-                exc,
-            )
-        except Exception:
-            logger.exception(
-                "CalibrationOrchestrator: unexpected error starting calibration " "provider=%s model=%s",
-                provider_id,
-                model_name,
-            )
-
-    async def _get_status(self, provider_id: int) -> dict[str, Any] | None:
-        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
-
-        try:
-            return await self._registry.send_command(
-                provider_id,
-                "get_calibration_status",
-                timeout_seconds=10,
-            )
-        except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
-            return None
-
-    async def _cancel_all_running(self) -> None:
-        """Outside the maintenance window: stop any in-progress calibrations.
-
-        Providers that report idle once are remembered in
-        ``_outside_window_idle`` and skipped on subsequent ticks until the
-        window re-opens — without this latch the cleanup pass would emit one
-        ``get_calibration_status`` RPC per provider every tick, all day.
-        """
-        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
-
-        for provider_id in self._facade.provider_ids():
-            if provider_id in self._outside_window_idle:
-                continue
-            status = await self._get_status(provider_id)
-            if status is None:
-                # Transient comms failure — retry next tick.
-                continue
-            if not status.get("active"):
-                self._outside_window_idle.add(provider_id)
-                continue
-            provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
-            logger.info(
-                "CalibrationOrchestrator: outside window — stopping calibration on provider=%s",
+                "CalibrationOrchestrator: provider=%s offline — could not start session",
                 provider_name,
             )
-            try:
-                await self._registry.send_command(
-                    provider_id,
-                    "stop_calibration",
-                    timeout_seconds=15,
-                )
-            except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
-                logger.debug(
-                    "CalibrationOrchestrator: failed to stop calibration on provider=%s (ignored)",
-                    provider_name,
-                )
+            self._active_provider_id = None
+        except LogosNodeCommandError as exc:
+            logger.warning(
+                "CalibrationOrchestrator: start_calibration_session failed on provider=%s: %s",
+                provider_name,
+                exc,
+            )
+            self._active_provider_id = None
+            # Don't retry this provider in this window — whatever made the
+            # worker refuse (e.g. node unhealthy at the last second) will
+            # likely repeat next tick.
+            self._completed_this_window.add(provider_id)
+        except Exception:
+            logger.exception(
+                "CalibrationOrchestrator: unexpected error starting session on provider=%s",
+                provider_name,
+            )
+            self._active_provider_id = None
+
+    async def _stop_active_session_if_any(self, reason: str) -> None:
+        """Outside the window (or on shutdown): tell the active worker to stop.
+
+        The worker reacts within ~2s — wait_ready polls cancel_event during
+        vLLM probe startup. The terminal session_cancelled event clears
+        ``_active_provider_id`` via on_event().
+        """
+        provider_id = self._active_provider_id
+        if provider_id is None:
+            return
+        from logos.logosnode_registry import LogosNodeCommandError, LogosNodeOfflineError
+
+        provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
+        logger.info(
+            "CalibrationOrchestrator: stopping calibration session on provider=%s (%s)",
+            provider_name,
+            reason,
+        )
+        try:
+            await self._registry.send_command(
+                provider_id,
+                "stop_calibration_session",
+                timeout_seconds=20,
+            )
+        except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
+            logger.debug(
+                "CalibrationOrchestrator: stop_calibration_session on provider=%s failed (ignored)",
+                provider_name,
+                exc_info=True,
+            )
+            # Even if the RPC fails (worker disconnected, etc.) we treat
+            # the slot as freed — the orchestrator doesn't own the worker's
+            # subprocess and a stale active slot would block other workers.
+            self._active_provider_id = None
+
+    # ------------------------------------------------------------------
+    # Event hook
+    # ------------------------------------------------------------------
+
+    def _on_provider_event(self, provider_id: int, event: dict) -> None:
+        """Registry calls this for every worker event.
+
+        We only care about terminal session events on the active provider —
+        they free the slot so the next tick can pick another worker.
+        """
+        if self._active_provider_id is None or provider_id != self._active_provider_id:
+            return
+        if not isinstance(event, dict):
+            return
+        event_name = str(event.get("event", "")).strip()
+        if event_name not in _TERMINAL_SESSION_EVENTS:
+            return
+        provider_name = self._facade.get_provider_name(provider_id) or str(provider_id)
+        logger.info(
+            "CalibrationOrchestrator: provider=%s emitted %s — slot freed",
+            provider_name,
+            event_name,
+        )
+        # The worker walks its full model list every session. Whatever it
+        # didn't calibrate this round (failures, unsupported, skipped) won't
+        # succeed on a retry in this window. Mark done so we move on.
+        self._completed_this_window.add(provider_id)
+        self._active_provider_id = None

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -311,14 +311,26 @@ class CalibrationOrchestrator:
         uncalibrated set anyway, so seeing one here again means the previous
         attempt failed and is likely to keep failing the same way until
         something (config, hardware, code) changes.
+
+        We iterate ``get_configured_models`` rather than
+        ``get_worker_capabilities`` because the worker strips uncalibrated
+        models from its capabilities list before advertising it. Without
+        configured_models the orchestrator would never see — and never
+        target — any model that has never been calibrated.
         """
-        capabilities = self._facade.get_worker_capabilities(provider_id)
+        candidates = self._facade.get_configured_models(provider_id)
+        if not candidates:
+            # Backwards compat: a worker that hasn't been updated to send
+            # configured_models still exposes its calibrated set via
+            # capabilities. The orchestrator can still keep those calibrated
+            # but nothing new will surface until the worker is updated.
+            candidates = self._facade.get_worker_capabilities(provider_id)
         try:
             profiles = self._facade.get_model_profiles(provider_id)
         except Exception:
             profiles = {}
 
-        for model_name in capabilities:
+        for model_name in candidates:
             profile = profiles.get(model_name)
             needs_calib = (
                 profile is None

--- a/logos/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/src/logos/capacity/calibration_orchestrator.py
@@ -93,8 +93,8 @@ class CalibrationConfig:
                 return default
 
         return cls(
-            window_start=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_START", ""), time(2, 0)),
-            window_end=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_END", ""), time(5, 0)),
+            window_start=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_START", ""), time(3, 0)),
+            window_end=_parse_time(os.getenv("LOGOS_CALIB_WINDOW_END", ""), time(8, 0)),
             timezone=os.getenv("LOGOS_CALIB_TIMEZONE", "Europe/Berlin").strip() or "Europe/Berlin",
             enabled=_parse_bool(os.getenv("LOGOS_CALIB_ENABLED", ""), True),
             sleep_level=_parse_int(os.getenv("LOGOS_CALIB_SLEEP_LEVEL", ""), 1),
@@ -258,6 +258,15 @@ class CalibrationOrchestrator:
             if not self._registry.has_received_first_status(provider_id):
                 continue
 
+            # Skip providers reporting node-level degradation (GPU
+            # ERR/N/A, HF cache EIO, …). The worker would refuse the
+            # start_calibration RPC anyway; checking here avoids the
+            # round-trip and the noisy refusal log line every minute.
+            # The registry's update_runtime hook already logged the
+            # transition once on receipt, so quiet skip is fine.
+            if self._provider_is_unhealthy(provider_id):
+                continue
+
             # Skip providers with active inference requests.
             if self._provider_has_active_requests(provider_id):
                 continue
@@ -268,6 +277,25 @@ class CalibrationOrchestrator:
                 return provider_id, model_name
 
         return None
+
+    def _provider_is_unhealthy(self, provider_id: int) -> bool:
+        """Return True if the worker's latest runtime status reports
+        ``node_health.healthy=False``. Legacy workers (no node_health
+        field) and providers without a session are treated as healthy.
+        """
+        try:
+            snap = self._registry.peek_runtime_snapshot(provider_id)
+        except Exception:
+            return False
+        if not isinstance(snap, dict):
+            return False
+        runtime = snap.get("runtime")
+        if not isinstance(runtime, dict):
+            return False
+        node_health = runtime.get("node_health")
+        if not isinstance(node_health, dict):
+            return False
+        return not bool(node_health.get("healthy", True))
 
     def _provider_has_active_requests(self, provider_id: int) -> bool:
         """Return True if the provider has any active inference requests.
@@ -312,6 +340,15 @@ class CalibrationOrchestrator:
         vLLM lane refuses /sleep there. Only ``base_residency_mb`` matters
         in that case.
 
+        Second exception: when the worker reports
+        ``calibration_unsupported=True`` for a model, calibration is known
+        to fail deterministically on this worker (bad repo id, gated repo,
+        vLLM architecture mismatch, …). Skip — retrying would just burn a
+        maintenance window watching the same identity-level error
+        reproduce. Operators clear this by editing
+        ``calibration_unsupported_models.txt`` on the worker after fixing
+        the underlying cause.
+
         Models we have already tried this window are skipped — a successful
         run will have populated the profile and removed them from the
         uncalibrated set anyway, so seeing one here again means the previous
@@ -338,6 +375,10 @@ class CalibrationOrchestrator:
 
         for model_name in candidates:
             profile = profiles.get(model_name)
+            # Worker has classified this model as permanently unsupported
+            # — every calibration attempt fails the same way. Skip.
+            if profile is not None and profile.calibration_unsupported:
+                continue
             # A worker that forbids sleep for this model (worker-wide
             # disable_sleep_mode kill switch, or per-model
             # enable_sleep_mode=false override) cannot produce

--- a/logos/src/logos/dbutils/dbrequest.py
+++ b/logos/src/logos/dbutils/dbrequest.py
@@ -203,6 +203,7 @@ class AddBillingRequest(LogosKeyModel):
 class LogosNodeAuthRequest(BaseModel):
     shared_key: str
     capabilities_models: list[str] = Field(default_factory=list)
+    configured_models: list[str] = Field(default_factory=list)
 
 
 class LogosNodeRegisterRequest(LogosKeyModel):

--- a/logos/src/logos/logosnode_registry.py
+++ b/logos/src/logos/logosnode_registry.py
@@ -886,6 +886,20 @@ class LogosNodeRuntimeRegistry:
         session = self._sessions.get(int(provider_id))
         return session is not None and session.first_status_received
 
+    def is_provider_online(self, provider_id: int, stale_after_seconds: int = 30) -> bool:
+        """Return True if the worker has a live session right now.
+
+        Mirrors `_get_active_session`'s criteria so callers (notably the
+        scheduler) can short-circuit before committing to a provider that
+        would only raise LogosNodeOfflineError at context-resolution time.
+        A worker that disconnected (session popped from `_sessions`) or whose
+        heartbeat is older than ``stale_after_seconds`` is considered offline.
+        """
+        session = self._sessions.get(int(provider_id))
+        if session is None:
+            return False
+        return not session.is_stale(stale_after_seconds)
+
     def get_desired_lane_set(self, provider_id: int) -> list[dict[str, Any]]:
         """Return the server's last-intended lane configuration for a provider."""
         session = self._sessions.get(int(provider_id))

--- a/logos/src/logos/logosnode_registry.py
+++ b/logos/src/logos/logosnode_registry.py
@@ -304,6 +304,10 @@ class LogosNodeRuntimeRegistry:
         # Optional callback invoked when a worker's capabilities_models change.
         # Signature: (provider_id, sorted_model_names) -> None
         self._on_capabilities_changed = on_capabilities_changed
+        # Subscribers notified on every worker event. The calibration
+        # orchestrator uses this to react to terminal session events
+        # without polling. Signature: (provider_id, event_dict) -> None
+        self._event_subscribers: list[Callable[[int, dict[str, Any]], None]] = []
 
     def _fire_capabilities_changed(self, provider_id: int, model_names: list[str]) -> None:
         if self._on_capabilities_changed is not None:
@@ -715,6 +719,31 @@ class LogosNodeRuntimeRegistry:
         if isinstance(event, dict):
             session.latest_events.append(event)
             session.latest_events = session.latest_events[-500:]
+            for subscriber in tuple(self._event_subscribers):
+                try:
+                    subscriber(provider_id, event)
+                except Exception:
+                    logger.exception(
+                        "Event subscriber failed for provider=%s event=%s",
+                        provider_id,
+                        event.get("event"),
+                    )
+
+    def subscribe_to_events(self, callback: Callable[[int, dict[str, Any]], None]) -> None:
+        """Register a callback fired for every worker event.
+
+        Called synchronously inside ``append_event`` so subscribers must do
+        cheap work (e.g. mutate in-memory state) and never block on I/O.
+        """
+        if callback not in self._event_subscribers:
+            self._event_subscribers.append(callback)
+
+    def unsubscribe_from_events(self, callback: Callable[[int, dict[str, Any]], None]) -> None:
+        """Remove a previously registered event subscriber."""
+        try:
+            self._event_subscribers.remove(callback)
+        except ValueError:
+            pass
 
     async def mark_heartbeat(self, provider_id: int) -> None:
         session = await self._get_session(provider_id)

--- a/logos/src/logos/logosnode_registry.py
+++ b/logos/src/logos/logosnode_registry.py
@@ -593,6 +593,34 @@ class LogosNodeRuntimeRegistry:
         session.last_heartbeat = _utc_now()
         if was_first:
             self.sync_desired_lanes_from_runtime(provider_id)
+
+        # Detect node-health transitions and log loudly on the master side
+        # so operators see the condition in the logos-server container
+        # logs (per the user requirement for feature #3). The worker
+        # already logs each heartbeat; here we only log on EDGES so a
+        # multi-hour outage doesn't flood the master journal.
+        _old_nh = (old_runtime or {}).get("node_health") if isinstance(old_runtime, dict) else None
+        _new_nh = (
+            (session.latest_runtime or {}).get("node_health") if isinstance(session.latest_runtime, dict) else None
+        )
+        _old_healthy = bool(_old_nh.get("healthy", True)) if isinstance(_old_nh, dict) else True
+        _new_healthy = bool(_new_nh.get("healthy", True)) if isinstance(_new_nh, dict) else True
+        if _old_healthy and not _new_healthy:
+            logger.error(
+                "*** NODE UNHEALTHY *** provider=%s (id=%d) reason=%s — %s. "
+                "Calibration scheduling is suspended for this worker until the "
+                "node recovers. Investigate immediately (likely reboot required).",
+                session.worker_id or str(provider_id),
+                provider_id,
+                (_new_nh or {}).get("reason_code"),
+                (_new_nh or {}).get("reason_detail"),
+            )
+        elif _new_healthy and not _old_healthy:
+            logger.info(
+                "*** NODE RECOVERED *** provider=%s (id=%d) — all sensors green, " "calibration scheduling resumed.",
+                session.worker_id or str(provider_id),
+                provider_id,
+            )
         if capabilities_models is not None:
             new_caps = {m for m in capabilities_models if isinstance(m, str) and m.strip()}
             if new_caps != session.capabilities_models:

--- a/logos/src/logos/logosnode_registry.py
+++ b/logos/src/logos/logosnode_registry.py
@@ -256,6 +256,7 @@ class AuthTicket:
     worker_id: str
     capabilities_models: set[str]
     expires_at: datetime
+    configured_models: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -264,6 +265,11 @@ class ProviderSession:
     worker_id: str
     websocket: WebSocket
     capabilities_models: set[str] = field(default_factory=set)
+    # Full set of models the worker is configured to serve, including those
+    # without a valid profile yet. Used by the calibration orchestrator to
+    # discover uncalibrated models (capabilities_models only contains
+    # already-calibrated entries that are safe to route requests to).
+    configured_models: set[str] = field(default_factory=set)
     last_heartbeat: datetime = field(default_factory=_utc_now)
     first_status_received: bool = False
     latest_runtime: dict[str, Any] = field(default_factory=dict)
@@ -406,13 +412,21 @@ class LogosNodeRuntimeRegistry:
         worker_id: str,
         capabilities_models: list[str],
         ttl_seconds: int = 60,
+        configured_models: list[str] | None = None,
     ) -> str:
         token = secrets.token_urlsafe(32)
         expires_at = _utc_now() + timedelta(seconds=max(5, ttl_seconds))
+        configured_set = {m for m in (configured_models or []) if isinstance(m, str) and m.strip()}
+        cap_set = {m for m in capabilities_models if isinstance(m, str) and m.strip()}
+        # Older workers don't send configured_models; treat their capabilities
+        # list as the full configured set so the orchestrator sees something.
+        if not configured_set:
+            configured_set = set(cap_set)
         ticket = AuthTicket(
             provider_id=int(provider_id),
             worker_id=worker_id,
-            capabilities_models={m for m in capabilities_models if isinstance(m, str) and m.strip()},
+            capabilities_models=cap_set,
+            configured_models=configured_set,
             expires_at=expires_at,
         )
         async with self._lock:
@@ -432,6 +446,7 @@ class LogosNodeRuntimeRegistry:
             worker_id=ticket.worker_id,
             websocket=websocket,
             capabilities_models=set(ticket.capabilities_models),
+            configured_models=set(ticket.configured_models),
         )
         async with self._lock:
             old = self._sessions.get(ticket.provider_id)
@@ -545,6 +560,7 @@ class LogosNodeRuntimeRegistry:
         worker_id: str,
         capabilities_models: list[str] | None = None,
         max_lanes: int = 0,
+        configured_models: list[str] | None = None,
     ) -> None:
         session = await self._get_session(provider_id)
         if session is None:
@@ -557,12 +573,15 @@ class LogosNodeRuntimeRegistry:
             if new_caps != session.capabilities_models:
                 session.capabilities_models = new_caps
                 self._fire_capabilities_changed(provider_id, sorted(new_caps))
+        if configured_models is not None:
+            session.configured_models = {m for m in configured_models if isinstance(m, str) and m.strip()}
 
     async def update_runtime(
         self,
         provider_id: int,
         runtime: dict[str, Any],
         capabilities_models: list[str] | None = None,
+        configured_models: list[str] | None = None,
     ) -> None:
         session = await self._get_session(provider_id)
         if session is None:
@@ -579,6 +598,8 @@ class LogosNodeRuntimeRegistry:
             if new_caps != session.capabilities_models:
                 session.capabilities_models = new_caps
                 self._fire_capabilities_changed(provider_id, sorted(new_caps))
+        if configured_models is not None:
+            session.configured_models = {m for m in configured_models if isinstance(m, str) and m.strip()}
 
         # Detect lane state and metric changes and log them as structured blocks.
         old_lanes = {
@@ -837,6 +858,7 @@ class LogosNodeRuntimeRegistry:
             "provider_id": session.provider_id,
             "worker_id": session.worker_id,
             "capabilities_models": sorted(session.capabilities_models),
+            "configured_models": sorted(session.configured_models),
             "first_status_received": session.first_status_received,
             "last_heartbeat": session.last_heartbeat.isoformat(),
             "runtime": session.latest_runtime,
@@ -851,6 +873,7 @@ class LogosNodeRuntimeRegistry:
             "provider_id": session.provider_id,
             "worker_id": session.worker_id,
             "capabilities_models": sorted(session.capabilities_models),
+            "configured_models": sorted(session.configured_models),
             "first_status_received": session.first_status_received,
             "last_heartbeat": session.last_heartbeat.isoformat(),
             "runtime": session.latest_runtime,

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -3374,10 +3374,11 @@ async def logosnode_reconfigure_lane(data: LogosNodeReconfigureLaneRequest):
 def _find_uncalibrated_models_on_provider(provider_id: int) -> list[str]:
     """Return every configured model on a provider that still needs calibration.
 
-    Mirrors CalibrationOrchestrator._find_uncalibrated_model's definition of
-    'needs calibration' but returns the full set instead of stopping at the
-    first hit. Sourced from configured_models so models the worker stripped
-    from capabilities_models (because they have no profile yet) are visible.
+    Used by the admin endpoint to report what the worker is likely to walk
+    in its next calibration session — the worker makes the final selection,
+    but this lets the API caller see the candidate list up front. Sourced
+    from configured_models so models the worker stripped from
+    capabilities_models (because they have no profile yet) are visible.
     """
     if _logosnode_facade is None:
         return []
@@ -3401,78 +3402,15 @@ def _find_uncalibrated_models_on_provider(provider_id: int) -> list[str]:
     return uncalibrated
 
 
-async def _run_calibration_batch(provider_id: int, models: list[str], sleep_level: int) -> None:
-    """Sequentially calibrate ``models`` on ``provider_id``.
-
-    Fires start_calibration per model and polls get_calibration_status until
-    the worker reports active=False (or a per-model timeout elapses) before
-    moving on. Failures are logged but don't abort the batch — the next model
-    still gets a chance.
-    """
-    pname = _resolve_provider_name(provider_id)
-    poll_interval_seconds = 5.0
-    per_model_timeout_seconds = 15 * 60
-    for model_name in models:
-        try:
-            logger.info(
-                "Admin calibrate-uncalibrated: starting provider=%s model=%s sleep_level=%d",
-                pname,
-                model_name,
-                sleep_level,
-            )
-            await _logosnode_registry.send_command(
-                provider_id,
-                "start_calibration",
-                params={"model_name": model_name, "sleep_level": sleep_level},
-                timeout_seconds=30,
-            )
-        except (LogosNodeOfflineError, LogosNodeCommandError) as exc:
-            logger.warning(
-                "Admin calibrate-uncalibrated: start failed provider=%s model=%s: %s",
-                pname,
-                model_name,
-                exc,
-            )
-            continue
-        except Exception:
-            logger.exception(
-                "Admin calibrate-uncalibrated: unexpected error starting provider=%s model=%s",
-                pname,
-                model_name,
-            )
-            continue
-
-        deadline = asyncio.get_running_loop().time() + per_model_timeout_seconds
-        while True:
-            await asyncio.sleep(poll_interval_seconds)
-            try:
-                status = await _logosnode_registry.send_command(
-                    provider_id,
-                    "get_calibration_status",
-                    timeout_seconds=10,
-                )
-            except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
-                status = None
-            if not (isinstance(status, dict) and status.get("active")):
-                break
-            if asyncio.get_running_loop().time() >= deadline:
-                logger.warning(
-                    "Admin calibrate-uncalibrated: timeout waiting for provider=%s model=%s — moving on",
-                    pname,
-                    model_name,
-                )
-                break
-    logger.info("Admin calibrate-uncalibrated: batch finished provider=%s (%d models)", pname, len(models))
-
-
 @app.post("/logosdb/providers/logosnode/calibrate_uncalibrated", tags=["logosnode"])
 async def logosnode_calibrate_uncalibrated(data: LogosNodeStatusRequest):
-    """Trigger calibration of every uncalibrated model on a worker immediately.
+    """Kick off a worker-driven calibration session immediately.
 
-    Returns the list of models that will be calibrated; calibration itself
-    runs in the background sequentially because the worker only calibrates
-    one model at a time. Each model is attempted exactly once — the endpoint
-    does not retry failures.
+    The worker picks which uncalibrated models to run and walks them one at
+    a time, emitting ``calibration_*`` events as each completes. The server
+    no longer chooses models or polls status — the response just confirms
+    the session was started and reports which models the worker will see
+    as uncalibrated right now.
     """
     _require_root_access(data.logos_key)
     snap = _logosnode_registry.peek_runtime_snapshot(data.provider_id)
@@ -3484,11 +3422,27 @@ async def logosnode_calibrate_uncalibrated(data: LogosNodeStatusRequest):
     if not models:
         return {"message": "No uncalibrated models on this worker", "count": 0, "models": []}
     sleep_level = _calibration_orchestrator._config.sleep_level if _calibration_orchestrator is not None else 1
-    task = asyncio.create_task(_run_calibration_batch(data.provider_id, list(models), sleep_level))
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
+    pname = _resolve_provider_name(data.provider_id)
+    try:
+        await _logosnode_registry.send_command(
+            data.provider_id,
+            "start_calibration_session",
+            params={"sleep_level": sleep_level},
+            timeout_seconds=30,
+        )
+    except LogosNodeOfflineError as exc:
+        logger.warning("Admin calibrate-uncalibrated: provider=%s offline: %s", pname, exc)
+        return JSONResponse(status_code=503, content={"error": "Worker not connected"})
+    except LogosNodeCommandError as exc:
+        logger.warning("Admin calibrate-uncalibrated: start_calibration_session refused on provider=%s: %s", pname, exc)
+        return JSONResponse(status_code=409, content={"error": str(exc)})
+    logger.info(
+        "Admin calibrate-uncalibrated: session started on provider=%s (%d candidate model(s))",
+        pname,
+        len(models),
+    )
     return {
-        "message": f"Calibration started for {len(models)} model(s)",
+        "message": f"Calibration session started on {pname} ({len(models)} candidate model(s))",
         "count": len(models),
         "models": models,
     }

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -3228,9 +3228,7 @@ async def logosnode_session(websocket: WebSocket, token: str):
                         else None
                     ),
                     configured_models=(
-                        payload.get("configured_models")
-                        if isinstance(payload.get("configured_models"), list)
-                        else None
+                        payload.get("configured_models") if isinstance(payload.get("configured_models"), list) else None
                     ),
                     max_lanes=(
                         int(payload.get("max_lanes", 0)) if isinstance(payload.get("max_lanes"), (int, float)) else 0
@@ -3247,9 +3245,7 @@ async def logosnode_session(websocket: WebSocket, token: str):
                         else None
                     ),
                     configured_models=(
-                        payload.get("configured_models")
-                        if isinstance(payload.get("configured_models"), list)
-                        else None
+                        payload.get("configured_models") if isinstance(payload.get("configured_models"), list) else None
                     ),
                 )
                 _capture_logosnode_provider_snapshot(ticket.provider_id, runtime)

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -3183,6 +3183,7 @@ async def logosnode_auth(data: LogosNodeAuthRequest, request: Request):
         provider_id=provider_id,
         worker_id=worker_id,
         capabilities_models=data.capabilities_models,
+        configured_models=data.configured_models or None,
         ttl_seconds=60,
     )
     return {
@@ -3226,6 +3227,11 @@ async def logosnode_session(websocket: WebSocket, token: str):
                         if isinstance(payload.get("capabilities_models"), list)
                         else None
                     ),
+                    configured_models=(
+                        payload.get("configured_models")
+                        if isinstance(payload.get("configured_models"), list)
+                        else None
+                    ),
                     max_lanes=(
                         int(payload.get("max_lanes", 0)) if isinstance(payload.get("max_lanes"), (int, float)) else 0
                     ),
@@ -3238,6 +3244,11 @@ async def logosnode_session(websocket: WebSocket, token: str):
                     capabilities_models=(
                         payload.get("capabilities_models")
                         if isinstance(payload.get("capabilities_models"), list)
+                        else None
+                    ),
+                    configured_models=(
+                        payload.get("configured_models")
+                        if isinstance(payload.get("configured_models"), list)
                         else None
                     ),
                 )

--- a/logos/src/logos/main.py
+++ b/logos/src/logos/main.py
@@ -3375,6 +3375,129 @@ async def logosnode_reconfigure_lane(data: LogosNodeReconfigureLaneRequest):
     )
 
 
+def _find_uncalibrated_models_on_provider(provider_id: int) -> list[str]:
+    """Return every configured model on a provider that still needs calibration.
+
+    Mirrors CalibrationOrchestrator._find_uncalibrated_model's definition of
+    'needs calibration' but returns the full set instead of stopping at the
+    first hit. Sourced from configured_models so models the worker stripped
+    from capabilities_models (because they have no profile yet) are visible.
+    """
+    if _logosnode_facade is None:
+        return []
+    candidates = _logosnode_facade.get_configured_models(provider_id)
+    if not candidates:
+        candidates = _logosnode_facade.get_worker_capabilities(provider_id)
+    try:
+        profiles = _logosnode_facade.get_model_profiles(provider_id)
+    except Exception:
+        profiles = {}
+    uncalibrated: list[str] = []
+    for model_name in candidates:
+        profile = profiles.get(model_name)
+        if (
+            profile is None
+            or profile.base_residency_mb is None
+            or profile.sleeping_residual_mb is None
+            or profile.sleep_l1_transient_host_ram_mb is None
+        ):
+            uncalibrated.append(model_name)
+    return uncalibrated
+
+
+async def _run_calibration_batch(provider_id: int, models: list[str], sleep_level: int) -> None:
+    """Sequentially calibrate ``models`` on ``provider_id``.
+
+    Fires start_calibration per model and polls get_calibration_status until
+    the worker reports active=False (or a per-model timeout elapses) before
+    moving on. Failures are logged but don't abort the batch — the next model
+    still gets a chance.
+    """
+    pname = _resolve_provider_name(provider_id)
+    poll_interval_seconds = 5.0
+    per_model_timeout_seconds = 15 * 60
+    for model_name in models:
+        try:
+            logger.info(
+                "Admin calibrate-uncalibrated: starting provider=%s model=%s sleep_level=%d",
+                pname,
+                model_name,
+                sleep_level,
+            )
+            await _logosnode_registry.send_command(
+                provider_id,
+                "start_calibration",
+                params={"model_name": model_name, "sleep_level": sleep_level},
+                timeout_seconds=30,
+            )
+        except (LogosNodeOfflineError, LogosNodeCommandError) as exc:
+            logger.warning(
+                "Admin calibrate-uncalibrated: start failed provider=%s model=%s: %s",
+                pname,
+                model_name,
+                exc,
+            )
+            continue
+        except Exception:
+            logger.exception(
+                "Admin calibrate-uncalibrated: unexpected error starting provider=%s model=%s",
+                pname,
+                model_name,
+            )
+            continue
+
+        deadline = asyncio.get_running_loop().time() + per_model_timeout_seconds
+        while True:
+            await asyncio.sleep(poll_interval_seconds)
+            try:
+                status = await _logosnode_registry.send_command(
+                    provider_id,
+                    "get_calibration_status",
+                    timeout_seconds=10,
+                )
+            except (LogosNodeOfflineError, LogosNodeCommandError, Exception):
+                status = None
+            if not (isinstance(status, dict) and status.get("active")):
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                logger.warning(
+                    "Admin calibrate-uncalibrated: timeout waiting for provider=%s model=%s — moving on",
+                    pname,
+                    model_name,
+                )
+                break
+    logger.info("Admin calibrate-uncalibrated: batch finished provider=%s (%d models)", pname, len(models))
+
+
+@app.post("/logosdb/providers/logosnode/calibrate_uncalibrated", tags=["logosnode"])
+async def logosnode_calibrate_uncalibrated(data: LogosNodeStatusRequest):
+    """Trigger calibration of every uncalibrated model on a worker immediately.
+
+    Returns the list of models that will be calibrated; calibration itself
+    runs in the background sequentially because the worker only calibrates
+    one model at a time. Each model is attempted exactly once — the endpoint
+    does not retry failures.
+    """
+    _require_root_access(data.logos_key)
+    snap = _logosnode_registry.peek_runtime_snapshot(data.provider_id)
+    if snap is None:
+        return JSONResponse(status_code=503, content={"error": "Worker not connected"})
+    if not snap.get("first_status_received"):
+        return JSONResponse(status_code=503, content={"error": "Worker has not sent its first status yet"})
+    models = _find_uncalibrated_models_on_provider(data.provider_id)
+    if not models:
+        return {"message": "No uncalibrated models on this worker", "count": 0, "models": []}
+    sleep_level = _calibration_orchestrator._config.sleep_level if _calibration_orchestrator is not None else 1
+    task = asyncio.create_task(_run_calibration_batch(data.provider_id, list(models), sleep_level))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return {
+        "message": f"Calibration started for {len(models)} model(s)",
+        "count": len(models),
+        "models": models,
+    }
+
+
 # ============================================================================
 # DATABASE MANAGEMENT ENDPOINTS
 # ============================================================================

--- a/logos/src/logos/pipeline/base_scheduler.py
+++ b/logos/src/logos/pipeline/base_scheduler.py
@@ -294,6 +294,20 @@ class BaseScheduler(SchedulerInterface):
             if ptype != "logosnode":
                 continue
 
+            # Symmetric with the offline-worker gate in
+            # `ClassificationCorrectingScheduler._compute_candidate_scores`:
+            # `_model_registry` is DB-derived and includes every deployment
+            # regardless of session state. Without this check, a queued
+            # future could be dispatched onto a worker whose session was
+            # popped after enqueue — the pipeline would then crash at
+            # execution-context resolution with
+            # LogosNodeOfflineError("No active logosnode worker session").
+            try:
+                if not self._logosnode.is_provider_online(provider_id):
+                    continue
+            except Exception:
+                continue
+
             # Use lane readiness as the primary check — it reads the runtime
             # snapshot directly, bypassing the 5s refresh_interval cache in
             # _loaded_models that can be stale right after a cold load confirms.

--- a/logos/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/src/logos/pipeline/correcting_scheduler.py
@@ -242,6 +242,20 @@ class ClassificationCorrectingScheduler(BaseScheduler):
                 provider_type = deployment["type"]
                 provider_id = deployment["provider_id"]
 
+                # Hotfix: never score or fall back to a logosnode provider whose
+                # worker session is gone — context resolution would raise
+                # LogosNodeOfflineError("No active logosnode worker session"),
+                # which the unavailable-fallback path can't recover from
+                # (there's no worker to cold-load on). Cloud providers don't
+                # have a session and are always considered online here.
+                if provider_type == "logosnode" and not self._logosnode.is_provider_online(provider_id):
+                    logger.info(
+                        "Skipping offline worker: model=%s worker=%s — no active session",
+                        self._logosnode.get_model_name(model_id, provider_id) or model_id,
+                        self._logosnode.get_provider_name(provider_id) or provider_id,
+                    )
+                    continue
+
                 ettft = self._estimate_ettft(model_id, provider_id, provider_type)
 
                 if ettft.tier == ReadinessTier.UNAVAILABLE:

--- a/logos/src/logos/sdi/logosnode_facade.py
+++ b/logos/src/logos/sdi/logosnode_facade.py
@@ -243,6 +243,17 @@ class LogosNodeSchedulingDataFacade:
         provider = self._providers.get(int(provider_id))
         return provider.get_gpu_performance_score() if provider else 100
 
+    def is_sleep_mode_disabled(self, provider_id: int) -> bool:
+        """Return True if the worker has globally disabled vLLM sleep mode.
+
+        Mirrors engines.vllm.disable_sleep_mode on the worker. The capacity
+        planner uses this as an early gate before proposing sleep_l1 actions
+        for any lane on the worker; the existing per-lane sleep_state check
+        remains the authoritative signal at action-emit time.
+        """
+        provider = self._providers.get(int(provider_id))
+        return provider.is_sleep_mode_disabled() if provider else False
+
     def provider_ids(self) -> list[int]:
         """Return list of registered provider IDs (for planner iteration)."""
         with self._lock:

--- a/logos/src/logos/sdi/logosnode_facade.py
+++ b/logos/src/logos/sdi/logosnode_facade.py
@@ -215,6 +215,15 @@ class LogosNodeSchedulingDataFacade:
         provider = self._providers.get(int(provider_id))
         return provider.get_worker_capabilities() if provider else []
 
+    def get_configured_models(self, provider_id: int) -> List[str]:
+        """Return every model the worker is configured to serve, including
+        models that haven't been calibrated yet. Driven by the calibration
+        orchestrator so uncalibrated models are still picked up for
+        calibration even though the worker strips them from
+        capabilities_models (the routing-eligible list)."""
+        provider = self._providers.get(int(provider_id))
+        return provider.get_configured_models() if provider else []
+
     def get_gpu_performance_score(self, provider_id: int) -> int:
         """Return the worker's declared GPU performance weight (default 100).
 

--- a/logos/src/logos/sdi/logosnode_facade.py
+++ b/logos/src/logos/sdi/logosnode_facade.py
@@ -215,6 +215,16 @@ class LogosNodeSchedulingDataFacade:
         provider = self._providers.get(int(provider_id))
         return provider.get_worker_capabilities() if provider else []
 
+    def is_provider_online(self, provider_id: int) -> bool:
+        """True if the worker has a live, non-stale session.
+
+        The correcting scheduler consults this so disconnected workers are
+        skipped at scoring time instead of being picked and then crashing
+        at execution-context resolution with LogosNodeOfflineError.
+        """
+        provider = self._providers.get(int(provider_id))
+        return provider.is_online() if provider else False
+
     def get_configured_models(self, provider_id: int) -> List[str]:
         """Return every model the worker is configured to serve, including
         models that haven't been calibrated yet. Driven by the calibration

--- a/logos/src/logos/sdi/models.py
+++ b/logos/src/logos/sdi/models.py
@@ -350,6 +350,15 @@ class ModelProfile:
     # uncalibrated value, so it stops nightly retries for a measurement
     # the worker can never produce.
     sleep_mode_disabled: Optional[bool] = None
+    # Worker reports True when calibration has classified this model as
+    # permanently uncalibratable here (bad repo id, gated repo without
+    # token, vLLM architecture mismatch, …). The calibration orchestrator
+    # skips models flagged this way so it doesn't burn a maintenance
+    # window each night reproducing the same identity-level error.
+    # ``calibration_unsupported_reason`` carries the FatalLoadErrorPattern
+    # reason code (e.g. "invalid-repo-id") for ops visibility.
+    calibration_unsupported: Optional[bool] = None
+    calibration_unsupported_reason: Optional[str] = None
 
     def estimate_vram_mb(self) -> float:
         """Best estimate of model footprint (not GPU reservation).
@@ -397,6 +406,8 @@ class ModelProfile:
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
             "sleep_mode_disabled": self.sleep_mode_disabled,
+            "calibration_unsupported": self.calibration_unsupported,
+            "calibration_unsupported_reason": self.calibration_unsupported_reason,
         }
 
 

--- a/logos/src/logos/sdi/models.py
+++ b/logos/src/logos/sdi/models.py
@@ -343,6 +343,13 @@ class ModelProfile:
     # weight-transfer size and is more predictive.
     sleep_l1_transient_host_ram_mb: Optional[float] = None
     sleep_l2_transient_host_ram_mb: Optional[float] = None
+    # Worker reports True when this model cannot sleep here (worker-wide
+    # disable_sleep_mode kill switch or per-model enable_sleep_mode=false
+    # override). The calibration orchestrator treats this as
+    # "sleep_l1_transient_host_ram_mb is N/A by design" instead of an
+    # uncalibrated value, so it stops nightly retries for a measurement
+    # the worker can never produce.
+    sleep_mode_disabled: Optional[bool] = None
 
     def estimate_vram_mb(self) -> float:
         """Best estimate of model footprint (not GPU reservation).
@@ -389,6 +396,7 @@ class ModelProfile:
             "residency_source": self.residency_source,
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
+            "sleep_mode_disabled": self.sleep_mode_disabled,
         }
 
 

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -715,6 +715,25 @@ class LogosNodeDataProvider:
         caps = snap.get("capabilities_models")
         return list(caps) if caps else []
 
+    def get_configured_models(self) -> List[str]:
+        """Return every model the worker is configured to serve.
+
+        Includes models without a valid profile yet — used by the calibration
+        orchestrator to discover targets that capabilities_models excludes.
+        Falls back to capabilities_models for older workers that don't yet
+        send a separate configured_models list.
+        """
+        if self._runtime_registry is None:
+            return []
+        snap = self._runtime_registry.peek_runtime_snapshot(self.provider_id)
+        if not snap:
+            return []
+        configured = snap.get("configured_models")
+        if configured:
+            return list(configured)
+        caps = snap.get("capabilities_models")
+        return list(caps) if caps else []
+
     def get_gpu_performance_score(self) -> int:
         """Return the operator-declared GPU performance weight.
 

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -766,6 +766,24 @@ class LogosNodeDataProvider:
             return 100
         return value if value >= 1 else 100
 
+    def is_sleep_mode_disabled(self) -> bool:
+        """Whether the worker has globally disabled vLLM sleep mode.
+
+        Mirrors engines.vllm.disable_sleep_mode on the worker. When True,
+        every vLLM lane on this worker is forced to enable_sleep_mode=False
+        at spawn time, so the planner must use stop/start (not sleep_l1) to
+        reclaim VRAM. Returns False when the worker has not sent a runtime
+        status yet — the planner falls back to the per-lane sleep_state
+        signal in that case.
+        """
+        if self._runtime_registry is None:
+            return False
+        snap = self._runtime_registry.peek_runtime_snapshot(self.provider_id)
+        if not snap:
+            return False
+        runtime = snap.get("runtime") or {}
+        return bool(runtime.get("sleep_mode_disabled"))
+
     def increment_active(self, model_id: int, request_id: Optional[str] = None) -> None:
         with self._lock:
             if request_id:

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -648,6 +648,8 @@ class LogosNodeDataProvider:
                 sleep_l1_transient_host_ram_mb=data.get("sleep_l1_transient_host_ram_mb"),
                 sleep_l2_transient_host_ram_mb=data.get("sleep_l2_transient_host_ram_mb"),
                 sleep_mode_disabled=data.get("sleep_mode_disabled"),
+                calibration_unsupported=data.get("calibration_unsupported"),
+                calibration_unsupported_reason=data.get("calibration_unsupported_reason"),
             )
 
         if isinstance(raw_lanes, list):

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -647,6 +647,7 @@ class LogosNodeDataProvider:
                 residency_source=data.get("residency_source"),
                 sleep_l1_transient_host_ram_mb=data.get("sleep_l1_transient_host_ram_mb"),
                 sleep_l2_transient_host_ram_mb=data.get("sleep_l2_transient_host_ram_mb"),
+                sleep_mode_disabled=data.get("sleep_mode_disabled"),
             )
 
         if isinstance(raw_lanes, list):
@@ -856,7 +857,18 @@ class LogosNodeDataProvider:
             return False
         snap = self._runtime_registry.peek_runtime_snapshot(self.provider_id)
         if not snap:
-            return True  # No snapshot yet, assume ready
+            # No snapshot can mean either "session not attached yet" or
+            # "session was popped on disconnect" — `peek_runtime_snapshot`
+            # returns None in both cases. The optimistic "assume ready"
+            # default is only safe before the worker has reported anything;
+            # for a worker that *was* online and has since gone away,
+            # returning True would let `try_reserve_capacity` and
+            # `reevaluate_model_queues` dispatch onto a dead session, and
+            # the pipeline would then crash at execution-context resolution
+            # with LogosNodeOfflineError("No active logosnode worker
+            # session").  Gate the optimistic branch on the worker being
+            # online right now.
+            return self._runtime_registry.is_provider_online(self.provider_id)
         lanes = (snap.get("runtime") or {}).get("lanes") or []
         for lane in lanes:
             if not isinstance(lane, dict):

--- a/logos/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/src/logos/sdi/providers/logosnode_provider.py
@@ -715,6 +715,17 @@ class LogosNodeDataProvider:
         caps = snap.get("capabilities_models")
         return list(caps) if caps else []
 
+    def is_online(self) -> bool:
+        """Whether the worker has a live, non-stale session right now.
+
+        The scheduler uses this to skip providers that would otherwise be
+        chosen but immediately fail at execution-context resolution with
+        ``LogosNodeOfflineError("No active logosnode worker session")``.
+        """
+        if self._runtime_registry is None:
+            return False
+        return self._runtime_registry.is_provider_online(self.provider_id)
+
     def get_configured_models(self) -> List[str]:
         """Return every model the worker is configured to serve.
 

--- a/logos/tests/unit/capacity/test_calibration_orchestrator.py
+++ b/logos/tests/unit/capacity/test_calibration_orchestrator.py
@@ -1,0 +1,104 @@
+"""Targeted tests for CalibrationOrchestrator selection logic."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from logos.capacity.calibration_orchestrator import CalibrationConfig, CalibrationOrchestrator
+from logos.sdi.models import ModelProfile
+
+
+class _StubFacade:
+    def __init__(self, profiles: dict[str, ModelProfile], configured: list[str]) -> None:
+        self._profiles = profiles
+        self._configured = configured
+
+    def get_configured_models(self, provider_id: int) -> list[str]:  # noqa: ARG002
+        return list(self._configured)
+
+    def get_worker_capabilities(self, provider_id: int) -> list[str]:  # noqa: ARG002
+        return list(self._configured)
+
+    def get_model_profiles(self, provider_id: int) -> dict[str, ModelProfile]:  # noqa: ARG002
+        return dict(self._profiles)
+
+    def get_provider_name(self, provider_id: int) -> str:  # noqa: ARG002
+        return f"worker-{provider_id}"
+
+
+class _StubRegistry:
+    def has_received_first_status(self, provider_id: int) -> bool:  # noqa: ARG002
+        return True
+
+
+def _make_orchestrator(profiles: dict[str, ModelProfile], configured: list[str]) -> CalibrationOrchestrator:
+    facade: Any = _StubFacade(profiles, configured)
+    registry: Any = _StubRegistry()
+    return CalibrationOrchestrator(registry=registry, facade=facade, config=CalibrationConfig())
+
+
+def test_find_uncalibrated_skips_models_with_sleep_mode_disabled():
+    """Regression for prod 2026-06-04: gpt-oss-120b on deimama is configured
+    with enable_sleep_mode=false, so sleep_l1_transient_host_ram_mb can
+    never be measured. Without recognizing the sleep_mode_disabled flag,
+    the orchestrator picks the model every maintenance window, the worker
+    spawns a doomed vLLM lane, and Phase 4 (POST /sleep) fails. With the
+    flag honored, the orchestrator treats the sleep fields as N/A and
+    moves on to a model that actually needs calibration."""
+    profile = ModelProfile(
+        model_name="openai/gpt-oss-120b",
+        base_residency_mb=91203.0,
+        # Both sleep-related fields are intentionally None because the
+        # worker config forbids sleeping this model.
+        sleeping_residual_mb=None,
+        sleep_l1_transient_host_ram_mb=None,
+        sleep_mode_disabled=True,
+    )
+    orch = _make_orchestrator(
+        profiles={"openai/gpt-oss-120b": profile},
+        configured=["openai/gpt-oss-120b"],
+    )
+
+    assert orch._find_uncalibrated_model(provider_id=15) is None
+
+
+def test_find_uncalibrated_still_targets_sleep_capable_models():
+    """A model whose sleep_mode_disabled is False/None and that is missing
+    sleep_l1_transient_host_ram_mb still needs calibration."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=47113.0,
+        sleeping_residual_mb=1329.0,
+        sleep_l1_transient_host_ram_mb=None,
+        sleep_mode_disabled=False,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+
+    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
+
+
+def test_find_uncalibrated_picks_sleep_capable_over_sleep_disabled_neighbor():
+    """Mixed worker: one sleep-disabled (fully measured for what it can
+    measure) and one sleep-capable but uncalibrated. Orchestrator must
+    skip the first and target the second."""
+    sleep_disabled = ModelProfile(
+        model_name="openai/gpt-oss-120b",
+        base_residency_mb=91203.0,
+        sleep_mode_disabled=True,
+    )
+    needs_calib = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={
+            "openai/gpt-oss-120b": sleep_disabled,
+            "microsoft/Phi-4-reasoning": needs_calib,
+        },
+        configured=["openai/gpt-oss-120b", "microsoft/Phi-4-reasoning"],
+    )
+
+    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"

--- a/logos/tests/unit/capacity/test_calibration_orchestrator.py
+++ b/logos/tests/unit/capacity/test_calibration_orchestrator.py
@@ -27,13 +27,24 @@ class _StubFacade:
 
 
 class _StubRegistry:
+    def __init__(self, node_health: dict[int, dict] | None = None) -> None:
+        self._node_health = node_health or {}
+
     def has_received_first_status(self, provider_id: int) -> bool:  # noqa: ARG002
         return True
 
+    def peek_runtime_snapshot(self, provider_id: int) -> dict | None:
+        nh = self._node_health.get(provider_id)
+        return {"runtime": {"node_health": nh}} if nh is not None else {"runtime": {}}
 
-def _make_orchestrator(profiles: dict[str, ModelProfile], configured: list[str]) -> CalibrationOrchestrator:
+
+def _make_orchestrator(
+    profiles: dict[str, ModelProfile],
+    configured: list[str],
+    node_health: dict[int, dict] | None = None,
+) -> CalibrationOrchestrator:
     facade: Any = _StubFacade(profiles, configured)
-    registry: Any = _StubRegistry()
+    registry: Any = _StubRegistry(node_health=node_health)
     return CalibrationOrchestrator(registry=registry, facade=facade, config=CalibrationConfig())
 
 
@@ -102,3 +113,91 @@ def test_find_uncalibrated_picks_sleep_capable_over_sleep_disabled_neighbor():
     )
 
     assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
+
+
+def test_find_uncalibrated_skips_calibration_unsupported_models():
+    """Regression for prod 2026-06-04: Qwen/Qwen-Image-Edit is configured on
+    deioma but it's a diffusion model — vLLM rejects it with 'Invalid
+    repository ID or local directory specified' at every load attempt.
+    Once the worker classifies it as calibration_unsupported, the
+    orchestrator must skip it on every subsequent maintenance window
+    instead of re-issuing start_calibration and watching the same
+    identity-level error reproduce."""
+    profile = ModelProfile(
+        model_name="Qwen/Qwen-Image-Edit",
+        # Nothing measured — the model never loaded.
+        base_residency_mb=None,
+        calibration_unsupported=True,
+        calibration_unsupported_reason="invalid-repo-id",
+    )
+    orch = _make_orchestrator(
+        profiles={"Qwen/Qwen-Image-Edit": profile},
+        configured=["Qwen/Qwen-Image-Edit"],
+    )
+
+    assert orch._find_uncalibrated_model(provider_id=15) is None
+
+
+def test_find_uncalibrated_picks_neighbor_when_one_is_calibration_unsupported():
+    """Mixed worker: one model on the unsupported list (skip) plus one
+    genuinely uncalibrated neighbor (target)."""
+    unsupported = ModelProfile(
+        model_name="Qwen/Qwen-Image-Edit",
+        calibration_unsupported=True,
+        calibration_unsupported_reason="invalid-repo-id",
+    )
+    needs_calib = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={
+            "Qwen/Qwen-Image-Edit": unsupported,
+            "microsoft/Phi-4-reasoning": needs_calib,
+        },
+        configured=["Qwen/Qwen-Image-Edit", "microsoft/Phi-4-reasoning"],
+    )
+
+    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
+
+
+def test_pick_calibration_target_skips_unhealthy_worker():
+    """Regression for deioma 2026-06-04: when a worker reports
+    node_health.healthy=False (e.g. Ceph-backed HF cache returning EIO),
+    the orchestrator must NOT schedule calibration on it. Without this
+    skip, the master would fire start_calibration once per minute, the
+    worker would refuse each one, and the logs would fill with
+    'refusing start_calibration' warnings every cycle."""
+    needs_calib = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": needs_calib},
+        configured=["microsoft/Phi-4-reasoning"],
+        node_health={15: {"healthy": False, "reason_code": "filesystem-eio"}},
+    )
+    orch._facade.provider_ids = lambda: [15]
+
+    assert orch._pick_calibration_target() is None
+
+
+def test_pick_calibration_target_resumes_after_node_recovers():
+    """Once a worker reports node_health.healthy=True again, the
+    orchestrator should pick up the previously-skipped uncalibrated
+    model on the very next tick."""
+    needs_calib = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": needs_calib},
+        configured=["microsoft/Phi-4-reasoning"],
+        node_health={15: {"healthy": True}},
+    )
+    orch._facade.provider_ids = lambda: [15]
+    # Stub doesn't implement get_all_provider_lane_signals; bypass that
+    # check so we exercise just the node-health gate.
+    orch._provider_has_active_requests = lambda provider_id: False
+
+    assert orch._pick_calibration_target() == (15, "microsoft/Phi-4-reasoning")

--- a/logos/tests/unit/capacity/test_calibration_orchestrator.py
+++ b/logos/tests/unit/capacity/test_calibration_orchestrator.py
@@ -1,8 +1,11 @@
-"""Targeted tests for CalibrationOrchestrator selection logic."""
+"""Targeted tests for the worker-driven CalibrationOrchestrator."""
 
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
 
 from logos.capacity.calibration_orchestrator import CalibrationConfig, CalibrationOrchestrator
 from logos.sdi.models import ModelProfile
@@ -13,6 +16,9 @@ class _StubFacade:
         self._profiles = profiles
         self._configured = configured
 
+    def provider_ids(self) -> list[int]:
+        return [15]
+
     def get_configured_models(self, provider_id: int) -> list[str]:  # noqa: ARG002
         return list(self._configured)
 
@@ -22,13 +28,18 @@ class _StubFacade:
     def get_model_profiles(self, provider_id: int) -> dict[str, ModelProfile]:  # noqa: ARG002
         return dict(self._profiles)
 
-    def get_provider_name(self, provider_id: int) -> str:  # noqa: ARG002
+    def get_provider_name(self, provider_id: int) -> str:
         return f"worker-{provider_id}"
+
+    def get_all_provider_lane_signals(self, provider_id: int) -> list:  # noqa: ARG002
+        return []
 
 
 class _StubRegistry:
     def __init__(self, node_health: dict[int, dict] | None = None) -> None:
         self._node_health = node_health or {}
+        self.send_command = AsyncMock(return_value={"ok": True})
+        self._subscribers = []
 
     def has_received_first_status(self, provider_id: int) -> bool:  # noqa: ARG002
         return True
@@ -36,6 +47,13 @@ class _StubRegistry:
     def peek_runtime_snapshot(self, provider_id: int) -> dict | None:
         nh = self._node_health.get(provider_id)
         return {"runtime": {"node_health": nh}} if nh is not None else {"runtime": {}}
+
+    def subscribe_to_events(self, cb):
+        self._subscribers.append(cb)
+
+    def unsubscribe_from_events(self, cb):
+        if cb in self._subscribers:
+            self._subscribers.remove(cb)
 
 
 def _make_orchestrator(
@@ -48,34 +66,8 @@ def _make_orchestrator(
     return CalibrationOrchestrator(registry=registry, facade=facade, config=CalibrationConfig())
 
 
-def test_find_uncalibrated_skips_models_with_sleep_mode_disabled():
-    """Regression for prod 2026-06-04: gpt-oss-120b on deimama is configured
-    with enable_sleep_mode=false, so sleep_l1_transient_host_ram_mb can
-    never be measured. Without recognizing the sleep_mode_disabled flag,
-    the orchestrator picks the model every maintenance window, the worker
-    spawns a doomed vLLM lane, and Phase 4 (POST /sleep) fails. With the
-    flag honored, the orchestrator treats the sleep fields as N/A and
-    moves on to a model that actually needs calibration."""
-    profile = ModelProfile(
-        model_name="openai/gpt-oss-120b",
-        base_residency_mb=91203.0,
-        # Both sleep-related fields are intentionally None because the
-        # worker config forbids sleeping this model.
-        sleeping_residual_mb=None,
-        sleep_l1_transient_host_ram_mb=None,
-        sleep_mode_disabled=True,
-    )
-    orch = _make_orchestrator(
-        profiles={"openai/gpt-oss-120b": profile},
-        configured=["openai/gpt-oss-120b"],
-    )
-
-    assert orch._find_uncalibrated_model(provider_id=15) is None
-
-
-def test_find_uncalibrated_still_targets_sleep_capable_models():
-    """A model whose sleep_mode_disabled is False/None and that is missing
-    sleep_l1_transient_host_ram_mb still needs calibration."""
+def test_provider_has_uncalibrated_models_true_when_profile_incomplete():
+    """Missing sleep_l1_transient_host_ram_mb still counts as needing calibration."""
     profile = ModelProfile(
         model_name="microsoft/Phi-4-reasoning",
         base_residency_mb=47113.0,
@@ -87,46 +79,29 @@ def test_find_uncalibrated_still_targets_sleep_capable_models():
         profiles={"microsoft/Phi-4-reasoning": profile},
         configured=["microsoft/Phi-4-reasoning"],
     )
+    assert orch._provider_has_uncalibrated_models(15) is True
 
-    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
 
-
-def test_find_uncalibrated_picks_sleep_capable_over_sleep_disabled_neighbor():
-    """Mixed worker: one sleep-disabled (fully measured for what it can
-    measure) and one sleep-capable but uncalibrated. Orchestrator must
-    skip the first and target the second."""
-    sleep_disabled = ModelProfile(
+def test_provider_has_uncalibrated_models_false_when_sleep_na_and_base_known():
+    """A sleep-disabled model with base_residency measured has nothing left
+    to calibrate — sleep fields are N/A by design on this worker."""
+    profile = ModelProfile(
         model_name="openai/gpt-oss-120b",
         base_residency_mb=91203.0,
         sleep_mode_disabled=True,
     )
-    needs_calib = ModelProfile(
-        model_name="microsoft/Phi-4-reasoning",
-        base_residency_mb=None,
-    )
     orch = _make_orchestrator(
-        profiles={
-            "openai/gpt-oss-120b": sleep_disabled,
-            "microsoft/Phi-4-reasoning": needs_calib,
-        },
-        configured=["openai/gpt-oss-120b", "microsoft/Phi-4-reasoning"],
+        profiles={"openai/gpt-oss-120b": profile},
+        configured=["openai/gpt-oss-120b"],
     )
+    assert orch._provider_has_uncalibrated_models(15) is False
 
-    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
 
-
-def test_find_uncalibrated_skips_calibration_unsupported_models():
-    """Regression for prod 2026-06-04: Qwen/Qwen-Image-Edit is configured on
-    deioma but it's a diffusion model — vLLM rejects it with 'Invalid
-    repository ID or local directory specified' at every load attempt.
-    Once the worker classifies it as calibration_unsupported, the
-    orchestrator must skip it on every subsequent maintenance window
-    instead of re-issuing start_calibration and watching the same
-    identity-level error reproduce."""
+def test_provider_has_uncalibrated_models_skips_unsupported_models():
+    """Models flagged calibration_unsupported never count as needing
+    calibration — they would fail the same way every window."""
     profile = ModelProfile(
         model_name="Qwen/Qwen-Image-Edit",
-        # Nothing measured — the model never loaded.
-        base_residency_mb=None,
         calibration_unsupported=True,
         calibration_unsupported_reason="invalid-repo-id",
     )
@@ -134,40 +109,11 @@ def test_find_uncalibrated_skips_calibration_unsupported_models():
         profiles={"Qwen/Qwen-Image-Edit": profile},
         configured=["Qwen/Qwen-Image-Edit"],
     )
-
-    assert orch._find_uncalibrated_model(provider_id=15) is None
-
-
-def test_find_uncalibrated_picks_neighbor_when_one_is_calibration_unsupported():
-    """Mixed worker: one model on the unsupported list (skip) plus one
-    genuinely uncalibrated neighbor (target)."""
-    unsupported = ModelProfile(
-        model_name="Qwen/Qwen-Image-Edit",
-        calibration_unsupported=True,
-        calibration_unsupported_reason="invalid-repo-id",
-    )
-    needs_calib = ModelProfile(
-        model_name="microsoft/Phi-4-reasoning",
-        base_residency_mb=None,
-    )
-    orch = _make_orchestrator(
-        profiles={
-            "Qwen/Qwen-Image-Edit": unsupported,
-            "microsoft/Phi-4-reasoning": needs_calib,
-        },
-        configured=["Qwen/Qwen-Image-Edit", "microsoft/Phi-4-reasoning"],
-    )
-
-    assert orch._find_uncalibrated_model(provider_id=15) == "microsoft/Phi-4-reasoning"
+    assert orch._provider_has_uncalibrated_models(15) is False
 
 
-def test_pick_calibration_target_skips_unhealthy_worker():
-    """Regression for deioma 2026-06-04: when a worker reports
-    node_health.healthy=False (e.g. Ceph-backed HF cache returning EIO),
-    the orchestrator must NOT schedule calibration on it. Without this
-    skip, the master would fire start_calibration once per minute, the
-    worker would refuse each one, and the logs would fill with
-    'refusing start_calibration' warnings every cycle."""
+def test_pick_next_provider_skips_unhealthy_worker():
+    """Worker reporting node_health.healthy=False is never picked."""
     needs_calib = ModelProfile(
         model_name="microsoft/Phi-4-reasoning",
         base_residency_mb=None,
@@ -177,15 +123,11 @@ def test_pick_calibration_target_skips_unhealthy_worker():
         configured=["microsoft/Phi-4-reasoning"],
         node_health={15: {"healthy": False, "reason_code": "filesystem-eio"}},
     )
-    orch._facade.provider_ids = lambda: [15]
-
-    assert orch._pick_calibration_target() is None
+    assert orch._pick_next_provider() is None
 
 
-def test_pick_calibration_target_resumes_after_node_recovers():
-    """Once a worker reports node_health.healthy=True again, the
-    orchestrator should pick up the previously-skipped uncalibrated
-    model on the very next tick."""
+def test_pick_next_provider_resumes_after_node_recovers():
+    """Once healthy=True returns, the provider becomes pickable again."""
     needs_calib = ModelProfile(
         model_name="microsoft/Phi-4-reasoning",
         base_residency_mb=None,
@@ -195,9 +137,123 @@ def test_pick_calibration_target_resumes_after_node_recovers():
         configured=["microsoft/Phi-4-reasoning"],
         node_health={15: {"healthy": True}},
     )
-    orch._facade.provider_ids = lambda: [15]
-    # Stub doesn't implement get_all_provider_lane_signals; bypass that
-    # check so we exercise just the node-health gate.
-    orch._provider_has_active_requests = lambda provider_id: False
+    assert orch._pick_next_provider() == 15
 
-    assert orch._pick_calibration_target() == (15, "microsoft/Phi-4-reasoning")
+
+def test_pick_next_provider_marks_fully_calibrated_worker_done_for_window():
+    """A worker with nothing left to calibrate is added to
+    _completed_this_window so we don't re-evaluate it every tick."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=47113.0,
+        sleeping_residual_mb=1329.0,
+        sleep_l1_transient_host_ram_mb=4096.0,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+    assert orch._pick_next_provider() is None
+    assert 15 in orch._completed_this_window
+
+
+@pytest.mark.asyncio
+async def test_start_session_sends_session_rpc_and_tracks_active_provider():
+    """Tick inside the window sends start_calibration_session and remembers
+    the active provider so the next tick doesn't double-fire."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+    await orch._start_session_on(15)
+
+    orch._registry.send_command.assert_awaited_once_with(
+        15,
+        "start_calibration_session",
+        params={"sleep_level": orch._config.sleep_level},
+        timeout_seconds=30,
+    )
+    assert orch._active_provider_id == 15
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_frees_active_slot():
+    """When the worker emits calibration_session_finished, the orchestrator
+    clears the active-provider slot and marks the worker done for the
+    current window so the next tick picks a different worker."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+    orch._active_provider_id = 15
+
+    orch._on_provider_event(15, {"event": "calibration_session_finished"})
+    assert orch._active_provider_id is None
+    assert 15 in orch._completed_this_window
+
+
+@pytest.mark.asyncio
+async def test_terminal_event_ignored_for_other_provider():
+    """Events from a provider other than the active one don't free the slot."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+    orch._active_provider_id = 15
+
+    orch._on_provider_event(99, {"event": "calibration_session_finished"})
+    assert orch._active_provider_id == 15
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_event_does_not_free_active_slot():
+    """Per-model events (started/completed/failed) are not session-terminal
+    and must not free the active-provider slot."""
+    profile = ModelProfile(
+        model_name="microsoft/Phi-4-reasoning",
+        base_residency_mb=None,
+    )
+    orch = _make_orchestrator(
+        profiles={"microsoft/Phi-4-reasoning": profile},
+        configured=["microsoft/Phi-4-reasoning"],
+    )
+    orch._active_provider_id = 15
+
+    orch._on_provider_event(15, {"event": "calibration_model_completed"})
+    assert orch._active_provider_id == 15
+    assert 15 not in orch._completed_this_window
+
+
+@pytest.mark.asyncio
+async def test_stop_active_session_sends_stop_session_rpc():
+    """Outside the window (or on shutdown), the orchestrator sends
+    stop_calibration_session to whichever worker holds the active slot."""
+    orch = _make_orchestrator(profiles={}, configured=[])
+    orch._active_provider_id = 15
+
+    await orch._stop_active_session_if_any("outside-window")
+    orch._registry.send_command.assert_awaited_once_with(
+        15,
+        "stop_calibration_session",
+        timeout_seconds=20,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_active_session_noop_when_none_active():
+    """No active session → no RPC fired, no error."""
+    orch = _make_orchestrator(profiles={}, configured=[])
+    await orch._stop_active_session_if_any("outside-window")
+    orch._registry.send_command.assert_not_awaited()

--- a/logos/tests/unit/main/test_calibrate_uncalibrated_endpoint.py
+++ b/logos/tests/unit/main/test_calibrate_uncalibrated_endpoint.py
@@ -1,0 +1,176 @@
+"""Tests for the admin "calibrate uncalibrated models on a node" path.
+
+Covers the model-selection helper that powers the endpoint (matches the
+orchestrator's notion of "uncalibrated") and the endpoint's interaction with
+the worker registry — without actually starting calibration on any worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from logos import main as main_mod
+from logos.sdi.models import ModelProfile
+
+
+def _profile(
+    *,
+    name: str,
+    base: float | None = 1000.0,
+    sleep: float | None = 50.0,
+    sleep_l1: float | None = 200.0,
+) -> ModelProfile:
+    return ModelProfile(
+        model_name=name,
+        base_residency_mb=base,
+        sleeping_residual_mb=sleep,
+        sleep_l1_transient_host_ram_mb=sleep_l1,
+    )
+
+
+class _FakeFacade:
+    """Minimal facade stub exposing the methods the helper consults."""
+
+    def __init__(self, configured: list[str], profiles: dict[str, ModelProfile]):
+        self._configured = configured
+        self._profiles = profiles
+
+    def get_configured_models(self, provider_id: int) -> list[str]:
+        return list(self._configured)
+
+    def get_worker_capabilities(self, provider_id: int) -> list[str]:
+        return list(self._configured)
+
+    def get_model_profiles(self, provider_id: int) -> dict[str, ModelProfile]:
+        return dict(self._profiles)
+
+
+def test_find_uncalibrated_returns_models_with_missing_profile_fields(monkeypatch):
+    facade = _FakeFacade(
+        configured=["calibrated-model", "no-profile", "missing-base", "missing-sleep", "missing-sleep-l1"],
+        profiles={
+            "calibrated-model": _profile(name="calibrated-model"),
+            "missing-base": _profile(name="missing-base", base=None),
+            "missing-sleep": _profile(name="missing-sleep", sleep=None),
+            "missing-sleep-l1": _profile(name="missing-sleep-l1", sleep_l1=None),
+        },
+    )
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    result = main_mod._find_uncalibrated_models_on_provider(7)
+
+    # "no-profile" is missing from the profiles dict entirely.
+    assert result == ["no-profile", "missing-base", "missing-sleep", "missing-sleep-l1"]
+
+
+def test_find_uncalibrated_empty_when_everything_calibrated(monkeypatch):
+    facade = _FakeFacade(
+        configured=["a", "b"],
+        profiles={"a": _profile(name="a"), "b": _profile(name="b")},
+    )
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    assert main_mod._find_uncalibrated_models_on_provider(1) == []
+
+
+def test_find_uncalibrated_falls_back_to_capabilities_when_configured_empty(monkeypatch):
+    class _LegacyFacade(_FakeFacade):
+        def get_configured_models(self, provider_id: int) -> list[str]:
+            return []
+
+    facade = _LegacyFacade(configured=["legacy"], profiles={})
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    # capabilities fallback exposes the model even though configured_models is empty.
+    assert main_mod._find_uncalibrated_models_on_provider(1) == ["legacy"]
+
+
+def test_find_uncalibrated_returns_empty_when_facade_unset(monkeypatch):
+    monkeypatch.setattr(main_mod, "_logosnode_facade", None, raising=False)
+    assert main_mod._find_uncalibrated_models_on_provider(1) == []
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_uncalibrated_list_and_kicks_off_background_task(monkeypatch):
+    facade = _FakeFacade(
+        configured=["calibrated", "new-model"],
+        profiles={"calibrated": _profile(name="calibrated")},
+    )
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    # Pretend the worker is connected and has reported status.
+    fake_registry = MagicMock()
+    fake_registry.peek_runtime_snapshot.return_value = {
+        "provider_id": 4,
+        "first_status_received": True,
+        "capabilities_models": ["calibrated"],
+        "configured_models": ["calibrated", "new-model"],
+    }
+    fake_registry.send_command = AsyncMock(return_value={"active": False})
+    monkeypatch.setattr(main_mod, "_logosnode_registry", fake_registry, raising=False)
+
+    # Bypass admin-key validation in the unit test.
+    monkeypatch.setattr(main_mod, "_require_root_access", lambda _key: None, raising=False)
+
+    # Track tasks spawned so the test can await the background work.
+    spawned: list[asyncio.Task[Any]] = []
+    original_create_task = asyncio.create_task
+
+    def _capture_create_task(coro, *, name=None):
+        task = original_create_task(coro, name=name)
+        spawned.append(task)
+        return task
+
+    monkeypatch.setattr("logos.main.asyncio.create_task", _capture_create_task)
+
+    body = main_mod.LogosNodeStatusRequest(logos_key="admin", provider_id=4)
+    response = await main_mod.logosnode_calibrate_uncalibrated(body)
+
+    assert response["count"] == 1
+    assert response["models"] == ["new-model"]
+    assert "Calibration started" in response["message"]
+    assert spawned, "endpoint must spawn a background calibration task"
+
+    # Let the background task finish so we can verify it actually issued the RPC.
+    await asyncio.gather(*spawned)
+    calls = [c.args + (c.kwargs,) for c in fake_registry.send_command.call_args_list]
+    actions = [c[1] for c in calls]
+    assert "start_calibration" in actions, f"expected start_calibration in {actions}"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_empty_when_no_uncalibrated_models(monkeypatch):
+    facade = _FakeFacade(configured=["a"], profiles={"a": _profile(name="a")})
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    fake_registry = MagicMock()
+    fake_registry.peek_runtime_snapshot.return_value = {
+        "provider_id": 4,
+        "first_status_received": True,
+    }
+    fake_registry.send_command = AsyncMock()
+    monkeypatch.setattr(main_mod, "_logosnode_registry", fake_registry, raising=False)
+    monkeypatch.setattr(main_mod, "_require_root_access", lambda _key: None, raising=False)
+
+    body = main_mod.LogosNodeStatusRequest(logos_key="admin", provider_id=4)
+    response = await main_mod.logosnode_calibrate_uncalibrated(body)
+
+    assert response == {"message": "No uncalibrated models on this worker", "count": 0, "models": []}
+    fake_registry.send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_503_when_worker_not_connected(monkeypatch):
+    fake_registry = MagicMock()
+    fake_registry.peek_runtime_snapshot.return_value = None
+    monkeypatch.setattr(main_mod, "_logosnode_registry", fake_registry, raising=False)
+    monkeypatch.setattr(main_mod, "_require_root_access", lambda _key: None, raising=False)
+
+    body = main_mod.LogosNodeStatusRequest(logos_key="admin", provider_id=99)
+    response = await main_mod.logosnode_calibrate_uncalibrated(body)
+
+    assert response.status_code == 503

--- a/logos/tests/unit/main/test_calibrate_uncalibrated_endpoint.py
+++ b/logos/tests/unit/main/test_calibrate_uncalibrated_endpoint.py
@@ -7,8 +7,6 @@ the worker registry — without actually starting calibration on any worker.
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -95,14 +93,15 @@ def test_find_uncalibrated_returns_empty_when_facade_unset(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_endpoint_returns_uncalibrated_list_and_kicks_off_background_task(monkeypatch):
+async def test_endpoint_starts_calibration_session_on_worker(monkeypatch):
+    """Endpoint sends a single start_calibration_session — the worker drives
+    the rest. No per-model RPCs, no polling."""
     facade = _FakeFacade(
         configured=["calibrated", "new-model"],
         profiles={"calibrated": _profile(name="calibrated")},
     )
     monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
 
-    # Pretend the worker is connected and has reported status.
     fake_registry = MagicMock()
     fake_registry.peek_runtime_snapshot.return_value = {
         "provider_id": 4,
@@ -110,36 +109,43 @@ async def test_endpoint_returns_uncalibrated_list_and_kicks_off_background_task(
         "capabilities_models": ["calibrated"],
         "configured_models": ["calibrated", "new-model"],
     }
-    fake_registry.send_command = AsyncMock(return_value={"active": False})
+    fake_registry.send_command = AsyncMock(return_value={"ok": True})
     monkeypatch.setattr(main_mod, "_logosnode_registry", fake_registry, raising=False)
-
-    # Bypass admin-key validation in the unit test.
     monkeypatch.setattr(main_mod, "_require_root_access", lambda _key: None, raising=False)
-
-    # Track tasks spawned so the test can await the background work.
-    spawned: list[asyncio.Task[Any]] = []
-    original_create_task = asyncio.create_task
-
-    def _capture_create_task(coro, *, name=None):
-        task = original_create_task(coro, name=name)
-        spawned.append(task)
-        return task
-
-    monkeypatch.setattr("logos.main.asyncio.create_task", _capture_create_task)
+    monkeypatch.setattr(main_mod, "_resolve_provider_name", lambda _pid: "worker-4", raising=False)
 
     body = main_mod.LogosNodeStatusRequest(logos_key="admin", provider_id=4)
     response = await main_mod.logosnode_calibrate_uncalibrated(body)
 
     assert response["count"] == 1
     assert response["models"] == ["new-model"]
-    assert "Calibration started" in response["message"]
-    assert spawned, "endpoint must spawn a background calibration task"
+    assert "Calibration session started" in response["message"]
+    # Single RPC, in-band — no background polling task.
+    actions = [c.args[1] for c in fake_registry.send_command.await_args_list]
+    assert actions == ["start_calibration_session"]
 
-    # Let the background task finish so we can verify it actually issued the RPC.
-    await asyncio.gather(*spawned)
-    calls = [c.args + (c.kwargs,) for c in fake_registry.send_command.call_args_list]
-    actions = [c[1] for c in calls]
-    assert "start_calibration" in actions, f"expected start_calibration in {actions}"
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_503_when_session_refused_by_worker_offline(monkeypatch):
+    """Worker offline at the moment of the RPC → 503 surfaces to the caller."""
+    from logos.logosnode_registry import LogosNodeOfflineError
+
+    facade = _FakeFacade(configured=["m"], profiles={})
+    monkeypatch.setattr(main_mod, "_logosnode_facade", facade, raising=False)
+
+    fake_registry = MagicMock()
+    fake_registry.peek_runtime_snapshot.return_value = {
+        "provider_id": 4,
+        "first_status_received": True,
+    }
+    fake_registry.send_command = AsyncMock(side_effect=LogosNodeOfflineError("disconnected"))
+    monkeypatch.setattr(main_mod, "_logosnode_registry", fake_registry, raising=False)
+    monkeypatch.setattr(main_mod, "_require_root_access", lambda _key: None, raising=False)
+    monkeypatch.setattr(main_mod, "_resolve_provider_name", lambda _pid: "worker-4", raising=False)
+
+    body = main_mod.LogosNodeStatusRequest(logos_key="admin", provider_id=4)
+    response = await main_mod.logosnode_calibrate_uncalibrated(body)
+    assert response.status_code == 503
 
 
 @pytest.mark.asyncio

--- a/logos/tests/unit/pipeline/test_correcting_scheduler.py
+++ b/logos/tests/unit/pipeline/test_correcting_scheduler.py
@@ -29,6 +29,7 @@ def _make_view(
         aggregate_active_requests=1 if is_loaded else 0,
         aggregate_queue_waiting=aggregate_queue_waiting,
         warmest_ttft_p95_seconds=warmest_ttft_p95_seconds,
+        warmest_e2e_latency_p50_seconds=0.5,
         gpu_cache_pressure_max=None,
         lanes=[
             LaneSchedulerSignals(
@@ -42,6 +43,7 @@ def _make_view(
                 requests_running=1.0 if is_loaded else 0.0,
                 gpu_cache_usage_percent=None,
                 ttft_p95_seconds=warmest_ttft_p95_seconds,
+                e2e_latency_p50_seconds=0.5,
                 effective_vram_mb=8000.0,
                 num_parallel=4,
             )
@@ -71,6 +73,7 @@ class MockLogosNodeFacade:
         self._tracking = {}
         self.raise_on_request_start = False
         self._gpu_scores: dict[int, int] = {}  # provider_id -> gpu_performance_score
+        self._offline_providers: set[int] = set()
 
     def set_view(self, model_id, provider_id, view):
         self._views[(model_id, provider_id)] = view
@@ -116,6 +119,12 @@ class MockLogosNodeFacade:
 
     def set_gpu_performance_score(self, provider_id, score):
         self._gpu_scores[provider_id] = score
+
+    def is_provider_online(self, provider_id):
+        return provider_id not in self._offline_providers
+
+    def mark_provider_offline(self, provider_id):
+        self._offline_providers.add(provider_id)
 
     def try_reserve_capacity(self, model_id, provider_id, request_id):
         return self._reserve_results.get((model_id, provider_id), True)
@@ -185,6 +194,54 @@ async def test_empty_candidates_returns_none():
     """No candidates → None."""
     scheduler = _make_scheduler()
     request = _make_request([], [])
+    result = await scheduler.schedule(request)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_offline_logosnode_provider_is_skipped_in_favor_of_online_one():
+    """Regression for prod 2026-06-04: a disconnected worker was still being
+    chosen by the correcting scheduler (treated as COLD/UNAVAILABLE fallback),
+    which then crashed at execution-context resolution with
+    ``LogosNodeOfflineError("No active logosnode worker session")``. The
+    scheduler now consults `is_provider_online` and skips offline workers
+    entirely so requests for the same model route to a healthy peer instead.
+    """
+    logosnode = MockLogosNodeFacade()
+    offline_provider = 15
+    online_provider = 16
+    logosnode.set_view(1, online_provider, _make_view(model_id=1, provider_id=online_provider))
+    logosnode.set_view(1, offline_provider, _make_view(model_id=1, provider_id=offline_provider))
+    logosnode.mark_provider_offline(offline_provider)
+
+    scheduler = _make_scheduler(logosnode=logosnode)
+    deployments = [
+        {"model_id": 1, "provider_id": offline_provider, "type": "logosnode"},
+        {"model_id": 1, "provider_id": online_provider, "type": "logosnode"},
+    ]
+    request = _make_request([(1, 1.0, 0, 4)], deployments)
+
+    result = await scheduler.schedule(request)
+
+    assert result is not None
+    assert result.provider_id == online_provider
+
+
+@pytest.mark.asyncio
+async def test_offline_only_logosnode_provider_returns_no_candidate():
+    """If every logosnode candidate for a model is offline, the scheduler
+    must not pick any of them — picking an offline provider would lead
+    straight to LogosNodeOfflineError in the pipeline. Returning None
+    surfaces the failure cleanly (the caller decides how to respond)."""
+    logosnode = MockLogosNodeFacade()
+    offline_provider = 15
+    logosnode.set_view(1, offline_provider, _make_view(model_id=1, provider_id=offline_provider))
+    logosnode.mark_provider_offline(offline_provider)
+
+    scheduler = _make_scheduler(logosnode=logosnode)
+    deployments = [{"model_id": 1, "provider_id": offline_provider, "type": "logosnode"}]
+    request = _make_request([(1, 1.0, 0, 4)], deployments)
+
     result = await scheduler.schedule(request)
     assert result is None
 

--- a/logos/tests/unit/pipeline/test_correcting_scheduler.py
+++ b/logos/tests/unit/pipeline/test_correcting_scheduler.py
@@ -246,6 +246,46 @@ async def test_offline_only_logosnode_provider_returns_no_candidate():
     assert result is None
 
 
+def test_reevaluate_model_queues_skips_offline_provider():
+    """Regression for prod 2026-06-04: a queued future enqueued for a
+    worker that has since disconnected must not be dispatched by
+    `reevaluate_model_queues`. Without the is_provider_online gate, the
+    queue dispatcher would iterate every deployment in the (DB-derived)
+    model registry, find that `is_model_lane_ready` lied "ready" because
+    `peek_runtime_snapshot` returns None for a popped session, and fire
+    the future with the dead provider_id — the pipeline would then crash
+    at execution-context resolution.
+    """
+    import asyncio
+
+    from logos.queue.priority_queue import Priority
+
+    logosnode = MockLogosNodeFacade()
+    offline_provider = 15
+    # The view + reservation state still exists in memory (typical pattern
+    # — the session can be popped before the scoring caches refresh).
+    logosnode.set_view(38, offline_provider, _make_view(model_id=38, provider_id=offline_provider))
+    logosnode.mark_provider_offline(offline_provider)
+    # Add is_model_lane_ready to the mock that *would* lie "ready" if asked.
+    # The new gate must short-circuit on is_provider_online before reaching
+    # is_model_lane_ready.
+    logosnode.is_model_lane_ready = lambda model_id, provider_id: True  # type: ignore[method-assign]
+
+    scheduler = _make_scheduler(logosnode=logosnode)
+    scheduler.update_model_registry({(38, offline_provider): "logosnode"})
+
+    # Enqueue a future against the now-offline provider, then trigger
+    # reevaluate. The gate should leave the future untouched.
+    loop = asyncio.new_event_loop()
+    try:
+        fut = loop.create_future()
+        scheduler._queue_mgr.enqueue(fut, 38, offline_provider, Priority.NORMAL)
+        scheduler.reevaluate_model_queues("openai/gpt-oss-120b")
+        assert not fut.done(), "queued future was dispatched onto an offline worker"
+    finally:
+        loop.close()
+
+
 # ---------------------------------------------------------------------------
 # Same model on two logosnode providers: picks loaded over cold
 # ---------------------------------------------------------------------------

--- a/logos/tests/unit/sdi/test_ollama_facade.py
+++ b/logos/tests/unit/sdi/test_ollama_facade.py
@@ -290,3 +290,48 @@ def test_logosnode_debug_state_includes_recent_scheduler_signals(monkeypatch):
     assert model_debug["scheduler_signals"]["requests_running_peak"] == 2.0
     assert model_debug["scheduler_signals"]["prompt_tokens_per_second"] == 60.0
     assert model_debug["scheduler_signals"]["generation_tokens_per_second"] == 120.0
+
+
+def test_is_model_lane_ready_returns_false_when_worker_disconnected(monkeypatch):
+    """Regression for prod 2026-06-04: when a worker disconnects,
+    `peek_runtime_snapshot` returns None — same as "no first status yet".
+    The optimistic "assume ready" default would let `try_reserve_capacity`
+    and `reevaluate_model_queues` dispatch onto a dead session and the
+    pipeline would crash at execution-context resolution with
+    LogosNodeOfflineError("No active logosnode worker session"). The
+    optimistic branch must be gated on the worker being online.
+    """
+
+    class _FakeRegistry:
+        def __init__(self) -> None:
+            self.online = False
+
+        def peek_runtime_snapshot(self, provider_id: int):  # noqa: ARG002
+            return None
+
+        def is_provider_online(self, provider_id: int) -> bool:  # noqa: ARG002
+            return self.online
+
+    registry = _FakeRegistry()
+    queue_mgr = PriorityQueueManager()
+    facade = LogosNodeSchedulingDataFacade(queue_mgr, runtime_registry=registry)
+
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._load_provider_config",
+        lambda self: {},
+    )
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._fetch_ps_data",
+        lambda self: {"models": []},
+    )
+
+    facade.register_model(38, "logosnode", "http://fake", "openai/gpt-oss-120b", 65536, provider_id=15)
+
+    # Disconnected: lane must not be considered ready.
+    registry.online = False
+    assert facade.is_model_lane_ready(38, 15) is False
+
+    # Connected but no first status yet: optimistic "assume ready" preserved
+    # so the legacy behavior for freshly-attached workers is unchanged.
+    registry.online = True
+    assert facade.is_model_lane_ready(38, 15) is True


### PR DESCRIPTION
## Summary
- Adds a standalone GSM8K benchmarking suite under `logos/benchmarks/` that measures **TTFT** (Time to First Token), **TTLT** (Time to Last Token), and **GPU energy per request** against Logos / vLLM / Ollama backends.
- Includes workload preparation script (`prepare_benchmark.py`), the runner (`benchmark_logos.py`), and scenario config (`benchmark_config.py`).
- Workloads (`benchmarks/workloads/`) and per-run result artifacts (`benchmarks/benchmark_results/`) are gitignored — only tooling is tracked.

## More changes coming
This branch will collect additional improvements before merge, starting with an admin UI button to trigger one-shot calibration for all uncalibrated models on a specific node.

## Test plan
- [ ] Run `prepare_benchmark.py` to regenerate a workload CSV from GSM8K
- [ ] Run `benchmark_logos.py` end-to-end against a Logos test deployment with `--logos-key`
- [ ] Verify `run_meta.json`, detailed/summary CSVs, and charts are produced under `benchmark_results/<timestamp>_*/`
- [ ] Confirm `.gitignore` keeps workloads + results out of the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full benchmarking suite: workload generation, runner CLI, analysis/plots, CSV outputs, and local/remote GPU energy measurement
  * Admin endpoint to batch-calibrate uncalibrated models and UI calibration action (with API-key gated button)
  * Node-wide "disable sleep mode" toggle to force sleep off across lanes

* **Bug Fixes**
  * Fixed crash when skipping KV-cache calibration path

* **Tests**
  * Added regression and endpoint tests for calibration and scheduler offline handling

* **Documentation**
  * Added comprehensive benchmark README

* **Chores**
  * Updated ignore rules, pre-commit hook config, and benchmark deps list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->