### PR TITLE
`Logos`: Stop stats DB queries from freezing streaming responses

### DIFF
--- a/logos/logos-orchestrator/pyproject.toml
+++ b/logos/logos-orchestrator/pyproject.toml
@@ -30,6 +30,7 @@ sentence-transformers = "^5.0.0"
 matplotlib = "^3.9.2"
 aiohttp = "^3.9.0"
 prometheus-client = "^0.21.0"
+anyio = "^4.5"
 
 [tool.poetry]
 packages = [{ include = "logos", from = "src" }]

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -11,6 +11,8 @@ import secrets
 import threading
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+import anyio
+import anyio.to_thread
 import sqlalchemy.exc
 import yaml
 from dateutil.parser import isoparse
@@ -31,6 +33,8 @@ __all__ = [
     "DBManager",
     "Deployment",
     "get_unique_models_from_deployments",
+    "with_db",
+    "STATS_DB_LIMITER",
 ]
 
 logger = logging.getLogger(__name__)
@@ -2156,7 +2160,7 @@ class DBManager:
         self.session.commit()
         return {"result": "Created log entry.", "log-id": row.id}, 200
 
-    def set_time_at_first_token(self, log_id: int):
+    def set_time_at_first_token(self, log_id: int, timestamp: Optional[datetime.datetime] = None):
         sql = text(
             """
                    UPDATE log_entry
@@ -2167,7 +2171,7 @@ class DBManager:
         self.session.execute(
             sql,
             {
-                "timestamp": datetime.datetime.now(datetime.timezone.utc),
+                "timestamp": timestamp or datetime.datetime.now(datetime.timezone.utc),
                 "log_id": log_id,
             },
         )
@@ -2542,3 +2546,22 @@ class DBManager:
                 self.session.rollback()
         finally:
             self.session.close()
+
+# Caps concurrent heavy stats queries so dashboards can't exhaust the threadpool or DB pool.
+STATS_DB_LIMITER = anyio.CapacityLimiter(8)
+
+
+async def with_db(fn, *, limiter=None):
+    """Run a sync callable `fn(db: DBManager) -> T` in a worker thread.
+
+    Keeps blocking SQLAlchemy work off the event loop. The session lives only
+    inside the thread; `fn` must return plain data, not ORM objects. Pass
+    `limiter=STATS_DB_LIMITER` for heavy stats queries.
+    """
+
+    def _work():
+        with DBManager() as db:
+            return fn(db)
+
+    return await anyio.to_thread.run_sync(_work, limiter=limiter)
+

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -24,7 +24,7 @@ from logos.capacity.capacity_planner import CapacityPlanner
 from logos.capacity.demand_tracker import DemandTracker
 from logos.classification.classification_balancer import Balancer
 from logos.classification.classification_manager import ClassificationManager
-from logos.dbutils.dbmanager import DBManager
+from logos.dbutils.dbmanager import DBManager, STATS_DB_LIMITER, with_db
 from logos.dbutils.dbmodules import JobStatus
 from logos.dbutils.dbrequest import *
 from logos.dbutils.types import (
@@ -678,33 +678,34 @@ def _merge_provider_samples(
     return sorted(by_key.values(), key=_sample_sort_key)
 
 
-def _load_persisted_local_provider_vram_payload(
+async def _load_persisted_local_provider_vram_payload(
     logos_key: str,
     *,
     day: str,
     after_snapshot_id: int = 0,
 ) -> Dict[str, Any]:
-    with DBManager() as db:
+    def _load(db):
         if int(after_snapshot_id or 0) > 0:
-            payload, status = db.get_ollama_vram_deltas(
+            return db.get_ollama_vram_deltas(
                 logos_key,
                 day=day,
                 after_snapshot_id=int(after_snapshot_id or 0),
             )
-        elif str(day).strip().lower() == "all":
+        if str(day).strip().lower() == "all":
             # Initial WS load with no cursor. Cap to a recent window so the
             # init payload stays small even after weeks of accumulated
             # snapshots — the UI only renders a 30-min live window anyway,
             # and live deltas keep flowing afterwards via after_snapshot_id.
             recent_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-            payload, status = db.get_ollama_vram_deltas(
+            return db.get_ollama_vram_deltas(
                 logos_key,
                 day="all",
                 after_snapshot_id=0,
                 since=recent_since,
             )
-        else:
-            payload, status = db.get_ollama_vram_stats(logos_key, day=day, bucket_seconds=5)
+        return db.get_ollama_vram_stats(logos_key, day=day, bucket_seconds=5)
+
+    payload, status = await with_db(_load, limiter=STATS_DB_LIMITER)
     if status != 200 or not isinstance(payload, dict):
         return {
             "providers": [],
@@ -715,7 +716,7 @@ def _load_persisted_local_provider_vram_payload(
     return payload
 
 
-def _capture_logosnode_provider_snapshot(
+async def _capture_logosnode_provider_snapshot(
     provider_id: int,
     runtime: Dict[str, Any],
 ) -> None:
@@ -740,7 +741,7 @@ def _capture_logosnode_provider_snapshot(
     if free_vram_mb is not None:
         free_bytes = int(float(free_vram_mb or 0.0) * 1024 * 1024)
 
-    with DBManager() as db:
+    def _persist(db):
         snapshot_id = db.insert_provider_snapshot(
             provider_id=provider_id,
             snapshot_ts=timestamp,
@@ -769,12 +770,13 @@ def _capture_logosnode_provider_snapshot(
                         _resolve_provider_name(provider_id),
                         exc_info=True,
                     )
+        return snapshot_id
 
-    sample["snapshot_id"] = snapshot_id
+    sample["snapshot_id"] = await with_db(_persist)
     asyncio.create_task(_logosnode_registry.record_runtime_sample(provider_id, sample))
 
 
-def _merge_local_provider_vram_payload(
+async def _merge_local_provider_vram_payload(
     logos_key: str,
     payload: Dict[str, Any],
     *,
@@ -797,8 +799,11 @@ def _merge_local_provider_vram_payload(
         else:
             unnamed_providers.append(entry)
 
-    with DBManager() as db:
-        inventory, status = db.get_local_provider_inventory(logos_key)
+    # Only the inventory fetch is offloaded; the registry reads below must
+    # stay on the event loop (peek_recent_samples mutates session state).
+    inventory, status = await with_db(
+        lambda db: db.get_local_provider_inventory(logos_key), limiter=STATS_DB_LIMITER
+    )
     if status != 200 or not isinstance(inventory, list):
         merged = list(providers_by_id.values()) + unnamed_providers
         merged.sort(key=lambda item: str(item.get("name") or "").lower())
@@ -887,18 +892,18 @@ def _merge_local_provider_vram_payload(
     return next_payload
 
 
-def _build_live_local_provider_vram_payload(
+async def _build_live_local_provider_vram_payload(
     logos_key: str,
     *,
     day: str,
     after_snapshot_id: int = 0,
 ) -> Dict[str, Any]:
-    payload = _load_persisted_local_provider_vram_payload(
+    payload = await _load_persisted_local_provider_vram_payload(
         logos_key,
         day=day,
         after_snapshot_id=after_snapshot_id,
     )
-    payload = _merge_local_provider_vram_payload(
+    payload = await _merge_local_provider_vram_payload(
         logos_key,
         payload,
         day=day,
@@ -913,6 +918,14 @@ def _build_live_local_provider_vram_payload(
                 last_snapshot_id = sample_id
     payload["last_snapshot_id"] = last_snapshot_id
     return payload
+
+
+def _record_ttft_in_background(log_id: int) -> None:
+    """Persist time-at-first-token without delaying the stream's next chunk."""
+    ttft_ts = datetime.datetime.now(datetime.timezone.utc)
+    task = asyncio.create_task(with_db(lambda db: db.set_time_at_first_token(log_id, timestamp=ttft_ts)))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
 
 def _record_log_failure(
@@ -1908,8 +1921,7 @@ async def _streaming_response(
                     yield chunk
                     if chunk and not ttft_recorded:
                         if log_id:
-                            with DBManager() as db:
-                                db.set_time_at_first_token(log_id)
+                            _record_ttft_in_background(log_id)
                         ttft_recorded = True
                     stream_log.feed(chunk)
             except Exception as e:
@@ -1920,8 +1932,8 @@ async def _streaming_response(
                 response_payload = stream_log.response_payload()
                 usage_tokens = _usage_tokens_from_payload(response_payload)
                 if log_id:
-                    with DBManager() as db:
-                        db.set_response_payload(
+                    await with_db(
+                        lambda db: db.set_response_payload(
                             log_id,
                             response_payload,
                             provider_id,
@@ -1937,6 +1949,7 @@ async def _streaming_response(
                                 scheduling_stats.get("utilization_at_arrival") if scheduling_stats else None
                             ),
                         )
+                    )
                 if rl_key:
                     from logos.rate_limiter import get_rate_limiter
 
@@ -2015,16 +2028,14 @@ async def _streaming_response(
                 stream_log.feed(first_chunk)
                 if not ttft_recorded:
                     if log_id:
-                        with DBManager() as db:
-                            db.set_time_at_first_token(log_id)
+                        _record_ttft_in_background(log_id)
                     ttft_recorded = True
 
             async for chunk in chunk_iter:
                 yield chunk
                 if chunk and not ttft_recorded:
                     if log_id:
-                        with DBManager() as db:
-                            db.set_time_at_first_token(log_id)
+                        _record_ttft_in_background(log_id)
                     ttft_recorded = True
                 stream_log.feed(chunk)
         except Exception as exc:
@@ -2040,8 +2051,8 @@ async def _streaming_response(
             response_payload = stream_log.response_payload()
             usage_tokens = _usage_tokens_from_payload(response_payload)
             if log_id:
-                with DBManager() as db:
-                    db.set_response_payload(
+                await with_db(
+                    lambda db: db.set_response_payload(
                         log_id,
                         response_payload,
                         provider_id,
@@ -2057,6 +2068,7 @@ async def _streaming_response(
                             scheduling_stats.get("utilization_at_arrival") if scheduling_stats else None
                         ),
                     )
+                )
             if rl_key:
                 from logos.rate_limiter import get_rate_limiter
 
@@ -2191,7 +2203,7 @@ async def _sync_response(
         usage_tokens = _usage_tokens_from_payload(response_payload)
 
         if log_id:
-            with DBManager() as db:
+            def _finalize(db):
                 if exec_result.success:
                     db.set_time_at_first_token(log_id)
                 db.set_response_payload(
@@ -2210,6 +2222,8 @@ async def _sync_response(
                         scheduling_stats.get("utilization_at_arrival") if scheduling_stats else None
                     ),
                 )
+
+            await with_db(_finalize)
 
         if scheduling_stats:
             status = "timeout" if timed_out else ("success" if exec_result.success else "error")
@@ -2306,8 +2320,7 @@ def _proxy_streaming_response(
                 if ttft is None:
                     ttft = datetime.datetime.now(datetime.timezone.utc)
                     if log_id:
-                        with DBManager() as db:
-                            db.set_time_at_first_token(log_id)
+                        _record_ttft_in_background(log_id)
 
                 yield chunk
 
@@ -2322,7 +2335,7 @@ def _proxy_streaming_response(
                 response_payload = stream_log.response_payload()
                 usage_tokens = _usage_tokens_from_payload(response_payload)
 
-                with DBManager() as db:
+                def _finalize(db):
                     if ttft is None and stream_log.first_chunk is not None and not error_message:
                         db.set_time_at_first_token(log_id)
                     db.set_response_payload(
@@ -2341,6 +2354,8 @@ def _proxy_streaming_response(
                         result_status="error" if error_message else "success",
                         error_message=error_message,
                     )
+
+                await with_db(_finalize)
 
     response_headers = {"X-Request-ID": request_id} if request_id else None
     return StreamingResponse(streamer(), media_type="text/event-stream", headers=response_headers)
@@ -2372,7 +2387,7 @@ async def _proxy_sync_response(
     if log_id:
         usage_tokens = _usage_tokens_from_payload(response_payload)
 
-        with DBManager() as db:
+        def _finalize(db):
             if exec_result.success:
                 db.set_time_at_first_token(log_id)
             db.set_response_payload(
@@ -2391,6 +2406,8 @@ async def _proxy_sync_response(
                 result_status="success" if exec_result.success else "error",
                 error_message=None if exec_result.success else exec_result.error,
             )
+
+        await with_db(_finalize)
 
     # Use upstream HTTP status code; fall back to 200/500 if unavailable
     status_code = (
@@ -3261,7 +3278,7 @@ async def logosnode_session(websocket: WebSocket, token: str):
                         payload.get("configured_models") if isinstance(payload.get("configured_models"), list) else None
                     ),
                 )
-                _capture_logosnode_provider_snapshot(ticket.provider_id, runtime)
+                await _capture_logosnode_provider_snapshot(ticket.provider_id, runtime)
             elif msg_type == "event":
                 await _logosnode_registry.append_event(
                     provider_id=ticket.provider_id,
@@ -3564,7 +3581,7 @@ async def get_ollama_vram_stats(request: Request):
         pass
 
     return JSONResponse(
-        content=_build_live_local_provider_vram_payload(logos_key, day=day, after_snapshot_id=0),
+        content=await _build_live_local_provider_vram_payload(logos_key, day=day, after_snapshot_id=0),
         status_code=200,
     )
 

--- a/logos/logos-orchestrator/tests/integration/sdi/test_api_endpoints.py
+++ b/logos/logos-orchestrator/tests/integration/sdi/test_api_endpoints.py
@@ -68,14 +68,17 @@ def stub_db(monkeypatch):
                 return provider
             return {"id": provider, "name": "azure", "base_url": "https://example.com"}
 
-        def set_time_at_first_token(self, log_id): ...
+        def set_time_at_first_token(self, log_id, timestamp=None): ...
 
         def set_response_payload(self, *a, **k): ...
 
+    from logos.dbutils import dbmanager as dbmanager_module
     import logos as responses
 
     monkeypatch.setattr(main, "DBManager", DummyDB, raising=False)
     monkeypatch.setattr(responses, "DBManager", DummyDB, raising=False)
+    # with_db resolves DBManager in the dbmanager module; patch that namespace too.
+    monkeypatch.setattr(dbmanager_module, "DBManager", DummyDB, raising=False)
 
 
 @pytest.fixture
@@ -280,9 +283,11 @@ def _stub_db_manager(monkeypatch):
             return {"log-id": 99}, 200
 
     monkeypatch.setattr(main, "DBManager", DummyDB, raising=False)
+    from logos.dbutils import dbmanager as dbmanager_module
     import logos as responses
 
     monkeypatch.setattr(responses, "DBManager", DummyDB, raising=False)
+    monkeypatch.setattr(dbmanager_module, "DBManager", DummyDB, raising=False)
 
 
 @pytest.mark.asyncio

--- a/logos/logos-orchestrator/tests/performance/mock_sse_upstream.py
+++ b/logos/logos-orchestrator/tests/performance/mock_sse_upstream.py
@@ -1,0 +1,69 @@
+"""Mock OpenAI-compatible SSE upstream with a fixed chunk cadence.
+
+Emits one content chunk every --interval seconds for --duration seconds,
+so any deviation in chunk arrival observed by stream_gap_probe.py is
+attributable to the proxy, not the backend.
+
+Usage:
+    python tests/performance/mock_sse_upstream.py --port 9999 --interval 0.2
+Register it in Logos as an OpenAI-type provider with base_url http://host:9999.
+"""
+
+import argparse
+import asyncio
+import json
+
+from aiohttp import web
+
+
+async def chat_completions(request: web.Request) -> web.StreamResponse:
+    interval = request.app["interval"]
+    duration = request.app["duration"]
+    response = web.StreamResponse(
+        status=200,
+        headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+    )
+    await response.prepare(request)
+
+    total_chunks = max(1, int(duration / interval))
+    for i in range(total_chunks):
+        chunk = {
+            "id": "mock-1",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"content": f"tok{i} "}, "finish_reason": None}],
+        }
+        await response.write(f"data: {json.dumps(chunk)}\n\n".encode())
+        await asyncio.sleep(interval)
+
+    usage_chunk = {
+        "id": "mock-1",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": total_chunks,
+            "total_tokens": total_chunks + 1,
+        },
+    }
+    await response.write(f"data: {json.dumps(usage_chunk)}\n\n".encode())
+    await response.write(b"data: [DONE]\n\n")
+    return response
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=9999)
+    parser.add_argument("--interval", type=float, default=0.2, help="Seconds between chunks")
+    parser.add_argument("--duration", type=float, default=60.0, help="Stream length in seconds")
+    args = parser.parse_args()
+
+    app = web.Application()
+    app["interval"] = args.interval
+    app["duration"] = args.duration
+    app.router.add_post("/chat/completions", chat_completions)
+    app.router.add_post("/v1/chat/completions", chat_completions)
+    web.run_app(app, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/logos/logos-orchestrator/tests/performance/stream_gap_probe.py
+++ b/logos/logos-orchestrator/tests/performance/stream_gap_probe.py
@@ -1,0 +1,88 @@
+"""Measure inter-chunk gaps of streaming responses through the Logos proxy.
+
+Opens N concurrent streaming chat completions and records the arrival time
+of every chunk. While the probe runs, load the statistics dashboard (or POST
+/logosdb/request_log_stats) — before the threadpool offload fix, every
+stream's inter-chunk gap jumped to the stats query duration; after the fix,
+gaps stay at the upstream cadence.
+
+Typical setup (see mock_sse_upstream.py for a deterministic backend):
+    python tests/performance/stream_gap_probe.py \\
+        --url http://localhost:8080/v1/chat/completions \\
+        --logos-key <key> --model <model-name> --streams 3
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import time
+
+import httpx
+
+
+async def probe_stream(client: httpx.AsyncClient, args, stream_idx: int) -> dict:
+    gaps: list[tuple[float, float]] = []  # (offset_since_start, gap)
+    start = time.monotonic()
+    prev = start
+    chunks = 0
+    body = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": "stream please"}],
+        "stream": True,
+    }
+    headers = {"Authorization": f"Bearer {args.logos_key}"}
+    async with client.stream("POST", args.url, json=body, headers=headers) as response:
+        response.raise_for_status()
+        async for _ in response.aiter_raw():
+            now = time.monotonic()
+            if chunks > 0:
+                gaps.append((now - start, now - prev))
+            prev = now
+            chunks += 1
+    return {"stream": stream_idx, "chunks": chunks, "gaps": gaps}
+
+
+def report(results: list[dict], threshold: float) -> bool:
+    ok = True
+    for result in results:
+        gap_values = [gap for _, gap in result["gaps"]]
+        if not gap_values:
+            print(f"stream {result['stream']}: no chunks received!")
+            ok = False
+            continue
+        max_gap = max(gap_values)
+        p99 = statistics.quantiles(gap_values, n=100)[98] if len(gap_values) >= 100 else max_gap
+        print(
+            f"stream {result['stream']}: chunks={result['chunks']} "
+            f"max_gap={max_gap * 1000:.0f}ms p99={p99 * 1000:.0f}ms"
+        )
+        stalls = [(offset, gap) for offset, gap in result["gaps"] if gap > threshold]
+        for offset, gap in stalls:
+            print(f"  STALL at t+{offset:.1f}s: {gap * 1000:.0f}ms")
+        if stalls:
+            ok = False
+    return ok
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://localhost:8080/v1/chat/completions")
+    parser.add_argument("--logos-key", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--streams", type=int, default=3)
+    parser.add_argument(
+        "--threshold", type=float, default=0.5, help="Report gaps above this many seconds as stalls"
+    )
+    args = parser.parse_args()
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        results = await asyncio.gather(*(probe_stream(client, args, i) for i in range(args.streams)))
+
+    ok = report(results, args.threshold)
+    print("PASS: no stalls above threshold" if ok else "FAIL: stalls detected")
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/logos/logos-orchestrator/tests/unit/main/test_error_handlers_integration.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_error_handlers_integration.py
@@ -73,7 +73,7 @@ def _stub_db(monkeypatch):
         def update_log_entry_metrics(self, *a, **k):
             pass
 
-        def set_time_at_first_token(self, *a):
+        def set_time_at_first_token(self, *a, **k):
             pass
 
         def set_response_payload(self, *a, **k):
@@ -116,7 +116,11 @@ def _stub_db(monkeypatch):
                 "auth_format": "Bearer {}",
             }
 
+    from logos.dbutils import dbmanager as dbmanager_module
+
+    # with_db resolves DBManager in the dbmanager module; patch both namespaces.
     monkeypatch.setattr(main, "DBManager", FakeDB, raising=False)
+    monkeypatch.setattr(dbmanager_module, "DBManager", FakeDB, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/logos/logos-orchestrator/tests/unit/main/test_event_loop_blocking.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_event_loop_blocking.py
@@ -1,0 +1,159 @@
+"""Regression guard: slow synchronous DB work must not block the event loop.
+
+Before the with_db offload, a slow stats query (or a streaming finalization
+write) executed directly on the event loop, pausing every in-flight streaming
+response. These tests run a heartbeat watchdog while exercising those paths
+against a deliberately slow DB stub and assert the loop keeps scheduling on
+time.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import logos as main
+from logos.dbutils import dbmanager as dbmanager_module
+
+SLOW_QUERY_SECONDS = 1.0
+# Generous bound for CI jitter; a blocking query stalls the loop for the
+# full SLOW_QUERY_SECONDS, so the two regimes are far apart.
+MAX_ALLOWED_DRIFT_SECONDS = 0.5
+HEARTBEAT_INTERVAL = 0.05
+
+
+class _LoopWatchdog:
+    """Measures how late the event loop schedules a periodic heartbeat."""
+
+    def __init__(self):
+        self.max_drift = 0.0
+        self._stop = asyncio.Event()
+        self._task = None
+
+    async def _run(self):
+        loop = asyncio.get_running_loop()
+        prev = loop.time()
+        while not self._stop.is_set():
+            await asyncio.sleep(HEARTBEAT_INTERVAL)
+            now = loop.time()
+            self.max_drift = max(self.max_drift, now - prev - HEARTBEAT_INTERVAL)
+            prev = now
+
+    async def __aenter__(self):
+        self._task = asyncio.create_task(self._run())
+        # Yield once so the watchdog is ticking before the guarded work runs —
+        # a loop-blocking path would otherwise finish before its first beat.
+        await asyncio.sleep(0)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._stop.set()
+        await self._task
+
+
+def _patch_db(monkeypatch, db_factory):
+    monkeypatch.setattr(main, "DBManager", db_factory)
+    monkeypatch.setattr(dbmanager_module, "DBManager", db_factory)
+
+
+def _make_request(body=None, headers=None):
+    request = MagicMock()
+    request.headers = headers or {"authorization": "Bearer test-key"}
+    request.json = AsyncMock(return_value=body or {})
+    return request
+
+
+@pytest.fixture(autouse=True)
+def mock_auth(monkeypatch):
+    auth_ctx = MagicMock()
+    auth_ctx.key_value = "test-key"
+    monkeypatch.setattr(main, "authenticate_api_key", lambda headers: auth_ctx)
+
+
+@pytest.mark.asyncio
+async def test_vram_stats_does_not_block_event_loop(monkeypatch):
+    class SlowStatsDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get_ollama_vram_stats(self, logos_key, day, bucket_seconds=5):
+            time.sleep(SLOW_QUERY_SECONDS)
+            return {"providers": [], "last_snapshot_id": 0}, 200
+
+        def get_local_provider_inventory(self, logos_key):
+            return [], 200
+
+    _patch_db(monkeypatch, SlowStatsDB)
+
+    async with _LoopWatchdog() as watchdog:
+        response = await main.get_ollama_vram_stats(_make_request(body={"day": "2026-01-01"}))
+
+    assert response.status_code == 200
+    assert watchdog.max_drift < MAX_ALLOWED_DRIFT_SECONDS, (
+        f"Event loop stalled {watchdog.max_drift:.3f}s during a "
+        f"{SLOW_QUERY_SECONDS}s stats query — sync DB work is back on the loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalization_does_not_block_event_loop(monkeypatch):
+    class SlowWriteDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def set_time_at_first_token(self, log_id, timestamp=None):
+            time.sleep(SLOW_QUERY_SECONDS / 2)
+
+        def set_response_payload(self, *args, **kwargs):
+            time.sleep(SLOW_QUERY_SECONDS)
+
+        def update_log_entry_metrics(self, **kwargs):
+            pass
+
+    _patch_db(monkeypatch, SlowWriteDB)
+
+    class DummyExecutor:
+        async def execute_streaming(self, url, headers, payload, on_headers=None):  # noqa: ARG002
+            if on_headers:
+                on_headers({})
+            yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+            yield b"data: [DONE]\n\n"
+
+    class DummyPipeline:
+        executor = DummyExecutor()
+
+        @staticmethod
+        def update_provider_stats(model_id, provider_id, headers):  # noqa: ARG002
+            return None
+
+    monkeypatch.setattr(main, "_pipeline", DummyPipeline(), raising=False)
+
+    async with _LoopWatchdog() as watchdog:
+        response = main._proxy_streaming_response(
+            "http://proxy",
+            {"Authorization": "Bearer x"},
+            {"stream": True},
+            7,
+            1,
+            2,
+            -1,
+            {},
+            request_id="req-loop-guard",
+        )
+        async for _ in response.body_iterator:
+            pass
+        # TTFT is written fire-and-forget; include it in the guarded window.
+        while main._background_tasks:
+            await asyncio.gather(*list(main._background_tasks))
+
+    assert watchdog.max_drift < MAX_ALLOWED_DRIFT_SECONDS, (
+        f"Event loop stalled {watchdog.max_drift:.3f}s during streaming "
+        f"DB writes — sync DB work is back on the loop"
+    )

--- a/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
@@ -1,9 +1,23 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 import logos as main
+from logos.dbutils import dbmanager as dbmanager_module
 from logos import ExecutionResult
+
+
+def _patch_db(monkeypatch, dummy_db):
+    # with_db resolves DBManager in the dbmanager module; patch both namespaces.
+    monkeypatch.setattr(main, "DBManager", dummy_db)
+    monkeypatch.setattr(dbmanager_module, "DBManager", dummy_db)
+
+
+async def _flush_background_tasks():
+    # TTFT writes are fire-and-forget tasks; wait for them before asserting.
+    while main._background_tasks:
+        await asyncio.gather(*list(main._background_tasks))
 
 
 def _make_dummy_db():
@@ -18,7 +32,7 @@ def _make_dummy_db():
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def set_time_at_first_token(self, log_id):
+        def set_time_at_first_token(self, log_id, timestamp=None):
             self.ttft_calls.append(log_id)
 
         def set_response_payload(
@@ -103,7 +117,7 @@ def _make_pipeline(
 @pytest.mark.asyncio
 async def test_streaming_response_logs_usage_when_sse_events_are_split(monkeypatch):
     dummy_db = _make_dummy_db()
-    monkeypatch.setattr(main, "DBManager", dummy_db)
+    _patch_db(monkeypatch, dummy_db)
     monkeypatch.setattr(
         main,
         "_context_resolver",
@@ -149,6 +163,7 @@ async def test_streaming_response_logs_usage_when_sse_events_are_split(monkeypat
         },
     )
     body = await _read_stream_response(response)
+    await _flush_background_tasks()
 
     assert "data: [DONE]" in body
     assert response.headers["x-request-id"] == "req-stream"
@@ -173,7 +188,7 @@ async def test_streaming_response_logs_usage_when_sse_events_are_split(monkeypat
 @pytest.mark.asyncio
 async def test_proxy_streaming_response_logs_usage_and_status(monkeypatch):
     dummy_db = _make_dummy_db()
-    monkeypatch.setattr(main, "DBManager", dummy_db)
+    _patch_db(monkeypatch, dummy_db)
 
     pipeline, _, _ = _make_pipeline(
         stream_chunks=[
@@ -198,6 +213,7 @@ async def test_proxy_streaming_response_logs_usage_and_status(monkeypatch):
         request_id="req-proxy-stream",
     )
     body = await _read_stream_response(response)
+    await _flush_background_tasks()
 
     assert "data: [DONE]" in body
     assert response.headers["x-request-id"] == "req-proxy-stream"
@@ -221,7 +237,7 @@ async def test_proxy_streaming_response_logs_usage_and_status(monkeypatch):
 @pytest.mark.asyncio
 async def test_sync_response_error_skips_ttft_and_records_error(monkeypatch):
     dummy_db = _make_dummy_db()
-    monkeypatch.setattr(main, "DBManager", dummy_db)
+    _patch_db(monkeypatch, dummy_db)
     monkeypatch.setattr(
         main,
         "_context_resolver",
@@ -276,7 +292,7 @@ async def test_sync_response_error_skips_ttft_and_records_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_sync_response_async_job_success_logs_usage(monkeypatch):
     dummy_db = _make_dummy_db()
-    monkeypatch.setattr(main, "DBManager", dummy_db)
+    _patch_db(monkeypatch, dummy_db)
     monkeypatch.setattr(
         main,
         "_context_resolver",
@@ -343,7 +359,7 @@ async def test_sync_response_async_job_success_logs_usage(monkeypatch):
 @pytest.mark.asyncio
 async def test_proxy_sync_response_logs_status_and_skips_ttft_on_error(monkeypatch):
     dummy_db = _make_dummy_db()
-    monkeypatch.setattr(main, "DBManager", dummy_db)
+    _patch_db(monkeypatch, dummy_db)
 
     pipeline, _, _ = _make_pipeline(
         sync_result=ExecutionResult(

--- a/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
@@ -63,6 +63,15 @@ class DummyRegistry:
 
 
 @pytest.fixture(autouse=True)
+def mirror_db_patch(monkeypatch):
+    # with_db resolves DBManager in the dbmanager module; delegate to
+    # main.DBManager at call time so per-test patches keep working.
+    from logos.dbutils import dbmanager as dbmanager_module
+
+    monkeypatch.setattr(dbmanager_module, "DBManager", lambda: main.DBManager())
+
+
+@pytest.fixture(autouse=True)
 def mock_auth(monkeypatch):
     mock_auth_ctx = MagicMock()
     mock_auth_ctx.key_value = "test-key"


### PR DESCRIPTION
### Problem

  While the statistics page was loading (which can take a few seconds), **all in-flight streaming responses stopped delivering tokens** until the stats finished
  loading.  

  The cause: the orchestrator handles everything on a single thread. Database queries were executed directly on that thread, so one slow stats query paused chunk
  forwarding for every active stream. The same (smaller) hiccup happened on every request when usage logging was written to the database.

  ### Solution
  
  Blocking database calls are now executed in a background worker thread pool via a small `with_db()` helper, so the main thread stays free to forward stream
  chunks. Applied to:

  - the VRAM statistics endpoint (the heaviest remaining Python stats path)
  - the per-request logging writes in all streaming and non-streaming response paths (time-to-first-token is now written in the background so it doesn't delay
  the stream itself)
  - worker status snapshot writes

  A concurrency cap ensures dashboard queries can't hog the database connection pool, and TTFT timestamps are captured at chunk arrival so the metric stays
  accurate.

  ### Testing

  - New regression test (`test_event_loop_blocking.py`) measures whether the main loop stalls during a slow query — it fails on `main` (detects a ~1–1.5 s
  freeze) and passes with this change.
  - Full unit suite passes (388 tests).
  - Added two scripts under `tests/performance/` to measure stream smoothness against a live deployment (`stream_gap_probe.py` + a mock streaming backend).
  - ⚠️  Not verified end-to-end on the test or production environments due to current limitations (no GPU worker attached to the local dev stack). The probe
  scripts above are ready for that once a real deployment is available.

  Note: most of the other stats endpoints were already moved off the Python service by the Spring Migration (#597), which is why this PR only touches the paths
  that remained.

  Closes #601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added performance monitoring tools for streaming response latency analysis.

* **Tests**
  * Added regression tests to detect event-loop blocking issues.
  * Added performance probe utilities for streaming behavior analysis.

* **Chores**
  * Enhanced database operations with asynchronous support to prevent blocking the request handler.
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->