### PR TITLE
`Logos`: Calibration — compute KV/max_model_len curve from vLLM's rep…

### DIFF
--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -3543,6 +3543,42 @@ async def _benchmark_scenario(
 _TRAFFIC_PATTERNS = ["burst", "poisson", "sequential", "mixed"]
 
 
+def _resolve_patterns(raw: Optional[str]) -> list[str]:
+    """Resolve the --patterns selection (comma-separated) to canonical order.
+
+    Empty/None → all four. Unknown names raise so a typo fails fast rather than
+    silently running everything.
+    """
+    if not raw or not str(raw).strip():
+        return list(_TRAFFIC_PATTERNS)
+    wanted = [p.strip().lower() for p in str(raw).split(",") if p.strip()]
+    unknown = [p for p in wanted if p not in _TRAFFIC_PATTERNS]
+    if unknown:
+        raise ValueError(f"Unknown traffic pattern(s) {unknown}; valid: {_TRAFFIC_PATTERNS}")
+    return [p for p in _TRAFFIC_PATTERNS if p in wanted]
+
+
+_ALL_SCENARIOS = ["logos-nosleep", "ollama", "logos-sleep"]
+
+
+def _resolve_scenarios(raw: Optional[str], only_ollama: bool) -> list[str]:
+    """Resolve the --scenarios selection for --run-all-scenarios.
+
+    only_ollama forces just ["ollama"]. Empty/None → all three. Unknown names
+    raise so a typo fails fast. Used to limit a quick debug run to e.g.
+    --scenarios logos-nosleep.
+    """
+    if only_ollama:
+        return ["ollama"]
+    if not raw or not str(raw).strip():
+        return list(_ALL_SCENARIOS)
+    wanted = [s.strip().lower() for s in str(raw).split(",") if s.strip()]
+    unknown = [s for s in wanted if s not in _ALL_SCENARIOS]
+    if unknown:
+        raise ValueError(f"Unknown scenario(s) {unknown}; valid: {_ALL_SCENARIOS}")
+    return [s for s in _ALL_SCENARIOS if s in wanted]
+
+
 async def _run_all_traffic_patterns(
     scenario: str,
     base_url: str,
@@ -3552,11 +3588,16 @@ async def _run_all_traffic_patterns(
     model_map: dict,
     args: argparse.Namespace,
 ) -> list:
-    """Run all four traffic patterns for a scenario; warmup is done only for the first."""
+    """Run the selected traffic patterns for a scenario; warmup is done only for the first.
+
+    The set of patterns is ``--patterns`` (comma-separated; default all four), so a
+    quick debug run can target a single pattern, e.g. ``--patterns mixed``.
+    """
+    selected = _resolve_patterns(getattr(args, "patterns", None))
     summaries = []
-    for i, pattern in enumerate(_TRAFFIC_PATTERNS):
+    for i, pattern in enumerate(selected):
         print(f"\n{'─' * 58}")
-        print(f"  Traffic pattern {i+1}/{len(_TRAFFIC_PATTERNS)}: {pattern.upper()}")
+        print(f"  Traffic pattern {i+1}/{len(selected)}: {pattern.upper()}")
         print(f"{'─' * 58}")
         summary = await _benchmark_scenario(
             scenario,
@@ -4335,6 +4376,10 @@ async def _async_run_all(args: argparse.Namespace) -> None:
     print(f"  Workload       : {len(workload)} requests from '{workload_name}'")
     print(f"{'='*58}")
 
+    selected_scenarios = _resolve_scenarios(getattr(args, "scenarios", None), only_ollama)
+    if selected_scenarios != _ALL_SCENARIOS:
+        print(f"  Scenarios      : {', '.join(selected_scenarios)}  (--scenarios filter)")
+
     try:
         if not only_ollama:
             # ── Step 0: ensure orchestrator + Traefik are running ─────────────
@@ -4431,143 +4476,147 @@ async def _async_run_all(args: argparse.Namespace) -> None:
                     )
 
             # ── Step 1: logos-nosleep ─────────────────────────────────────────
-            print("\n" + "─" * 58)
-            print("[Step 1/3] logos-nosleep")
-            print("─" * 58)
-            _set_logos_sleep_mode_via_ssh(
-                args.gpu_host,
-                args.gpu_ssh_user,
-                ssh_key,
-                args.workernode_dir,
-                enabled=False,
-                use_sudo=use_sudo,
-                relay_host=relay_host,
-                relay_user=relay_user,
-            )
-            _set_logos_poll_intervals_via_ssh(
-                args.gpu_host,
-                args.gpu_ssh_user,
-                ssh_key,
-                args.workernode_dir,
-                gpu_poll_interval=1,
-                status_refresh_interval_seconds=1,
-                use_sudo=use_sudo,
-                relay_host=relay_host,
-                relay_user=relay_user,
-            )
-            if not await _warmup_workernodes_sequentially(
-                args.gpu_host,
-                args.gpu_ssh_user,
-                ssh_key,
-                args.workernode_dir,
-                logos_url,
-                args.logos_key,
-                workload,
-                {},
-                "logos-nosleep",
-                args.warmup_timeout,
-                use_sudo,
-                relay_host,
-                relay_user,
-            ):
-                print("  WARNING: Per-node warmup had failures — continuing anyway.", file=sys.stderr)
-            await _run_all_traffic_patterns(
-                "logos-nosleep", logos_url, args.logos_key, workload, workload_name, {}, args
-            )
-            print("\n  Stopping workernodes ...")
-            _stop_workernode_via_ssh(
-                args.gpu_host, args.gpu_ssh_user, ssh_key, args.workernode_dir, use_sudo, relay_host, relay_user
-            )
-
-        # ── Step 2: ollama ────────────────────────────────────────────────────
-        step_label = "[Step 1/1] ollama" if only_ollama else "[Step 2/3] ollama"
-        print("\n" + "─" * 58)
-        print(step_label)
-        print("─" * 58)
-        if only_ollama:
-            # No orchestrator Step 0 in this mode — try the ingest route now
-            # (best-effort; works only if Traefik is already running persistently).
-            _ensure_shelly_sidecar()
-        # Ollama runs on one GPU node only — it has no native multi-node support.
-        # This is intentional: the benchmark compares Logos (multi-node orchestration)
-        # against Ollama (single-node baseline) to quantify the value of distribution.
-        if only_ollama:
-            # When running Ollama in isolation, make sure no logos-workernode
-            # containers are occupying GPU memory on the target node.
-            _stop_logos_workernodes_if_running_via_ssh(
-                args.gpu_host,
-                args.gpu_ssh_user,
-                ssh_key,
-                getattr(args, "workernode_dir", "/opt/logos-workernode"),
-                use_sudo,
-                relay_host,
-                relay_user,
-            )
-        _deploy_ollama_compose_via_ssh(
-            ollama_host,
-            args.gpu_ssh_user,
-            ssh_key,
-            ollama_compose_dir,
-            use_sudo,
-            ollama_models_dir,
-            ollama_local_models_dir,
-            relay_host,
-            relay_user,
-        )
-        _start_ollama_docker_via_ssh(
-            ollama_host, args.gpu_ssh_user, ssh_key, ollama_compose_dir, use_sudo, relay_host, relay_user
-        )
-
-        # Port 11434 on the GPU node is typically not reachable directly from the
-        # logos-test server (firewall).  Open an SSH local-port-forward so all
-        # HTTP calls go through the existing SSH path instead.
-        _ollama_host_part = ollama_url.split("://")[-1].split("/")[0]
-        _ollama_port = int(_ollama_host_part.split(":")[-1]) if ":" in _ollama_host_part else _OLLAMA_DEFAULT_PORT
-        tunnel_proc = _open_ssh_tunnel(
-            ollama_host[0],
-            args.gpu_ssh_user,
-            ssh_key,
-            local_port=_ollama_port,
-            remote_port=_ollama_port,
-            relay_host=relay_host,
-            relay_user=relay_user,
-        )
-        _tunnel_procs.append(tunnel_proc)
-        await asyncio.sleep(2.0)  # let the tunnel establish before the first HTTP probe
-        tunnel_url = f"http://localhost:{_ollama_port}"
-
-        try:
-            if not await _wait_for_ollama(tunnel_url, timeout_s=args.warmup_timeout):
-                print(
-                    "  WARNING: Ollama did not become ready — skipping ollama scenario.",
-                    file=sys.stderr,
-                )
-            else:
-                await _import_ollama_models_from_disk(
-                    tunnel_url,
-                    [(n, ollama_to_hf_map.get(n, "")) for n in ollama_models_needed],
-                    ollama_host,
+            if "logos-nosleep" in selected_scenarios:
+                print("\n" + "─" * 58)
+                print("[Step 1/3] logos-nosleep")
+                print("─" * 58)
+                _set_logos_sleep_mode_via_ssh(
+                    args.gpu_host,
                     args.gpu_ssh_user,
                     ssh_key,
-                    local_models_dir=ollama_local_models_dir,
-                    timeout_s=args.warmup_timeout,
+                    args.workernode_dir,
+                    enabled=False,
+                    use_sudo=use_sudo,
                     relay_host=relay_host,
                     relay_user=relay_user,
                 )
-                await _ensure_ollama_models(tunnel_url, ollama_models_needed, timeout_per_model_s=args.warmup_timeout)
-                await _run_all_traffic_patterns(
-                    "ollama", tunnel_url, None, workload, workload_name, ollama_model_map, args
+                _set_logos_poll_intervals_via_ssh(
+                    args.gpu_host,
+                    args.gpu_ssh_user,
+                    ssh_key,
+                    args.workernode_dir,
+                    gpu_poll_interval=1,
+                    status_refresh_interval_seconds=1,
+                    use_sudo=use_sudo,
+                    relay_host=relay_host,
+                    relay_user=relay_user,
                 )
-        finally:
-            # Always stop the Ollama container and close the tunnel, even on abort.
-            _stop_ollama_docker_via_ssh(
+                if not await _warmup_workernodes_sequentially(
+                    args.gpu_host,
+                    args.gpu_ssh_user,
+                    ssh_key,
+                    args.workernode_dir,
+                    logos_url,
+                    args.logos_key,
+                    workload,
+                    {},
+                    "logos-nosleep",
+                    args.warmup_timeout,
+                    use_sudo,
+                    relay_host,
+                    relay_user,
+                ):
+                    print("  WARNING: Per-node warmup had failures — continuing anyway.", file=sys.stderr)
+                await _run_all_traffic_patterns(
+                    "logos-nosleep", logos_url, args.logos_key, workload, workload_name, {}, args
+                )
+                print("\n  Stopping workernodes ...")
+                _stop_workernode_via_ssh(
+                    args.gpu_host, args.gpu_ssh_user, ssh_key, args.workernode_dir, use_sudo, relay_host, relay_user
+                )
+
+        if "ollama" in selected_scenarios:
+            # ── Step 2: ollama ────────────────────────────────────────────────────
+            step_label = "[Step 1/1] ollama" if only_ollama else "[Step 2/3] ollama"
+            print("\n" + "─" * 58)
+            print(step_label)
+            print("─" * 58)
+            if only_ollama:
+                # No orchestrator Step 0 in this mode — try the ingest route now
+                # (best-effort; works only if Traefik is already running persistently).
+                _ensure_shelly_sidecar()
+            # Ollama runs on one GPU node only — it has no native multi-node support.
+            # This is intentional: the benchmark compares Logos (multi-node orchestration)
+            # against Ollama (single-node baseline) to quantify the value of distribution.
+            if only_ollama:
+                # When running Ollama in isolation, make sure no logos-workernode
+                # containers are occupying GPU memory on the target node.
+                _stop_logos_workernodes_if_running_via_ssh(
+                    args.gpu_host,
+                    args.gpu_ssh_user,
+                    ssh_key,
+                    getattr(args, "workernode_dir", "/opt/logos-workernode"),
+                    use_sudo,
+                    relay_host,
+                    relay_user,
+                )
+            _deploy_ollama_compose_via_ssh(
+                ollama_host,
+                args.gpu_ssh_user,
+                ssh_key,
+                ollama_compose_dir,
+                use_sudo,
+                ollama_models_dir,
+                ollama_local_models_dir,
+                relay_host,
+                relay_user,
+            )
+            _start_ollama_docker_via_ssh(
                 ollama_host, args.gpu_ssh_user, ssh_key, ollama_compose_dir, use_sudo, relay_host, relay_user
             )
-            _close_ssh_tunnel(tunnel_proc)
-            if tunnel_proc in _tunnel_procs:
-                _tunnel_procs.remove(tunnel_proc)
 
-        if not only_ollama:
+            # Port 11434 on the GPU node is typically not reachable directly from the
+            # logos-test server (firewall).  Open an SSH local-port-forward so all
+            # HTTP calls go through the existing SSH path instead.
+            _ollama_host_part = ollama_url.split("://")[-1].split("/")[0]
+            _ollama_port = int(_ollama_host_part.split(":")[-1]) if ":" in _ollama_host_part else _OLLAMA_DEFAULT_PORT
+            tunnel_proc = _open_ssh_tunnel(
+                ollama_host[0],
+                args.gpu_ssh_user,
+                ssh_key,
+                local_port=_ollama_port,
+                remote_port=_ollama_port,
+                relay_host=relay_host,
+                relay_user=relay_user,
+            )
+            _tunnel_procs.append(tunnel_proc)
+            await asyncio.sleep(2.0)  # let the tunnel establish before the first HTTP probe
+            tunnel_url = f"http://localhost:{_ollama_port}"
+
+            try:
+                if not await _wait_for_ollama(tunnel_url, timeout_s=args.warmup_timeout):
+                    print(
+                        "  WARNING: Ollama did not become ready — skipping ollama scenario.",
+                        file=sys.stderr,
+                    )
+                else:
+                    await _import_ollama_models_from_disk(
+                        tunnel_url,
+                        [(n, ollama_to_hf_map.get(n, "")) for n in ollama_models_needed],
+                        ollama_host,
+                        args.gpu_ssh_user,
+                        ssh_key,
+                        local_models_dir=ollama_local_models_dir,
+                        timeout_s=args.warmup_timeout,
+                        relay_host=relay_host,
+                        relay_user=relay_user,
+                    )
+                    await _ensure_ollama_models(
+                        tunnel_url, ollama_models_needed, timeout_per_model_s=args.warmup_timeout
+                    )
+                    await _run_all_traffic_patterns(
+                        "ollama", tunnel_url, None, workload, workload_name, ollama_model_map, args
+                    )
+            finally:
+                # Always stop the Ollama container and close the tunnel, even on abort.
+                _stop_ollama_docker_via_ssh(
+                    ollama_host, args.gpu_ssh_user, ssh_key, ollama_compose_dir, use_sudo, relay_host, relay_user
+                )
+                _close_ssh_tunnel(tunnel_proc)
+                if tunnel_proc in _tunnel_procs:
+                    _tunnel_procs.remove(tunnel_proc)
+
+        if not only_ollama and "logos-sleep" in selected_scenarios:
             # ── Step 3: logos-sleep ───────────────────────────────────────────
             print("\n" + "─" * 58)
             print("[Step 3/3] logos-sleep")
@@ -4821,6 +4870,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "Each scenario is run 4× with different traffic shapes: " "burst, Poisson, sequential, and mixed.",
     )
     tp_grp.add_argument(
+        "--patterns",
+        type=str,
+        default=None,
+        metavar="LIST",
+        help="Comma-separated subset of traffic patterns to run "
+        "(burst,poisson,sequential,mixed). Default: all four. "
+        "E.g. --patterns mixed for a quick debug run.",
+    )
+    tp_grp.add_argument(
         "--burst-size",
         type=int,
         default=5,
@@ -4863,6 +4921,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "--run-all-scenarios",
         action="store_true",
         help="Run all three scenarios in sequence (ignores --scenario).",
+    )
+    svc_grp.add_argument(
+        "--scenarios",
+        type=str,
+        default=None,
+        metavar="LIST",
+        help="Comma-separated subset of scenarios to run with --run-all-scenarios "
+        "(logos-nosleep,ollama,logos-sleep). Default: all three. "
+        "E.g. --scenarios logos-nosleep for a quick debug run.",
     )
     svc_grp.add_argument(
         "--logos-dir",

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -1037,6 +1037,65 @@ def _result_line(r: RequestResult) -> str:
     return "  ".join(parts)
 
 
+class _LiveStats:
+    """Aggregates request stats for a once-per-second progress line.
+
+    Counts requests SENT (dispatched), SUCCESS responses, and ERROR responses
+    (anything not 2xx/3xx, including ERR=200 stream drops), plus live throughput
+    and average/p50 TTFT. ``mark_sent`` is called when a request is launched and
+    ``mark_done`` when its result returns; ``report_loop`` prints every second.
+    """
+
+    def __init__(self, total: int, label: str = "") -> None:
+        self.total = total
+        self.label = label
+        self.sent = 0
+        self.success = 0
+        self.error = 0
+        self._ttfts: list[float] = []
+        self._t0 = time.monotonic()
+
+    def mark_sent(self) -> None:
+        self.sent += 1
+
+    def mark_done(self, r: "RequestResult") -> None:
+        if r.success:
+            self.success += 1
+        else:
+            self.error += 1
+        if r.ttft_ms is not None:
+            self._ttfts.append(r.ttft_ms)
+
+    @property
+    def in_flight(self) -> int:
+        return self.sent - self.success - self.error
+
+    def _line(self) -> str:
+        elapsed = max(1e-9, time.monotonic() - self._t0)
+        done = self.success + self.error
+        if self._ttfts:
+            avg = sum(self._ttfts) / len(self._ttfts)
+            s = sorted(self._ttfts)
+            p50 = s[len(s) // 2]
+            ttft = f"avg_ttft={avg:.0f}ms p50_ttft={p50:.0f}ms"
+        else:
+            ttft = "avg_ttft=—"
+        return (
+            f"  [live]{self.label} t={elapsed:.0f}s "
+            f"sent={self.sent}/{self.total} ok={self.success} err={self.error} "
+            f"inflight={self.in_flight} | {done/elapsed:.2f} done/s {ttft}"
+        )
+
+    async def report_loop(self, interval: float = 1.0) -> None:
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                print(self._line(), flush=True)
+        except asyncio.CancelledError:
+            print(self._line(), flush=True)  # final snapshot
+            raise
+
+
 async def run_sequential(
     workload: list[WorkloadEntry],
     base_url: str,
@@ -1050,13 +1109,16 @@ async def run_sequential(
     results: list[RequestResult] = []
     n = len(workload)
     width = len(str(n))
+    stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
     async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+        reporter = asyncio.create_task(stats.report_loop(1.0))
         for i, entry in enumerate(workload):
             print(
                 f"  {label_prefix}[{i+1:{width}}/{n}] {entry.request_id} ... ",
                 end="",
                 flush=True,
             )
+            stats.mark_sent()
             r = await _dispatch(
                 client,
                 base_url,
@@ -1069,7 +1131,13 @@ async def run_sequential(
                 model_map=model_map,
             )
             results.append(r)
+            stats.mark_done(r)
             print(_result_line(r), flush=True)
+        reporter.cancel()
+        try:
+            await reporter
+        except asyncio.CancelledError:
+            pass
     return results
 
 
@@ -1141,8 +1209,10 @@ async def run_burst(
     width = len(str(n))
     done_counter = [0]
     lock = asyncio.Lock()
+    stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
 
     async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+        reporter = asyncio.create_task(stats.report_loop(1.0))
         for batch_idx, batch_start in enumerate(range(0, n, burst_size)):
             if batch_idx > 0 and inter_burst_delay_s > 0:
                 await asyncio.sleep(inter_burst_delay_s)
@@ -1165,12 +1235,21 @@ async def run_burst(
                 async with lock:
                     results.append(r)
                     done_counter[0] += 1
+                    stats.mark_done(r)
                     print(
                         f"  {label_prefix}[{done_counter[0]:{width}}/{n}]" f" {r.request_id}  {_result_line(r)}",
                         flush=True,
                     )
 
+            for _e in batch:
+                stats.mark_sent()
             await asyncio.gather(*[_one(e) for e in batch])
+
+        reporter.cancel()
+        try:
+            await reporter
+        except asyncio.CancelledError:
+            pass
 
     return results
 
@@ -1198,9 +1277,11 @@ async def run_poisson(
     done_counter = [0]
     lock = asyncio.Lock()
     rate = lam / zeitraum_s  # effective rate in req/s
+    stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
 
     async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
         start_mono = time.monotonic()
+        reporter = asyncio.create_task(stats.report_loop(1.0))
 
         async def _one(entry: WorkloadEntry) -> None:
             r = await _dispatch(
@@ -1217,6 +1298,7 @@ async def run_poisson(
             async with lock:
                 results.append(r)
                 done_counter[0] += 1
+                stats.mark_done(r)
                 print(
                     f"  {label_prefix}[{done_counter[0]:{width}}/{n}]" f" {r.request_id}  {_result_line(r)}",
                     flush=True,
@@ -1224,11 +1306,17 @@ async def run_poisson(
 
         tasks: list[asyncio.Task] = []
         for i, entry in enumerate(workload):
+            stats.mark_sent()
             tasks.append(asyncio.create_task(_one(entry)))
             if i < n - 1:
                 await asyncio.sleep(random.expovariate(rate))
 
         await asyncio.gather(*tasks)
+        reporter.cancel()
+        try:
+            await reporter
+        except asyncio.CancelledError:
+            pass
 
     return results
 

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -1104,21 +1104,27 @@ async def run_sequential(
     timeout_s: float,
     scenario: str,
     model_map: dict[str, str],
+    dispatch_rate: float = 1.0,
     label_prefix: str = "",
 ) -> list[RequestResult]:
+    """Open-loop constant-rate dispatch: fire one request every 1/dispatch_rate
+    seconds WITHOUT waiting for the previous response. Dispatch wall-time is
+    n/dispatch_rate, independent of how fast the server responds (a request that
+    is slow or times out does not hold up the next send). Deterministic spacing
+    distinguishes it from the poisson pattern's random spacing.
+    """
     results: list[RequestResult] = []
     n = len(workload)
     width = len(str(n))
+    done = [0]
+    lock = asyncio.Lock()
     stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
+    interval = (1.0 / dispatch_rate) if dispatch_rate and dispatch_rate > 0 else 0.0
+
     async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
         reporter = asyncio.create_task(stats.report_loop(1.0))
-        for i, entry in enumerate(workload):
-            print(
-                f"  {label_prefix}[{i+1:{width}}/{n}] {entry.request_id} ... ",
-                end="",
-                flush=True,
-            )
-            stats.mark_sent()
+
+        async def _one(entry: WorkloadEntry) -> None:
             r = await _dispatch(
                 client,
                 base_url,
@@ -1126,13 +1132,27 @@ async def run_sequential(
                 entry,
                 0.0,
                 tracker,
-                sequential=True,
+                sequential=True,  # send immediately when this task runs (runner controls the rate)
                 scenario=scenario,
                 model_map=model_map,
             )
-            results.append(r)
-            stats.mark_done(r)
-            print(_result_line(r), flush=True)
+            async with lock:
+                results.append(r)
+                done[0] += 1
+                stats.mark_done(r)
+                print(
+                    f"  {label_prefix}[{done[0]:{width}}/{n}] {r.request_id}  {_result_line(r)}",
+                    flush=True,
+                )
+
+        tasks: list[asyncio.Task] = []
+        for i, entry in enumerate(workload):
+            stats.mark_sent()
+            tasks.append(asyncio.create_task(_one(entry)))
+            if i < n - 1 and interval > 0:
+                await asyncio.sleep(interval)
+
+        await asyncio.gather(*tasks)
         reporter.cancel()
         try:
             await reporter
@@ -1200,9 +1220,10 @@ async def run_burst(
     inter_burst_delay_s: float = 1.0,
     label_prefix: str = "",
 ) -> list[RequestResult]:
-    """Send requests in batches of burst_size fully-concurrent requests.
-
-    After each batch completes, waits inter_burst_delay_s before starting the next burst.
+    """Open-loop bursts: fire burst_size fully-concurrent requests, wait
+    inter_burst_delay_s, then fire the next burst — WITHOUT waiting for the
+    previous burst's responses. Dispatch wall-time is (n/burst_size)·delay,
+    independent of how fast the server responds.
     """
     results: list[RequestResult] = []
     n = len(workload)
@@ -1213,38 +1234,37 @@ async def run_burst(
 
     async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
         reporter = asyncio.create_task(stats.report_loop(1.0))
+
+        async def _one(entry: WorkloadEntry) -> None:
+            r = await _dispatch(
+                client,
+                base_url,
+                logos_key,
+                entry,
+                0.0,
+                tracker,
+                sequential=True,  # send immediately; the burst schedule controls dispatch timing
+                scenario=scenario,
+                model_map=model_map,
+            )
+            async with lock:
+                results.append(r)
+                done_counter[0] += 1
+                stats.mark_done(r)
+                print(
+                    f"  {label_prefix}[{done_counter[0]:{width}}/{n}]" f" {r.request_id}  {_result_line(r)}",
+                    flush=True,
+                )
+
+        tasks: list[asyncio.Task] = []
         for batch_idx, batch_start in enumerate(range(0, n, burst_size)):
             if batch_idx > 0 and inter_burst_delay_s > 0:
                 await asyncio.sleep(inter_burst_delay_s)
-            batch = workload[batch_start : batch_start + burst_size]
-            start_mono = time.monotonic()
-
-            # Default-arg captures start_mono by value at definition time for this batch.
-            async def _one(entry: WorkloadEntry, _sm: float = start_mono) -> None:
-                r = await _dispatch(
-                    client,
-                    base_url,
-                    logos_key,
-                    entry,
-                    _sm,
-                    tracker,
-                    sequential=False,
-                    scenario=scenario,
-                    model_map=model_map,
-                )
-                async with lock:
-                    results.append(r)
-                    done_counter[0] += 1
-                    stats.mark_done(r)
-                    print(
-                        f"  {label_prefix}[{done_counter[0]:{width}}/{n}]" f" {r.request_id}  {_result_line(r)}",
-                        flush=True,
-                    )
-
-            for _e in batch:
+            for entry in workload[batch_start : batch_start + burst_size]:
                 stats.mark_sent()
-            await asyncio.gather(*[_one(e) for e in batch])
+                tasks.append(asyncio.create_task(_one(entry)))
 
+        await asyncio.gather(*tasks)
         reporter.cancel()
         try:
             await reporter
@@ -1377,6 +1397,7 @@ async def run_mixed(
             timeout_s,
             scenario,
             model_map,
+            dispatch_rate=(lam / zeitraum_s if zeitraum_s else 1.0),
             label_prefix="[S]",
         ),
     )
@@ -3354,6 +3375,7 @@ async def _benchmark_scenario(
             args.request_timeout_s,
             scenario,
             model_map,
+            dispatch_rate=(poisson_lam / poisson_zeitraum_s if poisson_zeitraum_s else 1.0),
         )
 
     t_run_end = time.monotonic()

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -3709,6 +3709,197 @@ async def _reset_and_calibrate_all_nodes(
     )
 
 
+def _reset_profile_entries_via_ssh(
+    host: str,
+    ssh_user: str,
+    ssh_key: Optional[str],
+    workernode_dir: str,
+    models: list[str],
+    use_sudo: bool,
+    relay_host: Optional[str] = None,
+    relay_user: Optional[str] = None,
+) -> list[str]:
+    """Delete specific model entries from one node's model_profiles.yml.
+
+    The worker treats a model as calibrated the moment ``base_residency_mb`` is
+    known — even if the sleep-residual measurement is missing (it was calibrated
+    with sleep off, leaving ``sleeping_residual_mb: None``) — so it will NOT
+    re-pick that model for calibration. The benchmark needs the COMPLETE profile
+    (sleep scenarios size lanes from it), so we drop the entry to force a clean
+    recalibration. The node must be stopped first, or the running worker
+    re-saves the entry from memory. Reads/writes over SSH the same way as the
+    config helpers (cat -> edit locally -> tee); needs pyyaml on this host.
+    Returns the model names actually removed.
+    """
+    if not models:
+        return []
+    sudo = "sudo " if use_sudo else ""
+    profiles_path = f"{workernode_dir}/data/model_profiles.yml"
+    read_res = subprocess.run(
+        _build_ssh_cmd(
+            host,
+            ssh_user,
+            ssh_key,
+            f"{sudo}cat {shlex.quote(profiles_path)} 2>/dev/null || true",
+            relay_host,
+            relay_user,
+        ),
+        capture_output=True,
+        text=True,
+    )
+    if not _YAML or not (read_res.stdout or "").strip():
+        print(f"  [calib] {host}: no profiles file to reset (or pyyaml missing).")
+        return []
+    data = _yaml.safe_load(read_res.stdout) or {}
+    mp = data.get("model_profiles") or {}
+    removed = [m for m in models if mp.pop(m, None) is not None]
+    if not removed:
+        return []
+    data["model_profiles"] = mp
+    new_yaml = _yaml.safe_dump(data, default_flow_style=False)
+    write_res = subprocess.run(
+        _build_ssh_cmd(
+            host,
+            ssh_user,
+            ssh_key,
+            f"{sudo}tee {shlex.quote(profiles_path)} > /dev/null",
+            relay_host,
+            relay_user,
+        ),
+        input=new_yaml.encode(),
+        capture_output=True,
+    )
+    if write_res.returncode != 0:
+        raise RuntimeError(f"Cannot rewrite profiles on {host}: {write_res.stderr.decode().strip()}")
+    print(f"  [calib] {host}: reset {len(removed)} incomplete profile(s): {', '.join(removed)}")
+    return removed
+
+
+async def _ensure_calibration_complete_all_nodes(
+    hosts: list[str],
+    ssh_user: str,
+    ssh_key: Optional[str],
+    workernode_dir: str,
+    benchmark_models: list[str],
+    calibration_timeout_s: float,
+    logos_url: str,
+    logos_key: str,
+    provider_ids: list[int],
+    admin_port: int,
+    use_sudo: bool,
+    relay_host: Optional[str] = None,
+    relay_user: Optional[str] = None,
+) -> bool:
+    """Finish calibration for any incomplete model WITHOUT wiping prior work.
+
+    The full-reset path (:func:`_reset_and_calibrate_all_nodes`) is skipped when
+    ``--reset-calibration`` is off, but the run must still guarantee every
+    benchmark model is *completely* calibrated before firing traffic. Two failure
+    modes this closes:
+
+    * Never calibrated — the deployed worker parks in ZERO-LANE and does NOT
+      auto-calibrate, so requests to it just fail.
+    * Half-calibrated — the worker considers a model calibrated as soon as
+      ``base_residency_mb`` is known, but a model calibrated with sleep OFF has
+      ``sleeping_residual_mb: None``. The benchmark needs the full profile, so it
+      counts that model uncalibrated — yet the worker will NOT re-pick it on its
+      own. (This is exactly why two identical nodes can disagree: one calibrated
+      a model with sleep on, the other with sleep off.)
+
+    Order matters and mirrors the reset path:
+
+    1. Read each node's profiles straight off disk (no worker needed — reading
+       while a starting worker rewrites the file races). List the incomplete
+       benchmark models per host. If none anywhere, re-using calibration is free.
+    2. Stop the nodes (so the disk edits stick and the restart re-reads config),
+       drop the incomplete entries so the worker actually re-picks them, and
+       enable sleep mode (calibration *skips* sleep-disabled models AND needs
+       sleep on to record the residual) — all while stopped.
+    3. Start the nodes, trigger ``calibrate_uncalibrated`` on every provider, and
+       block until every model has a complete profile.
+    """
+    sudo = "sudo " if use_sudo else ""
+    profiles_path = f"{workernode_dir}/data/model_profiles.yml"
+    unsupported_path = f"{workernode_dir}/data/calibration_logs/calibration_unsupported_models.txt"
+    models = list(benchmark_models)
+
+    # Read status from disk — the file exists whether or not the worker runs, and
+    # reading it mid-startup-rewrite would catch a partial file.
+    print("\n[Ensure-Calibrate] Checking calibration status on all nodes ...")
+    pending_by_host: dict[str, list[str]] = {}
+    pending_anywhere: set[str] = set()
+    for host in hosts:
+        done, pending = _calibration_status_for_host(
+            host, ssh_user, ssh_key, profiles_path, unsupported_path, models, sudo, relay_host, relay_user
+        )
+        pending_by_host[host] = pending
+        line = f"  [calib] {host}: {len(done)}/{len(models)} calibrated"
+        if pending:
+            line += f"  | incomplete: {', '.join(pending)}"
+            pending_anywhere.update(pending)
+        print(line)
+
+    if not pending_anywhere:
+        print("[Ensure-Calibrate] All benchmark models already calibrated on all nodes — nothing to do.")
+        return True
+
+    if not provider_ids:
+        print(
+            "  ERROR: models still need calibration "
+            f"({', '.join(sorted(pending_anywhere))}) but no --calibration-provider-ids "
+            "were given, so a session cannot be triggered. Pass them (or "
+            "--reset-calibration) so the run can complete calibration first.",
+            file=sys.stderr,
+        )
+        return False
+
+    print("\n" + "=" * 58)
+    print("  [Ensure-Calibrate] Finishing calibration for incomplete models")
+    print("=" * 58)
+    print(f"  Incomplete across nodes: {', '.join(sorted(pending_anywhere))}")
+
+    # Stop first: profile edits would be overwritten by a running worker, and the
+    # sleep-mode override is only read at startup.
+    _stop_workernode_via_ssh(hosts, ssh_user, ssh_key, workernode_dir, use_sudo, relay_host, relay_user)
+
+    # Drop the incomplete entries so the worker re-picks them (it would otherwise
+    # skip a base_residency-only profile, treating it as already calibrated).
+    for host in hosts:
+        _reset_profile_entries_via_ssh(
+            host, ssh_user, ssh_key, workernode_dir, pending_by_host[host], use_sudo, relay_host, relay_user
+        )
+
+    # Calibration needs sleep enabled to produce a complete profile.
+    _set_logos_sleep_mode_via_ssh(
+        hosts,
+        ssh_user,
+        ssh_key,
+        workernode_dir,
+        enabled=True,
+        use_sudo=use_sudo,
+        relay_host=relay_host,
+        relay_user=relay_user,
+    )
+
+    print("\n[Ensure-Calibrate] Starting nodes ...")
+    _start_workernode_via_ssh(hosts, ssh_user, ssh_key, workernode_dir, use_sudo, relay_host, relay_user)
+
+    print(f"\n[Ensure-Calibrate] Triggering calibration on provider(s) {provider_ids} (admin port {admin_port}) ...")
+    if not await _trigger_calibration_via_rest(logos_url, logos_key, provider_ids, admin_port):
+        print("  WARNING: could not start a calibration session on every provider.", file=sys.stderr)
+    return await _wait_for_calibration_complete_via_ssh(
+        hosts,
+        ssh_user,
+        ssh_key,
+        workernode_dir,
+        models,
+        calibration_timeout_s,
+        use_sudo,
+        relay_host,
+        relay_user,
+    )
+
+
 async def _warmup_workernodes_sequentially(
     hosts: list[str],
     ssh_user: str,
@@ -3994,9 +4185,9 @@ async def _async_run_all(args: argparse.Namespace) -> None:
             # Traefik is up — register the Shelly HTTPS ingest route (if requested).
             _ensure_shelly_sidecar()
 
-            # ── Optional: full reset + fresh calibration before any scenario ──
+            # ── Calibration: full reset, or just finish what's uncalibrated ──
+            unique_logos_models = list(dict.fromkeys(e.body["model"] for e in workload if e.body.get("model")))
             if getattr(args, "reset_calibration", False):
-                unique_logos_models = list(dict.fromkeys(e.body["model"] for e in workload if e.body.get("model")))
                 if not await _reset_and_calibrate_all_nodes(
                     args.gpu_host,
                     args.gpu_ssh_user,
@@ -4008,6 +4199,28 @@ async def _async_run_all(args: argparse.Namespace) -> None:
                     logos_url,
                     args.logos_key,
                     args.calibration_provider_ids,
+                    args.logos_admin_port,
+                    use_sudo,
+                    relay_host,
+                    relay_user,
+                ):
+                    print(
+                        "  WARNING: calibration did not fully complete — continuing anyway.",
+                        file=sys.stderr,
+                    )
+            else:
+                # Re-using prior calibration: still finish any model the deployed
+                # worker never calibrated, or we'd just fire failing requests at it.
+                if not await _ensure_calibration_complete_all_nodes(
+                    args.gpu_host,
+                    args.gpu_ssh_user,
+                    ssh_key,
+                    args.workernode_dir,
+                    unique_logos_models,
+                    getattr(args, "calibration_timeout", 86400.0),
+                    logos_url,
+                    args.logos_key,
+                    getattr(args, "calibration_provider_ids", None) or [],
                     args.logos_admin_port,
                     use_sudo,
                     relay_host,
@@ -4569,8 +4782,10 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="ID",
         help="Provider IDs of the GPU worker nodes (e.g. '3 2' for deipapa deimama). "
-        "Required with --reset-calibration: the calibrate trigger is per-provider and "
-        "the orchestrator exposes no provider-listing endpoint reachable with a root key.",
+        "Required with --reset-calibration, and used WITHOUT it too: every run "
+        "triggers calibration for any model the worker never calibrated, and the "
+        "calibrate trigger is per-provider (the orchestrator exposes no "
+        "provider-listing endpoint reachable with a root key).",
     )
     svc_grp.add_argument(
         "--logos-admin-port",

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -864,6 +864,52 @@ def _parse_float_or_none(raw: Optional[str]) -> Optional[float]:
         return None
 
 
+# httpx connection-pool limits for the load runners. The benchmark dispatches
+# OPEN-LOOP (a new request every 1/rate s regardless of how many are in flight),
+# so when the server serves slower than the offered rate, in-flight requests
+# accumulate. Steady-state in-flight ≈ offered_rate × REQUEST_TIMEOUT_S — at most
+# a few thousand for the benchmark patterns. httpx's DEFAULT max_connections=100
+# capped concurrency far below that: every excess dispatch blocked acquiring a
+# pool slot and, after REQUEST_TIMEOUT_S elapsed, failed with PoolTimeout WITHOUT
+# EVER REACHING THE SERVER. Those never-sent requests inflated the error rate with
+# a pure client-side artifact and recorded a bogus sent_at/ttlt (≈ the full
+# timeout). Uncapping the pool lets every offered request actually reach the
+# orchestrator, so the benchmark measures the server and sent_at is the real
+# on-wire send time. _raise_fd_limit() (called from main) ensures the process has
+# enough file descriptors for the resulting socket count.
+_HTTP_LIMITS = httpx.Limits(max_connections=None, max_keepalive_connections=50)
+
+
+def _build_load_client(timeout_s: float) -> httpx.AsyncClient:
+    """AsyncClient for the load runners: uncapped connection pool and an explicit
+    timeout with ``pool=None`` so a dispatch never blocks waiting for a pool slot.
+    Read/write/connect still honour ``timeout_s``. With no pool wait, the sent_at
+    captured just before ``client.stream`` is the true moment the request goes out."""
+    timeout = httpx.Timeout(timeout_s, pool=None)
+    return httpx.AsyncClient(timeout=timeout, limits=_HTTP_LIMITS, verify=False)
+
+
+def _raise_fd_limit() -> None:
+    """Raise the soft open-file limit toward the hard limit so the uncapped httpx
+    pool can hold the thousands of concurrent streaming sockets that open-loop
+    dispatch into an overloaded server produces. The common 1024 default soft
+    limit is far below offered_rate × REQUEST_TIMEOUT_S and would reintroduce the
+    very connection starvation we just removed (as ConnectError/OSError)."""
+    try:
+        import resource
+    except ImportError:  # non-Unix platform — nothing to do
+        return
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = hard if hard != resource.RLIM_INFINITY else 1_048_576
+    if soft >= target:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+        print(f"  [fd] raised RLIMIT_NOFILE soft {soft} -> {target}", flush=True)
+    except (ValueError, OSError) as exc:
+        print(f"  [fd] could not raise RLIMIT_NOFILE (soft={soft}): {exc}", flush=True)
+
+
 async def _dispatch(
     client: httpx.AsyncClient,
     base_url: str,
@@ -912,6 +958,10 @@ async def _dispatch(
     # tracker — e.g. the warmup _NullTracker — is treated as a single "gpu" source.
     energy_sources: "dict[str, object]" = getattr(tracker, "children", None) or {"gpu": tracker}
     e_start = {name: t.snapshot_energy_mj() for name, t in energy_sources.items()}
+    # Captured immediately before client.stream(). With the load client's pool
+    # uncapped (see _build_load_client), the stream call does not block waiting for
+    # a connection slot, so this timestamp is the true moment the request is sent —
+    # not, as before, the moment a request entered a saturated pool queue.
     t_start = time.monotonic()
     sent_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -1121,7 +1171,7 @@ async def run_sequential(
     stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
     interval = (1.0 / dispatch_rate) if dispatch_rate and dispatch_rate > 0 else 0.0
 
-    async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+    async with _build_load_client(timeout_s) as client:
         reporter = asyncio.create_task(stats.report_loop(1.0))
 
         async def _one(entry: WorkloadEntry) -> None:
@@ -1178,7 +1228,7 @@ async def run_concurrent(
     n = len(workload)
     width = len(str(n))
 
-    async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+    async with _build_load_client(timeout_s) as client:
 
         async def _run(entry: WorkloadEntry, start_mono: float) -> None:
             nonlocal completed
@@ -1232,7 +1282,7 @@ async def run_burst(
     lock = asyncio.Lock()
     stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
 
-    async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+    async with _build_load_client(timeout_s) as client:
         reporter = asyncio.create_task(stats.report_loop(1.0))
 
         async def _one(entry: WorkloadEntry) -> None:
@@ -1299,7 +1349,7 @@ async def run_poisson(
     rate = lam / zeitraum_s  # effective rate in req/s
     stats = _LiveStats(n, label=(f" {label_prefix.strip()}" if label_prefix.strip() else ""))
 
-    async with httpx.AsyncClient(timeout=timeout_s, verify=False) as client:
+    async with _build_load_client(timeout_s) as client:
         start_mono = time.monotonic()
         reporter = asyncio.create_task(stats.report_loop(1.0))
 
@@ -1444,7 +1494,7 @@ async def _warmup(
             )
         )
 
-    async with httpx.AsyncClient(timeout=timeout_s + 5.0, verify=False) as client:
+    async with _build_load_client(timeout_s + 5.0) as client:
         tasks = [
             asyncio.create_task(
                 _dispatch(
@@ -4973,6 +5023,7 @@ async def _async_main(args: argparse.Namespace) -> None:
 
 def main() -> None:
     args = _build_parser().parse_args()
+    _raise_fd_limit()
     if args.run_all_scenarios:
         asyncio.run(_async_run_all(args))
     else:

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -2292,15 +2292,31 @@ def _stop_workernode_via_ssh(
     relay_host: Optional[str] = None,
     relay_user: Optional[str] = None,
 ) -> None:
-    """Stop the logos workernode on each GPU node via SSH docker compose down."""
+    """Stop the logos workernode on each GPU node via SSH docker compose down.
+
+    Before tearing the container down, dump its full docker logs to
+    ``{workernode_dir}/saved_logs/worker-<UTC timestamp>.log`` on the GPU host so
+    the worker-side record survives container removal (e.g. when the ollama
+    scenario replaces it) and can be analyzed after the run.
+    """
     sudo = "sudo " if use_sudo else ""
-    remote_cmd = f"cd {shlex.quote(workernode_dir)} && {sudo}docker compose down"
+    save_dir = f"{workernode_dir}/saved_logs"
+    # Save logs first, then bring the workernode down. The log dump is best-effort
+    # (|| true) so a logging hiccup never blocks the teardown.
+    dump = shlex.quote(
+        f"docker compose logs --no-color --timestamps > " f"{save_dir}/worker-$(date -u +%Y%m%dT%H%M%SZ).log 2>&1"
+    )
+    remote_cmd = (
+        f"cd {shlex.quote(workernode_dir)} && {sudo}mkdir -p {shlex.quote(save_dir)} && "
+        f"{sudo}sh -c {dump} || true; "
+        f"{sudo}docker compose down"
+    )
     for host in hosts:
-        print(f"  [logos] {host}: $ {remote_cmd}")
+        print(f"  [logos] {host}: saving worker logs to {save_dir}/ then stopping")
         result = subprocess.run(_build_ssh_cmd(host, ssh_user, ssh_key, remote_cmd, relay_host, relay_user))
         if result.returncode != 0:
             raise RuntimeError(f"Failed to stop workernode on {host} (exit {result.returncode}).")
-        print(f"  [logos] {host}: workernode stopped.")
+        print(f"  [logos] {host}: worker logs saved under {save_dir}/, workernode stopped.")
 
 
 def _start_workernode_via_ssh(
@@ -4790,7 +4806,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="(Legacy) Send one request at a time in the sequential traffic pattern.",
     )
     p.add_argument("--max-concurrent", type=int, default=64)
-    p.add_argument("--request-timeout-s", type=float, default=600.0)
+    # Per-request client timeout. Defaults to the global LOGOS_TIMEOUT_S knob when
+    # set (so one env var makes client + orchestrator agree on a ridiculous value
+    # and no request times out client-side), else 600s.
+    p.add_argument(
+        "--request-timeout-s",
+        type=float,
+        default=float(os.getenv("LOGOS_TIMEOUT_S") or 600.0),
+    )
 
     # Traffic patterns
     tp_grp = p.add_argument_group(

--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -3459,13 +3459,24 @@ def _wipe_calibration_and_weights_via_ssh(
 def _profile_is_calibrated(profile: object) -> bool:
     """Mirror the worker's own 'is this model calibrated?' test.
 
-    A model counts as calibrated when its profile has the residency and sleep
-    measurements populated and the KV envelope is not collapsed (min == max).
-    Matches logos-workernode main._auto_calibrate_if_needed /
-    main._find_uncalibrated_models_on_provider so we stop waiting exactly when
-    the worker would stop re-calibrating. A model explicitly flagged
-    ``calibration_unsupported`` is terminal too — it will never produce a
-    profile, so treat it as done (it just won't serve).
+    Must match logos-workernode ``main._auto_calibrate_if_needed`` exactly so we
+    stop waiting exactly when the worker would stop re-calibrating — and, just as
+    importantly, so we do NOT treat as done a *legacy* calibrated profile the
+    worker would itself recalibrate. If we were more lenient than the worker we
+    would skip such a model, then fire requests the worker can't serve.
+
+    A model counts as calibrated when:
+      * not flagged ``calibration_unsupported`` (terminal — never serves, but it
+        will never produce a profile either, so don't wait on it);
+      * residency + sleep measurements are populated;
+      * the KV envelope is not collapsed (min == max); and
+      * for a ``calibrated`` profile: it carries kv_cache_to_max_model_len_pairs
+        and is not in the old weights-only format (loaded_vram_mb sitting a full
+        kv_budget above base_residency_mb).
+
+    The worker's (tp, enforce_eager) provenance check is intentionally NOT
+    mirrored here — it needs the per-model production plan from config; the
+    workernode applies it on its own at calibration time.
     """
     if not isinstance(profile, dict):
         return False
@@ -3477,6 +3488,18 @@ def _profile_is_calibrated(profile: object) -> bool:
     mn, mx = profile.get("min_kv_cache_mb"), profile.get("max_kv_cache_mb")
     if mn is not None and mx is not None and mn > 0 and mn == mx:
         return False  # collapsed KV envelope → worker re-calibrates
+    if profile.get("residency_source") == "calibrated":
+        # Legacy calibrated profile without the KV→max-model-len curve: the
+        # worker recalibrates it ("missing kv_cache_to_max_model_len_pairs").
+        if not profile.get("kv_cache_to_max_model_len_pairs"):
+            return False
+        # Old weights-only format: base stored weights-only, so loaded sits a
+        # full kv_budget above base. New format stores full loaded VRAM.
+        loaded = profile.get("loaded_vram_mb")
+        kv_budget = profile.get("kv_budget_mb")
+        base = profile.get("base_residency_mb")
+        if loaded is not None and kv_budget is not None and base is not None and loaded - base > 0.5 * kv_budget:
+            return False
     return True
 
 

--- a/logos/benchmarks/run_bench.sh
+++ b/logos/benchmarks/run_bench.sh
@@ -123,7 +123,10 @@ bench_args=(
 [[ "$ONLY_OLLAMA" == "1" ]] && bench_args+=(--only-ollama)
 [[ "$MANAGE_CALIB_WINDOW" == "0" ]] && bench_args+=(--no-manage-calibration-window)
 [[ "$SHELLY" == "1" ]] && bench_args+=(--shelly --shelly-port "$SHELLY_PORT" --shelly-transport "$SHELLY_TRANSPORT" --shelly-ingest-image "$SHELLY_INGEST_IMAGE")
-[[ "$RESET_CALIBRATION" == "1" ]] && bench_args+=(--reset-calibration --calibration-provider-ids $CALIBRATION_PROVIDER_IDS)
+# Provider IDs are needed whether or not we reset: without a full reset the run
+# still triggers calibration for any model the worker never calibrated.
+[[ -n "$CALIBRATION_PROVIDER_IDS" ]] && bench_args+=(--calibration-provider-ids $CALIBRATION_PROVIDER_IDS)
+[[ "$RESET_CALIBRATION" == "1" ]] && bench_args+=(--reset-calibration)
 [[ -n "$BENCHMARK_LOCAL_CACHE" ]] && bench_args+=(--benchmark-local-cache "$BENCHMARK_LOCAL_CACHE")
 # shellcheck disable=SC2206
 [[ -n "$EXTRA_ARGS" ]] && bench_args+=($EXTRA_ARGS)

--- a/logos/benchmarks/run_bench.sh
+++ b/logos/benchmarks/run_bench.sh
@@ -85,7 +85,15 @@ SHELLY="${SHELLY:-0}"
 SHELLY_PORT="${SHELLY_PORT:-9876}"
 SHELLY_TRANSPORT="${SHELLY_TRANSPORT:-http}"
 SHELLY_INGEST_IMAGE="${SHELLY_INGEST_IMAGE:-python:3-alpine}"
-REQUEST_TIMEOUT_S="${REQUEST_TIMEOUT_S:-1800}"
+# Global request-lifecycle timeout (seconds): ONE knob shared by the benchmark
+# client and the orchestrator (LOGOS_TIMEOUT_S in the orchestrator/worker env).
+# Set it to a ridiculous value (e.g. 86400) so no request ever times out and the
+# run measures scheduling/lane behaviour, not timeouts. Empty = per-stage defaults.
+LOGOS_TIMEOUT_S="${LOGOS_TIMEOUT_S:-}"
+export LOGOS_TIMEOUT_S
+# When the global knob is set it also drives the client request timeout (unless
+# REQUEST_TIMEOUT_S is set explicitly).
+REQUEST_TIMEOUT_S="${REQUEST_TIMEOUT_S:-${LOGOS_TIMEOUT_S:-1800}}"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 LOGOS_KEY="${LOGOS_KEY:-}"
 

--- a/logos/benchmarks/run_bench.sh
+++ b/logos/benchmarks/run_bench.sh
@@ -94,6 +94,9 @@ export LOGOS_TIMEOUT_S
 # When the global knob is set it also drives the client request timeout (unless
 # REQUEST_TIMEOUT_S is set explicitly).
 REQUEST_TIMEOUT_S="${REQUEST_TIMEOUT_S:-${LOGOS_TIMEOUT_S:-1800}}"
+# Quick-debug subsetting (empty = all). E.g. SCENARIOS=logos-nosleep PATTERNS=mixed.
+SCENARIOS="${SCENARIOS:-}"
+PATTERNS="${PATTERNS:-}"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 LOGOS_KEY="${LOGOS_KEY:-}"
 
@@ -128,6 +131,10 @@ bench_args=(
   --request-timeout-s "$REQUEST_TIMEOUT_S"
 )
 [[ -n "$LOGOS_KEY" ]] && bench_args+=(--logos-key "$LOGOS_KEY")
+# Quick-debug subsetting: SCENARIOS=logos-nosleep PATTERNS=mixed runs just that
+# scenario/pattern. Empty = all scenarios / all 4 patterns.
+[[ -n "$SCENARIOS" ]] && bench_args+=(--scenarios "$SCENARIOS")
+[[ -n "$PATTERNS" ]] && bench_args+=(--patterns "$PATTERNS")
 [[ "$ONLY_OLLAMA" == "1" ]] && bench_args+=(--only-ollama)
 [[ "$MANAGE_CALIB_WINDOW" == "0" ]] && bench_args+=(--no-manage-calibration-window)
 [[ "$SHELLY" == "1" ]] && bench_args+=(--shelly --shelly-port "$SHELLY_PORT" --shelly-transport "$SHELLY_TRANSPORT" --shelly-ingest-image "$SHELLY_INGEST_IMAGE")

--- a/logos/benchmarks/tests/test_run_all_helpers.py
+++ b/logos/benchmarks/tests/test_run_all_helpers.py
@@ -123,6 +123,37 @@ def test_profile_is_calibrated_distinguishes_stub_from_complete():
     }
     assert bm._profile_is_calibrated(collapsed) is False
 
+    # Legacy calibrated profile the worker would still recalibrate — the
+    # benchmark must mirror the worker, not skip it (else it fires failing
+    # requests). Missing kv_cache_to_max_model_len_pairs:
+    legacy_no_pairs = {
+        "residency_source": "calibrated",
+        "base_residency_mb": 100.0,
+        "sleeping_residual_mb": 50.0,
+        "sleep_l1_transient_host_ram_mb": 10.0,
+        "min_kv_cache_mb": 1024.0,
+        "max_kv_cache_mb": 4096.0,
+        "kv_cache_to_max_model_len_pairs": None,
+    }
+    assert bm._profile_is_calibrated(legacy_no_pairs) is False
+    # Same but WITH the curve → calibrated.
+    assert (
+        bm._profile_is_calibrated({**legacy_no_pairs, "kv_cache_to_max_model_len_pairs": [{"kv": 1, "mml": 1}]}) is True
+    )
+    # Old weights-only format (loaded sits a full kv_budget above base):
+    stale = {
+        "residency_source": "calibrated",
+        "base_residency_mb": 1000.0,
+        "sleeping_residual_mb": 50.0,
+        "sleep_l1_transient_host_ram_mb": 10.0,
+        "min_kv_cache_mb": 1024.0,
+        "max_kv_cache_mb": 4096.0,
+        "kv_cache_to_max_model_len_pairs": [{"kv": 1, "mml": 1}],
+        "loaded_vram_mb": 5000.0,
+        "kv_budget_mb": 4000.0,
+    }
+    assert bm._profile_is_calibrated(stale) is False
+
 
 def test_ensure_calibration_noop_when_all_calibrated():
     with (

--- a/logos/benchmarks/tests/test_run_all_helpers.py
+++ b/logos/benchmarks/tests/test_run_all_helpers.py
@@ -6,10 +6,11 @@
   by recreating only the orchestrator.
 """
 
+import asyncio
 import importlib.util
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Import the benchmark script by path (it's a standalone module, no package).
 _BM_PATH = Path(__file__).resolve().parent.parent / "benchmark_logos.py"
@@ -84,3 +85,118 @@ def test_manage_calibration_window_flag_default_and_off():
     assert on.manage_calibration_window is True
     off = parser.parse_args(["--run-all-scenarios", "--workload", "x.csv", "--no-manage-calibration-window"])
     assert off.manage_calibration_window is False
+
+
+# ── Ensure-calibration (non-reset path) ──────────────────────────────────────
+# Without a full reset the run must still finish any model the worker never
+# calibrated, instead of firing requests at it. These guard that gap.
+
+
+def test_profile_is_calibrated_distinguishes_stub_from_complete():
+    # The interrupted-calibration stub: residency 'cached', measurements None.
+    stub = {
+        "residency_source": "cached",
+        "base_residency_mb": None,
+        "sleeping_residual_mb": None,
+        "sleep_l1_transient_host_ram_mb": None,
+        "last_measured_epoch": 0.0,
+    }
+    assert bm._profile_is_calibrated(stub) is False
+
+    full = {
+        "base_residency_mb": 100.0,
+        "sleeping_residual_mb": 50.0,
+        "sleep_l1_transient_host_ram_mb": 10.0,
+        "min_kv_cache_mb": 1024.0,
+        "max_kv_cache_mb": 4096.0,
+    }
+    assert bm._profile_is_calibrated(full) is True
+
+    # Unsupported is terminal (done); a collapsed KV envelope re-calibrates.
+    assert bm._profile_is_calibrated({"calibration_unsupported": True}) is True
+    collapsed = {
+        "base_residency_mb": 1.0,
+        "sleeping_residual_mb": 1.0,
+        "sleep_l1_transient_host_ram_mb": 1.0,
+        "min_kv_cache_mb": 2048.0,
+        "max_kv_cache_mb": 2048.0,
+    }
+    assert bm._profile_is_calibrated(collapsed) is False
+
+
+def test_ensure_calibration_noop_when_all_calibrated():
+    with (
+        patch.object(bm, "_start_workernode_via_ssh") as start,
+        patch.object(bm, "_stop_workernode_via_ssh") as stop,
+        patch.object(bm, "_reset_profile_entries_via_ssh") as reset,
+        patch.object(bm, "_calibration_status_for_host", return_value=({"m1", "m2"}, [])),
+        patch.object(bm, "_set_logos_sleep_mode_via_ssh") as sleep_set,
+        patch.object(bm, "_trigger_calibration_via_rest", new=AsyncMock(return_value=True)) as trig,
+        patch.object(bm, "_wait_for_calibration_complete_via_ssh", new=AsyncMock(return_value=True)) as wait,
+    ):
+        ok = asyncio.run(
+            bm._ensure_calibration_complete_all_nodes(
+                ["h1"], "u", None, "/opt/wn", ["m1", "m2"], 10.0, "https://x", "k", [3], 9443, True
+            )
+        )
+    assert ok is True
+    # Nothing pending → no node churn, no reset, no trigger, no wait.
+    start.assert_not_called()
+    stop.assert_not_called()
+    reset.assert_not_called()
+    sleep_set.assert_not_called()
+    trig.assert_not_awaited()
+    wait.assert_not_awaited()
+
+
+def test_ensure_calibration_resets_incomplete_then_triggers_with_sleep_on():
+    order: list = []
+    with (
+        patch.object(bm, "_calibration_status_for_host", return_value=(set(), ["m1"])),
+        patch.object(bm, "_stop_workernode_via_ssh", side_effect=lambda *a, **k: order.append("stop")),
+        patch.object(
+            bm, "_reset_profile_entries_via_ssh", side_effect=lambda *a, **k: order.append("reset") or ["m1"]
+        ) as reset,
+        patch.object(
+            bm, "_set_logos_sleep_mode_via_ssh", side_effect=lambda *a, **k: order.append("sleep")
+        ) as sleep_set,
+        patch.object(bm, "_start_workernode_via_ssh", side_effect=lambda *a, **k: order.append("start")),
+        patch.object(bm, "_trigger_calibration_via_rest", new=AsyncMock(return_value=True)) as trig,
+        patch.object(bm, "_wait_for_calibration_complete_via_ssh", new=AsyncMock(return_value=True)) as wait,
+    ):
+        ok = asyncio.run(
+            bm._ensure_calibration_complete_all_nodes(
+                ["h1"], "u", None, "/opt/wn", ["m1"], 10.0, "https://x", "k", [3], 9443, True
+            )
+        )
+    assert ok is True
+    reset.assert_called_once()  # incomplete entry dropped so worker re-picks it
+    sleep_set.assert_called_once()
+    trig.assert_awaited_once()
+    wait.assert_awaited_once()
+    # Critical ordering: stop + reset + enable sleep all BEFORE (re)starting nodes.
+    assert order.index("stop") < order.index("start")
+    assert order.index("reset") < order.index("start")
+    assert order.index("sleep") < order.index("start")
+
+
+def test_ensure_calibration_fails_without_provider_ids():
+    # Pending models but no provider IDs → cannot trigger, must not hang/pass.
+    with (
+        patch.object(bm, "_stop_workernode_via_ssh") as stop,
+        patch.object(bm, "_reset_profile_entries_via_ssh") as reset,
+        patch.object(bm, "_calibration_status_for_host", return_value=(set(), ["m1"])),
+        patch.object(bm, "_trigger_calibration_via_rest", new=AsyncMock(return_value=True)) as trig,
+        patch.object(bm, "_wait_for_calibration_complete_via_ssh", new=AsyncMock(return_value=True)) as wait,
+    ):
+        ok = asyncio.run(
+            bm._ensure_calibration_complete_all_nodes(
+                ["h1"], "u", None, "/opt/wn", ["m1"], 10.0, "https://x", "k", [], 9443, True
+            )
+        )
+    assert ok is False
+    # Bail before touching the nodes.
+    stop.assert_not_called()
+    reset.assert_not_called()
+    trig.assert_not_awaited()
+    wait.assert_not_awaited()

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -37,6 +37,12 @@ services:
     environment:
       LOGOS_DOMAIN: "${LOGOS_DOMAIN:-localhost}"
       LOGOS_CAPACITY_PLANNER_ENABLED: "${LOGOS_CAPACITY_PLANNER_ENABLED:-true}"
+      # Global request-lifecycle timeout knob. When set (>0) it overrides the
+      # scheduler queue-wait, execution-context resolve, and worker stream
+      # timeouts so a request effectively never times out (benchmark uses
+      # 86400 to isolate scheduling from timeout-induced failures). Empty =
+      # each stage keeps its own default (prod behaviour unchanged).
+      LOGOS_TIMEOUT_S: "${LOGOS_TIMEOUT_S:-}"
       # Nightly calibration maintenance window (CalibrationOrchestrator). Set
       # LOGOS_CALIB_ENABLED=false to suppress it — the benchmark turns it off
       # for the duration of a run so a window session can't fire mid-benchmark.

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -43,6 +43,14 @@ services:
       LOGOS_CALIB_ENABLED: "${LOGOS_CALIB_ENABLED:-true}"
       LOGOS_CALIB_WINDOW_START: "${LOGOS_CALIB_WINDOW_START:-03:00}"
       LOGOS_CALIB_WINDOW_END: "${LOGOS_CALIB_WINDOW_END:-08:00}"
+      # How long the orchestrator waits for a worker to produce the next stream
+      # chunk before closing the connection ("Stream timeout waiting for worker
+      # response" → client sees RemoteProtocolError). The default 120s is too
+      # short under model thrashing: a request for a not-yet-loaded model must
+      # wait for the demand-preemptive drain to swap a busy lane AND the big
+      # model to load (can exceed 120s), so it timed out before being served.
+      LOGOSNODE_INFER_TIMEOUT_SECONDS: "${LOGOSNODE_INFER_TIMEOUT_SECONDS:-600}"
+      LOGOSNODE_STREAM_TIMEOUT_SECONDS: "${LOGOSNODE_STREAM_TIMEOUT_SECONDS:-600}"
       LOGOS_NODE_DEV_ALLOW_INSECURE_HTTP: "${LOGOS_NODE_DEV_ALLOW_INSECURE_HTTP:-}"
       PROMETHEUS_API_KEY: "${PROMETHEUS_API_KEY:-}"
       LOGOS_INTERNAL_SECRET: "${LOGOS_INTERNAL_SECRET:-}"

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5517,16 +5517,29 @@ class CapacityPlanner:
         if profile is not None and profile.residency_source == "calibrated":
             baked_kv_per_rank_mb = float(profile.kv_budget_mb or profile.max_kv_cache_mb or 0.0)
             weights_total = max(float(base_total) - baked_kv_per_rank_mb * float(tp), 0.0)
-        raw_available_total = float(getattr(capacity, "available_vram_mb", 0) or 0)
-        if raw_available_total <= 0:
-            return None
-        available_total = self._vram_ledger.get_effective_available_mb(provider_id, raw_available_total)
-        # Spread evenly across the TP GPUs as a first approximation. The
-        # actual placement may end up tighter on one GPU than another, but
-        # the worker's add_lane code already rejects placements that don't
-        # fit, and the calibrated min_kv_cache_mb gives us a safe floor —
-        # so a small per-GPU estimate error here is bounded by the clamp.
-        per_gpu_total = available_total / float(tp)
+        # Node-ownership basis. The calibrated KV pairs were measured with the
+        # model effectively OWNING its GPU(s), and the planner reclaims idle
+        # co-resident lanes to place a cold load. So budget KV against the room
+        # the lane will own AFTER placement (total VRAM minus its own weights),
+        # NOT the transient pre-reclaim free VRAM. Using current-free starves a
+        # large model — whose weights need most of the node — to a floor KV
+        # whenever another warmup/idle lane is briefly co-resident, even though
+        # that lane gets evicted before this one serves. The worker's add_lane
+        # placement check still rejects a budget that genuinely cannot fit, and
+        # the calibrated min_kv floor bounds the low end, so node-ownership is
+        # safe; the per-pair "smallest KV for the affordable context" selection
+        # keeps small models from over-grabbing.
+        total_vram_total = float(getattr(capacity, "total_vram_mb", 0) or 0)
+        if total_vram_total <= 0:
+            # No total reported — fall back to the (reclaim-reduced) current free.
+            raw_available_total = float(getattr(capacity, "available_vram_mb", 0) or 0)
+            if raw_available_total <= 0:
+                return None
+            total_vram_total = self._vram_ledger.get_effective_available_mb(provider_id, raw_available_total)
+        # Spread evenly across the TP GPUs as a first approximation. The actual
+        # placement may end up tighter on one GPU than another, but the worker's
+        # add_lane code already rejects placements that don't fit.
+        per_gpu_total = total_vram_total / float(tp)
         per_gpu_base = weights_total / float(tp)
         # Leave ~1 GiB of per-GPU headroom for activation buffers and the
         # compile cache that vLLM holds outside of the KV pool.

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -4937,6 +4937,24 @@ class CapacityPlanner:
             tp = 1
             if profile is not None and profile.tensor_parallel_size and int(profile.tensor_parallel_size) > 1:
                 tp = int(profile.tensor_parallel_size)
+            # Don't propose a load when not even the smallest calibrated KV pair
+            # fits the estimated per-GPU KV headroom — spawning it would only
+            # yield a doomed vLLM start (the budget can't serve one request at
+            # any calibrated context). Better to defer until VRAM frees up.
+            if profile is not None and profile.residency_source == "calibrated":
+                pairs = self._parse_kv_max_model_len_pairs(profile)
+                viable = [pkv for pkv, pmml in pairs if pmml and pmml > 0]
+                if viable:
+                    avail_kv = self._estimate_available_for_kv_mb(profile, capacity, provider_id, tp)
+                    if avail_kv is not None and avail_kv < min(viable):
+                        logger.info(
+                            "Feasibility FAILED for %s: smallest calibrated KV pair %.0fMB > "
+                            "available-for-KV %.0fMB/GPU — not spawning",
+                            model_name,
+                            min(viable),
+                            avail_kv,
+                        )
+                        return False
         else:
             if kv_cache_bytes_str:
                 kv_mb = self._parse_kv_cache_to_mb(kv_cache_bytes_str)
@@ -5235,7 +5253,22 @@ class CapacityPlanner:
         available_for_kv_mb = self._estimate_available_for_kv_mb(profile, capacity, provider_id, tp)
         kv_mb, selected_max_model_len = self._select_kv_mb_max_model_len_pair(profile, available_for_kv_mb)
         if kv_mb is None:
-            kv = self._compute_kv_cache_bytes(profile, available_for_kv_mb=available_for_kv_mb)
+            # No calibrated pair fits the estimated KV headroom. If the profile
+            # HAS a pair curve, fall back to the SMALLEST calibrated pair as a
+            # consistent (kv, max_model_len) unit — never a floor KV left with
+            # the worker's full-context max_model_len fallback, which produces a
+            # "kv=1G + max_model_len=<full context>" split-brain vLLM rejects
+            # outright. (Planner-initiated loads are already gated by
+            # _passes_minimum_load_feasibility, which refuses to propose a load
+            # when not even the smallest pair fits; this branch is the safety
+            # net for paths that bypass that gate, e.g. request-time cold load.)
+            parsed_pairs = self._parse_kv_max_model_len_pairs(profile)
+            viable_pairs = [(pkv, pmml) for pkv, pmml in parsed_pairs if pmml and pmml > 0]
+            if viable_pairs:
+                kv_mb, selected_max_model_len = min(viable_pairs, key=lambda p: p[0])
+                kv = self._format_bytes_human(int(kv_mb * 1024 * 1024))
+            else:
+                kv = self._compute_kv_cache_bytes(profile, available_for_kv_mb=available_for_kv_mb)
         else:
             kv = self._format_bytes_human(int(kv_mb * 1024 * 1024))
         if kv:
@@ -5463,6 +5496,20 @@ class CapacityPlanner:
         base_total = profile.estimate_base_residency_mb() if profile is not None else None
         if not base_total or base_total <= 0:
             return None
+        # Calibrated base_residency_mb already INCLUDES the KV pool it was
+        # measured with (kv_budget_mb / max_kv_cache_mb). The KV budget we are
+        # about to pick from the pair curve REPLACES that baked-in pool rather
+        # than stacking on top of it, so the figure that actually competes for
+        # VRAM is the weights-only footprint. Subtracting the baked-in KV is
+        # essential: without it, available-for-KV is under-counted by a whole
+        # kv_budget (e.g. a 35B lane reports ~0.5 GiB free when ~5.6 GiB is
+        # really available), every calibrated pair is rejected, and the planner
+        # falls back to a floor KV with the worker's full-context max_model_len
+        # — a split-brain launch vLLM rejects outright.
+        weights_total = float(base_total)
+        if profile is not None and profile.residency_source == "calibrated":
+            baked_kv_mb = float(profile.kv_budget_mb or profile.max_kv_cache_mb or 0.0)
+            weights_total = max(float(base_total) - baked_kv_mb, 0.0)
         raw_available_total = float(getattr(capacity, "available_vram_mb", 0) or 0)
         if raw_available_total <= 0:
             return None
@@ -5473,7 +5520,7 @@ class CapacityPlanner:
         # fit, and the calibrated min_kv_cache_mb gives us a safe floor —
         # so a small per-GPU estimate error here is bounded by the clamp.
         per_gpu_total = available_total / float(tp)
-        per_gpu_base = float(base_total) / float(tp)
+        per_gpu_base = weights_total / float(tp)
         # Leave ~1 GiB of per-GPU headroom for activation buffers and the
         # compile cache that vLLM holds outside of the KV pool.
         headroom_per_gpu_mb = 1024.0

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5502,14 +5502,21 @@ class CapacityPlanner:
         # than stacking on top of it, so the figure that actually competes for
         # VRAM is the weights-only footprint. Subtracting the baked-in KV is
         # essential: without it, available-for-KV is under-counted by a whole
-        # kv_budget (e.g. a 35B lane reports ~0.5 GiB free when ~5.6 GiB is
+        # kv_budget (e.g. a 35B lane reports ~0.5 GiB free when ~10 GiB is
         # really available), every calibrated pair is rejected, and the planner
         # falls back to a floor KV with the worker's full-context max_model_len
         # — a split-brain launch vLLM rejects outright.
+        #
+        # Mind the units: kv_budget_mb / max_kv_cache_mb are PER-RANK budgets
+        # (same units as kv_cache_memory_bytes and the pair curve's kv_mb),
+        # whereas base_residency_mb is the TOTAL footprint across all TP GPUs.
+        # So the KV baked into base spans every rank — subtract budget × tp, not
+        # a single rank's budget (which would still undercount KV for TP>1 and
+        # leave the weights estimate too high).
         weights_total = float(base_total)
         if profile is not None and profile.residency_source == "calibrated":
-            baked_kv_mb = float(profile.kv_budget_mb or profile.max_kv_cache_mb or 0.0)
-            weights_total = max(float(base_total) - baked_kv_mb, 0.0)
+            baked_kv_per_rank_mb = float(profile.kv_budget_mb or profile.max_kv_cache_mb or 0.0)
+            weights_total = max(float(base_total) - baked_kv_per_rank_mb * float(tp), 0.0)
         raw_available_total = float(getattr(capacity, "available_vram_mb", 0) or 0)
         if raw_available_total <= 0:
             return None

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -67,6 +67,7 @@ from logos.terminal_logging import (
     style_model,
     style_request_id,
 )
+from logos.timeouts import global_timeout_s
 
 _SERVER_START_TIME = int(time.time())
 
@@ -152,10 +153,14 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-_LOGOSNODE_INFER_TIMEOUT_SECONDS = _env_int("LOGOSNODE_INFER_TIMEOUT_SECONDS", 120)
-_LOGOSNODE_STREAM_TIMEOUT_SECONDS = _env_int(
-    "LOGOSNODE_STREAM_TIMEOUT_SECONDS",
-    _LOGOSNODE_INFER_TIMEOUT_SECONDS,
+_LOGOSNODE_INFER_TIMEOUT_SECONDS = int(global_timeout_s(_env_int("LOGOSNODE_INFER_TIMEOUT_SECONDS", 120)))
+_LOGOSNODE_STREAM_TIMEOUT_SECONDS = int(
+    global_timeout_s(
+        _env_int(
+            "LOGOSNODE_STREAM_TIMEOUT_SECONDS",
+            _LOGOSNODE_INFER_TIMEOUT_SECONDS,
+        )
+    )
 )
 _LOGOSNODE_STATS_STALE_AFTER_SECONDS = _env_int("LOGOSNODE_STATS_STALE_AFTER_SECONDS", 30)
 

--- a/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Tuple
 
 from logos.queue.priority_queue import Priority
 from logos.terminal_logging import style_model, style_provider
+from logos.timeouts import global_timeout_s
 
 from .base_scheduler import BaseScheduler
 from .ettft_estimator import (
@@ -697,7 +698,9 @@ class ClassificationCorrectingScheduler(BaseScheduler):
                 )
 
         try:
-            timeout = request.timeout_s if request.timeout_s else 1200  # 20 minutes for queue wait
+            timeout = (
+                request.timeout_s if request.timeout_s else global_timeout_s(1200)
+            )  # 20 min queue wait (or LOGOS_TIMEOUT_S)
             result = await asyncio.wait_for(future, timeout=timeout)
 
             # Attach ETTFT info to the dequeued result (decision-time values:

--- a/logos/logos-orchestrator/src/logos/pipeline/fcfs_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/fcfs_scheduler.py
@@ -10,6 +10,7 @@ import logging
 from typing import Optional
 
 from logos.queue.priority_queue import Priority
+from logos.timeouts import global_timeout_s
 
 from .base_scheduler import BaseScheduler
 from .scheduler_interface import QueueTimeoutError, SchedulingRequest, SchedulingResult
@@ -97,7 +98,7 @@ class FcfScheduler(BaseScheduler):
         )
 
         try:
-            timeout = request.timeout_s if request.timeout_s else 1200
+            timeout = request.timeout_s if request.timeout_s else global_timeout_s(1200)
             result = await asyncio.wait_for(future, timeout=timeout)
 
             if provider_type == "logosnode":

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -16,6 +16,7 @@ from logos.dbutils.types import Deployment, get_unique_models_from_deployments
 from logos.monitoring import prometheus_metrics as prom
 from logos.monitoring.recorder import MonitoringRecorder
 from logos.queue.models import Priority
+from logos.timeouts import global_timeout_s
 
 from .context_resolver import ContextResolver, ExecutionContext
 from .executor import Executor
@@ -279,7 +280,7 @@ class RequestPipeline:
     # request's lane may need the demand-preemptive drain to evict a busy lane
     # AND load a large model, which can exceed 180s — the request then 503'd
     # before its lane was ever ready. 600s gives the drain+load the full window.
-    _CONTEXT_RESOLVE_TIMEOUT_S = 600.0
+    _CONTEXT_RESOLVE_TIMEOUT_S = global_timeout_s(600.0)
     _CONTEXT_RESOLVE_INTERVAL_S = 2.0
 
     async def _resolve_context_with_retry(

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -273,7 +273,13 @@ class RequestPipeline:
                 self._demand_tracker.record_latent_demand(top_model_name)
                 prom.DEMAND_LATENT_TOTAL.labels(model=top_model_name).inc()
 
-    _CONTEXT_RESOLVE_TIMEOUT_S = 180.0
+    # How long to wait for a worker lane to become READY before failing with
+    # "Failed to resolve execution context". Raised 180→600 to match the worker
+    # stream timeout: under model thrashing (more models than fit in VRAM), a
+    # request's lane may need the demand-preemptive drain to evict a busy lane
+    # AND load a large model, which can exceed 180s — the request then 503'd
+    # before its lane was ever ready. 600s gives the drain+load the full window.
+    _CONTEXT_RESOLVE_TIMEOUT_S = 600.0
     _CONTEXT_RESOLVE_INTERVAL_S = 2.0
 
     async def _resolve_context_with_retry(

--- a/logos/logos-orchestrator/src/logos/pipeline/utilization_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/utilization_scheduler.py
@@ -11,6 +11,7 @@ import logging
 from typing import List, Optional, Tuple
 
 from logos.queue.priority_queue import Priority
+from logos.timeouts import global_timeout_s
 
 from .base_scheduler import BaseScheduler
 from .scheduler_interface import QueueTimeoutError, SchedulingRequest, SchedulingResult
@@ -106,7 +107,7 @@ class UtilizationAwareScheduler(BaseScheduler):
         )
 
         try:
-            timeout = request.timeout_s if request.timeout_s else 1200
+            timeout = request.timeout_s if request.timeout_s else global_timeout_s(1200)
             result = await asyncio.wait_for(future, timeout=timeout)
 
             if provider_type == "logosnode":

--- a/logos/logos-orchestrator/src/logos/timeouts.py
+++ b/logos/logos-orchestrator/src/logos/timeouts.py
@@ -1,0 +1,26 @@
+"""Single global request-lifecycle timeout knob.
+
+``LOGOS_TIMEOUT_S``, when set (> 0), overrides every per-stage request timeout in
+the orchestrator — scheduler queue-wait, execution-context resolve, and the
+orchestrator↔worker stream timeout — so one value makes a request effectively
+never time out. This is used by the benchmark to isolate scheduling/lane
+behaviour from timeout-induced failures (set it to e.g. 86400). When unset or
+non-positive, every call site keeps its own default and production behaviour is
+unchanged.
+"""
+
+import os
+
+_ENV = "LOGOS_TIMEOUT_S"
+
+
+def global_timeout_s(default: float) -> float:
+    """Return the global request timeout if ``LOGOS_TIMEOUT_S`` is set, else ``default``."""
+    raw = os.getenv(_ENV)
+    if not raw or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default

--- a/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
@@ -262,9 +262,15 @@ def test_estimate_available_for_kv_subtracts_baked_in_kv_for_calibrated():
     """Calibrated base_residency_mb already includes the KV pool, so the KV we
     pick REPLACES it — available-for-KV must be computed against weights only.
 
-    Qwen-3.6-35B: base=94667 (incl. 10240 KV budget), tp=2, 97770MB free.
-    Weights-based: 48885 - (84427/2) - 1024 ≈ 5648/GPU (fits the 2G pair).
-    The old base-inclusive math gave ~527/GPU and rejected every pair.
+    Units matter: base_residency_mb is the TOTAL footprint across all TP GPUs,
+    while kv_budget_mb is PER-RANK, so the baked-in KV is kv_budget × tp.
+
+    Qwen-3.6-35B: base=94667 (incl. 10240/rank × tp=2 = 20480 KV), 97770MB free.
+      weights_total = 94667 - 20480 = 74187
+      avail/GPU     = 97770/2 - 74187/2 - 1024 ≈ 10767  (fits the 2G pair)
+    Regression guards:
+      * single-rank subtraction (−10240) would give ~5648/GPU
+      * the original base-inclusive math gave ~527/GPU and rejected every pair
     """
     from unittest.mock import MagicMock
 
@@ -283,8 +289,9 @@ def test_estimate_available_for_kv_subtracts_baked_in_kv_for_calibrated():
 
     avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
     assert avail is not None
-    assert avail > 2048.0  # the (2G, 205920) pair now fits
-    assert 5000.0 < avail < 6200.0  # weights-based, not the ~527 base-inclusive underflow
+    assert avail > 2048.0  # the (2G, 205920) pair fits
+    # TP-correct (kv_budget × tp subtracted): ~10767, NOT the single-rank ~5648.
+    assert 10500.0 < avail < 11000.0
 
 
 def test_estimate_available_for_kv_uses_full_base_for_uncalibrated():

--- a/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
@@ -258,19 +258,17 @@ def _planner_for_kv_estimate(available_total_mb: float) -> CapacityPlanner:
     return planner
 
 
-def test_estimate_available_for_kv_subtracts_baked_in_kv_for_calibrated():
-    """Calibrated base_residency_mb already includes the KV pool, so the KV we
-    pick REPLACES it — available-for-KV must be computed against weights only.
+def test_estimate_available_for_kv_uses_node_ownership_basis_not_transient_free():
+    """KV is sized against the room the lane OWNS post-placement (total VRAM −
+    weights), NOT the transient pre-reclaim free VRAM. A large lane must not be
+    starved to a floor KV just because idle warmup lanes are briefly co-resident.
 
-    Units matter: base_residency_mb is the TOTAL footprint across all TP GPUs,
-    while kv_budget_mb is PER-RANK, so the baked-in KV is kv_budget × tp.
-
-    Qwen-3.6-35B: base=94667 (incl. 10240/rank × tp=2 = 20480 KV), 97770MB free.
-      weights_total = 94667 - 20480 = 74187
-      avail/GPU     = 97770/2 - 74187/2 - 1024 ≈ 10767  (fits the 2G pair)
-    Regression guards:
-      * single-rank subtraction (−10240) would give ~5648/GPU
-      * the original base-inclusive math gave ~527/GPU and rejected every pair
+    Two unit subtleties also covered:
+      * weights = base − kv_budget×tp  (base is TOTAL across TP GPUs; kv_budget
+        is PER-RANK). Qwen35B: 94667 − 10240×2 = 74187.
+      * basis is total_vram_mb (98280), so even with only 45001MB currently free
+        (other models resident) the estimate stays high:
+        98280/2 − 74187/2 − 1024 ≈ 11022/GPU  → the (2G, 205920) pair fits.
     """
     from unittest.mock import MagicMock
 
@@ -284,13 +282,35 @@ def test_estimate_available_for_kv_subtracts_baked_in_kv_for_calibrated():
         max_kv_cache_mb=10240.0,
     )
     capacity = MagicMock()
+    capacity.total_vram_mb = 98280.0
+    capacity.available_vram_mb = 45001.0  # other warmup lanes resident — must be IGNORED
+    planner = _planner_for_kv_estimate(45001.0)
+
+    avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
+    assert avail is not None
+    assert avail > 2048.0  # the (2G, 205920) pair fits despite tight current-free
+    # Node-ownership basis (total, not the 45001 transient free): ~11022/GPU.
+    assert 10500.0 < avail < 11500.0
+
+
+def test_estimate_available_for_kv_falls_back_to_free_when_total_unknown():
+    """If the capacity snapshot has no total_vram_mb, fall back to current free."""
+    from unittest.mock import MagicMock
+
+    profile = ModelProfile(
+        model_name="qwen/35b",
+        engine="vllm",
+        residency_source="calibrated",
+        base_residency_mb=94667.0,
+        kv_budget_mb=10240.0,
+    )
+    capacity = MagicMock()
+    capacity.total_vram_mb = 0.0
     capacity.available_vram_mb = 97770.0
     planner = _planner_for_kv_estimate(97770.0)
 
     avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
-    assert avail is not None
-    assert avail > 2048.0  # the (2G, 205920) pair fits
-    # TP-correct (kv_budget × tp subtracted): ~10767, NOT the single-rank ~5648.
+    # Fallback path: 97770/2 − 74187/2 − 1024 ≈ 10767.
     assert 10500.0 < avail < 11000.0
 
 
@@ -307,9 +327,11 @@ def test_estimate_available_for_kv_uses_full_base_for_uncalibrated():
         kv_budget_mb=4096.0,
     )
     capacity = MagicMock()
-    capacity.available_vram_mb = 90000.0
-    planner = _planner_for_kv_estimate(90000.0)
+    capacity.total_vram_mb = 90000.0
+    capacity.available_vram_mb = 50000.0  # ignored — node-ownership uses total
+    planner = _planner_for_kv_estimate(50000.0)
 
     avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
-    # per_gpu_total 45000 - per_gpu_base 20000 - 1024 headroom = 23976 (no kv subtraction)
+    # node-ownership: per_gpu_total 45000 - per_gpu_base 20000 - 1024 headroom = 23976
+    # (measured profile → no kv_budget subtraction from the weights-only base)
     assert abs(avail - 23976.0) < 1.0

--- a/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
@@ -224,3 +224,85 @@ def test_select_kv_pair_only_uses_fitting_pairs():
     )
     assert kv_mb_25g == 2048.0
     assert max_model_len_25g == 2000
+
+
+def test_select_kv_pair_ignores_zero_plateau_entries():
+    """Stale 0-max_model_len plateau points must not break selection.
+
+    Qwen-3.6-35B shipped pairs (1G->101376),(2G->205920) plus a 0-plateau for
+    3G..10G. With enough KV headroom the planner must still pick (2G, 205920) —
+    the 0 entries are never the max, so they are inert.
+    """
+    profile = ModelProfile(
+        model_name="qwen/35b",
+        engine="vllm",
+        kv_cache_to_max_model_len_pairs=[
+            {"kv_mb": 1024.0, "max_model_len": 101376},
+            {"kv_mb": 2048.0, "max_model_len": 205920},
+            {"kv_mb": 3072.0, "max_model_len": 0},
+            {"kv_mb": 4096.0, "max_model_len": 0},
+        ],
+    )
+    kv_mb, max_model_len = CapacityPlanner._select_kv_mb_max_model_len_pair(profile, available_for_kv_mb=5647.0)
+    assert (kv_mb, max_model_len) == (2048.0, 205920)
+
+
+def _planner_for_kv_estimate(available_total_mb: float) -> CapacityPlanner:
+    """A CapacityPlanner stub exposing just what _estimate_available_for_kv_mb needs."""
+    from unittest.mock import MagicMock
+
+    planner = CapacityPlanner.__new__(CapacityPlanner)
+    ledger = MagicMock()
+    ledger.get_effective_available_mb.side_effect = lambda _pid, raw: raw
+    planner._vram_ledger = ledger
+    return planner
+
+
+def test_estimate_available_for_kv_subtracts_baked_in_kv_for_calibrated():
+    """Calibrated base_residency_mb already includes the KV pool, so the KV we
+    pick REPLACES it — available-for-KV must be computed against weights only.
+
+    Qwen-3.6-35B: base=94667 (incl. 10240 KV budget), tp=2, 97770MB free.
+    Weights-based: 48885 - (84427/2) - 1024 ≈ 5648/GPU (fits the 2G pair).
+    The old base-inclusive math gave ~527/GPU and rejected every pair.
+    """
+    from unittest.mock import MagicMock
+
+    profile = ModelProfile(
+        model_name="qwen/35b",
+        engine="vllm",
+        residency_source="calibrated",
+        base_residency_mb=94667.0,
+        kv_budget_mb=10240.0,
+        min_kv_cache_mb=1024.0,
+        max_kv_cache_mb=10240.0,
+    )
+    capacity = MagicMock()
+    capacity.available_vram_mb = 97770.0
+    planner = _planner_for_kv_estimate(97770.0)
+
+    avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
+    assert avail is not None
+    assert avail > 2048.0  # the (2G, 205920) pair now fits
+    assert 5000.0 < avail < 6200.0  # weights-based, not the ~527 base-inclusive underflow
+
+
+def test_estimate_available_for_kv_uses_full_base_for_uncalibrated():
+    """Uncalibrated/measured profiles keep the weights-only base convention —
+    no kv_budget to subtract, so the full base is used."""
+    from unittest.mock import MagicMock
+
+    profile = ModelProfile(
+        model_name="x/y",
+        engine="vllm",
+        residency_source="measured",
+        base_residency_mb=40000.0,
+        kv_budget_mb=4096.0,
+    )
+    capacity = MagicMock()
+    capacity.available_vram_mb = 90000.0
+    planner = _planner_for_kv_estimate(90000.0)
+
+    avail = planner._estimate_available_for_kv_mb(profile, capacity, provider_id=1, tp=2)
+    # per_gpu_total 45000 - per_gpu_base 20000 - 1024 headroom = 23976 (no kv subtraction)
+    assert abs(avail - 23976.0) < 1.0

--- a/logos/logos-workernode/docker-compose.yml
+++ b/logos/logos-workernode/docker-compose.yml
@@ -38,6 +38,11 @@ services:
       # ── Fixed container paths ──────────────────────────────────────────
       LOGOS_WORKER_NODE_CONFIG: /app/config.yml
       LOGOS_STATE_DIR: /app/data
+      # Global request-lifecycle timeout (empty = per-stage defaults; benchmark sets 86400).
+      LOGOS_TIMEOUT_S: ${LOGOS_TIMEOUT_S:-}
+      # Stuck-detection dwell (seconds) before a no-progress lane may be killed
+      # (empty = code default 180s). Raise to reduce false positives on slow lanes.
+      LOGOS_STUCK_DURATION_SECONDS: ${LOGOS_STUCK_DURATION_SECONDS:-}
       HF_HOME: /usr/share/ollama/.ollama/models/.hf_cache
       # ── GPU / CUDA ────────────────────────────────────────────────────
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
@@ -110,6 +115,11 @@ services:
     environment:
       LOGOS_WORKER_NODE_CONFIG: /app/config.yml
       LOGOS_STATE_DIR: /app/data
+      # Global request-lifecycle timeout (empty = per-stage defaults; benchmark sets 86400).
+      LOGOS_TIMEOUT_S: ${LOGOS_TIMEOUT_S:-}
+      # Stuck-detection dwell (seconds) before a no-progress lane may be killed
+      # (empty = code default 180s). Raise to reduce false positives on slow lanes.
+      LOGOS_STUCK_DURATION_SECONDS: ${LOGOS_STUCK_DURATION_SECONDS:-}
       HF_TOKEN: ${HF_TOKEN:-}
       HF_HOME: /usr/share/ollama/.ollama/models/.hf_cache
       LOGOS_TMPFS_CACHE_PATH: ${LOGOS_TMPFS_CACHE_PATH:-}

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -559,6 +559,21 @@ def _classify_node_transient_error(log_tail: str) -> NodeTransientErrorPattern |
 _VLLM_MAX_MODEL_LEN_SUGGESTION_RE = re.compile(r"estimated maximum model length is (\d+)")
 _VLLM_MAX_SEQ_LEN_RE = re.compile(r"max seq len \((\d+)\)")
 _VLLM_MAX_MODEL_LEN_CONFIG_RE = re.compile(r"max_model_len\s*[=:]\s*(\d+)")
+# "... the model's max seq len (131072), 8.94 GiB KV cache is needed ..." — the
+# KV required to serve the model's FULL context. With the max seq len this gives
+# the KV→context rate, letting the sweep COMPUTE the curve instead of crawling.
+_VLLM_KV_GIB_NEEDED_RE = re.compile(r"([\d.]+)\s*GiB KV cache is needed")
+
+
+def _extract_vllm_kv_gib_needed_for_full(log_tail: str) -> float | None:
+    """GiB of KV cache vLLM says it needs to serve the model's full max seq len."""
+    m = _VLLM_KV_GIB_NEEDED_RE.search(log_tail)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
 
 
 def _extract_vllm_max_model_len_suggestion(log_tail: str) -> int | None:
@@ -1687,10 +1702,11 @@ def calibrate_model(
         # the resolved max_model_len on success, or None if the model failed to
         # start at this KV size. Records the probe in _probes and renders the bar.
         model_default_max_len: int | None = None
+        kv_needed_for_full_mb: float | None = None
         best_kv: float | None = None
 
         def _probe_kv(kv_mb: float) -> int | None:
-            nonlocal model_default_max_len, best_kv, resolved_max_num_seqs
+            nonlocal model_default_max_len, kv_needed_for_full_mb, best_kv, resolved_max_num_seqs
             probe_overrides: dict[str, Any] = {"max_model_len": None, "_max_model_len_retry_count": 0}
             p = _try_start(kv_mb, plan_overrides=probe_overrides, record_blacklist=False, allow_whitelist=False)
             if p is None:
@@ -1705,6 +1721,10 @@ def calibrate_model(
             suggested_mml = _extract_vllm_max_model_len_suggestion(log_tail)
             if model_default_max_len is None:
                 model_default_max_len = _extract_vllm_max_seq_len(log_tail)
+            if kv_needed_for_full_mb is None:
+                _gib = _extract_vllm_kv_gib_needed_for_full(log_tail)
+                if _gib:
+                    kv_needed_for_full_mb = _gib * 1024.0
             resolved_mml = int(probe_overrides.get("_resolved_max_model_len") or 0)
             if resolved_mml <= 0:
                 resolved_mml = int(suggested_mml or model_default_max_len or 0)
@@ -1758,37 +1778,22 @@ def calibrate_model(
         kv_max_model_len_pairs.append((kv_lo, first_mml))
         max_mml_seen = first_mml
 
-        # 2) Rising edge: step upward from kv_lo, PROBING each (kv, max_model_len),
-        #    until max_model_len reaches the model's full context (plateau) or a
-        #    step OOMs (window ceiling). Above kv_lo, loadability is monotonic, so
-        #    the first OOM is the ceiling. The rising edge is probed empirically
-        #    (vLLM allocates KV in blocks — not cleanly linear); only the plateau
-        #    (step 4) is safe to fill by inference.
-        plateau_kv: float | None = None
-        if model_default_max_len and first_mml >= model_default_max_len:
-            plateau_kv = kv_lo  # full context already fits at the lower edge
-        else:
-            kv = kv_lo + _KV_CACHE_MIN_STEP_MB
-            while kv <= search_hi:
-                if _cancelled():
-                    return partial
-                mml = _probe_kv(kv)
-                if mml is None:
-                    break  # hit the VRAM ceiling; best_kv is the largest that loaded
-                best_kv = kv
-                kv_max_model_len_pairs.append((kv, mml))
-                max_mml_seen = max(max_mml_seen, mml)
-                if model_default_max_len and mml >= model_default_max_len:
-                    plateau_kv = kv  # full context reached — stop probing upward
-                    break
-                kv += _KV_CACHE_MIN_STEP_MB
+        # 2) Determine the curve WITHOUT crawling 1 GiB at a time. vLLM's "KV too
+        #    small" error reports both the model's full context (M) and the KV
+        #    needed to serve it, i.e. the KV→context rate. So: binary-search the
+        #    startable-window ceiling (recording real anchor points), then COMPUTE
+        #    max_model_len at every KV step from that rate (capped at M), validated
+        #    against the anchors. If the rate is unavailable or fails validation,
+        #    fall back to the (sparse but correct) probed anchors.
+        plateau_at_floor = bool(model_default_max_len and first_mml >= model_default_max_len)
 
-        # 3) Find the startable-window ceiling. If the context plateaued, larger
-        #    KV still fits more VRAM — binary-search upward to the ceiling
-        #    (loadability is monotonic), recording the points it probes. This
-        #    avoids both a long linear walk and a tail of failing OOM probes.
-        if plateau_kv is not None and search_hi - plateau_kv >= _KV_CACHE_MIN_STEP_MB:
-            lo, hi = plateau_kv, search_hi
+        # Real anchor points (kv -> actual max_model_len), starting at the floor.
+        anchors: dict[float, int] = {kv_lo: first_mml}
+
+        # Binary-search the largest startable KV (loadability is monotonic above
+        # kv_lo) — ~log2(window) probes instead of a 1 GiB-per-step walk.
+        if search_hi - kv_lo >= _KV_CACHE_MIN_STEP_MB:
+            lo, hi = kv_lo, search_hi
             while hi - lo >= _KV_CACHE_MIN_STEP_MB:
                 if _cancelled():
                     return partial
@@ -1800,20 +1805,50 @@ def calibrate_model(
                     hi = mid - _KV_CACHE_MIN_STEP_MB
                 else:
                     best_kv = mid
-                    kv_max_model_len_pairs.append((mid, m))
+                    anchors[mid] = m
+                    max_mml_seen = max(max_mml_seen, m)
                     lo = mid
         kv_max = best_kv
 
-        # 4) Fill the plateau by inference: once the full context is reachable,
-        #    every larger KV that still loads (≤ kv_max) serves that same max
-        #    context — record those residual points without probing each one.
-        if plateau_kv is not None:
-            plateau_value = max_mml_seen
-            fill_kv = plateau_kv + _KV_CACHE_MIN_STEP_MB
-            while fill_kv <= kv_max:
-                if fill_kv not in _probes:
-                    kv_max_model_len_pairs.append((fill_kv, plateau_value))
-                fill_kv += _KV_CACHE_MIN_STEP_MB
+        cap = model_default_max_len or max_mml_seen or first_mml
+
+        # Derive the KV→context rate from vLLM's report and validate it against
+        # every real anchor; discard it (anchors-only) if it is >10% off anywhere.
+        per_token_bytes: float | None = None
+        if kv_needed_for_full_mb and model_default_max_len:
+            per_token_bytes = (kv_needed_for_full_mb * 1024.0 * 1024.0) / model_default_max_len
+            for a_kv, a_mml in anchors.items():
+                if a_mml <= 0:
+                    continue
+                comp = min(cap, int((a_kv * 1024.0 * 1024.0) / per_token_bytes))
+                if abs(comp - a_mml) / a_mml > 0.10:
+                    logger.warning(
+                        "  KV/context rate off at %s (computed=%d vs actual=%d) — using probed anchors only.",
+                        _format_kv_mb(a_kv),
+                        comp,
+                        a_mml,
+                    )
+                    per_token_bytes = None
+                    break
+
+        # Emit the full curve across [kv_lo, kv_max]: real anchors win; gaps are
+        # filled from the validated rate (rising + plateau, capped at M), or from
+        # the plateau value when the full context already fit at the floor.
+        kv_step = kv_lo
+        while kv_step <= kv_max:
+            if kv_step in anchors:
+                mml_pt = anchors[kv_step]
+            elif per_token_bytes:
+                mml_pt = min(cap, int((kv_step * 1024.0 * 1024.0) / per_token_bytes))
+            elif plateau_at_floor:
+                mml_pt = cap
+            else:
+                kv_step += _KV_CACHE_MIN_STEP_MB
+                continue  # no signal for this gap — rely on the anchors
+            if mml_pt > 0:
+                kv_max_model_len_pairs.append((kv_step, mml_pt))
+                max_mml_seen = max(max_mml_seen, mml_pt)
+            kv_step += _KV_CACHE_MIN_STEP_MB
 
         kv_cache_sent_mb = best_kv
         # Keep the FULL window (rising edge + filled plateau), deduped on exact

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1850,6 +1850,30 @@ def calibrate_model(
                 max_mml_seen = max(max_mml_seen, mml_pt)
             kv_step += _KV_CACHE_MIN_STEP_MB
 
+        # Backfill the plateau and drop non-positive points. Once the curve
+        # reaches the model's full context, every LARGER KV still serves at
+        # least that context — leaving those upper steps at 0 (or absent) wrongly
+        # documents a big-KV lane as max_model_len=0. Hold the plateau (highest
+        # mml seen, capped at the model max) across [first-full-context-KV,
+        # kv_max], and discard any 0/garbage entries.
+        _clean = [(k, m) for k, m in kv_max_model_len_pairs if m and m > 0]
+        if _clean:
+            _plateau = max(m for _, m in _clean)
+            if model_default_max_len:
+                _plateau = min(_plateau, int(model_default_max_len))
+            _by_kv: dict[float, int] = {}
+            for k, m in _clean:
+                rk = round(k, 1)
+                _by_kv[rk] = max(_by_kv.get(rk, 0), int(m))
+            _first_full_kv = min((k for k, m in _clean if m >= _plateau), default=None)
+            if _first_full_kv is not None:
+                _s = _first_full_kv
+                while _s <= kv_max:
+                    rk = round(_s, 1)
+                    _by_kv[rk] = max(_by_kv.get(rk, 0), _plateau)
+                    _s += _KV_CACHE_MIN_STEP_MB
+            kv_max_model_len_pairs = sorted(_by_kv.items())
+
         kv_cache_sent_mb = best_kv
         # Keep the FULL window (rising edge + filled plateau), deduped on exact
         # (kv, max_model_len) and ordered by ascending KV. The planner picks the

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -758,6 +758,14 @@ def _build_vllm_cmd(
     max_num_seqs = plan.get("max_num_seqs")
     enforce_eager = bool(plan.get("enforce_eager", False))
     disable_custom_all_reduce = bool(plan.get("disable_custom_all_reduce", False))
+    # Match the serving lane's engine config. Runtime lanes default to
+    # enable_prefix_caching=True (models.LaneConfig), which changes vLLM's KV
+    # accounting: the max_model_len that fits a given KV budget WITH prefix
+    # caching is a few % lower than without it. Calibrating WITHOUT prefix
+    # caching therefore records an optimistic max_model_len that the serving
+    # lane can't actually honor (vLLM rejects "needs X GiB > budget" at start).
+    # Calibrate the same engine config that serves so the pair curve is exact.
+    enable_prefix_caching = bool(plan.get("enable_prefix_caching", True))
     extra_args: list[str] = list(plan.get("extra_args") or [])
     kv_bytes = str(plan.get("kv_cache_memory_bytes") or kv_cache_memory_bytes)
     kv_cache_dtype = str(plan.get("kv_cache_dtype") or "")
@@ -779,6 +787,8 @@ def _build_vllm_cmd(
         kv_bytes,
         "--enable-sleep-mode",
     ]
+    if enable_prefix_caching:
+        cmd.append("--enable-prefix-caching")
     if explicit_gmu is not None:
         cmd.extend(["--gpu-memory-utilization", str(explicit_gmu)])
     if max_model_len:

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import socket
 from datetime import datetime, timezone
 from itertools import combinations
@@ -291,8 +292,12 @@ class LaneManager:
         # many polls in seconds and trip a count-based threshold during
         # normal prefill.
         self._stuck_since: dict[str, float] = {}
-        _STUCK_DURATION_SECONDS = 60.0
-        self._stuck_duration_seconds = _STUCK_DURATION_SECONDS
+        # Dwell window before a no-progress lane is considered stuck. A genuine
+        # wedge (NCCL deadlock / mm-cache desync) never recovers, so a longer
+        # window costs nothing but stops merely-slow lanes (slow first token on a
+        # cold 35B, long reasoning generations) from being false-flagged.
+        # Overridable via LOGOS_STUCK_DURATION_SECONDS.
+        self._stuck_duration_seconds = float(os.getenv("LOGOS_STUCK_DURATION_SECONDS") or 180.0)
         self._last_crash_restart_attempt_at: dict[str, float] = {}
         self._crash_restart_counts: dict[str, int] = {}
         self._static_lane_ids: set[str] = set()
@@ -2128,19 +2133,82 @@ class LaneManager:
                 liveness_stuck = liveness_failures >= _LIVENESS_FAILURE_THRESHOLD
 
             if engine_stuck or proxy_stuck or liveness_stuck:
+                # Name every sub-detection that is currently asserting (more than
+                # one can fire at once) so the logs show exactly WHY a lane is on
+                # the stuck-watch and which signal ultimately kills it.
+                active_signals = ",".join(
+                    s
+                    for s, on in (
+                        ("engine_stuck", engine_stuck),
+                        ("proxy_stuck", proxy_stuck),
+                        ("liveness_stuck", liveness_stuck),
+                    )
+                    if on
+                )
+                reason = "engine_stuck" if engine_stuck else ("proxy_stuck" if proxy_stuck else "liveness_stuck")
                 stuck_since = self._stuck_since.get(lid)
                 if stuck_since is None:
                     self._stuck_since[lid] = now
+                    worker_active = self._active_requests.get(lid, 0)
+                    logger.warning(
+                        "Lane '%s' entered stuck-watch [%s]: requests_running=%s "
+                        "prompt_tokens=%s generation_tokens=%s worker_active=%d "
+                        "liveness_failures=%d. Will kill if unchanged for %.0fs.",
+                        lid,
+                        active_signals,
+                        requests_running,
+                        prompt_tokens,
+                        gen_tokens,
+                        worker_active,
+                        liveness_failures,
+                        self._stuck_duration_seconds,
+                    )
+                    self._record_event(
+                        lid,
+                        "stuck_watch_started",
+                        model=status.model,
+                        details=(
+                            f"signals={active_signals}, running={requests_running}, "
+                            f"worker_active={worker_active}, liveness_failures={liveness_failures}"
+                        ),
+                    )
                     continue
                 elapsed = now - stuck_since
                 if elapsed >= self._stuck_duration_seconds:
-                    if engine_stuck:
-                        reason = "engine_stuck"
-                    elif proxy_stuck:
-                        reason = "proxy_stuck"
-                    else:
-                        reason = "liveness_stuck"
                     worker_active = self._active_requests.get(lid, 0)
+                    # "Really stuck" confirmation. A no-progress window alone is not
+                    # proof of a wedge — token counters freeze briefly on a healthy
+                    # lane (slow first token on a cold 35B, a long reasoning step).
+                    # When the lane is not already flagged dead by the liveness
+                    # probe, do a final active EngineCore round-trip: if /is_sleeping
+                    # answers, the engine RPC is alive and this is slowness, not a
+                    # wedge — hold off and re-arm. A genuine wedge (NCCL deadlock /
+                    # post-wake mm-cache desync) fails the probe and is killed below,
+                    # cancelling its in-flight request as intended.
+                    if not liveness_stuck and isinstance(handle, VllmProcessHandle):
+                        try:
+                            probe = await handle.is_sleeping()
+                        except Exception:  # noqa: BLE001
+                            probe = None
+                        if probe is not None:  # True/False == a successful RPC round-trip
+                            logger.warning(
+                                "Lane '%s' flagged %s after %.1fs but EngineCore RPC still "
+                                "responds (is_sleeping=%s) — slow, not stuck; not killing.",
+                                lid,
+                                reason,
+                                elapsed,
+                                probe,
+                            )
+                            self._record_event(
+                                lid,
+                                "stuck_probe_alive",
+                                model=status.model,
+                                details=f"reason={reason}, elapsed={elapsed:.1f}s, is_sleeping={probe}",
+                            )
+                            self._stuck_since.pop(lid, None)
+                            self._last_gen_tokens.pop(lid, None)
+                            self._last_prompt_tokens.pop(lid, None)
+                            continue
                     logger.error(
                         "Lane '%s' appears stuck (%s): elapsed=%.1fs "
                         "requests_running=%s prompt_tokens=%s "
@@ -2161,6 +2229,7 @@ class LaneManager:
                         model=status.model,
                         details=(
                             f"reason={reason}, "
+                            f"signals={active_signals}, "
                             f"prompt_tokens={prompt_tokens}, "
                             f"gen_tokens={gen_tokens}, "
                             f"running={requests_running}, "

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -26,6 +26,7 @@ from logos_worker_node.calibration import (
     _UNSUPPORTED_MODELS_FILE,
     CalibrationResult,
     UnsupportedModelEntry,
+    _build_vllm_cmd,
     _classify_fatal_load_error,
     _classify_node_transient_error,
     _extract_vllm_max_model_len_suggestion,
@@ -1924,3 +1925,18 @@ def test_sweep_computes_rising_curve_from_vllm_rate_without_crawling():
     assert len({round(k) for k, _ in pairs}) >= 15
     # ... but we did NOT probe every 1 GiB step to get there.
     assert len(kv_calls) < 12
+
+
+def test_build_vllm_cmd_enables_prefix_caching_to_match_serving():
+    """Calibration must spawn vLLM with --enable-prefix-caching, because serving
+    lanes default to it (models.LaneConfig.enable_prefix_caching=True). Without
+    matching, the calibrated max_model_len is optimistic vs the serving config
+    and the lane fails to start ("KV needed > budget"). Default on; explicit
+    False omits it."""
+    plan = {"model": "m", "tensor_parallel_size": 2, "max_model_len": 1000}
+    cmd = _build_vllm_cmd(plan, "vllm", "127.0.0.1", 11499, "1G")
+    assert "--enable-prefix-caching" in cmd
+
+    plan_off = {**plan, "enable_prefix_caching": False}
+    cmd_off = _build_vllm_cmd(plan_off, "vllm", "127.0.0.1", 11499, "1G")
+    assert "--enable-prefix-caching" not in cmd_off

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -1874,3 +1874,53 @@ def test_sweep_detects_window_ceiling_and_fills_plateau():
     kvs = sorted(round(kv) for kv, _ in pairs)
     assert kvs == [1024, 2048, 3072, 4096, 5120]
     assert result.max_model_len == 8192
+
+
+def test_sweep_computes_rising_curve_from_vllm_rate_without_crawling():
+    """Plateau unreachable (full context needs more KV than fits): the sweep must
+    derive the KV->context rate from vLLM's report and COMPUTE the curve with only
+    a handful of probes — not a 1 GiB-per-step crawl to the ceiling."""
+    M = 131072
+    K_FULL_GIB = 22.0  # KV needed for full context > 20G ceiling => never plateaus
+    per_token = (K_FULL_GIB * 1024 * 1024 * 1024) / M
+    kv_calls: list = []
+
+    def spawn_side_effect(plan, vllm_binary, host, port, log_path, kv_cache_memory_bytes, **kwargs):
+        kv_calls.append(_parse_kv_to_mb(kv_cache_memory_bytes))
+        mp = MagicMock()
+        mp.pid = 1
+        mp.poll.return_value = None
+        return (mp, ["vllm", "serve"])
+
+    def wait_ready_side_effect(*a, **k):
+        if kv_calls[-1] >= 21504.0:  # OOM at 21G+
+            raise RuntimeError("OOM")
+        return None
+
+    def suggest_side_effect(log_tail):
+        return min(M - 1, int(kv_calls[-1] * 1024 * 1024 / per_token))
+
+    patches = _patch_search_infra(wait_ready_side_effect=wait_ready_side_effect, gpu_vram_total_mb=48000.0)
+    patches["spawn"] = patch("logos_worker_node.calibration.spawn_vllm", side_effect=spawn_side_effect)
+    patches["ready"] = patch("logos_worker_node.calibration.wait_ready", side_effect=wait_ready_side_effect)
+    patches["maxseq"] = patch("logos_worker_node.calibration._extract_vllm_max_seq_len", return_value=M)
+    patches["kvneeded"] = patch(
+        "logos_worker_node.calibration._extract_vllm_kv_gib_needed_for_full", return_value=K_FULL_GIB
+    )
+    patches["suggest"] = patch(
+        "logos_worker_node.calibration._extract_vllm_max_model_len_suggestion", side_effect=suggest_side_effect
+    )
+
+    result, _ = _run_search_calibrate(patches, plan=_make_search_plan())
+
+    assert result.success
+    pairs = result.kv_max_model_len_pairs
+    assert pairs
+    assert all(0 < mml < M for _, mml in pairs)  # never plateaus
+    by_kv = sorted(pairs)
+    assert by_kv[0][1] < by_kv[-1][1]  # rising
+    assert 19456 <= by_kv[-1][0] <= 20480  # ceiling ~20G (OOM at 21G)
+    # The whole window is covered by the computed curve ...
+    assert len({round(k) for k, _ in pairs}) >= 15
+    # ... but we did NOT probe every 1 GiB step to get there.
+    assert len(kv_calls) < 12


### PR DESCRIPTION
…orted rate

The KV sweep crawled the rising edge 1 GiB at a time (a full vLLM start per step), which is very slow for models whose full context needs more KV than fits (no plateau → walks the whole window, ~20+ loads/model/node).

vLLM's "KV too small" error already reports the model's full context (M) and the KV needed to serve it ("<X> GiB KV cache is needed") — the KV→context rate. Use it:
- Binary-search the startable-window ceiling (records real anchor points), ~log2 probes instead of a per-GiB walk.
- Derive per-token KV from the reported rate and COMPUTE max_model_len at each KV step (capped at M), validated against the probed anchors; fall back to anchors-only if the rate is unavailable or off by >10%.

Cuts a ~20-probe rising crawl to a handful. Adds a test asserting the computed curve is produced with <12 probes for an unreachable-plateau model.

Please go to the `Preview` tab and select the appropriate sub-template:

* [Athena](?expand=1&template=athena.md)
* [Atlas](?expand=1&template=atlas.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced KV-cache calibration with validated KV→context curve generation and improved plateau handling for more reliable results.
  * Benchmark calibration now more reliably finishes pending calibrations (without full resets), shows live progress during runs, and always applies configured calibration provider IDs.
  * Safer capacity planning for calibrated KV via improved envelope selection and corrected KV headroom estimation.
  * vLLM serving enables prefix caching by default; increased inference/stream timeouts help reduce load-time stream/protocol errors.
* **Tests**
  * Added coverage for calibration edge cases, orchestration behavior, and calibrated KV envelope/headroom logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->