### PR TITLE
`Logos`: Use sharded model checkpoint for TP>1 lanes

### DIFF
--- a/logos/logos-workernode/config.yml
+++ b/logos/logos-workernode/config.yml
@@ -51,6 +51,20 @@ engines:
     # lane and via sleep_mode_disabled in WorkerRuntimeStatus, so the
     # planner falls back to stop/start for VRAM reclamation here.
     disable_sleep_mode: false
+    # Sharded-checkpoint loading for tensor-parallel (TP>1) lanes. With TP>1
+    # every vLLM rank otherwise reads the whole checkpoint and slices out its
+    # shard, so cold-start load time grows with TP. When enabled, the worker
+    # pre-converts the model to a sharded_state checkpoint (each rank reads
+    # only its own shard → load time roughly constant in TP) and serves it
+    # with --load-format sharded_state. Conversion runs right after calibration
+    # when the calibrated TP is >1, or lazily before a TP>1 lane is spawned if
+    # not yet converted. Checkpoints live under
+    # <cache_root>/.sharded_cache/<model>/tp<N>/.
+    sharded_checkpoint_enabled: true
+    # Allow the lazy, spawn-time fallback conversion (set false to only use
+    # checkpoints converted by the post-calibration trigger, so a lane spawn
+    # never blocks on a conversion).
+    sharded_checkpoint_convert_on_spawn: true
     # Turing (SM 7.5) workaround for AWQ + TP=2 on Quadro RTX 5000:
     # force AWQ path, disable vLLM custom all-reduce kernels (PCIe, no NVLink),
     # disable NCCL P2P transfers, and run in eager mode for SM 7.5 stability.

--- a/logos/logos-workernode/logos_worker_node/_sharded_convert.py
+++ b/logos/logos-workernode/logos_worker_node/_sharded_convert.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Standalone vLLM sharded-state checkpoint converter (run as a subprocess).
+
+This script is intentionally free of any ``logos_worker_node`` imports so it can
+be executed by whichever Python interpreter has vLLM installed — which is not
+necessarily the interpreter running the worker process (vLLM frequently lives
+in a dedicated venv such as ``/opt/venv``). It is therefore invoked by file
+path, e.g. ``/opt/venv/bin/python _sharded_convert.py --model ... --output ...``.
+
+It mirrors vLLM's official ``examples/features/sharded_state/
+save_sharded_state_offline.py`` (pinned to the vLLM version in the worker
+image), adding HuggingFace resolution so a bare model id can be converted
+without a pre-resolved local path.
+
+Usage::
+
+    python _sharded_convert.py \\
+        --model <hf-id-or-local-dir> \\
+        --tensor-parallel-size N \\
+        --output /path/to/sharded/dir \\
+        [--dtype auto] [--quantization awq] [--trust-remote-code] \\
+        [--max-file-size BYTES] [--file-pattern PATTERN]
+
+On success it prints a confirmation line and exits 0; the caller writes the
+completion marker once it sees a clean exit and shard files on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+_WEIGHT_SUFFIXES = (".bin", ".pt", ".safetensors")
+
+
+def _resolve_local_model_dir(model: str) -> str:
+    """Return a local directory for ``model``, downloading from HF if needed."""
+    if Path(model).is_dir():
+        return model
+    from huggingface_hub import snapshot_download  # noqa: PLC0415
+
+    # Respects HF_HOME / HF_TOKEN from the environment, which the caller sets.
+    return snapshot_download(model, token=os.environ.get("HF_TOKEN") or None)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert a model checkpoint to a vLLM sharded_state checkpoint.")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tensor-parallel-size", type=int, required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--dtype", default="auto")
+    parser.add_argument("--quantization", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--max-file-size", type=int, default=5 * 1024**3)
+    parser.add_argument("--file-pattern", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    from vllm import LLM, EngineArgs  # noqa: PLC0415
+    from vllm.model_executor.model_loader import ShardedStateLoader  # noqa: PLC0415
+
+    model_path = _resolve_local_model_dir(args.model)
+    if not Path(model_path).is_dir():
+        print(
+            f"[sharded-convert] model path is not a local directory: {model_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    pattern = args.file_pattern or ShardedStateLoader.DEFAULT_PATTERN
+
+    engine_args = EngineArgs(
+        model=model_path,
+        tensor_parallel_size=args.tensor_parallel_size,
+        dtype=args.dtype,
+        quantization=(args.quantization or None),
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    # Loads the full checkpoint across ``tensor_parallel_size`` ranks on GPU.
+    llm = LLM.from_engine_args(engine_args)
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Dump each rank's shard directly to the output directory.
+    llm.llm_engine.engine_core.save_sharded_state(path=str(out), pattern=pattern, max_size=args.max_file_size)
+
+    # Copy metadata (config.json, tokenizer, generation config, …) — everything
+    # that is not a raw weight file — so the output is a self-contained model
+    # directory vLLM can serve with --load-format sharded_state.
+    for name in os.listdir(model_path):
+        if os.path.splitext(name)[1] in _WEIGHT_SUFFIXES:
+            continue
+        src = os.path.join(model_path, name)
+        dst = os.path.join(str(out), name)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy(src, dst)
+
+    print(f"[sharded-convert] wrote sharded checkpoint to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -967,6 +967,12 @@ class LogosBridgeClient:
                             lane_manager._mark_status_dirty()  # noqa: SLF001
                         except Exception:  # noqa: BLE001
                             logger.debug("[Calibration] _mark_status_dirty failed", exc_info=True)
+
+                    # Issue #615: when the calibrated TP is >1, pre-shard the
+                    # checkpoint now while the GPU is free, so the lane that
+                    # serves this model later loads each rank's shard directly
+                    # instead of every rank re-reading the full checkpoint.
+                    await self._maybe_convert_sharded_checkpoint(model_name, result, plan, session, cfg, log_dir)
                 else:
                     logger.warning(
                         "[Calibration] Failed model=%s error=%s",
@@ -1015,6 +1021,87 @@ class LogosBridgeClient:
             if self._active_calibration_session is session:
                 self._active_calibration_session = None
             logger.info("[Calibration] Session ended (%s)", terminal_event)
+
+    async def _maybe_convert_sharded_checkpoint(
+        self,
+        model_name: str,
+        result: Any,
+        plan: dict[str, Any],
+        session: _CalibrationSession,
+        cfg: Any,
+        log_dir: Any,
+    ) -> None:
+        """Pre-shard a model's checkpoint after calibration when its TP is >1.
+
+        Runs the (blocking, GPU-loading) conversion on the thread executor with
+        the session's cancel_event wired through, so stop_calibration_session
+        tears it down within ~2s. Best-effort: any failure is logged and the
+        model still serves from its full checkpoint. See issue #615.
+        """
+        try:
+            from pathlib import Path  # noqa: PLC0415
+
+            from logos_worker_node import sharded_checkpoint as sc  # noqa: PLC0415
+            from logos_worker_node.calibration import _DEFAULT_VLLM  # noqa: PLC0415
+
+            vc_engine = cfg.engines.vllm if cfg.engines else None
+            if vc_engine is None or not getattr(vc_engine, "sharded_checkpoint_enabled", True):
+                return
+            tp = int(getattr(result, "tensor_parallel_size", 1) or 1)
+            min_tp = max(2, int(getattr(vc_engine, "sharded_checkpoint_min_tensor_parallel_size", 2)))
+            if tp < min_tp:
+                return
+
+            models_path = cfg.engines.ollama.models_path if cfg.engines else ""
+            cache_root = sc.resolve_cache_root(models_path)
+            if not cache_root:
+                return
+            target = sc.sharded_checkpoint_dir(cache_root, model_name, tp)
+            if sc.is_sharded_checkpoint_ready(target):
+                return
+
+            import os as _os  # noqa: PLC0415
+
+            hf_home = _os.environ.get("HF_HOME", "").strip() or str(Path(cache_root) / ".hf_cache")
+            gpu_devices = str(getattr(result, "gpu_devices", "") or plan.get("gpu_devices") or "")
+            dtype = str(plan.get("dtype", "auto") or "auto")
+            quant = str(plan.get("quantization") or "")
+            trust = "--trust-remote-code" in (plan.get("extra_args") or [])
+
+            self._record_calibration_event("sharded_conversion_started", model=model_name, details=f"tp={tp}")
+            logger.info("[Calibration] Converting %s to sharded checkpoint (tp=%d)", model_name, tp)
+
+            loop = asyncio.get_running_loop()
+            out = await loop.run_in_executor(
+                None,
+                lambda: sc.ensure_sharded_checkpoint(
+                    model=model_name,
+                    tensor_parallel_size=tp,
+                    cache_root=cache_root,
+                    vllm_binary=_DEFAULT_VLLM,
+                    hf_home=hf_home,
+                    gpu_devices=gpu_devices,
+                    dtype=dtype,
+                    quantization=quant,
+                    trust_remote_code=trust,
+                    nccl_p2p_available=vc_engine.nccl_p2p_available,
+                    max_file_size_bytes=int(
+                        getattr(vc_engine, "sharded_checkpoint_max_file_size_bytes", sc.DEFAULT_MAX_FILE_SIZE_BYTES)
+                    ),
+                    log_path=log_dir / f"sharded_{model_name.replace('/', '__')}_tp{tp}.log",
+                    cancel_event=session.cancel_event,
+                ),
+            )
+            if out is not None:
+                self._record_calibration_event(
+                    "sharded_conversion_completed", model=model_name, details=f"tp={tp} path={out}"
+                )
+                logger.info("[Calibration] Sharded checkpoint ready for %s: %s", model_name, out)
+            else:
+                self._record_calibration_event("sharded_conversion_failed", model=model_name, details=f"tp={tp}")
+                logger.warning("[Calibration] Sharded conversion failed/skipped for %s (tp=%d)", model_name, tp)
+        except Exception:  # noqa: BLE001
+            logger.exception("[Calibration] Sharded conversion errored for %s", model_name)
 
     # vLLM endpoints that must never be reachable through proxied inference
     # requests.  These are internal management endpoints (sleep/wake, cache

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -242,6 +242,38 @@ class VllmEngineConfig(BaseModel):
             "(EXT4 over rbd-nbd / kernel block layer rather than NFS/Lustre)."
         ),
     )
+    sharded_checkpoint_enabled: bool = Field(
+        default=True,
+        description=(
+            "Use pre-sharded vLLM checkpoints for tensor-parallel (TP>1) lanes. "
+            "When enabled, the worker converts a model to a sharded_state "
+            "checkpoint (each rank then reads only its own shard, keeping "
+            "cold-start load time roughly constant in TP instead of growing "
+            "linearly) and serves it with --load-format sharded_state. "
+            "Conversion runs right after calibration when the calibrated TP is "
+            ">1, or lazily before a TP>1 lane is spawned if not yet converted. "
+            "Set false to always load the full checkpoint."
+        ),
+    )
+    sharded_checkpoint_convert_on_spawn: bool = Field(
+        default=True,
+        description=(
+            "Allow the lazy, spawn-time fallback conversion when a TP>1 lane is "
+            "spawned and no sharded checkpoint exists yet. Disable to only ever "
+            "use checkpoints converted by the post-calibration trigger, so a "
+            "lane spawn never blocks on a (potentially long) conversion."
+        ),
+    )
+    sharded_checkpoint_min_tensor_parallel_size: int = Field(
+        default=2,
+        ge=2,
+        description="Minimum tensor_parallel_size that triggers sharded-checkpoint conversion.",
+    )
+    sharded_checkpoint_max_file_size_bytes: int = Field(
+        default=5 * 1024**3,
+        ge=1,
+        description="Max size (bytes) of each shard file written during conversion (vLLM --max-file-size).",
+    )
 
     @field_validator("model_overrides", mode="before")
     @classmethod

--- a/logos/logos-workernode/logos_worker_node/sharded_checkpoint.py
+++ b/logos/logos-workernode/logos_worker_node/sharded_checkpoint.py
@@ -1,0 +1,349 @@
+"""Sharded-state checkpoint conversion + resolution for vLLM TP>1 lanes.
+
+With ``tensor_parallel_size > 1`` every vLLM rank otherwise reads the *entire*
+checkpoint and slices out its own shard, so cold-start load time grows roughly
+linearly with TP (proportional to the model size × TP of disk reads). vLLM
+supports pre-sharded checkpoints (``--load-format sharded_state``) where each
+rank reads only its own shard, keeping load time roughly constant in TP.
+
+This module owns:
+
+  * the on-disk layout for converted checkpoints (keyed by model **and** TP —
+    a sharded checkpoint is only valid for the exact TP it was produced for),
+  * a readiness check (a completion marker written only after a fully-copied,
+    successful conversion — so an interrupted run is never mistaken for done),
+  * the conversion itself, run as a subprocess against the vLLM-equipped
+    interpreter via the standalone :mod:`logos_worker_node._sharded_convert`
+    entrypoint.
+
+Conversion is triggered from two places (issue #615):
+
+  1. right after calibration, when the calibrated TP is > 1
+     (``logos_bridge._run_calibration_session``), and
+  2. lazily, right before a lane with TP>1 is spawned, if no converted
+     checkpoint exists yet (``vllm_process.VllmProcessHandle``).
+
+Both call :func:`ensure_sharded_checkpoint`, which is idempotent: if a ready
+checkpoint already exists it is returned immediately. On any failure it returns
+``None`` and the caller falls back to loading the full checkpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger("logos_worker_node.sharded_checkpoint")
+
+_SHARDED_CACHE_SUBDIR = ".sharded_cache"
+_COMPLETION_MARKER = ".logos_sharded_complete"
+DEFAULT_MAX_FILE_SIZE_BYTES = 5 * 1024**3
+
+_CONVERT_ENTRYPOINT = Path(__file__).with_name("_sharded_convert.py")
+
+# In-process locks keyed by target dir so the calibration trigger and the
+# spawn-time fallback never convert the same checkpoint concurrently. One
+# worker process per node, so cross-process locking is unnecessary.
+_locks_guard = threading.Lock()
+_dir_locks: dict[str, threading.Lock] = {}
+
+
+def _sanitize_model(model: str) -> str:
+    """Filesystem-safe directory name for a HuggingFace model id."""
+    return model.replace("/", "__").replace(":", "__")
+
+
+def resolve_cache_root(models_path: str) -> str:
+    """Resolve the persistent cache root the same way ``vllm_process`` does.
+
+    ``LOGOS_WORKER_CACHE_ROOT`` wins; otherwise the ollama ``models_path``
+    (mounted as a persistent volume in the standard docker-compose) is used.
+    """
+    override = os.environ.get("LOGOS_WORKER_CACHE_ROOT", "").strip()
+    if override:
+        return override
+    return models_path or ""
+
+
+def sharded_checkpoint_dir(cache_root: str, model: str, tp: int) -> Path:
+    """Directory holding the sharded checkpoint for ``(model, tp)``."""
+    return Path(cache_root) / _SHARDED_CACHE_SUBDIR / _sanitize_model(model) / f"tp{int(tp)}"
+
+
+def is_sharded_checkpoint_ready(directory: Path) -> bool:
+    """True when ``directory`` holds a completed conversion."""
+    try:
+        return (directory / _COMPLETION_MARKER).is_file()
+    except OSError:
+        return False
+
+
+def _lock_for(directory: Path) -> threading.Lock:
+    key = str(directory)
+    with _locks_guard:
+        lock = _dir_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _dir_locks[key] = lock
+        return lock
+
+
+def resolve_vllm_python(vllm_binary: str) -> str:
+    """Find a Python interpreter that has vLLM importable.
+
+    The converter runs as ``<python> _sharded_convert.py …`` so it only needs
+    vLLM on its path, not ``logos_worker_node``. vLLM may live in a different
+    venv than the worker process, so the interpreter is derived from the
+    resolved ``vllm`` executable rather than assuming ``sys.executable``.
+    """
+    raw = (vllm_binary or "vllm").strip() or "vllm"
+    candidates: list[str] = []
+
+    # Explicit path to the vllm executable → sibling python in the same venv.
+    if os.path.sep in raw:
+        exe = Path(os.path.expanduser(raw))
+        candidates += [str(exe.with_name("python")), str(exe.with_name("python3"))]
+
+    found = shutil.which(raw) or shutil.which("vllm")
+    if found:
+        p = Path(found)
+        candidates += [str(p.with_name("python")), str(p.with_name("python3"))]
+
+    for root in ("/opt/venv/bin", "/usr/local/bin"):
+        candidates += [os.path.join(root, "python"), os.path.join(root, "python3")]
+
+    for cand in candidates:
+        if cand and os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+
+    # Last resort: the current interpreter — correct when vLLM is installed in
+    # the worker's own venv (the ``sys.executable -m vllm`` resolution path).
+    return sys.executable
+
+
+def _build_convert_env(
+    *,
+    hf_home: str | None,
+    gpu_devices: str,
+    tp: int,
+    nccl_p2p_available: bool,
+    env_overrides: dict[str, str] | None,
+) -> dict[str, str]:
+    """Environment for the converter — mirrors the serving lane's vLLM env."""
+    env = os.environ.copy()
+    if hf_home:
+        env["HF_HOME"] = hf_home
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        env["HF_TOKEN"] = hf_token
+
+    gpu = (gpu_devices or "").strip().lower()
+    if gpu_devices and gpu not in ("all", "none", ""):
+        env["CUDA_VISIBLE_DEVICES"] = gpu_devices
+    elif gpu == "none":
+        env["CUDA_VISIBLE_DEVICES"] = ""
+
+    # NCCL topology — match spawn_vllm / VllmProcessHandle defaults so the
+    # TP>1 conversion behaves like a real lane.
+    if not nccl_p2p_available:
+        env.setdefault("NCCL_P2P_DISABLE", "1")
+    if tp > 1:
+        env.setdefault("TORCH_NCCL_ASYNC_ERROR_HANDLING", "1")
+        env.setdefault("NCCL_CUMEM_ENABLE", "0")
+        env.setdefault("NCCL_TIMEOUT", "1800")
+
+    for k, v in (env_overrides or {}).items():
+        env[str(k)] = str(v)
+    return env
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        proc.wait(timeout=10)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _run_conversion_subprocess(
+    cmd: list[str],
+    env: dict[str, str],
+    log_path: Path | None,
+    timeout_s: float,
+    cancel_event: threading.Event | None,
+) -> bool:
+    """Run the converter, polling for cancellation/timeout. True on exit 0."""
+    log_file = None
+    try:
+        if log_path is not None:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = log_path.open("a", encoding="utf-8")
+            sep = "=" * 72
+            log_file.write(
+                f"\n{sep}\n"
+                f"  Sharded conversion — {time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+                f"  Command: {' '.join(cmd)}\n"
+                f"{sep}\n\n"
+            )
+            log_file.flush()
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=log_file or subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,  # own process group → kill the whole TP tree
+            text=True,
+        )
+    except Exception:
+        logger.exception("[sharded] failed to launch converter")
+        if log_file is not None:
+            log_file.close()
+        return False
+
+    try:
+        deadline = time.monotonic() + max(60.0, timeout_s)
+        while True:
+            try:
+                rc: int | None = proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                rc = None
+            if rc is not None:
+                if rc == 0:
+                    return True
+                logger.error("[sharded] converter exited with code %d", rc)
+                return False
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info("[sharded] conversion cancelled — killing converter")
+                _kill_process_group(proc)
+                return False
+            if time.monotonic() > deadline:
+                logger.error("[sharded] conversion timed out after %.0fs — killing", timeout_s)
+                _kill_process_group(proc)
+                return False
+    finally:
+        if log_file is not None:
+            log_file.close()
+
+
+def _shard_files(directory: Path) -> list[Path]:
+    files: list[Path] = []
+    for suffix in ("*.safetensors", "*.bin", "*.pt"):
+        files.extend(directory.glob(suffix))
+    return files
+
+
+def ensure_sharded_checkpoint(
+    *,
+    model: str,
+    tensor_parallel_size: int,
+    cache_root: str,
+    vllm_binary: str = "vllm",
+    hf_home: str | None = None,
+    gpu_devices: str = "",
+    dtype: str = "auto",
+    quantization: str = "",
+    trust_remote_code: bool = False,
+    nccl_p2p_available: bool = False,
+    max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES,
+    env_overrides: dict[str, str] | None = None,
+    log_path: Path | None = None,
+    timeout_s: float = 3600.0,
+    cancel_event: threading.Event | None = None,
+) -> Path | None:
+    """Return a ready sharded checkpoint for ``(model, tp)``, building if needed.
+
+    Idempotent and blocking. Loads the full checkpoint on GPU once to dump
+    per-rank shards, so the caller must run it with the relevant GPUs free
+    (e.g. right after calibration, or before the lane it precedes is spawned).
+    Returns the checkpoint directory, or ``None`` on failure/cancellation —
+    in which case the caller loads the full checkpoint as before.
+    """
+    tp = int(tensor_parallel_size)
+    if tp < 2:
+        return None
+    if not cache_root:
+        logger.warning("[sharded] no cache_root resolved; skipping conversion for %s", model)
+        return None
+
+    target = sharded_checkpoint_dir(cache_root, model, tp)
+    if is_sharded_checkpoint_ready(target):
+        return target
+
+    if not _CONVERT_ENTRYPOINT.is_file():
+        logger.error("[sharded] converter entrypoint missing: %s", _CONVERT_ENTRYPOINT)
+        return None
+
+    lock = _lock_for(target)
+    if not lock.acquire(blocking=False):
+        logger.info("[sharded] waiting for in-progress conversion of %s (tp=%d)", model, tp)
+        lock.acquire()
+    try:
+        # Double-check after acquiring the lock — another caller may have just
+        # finished while we were waiting.
+        if is_sharded_checkpoint_ready(target):
+            return target
+
+        # Clear any partial output from a previously interrupted attempt.
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+        target.mkdir(parents=True, exist_ok=True)
+
+        python = resolve_vllm_python(vllm_binary)
+        cmd = [
+            python,
+            str(_CONVERT_ENTRYPOINT),
+            "--model",
+            model,
+            "--tensor-parallel-size",
+            str(tp),
+            "--output",
+            str(target),
+            "--dtype",
+            dtype or "auto",
+            "--max-file-size",
+            str(int(max_file_size_bytes)),
+        ]
+        if quantization:
+            cmd.extend(["--quantization", quantization])
+        if trust_remote_code:
+            cmd.append("--trust-remote-code")
+
+        env = _build_convert_env(
+            hf_home=hf_home,
+            gpu_devices=gpu_devices,
+            tp=tp,
+            nccl_p2p_available=nccl_p2p_available,
+            env_overrides=env_overrides,
+        )
+
+        logger.info("[sharded] converting %s → %s (tp=%d) via %s", model, target, tp, python)
+        ok = _run_conversion_subprocess(cmd, env, log_path, timeout_s, cancel_event)
+        if not ok:
+            shutil.rmtree(target, ignore_errors=True)
+            return None
+
+        shards = _shard_files(target)
+        if not shards:
+            logger.error("[sharded] conversion produced no shard files in %s", target)
+            shutil.rmtree(target, ignore_errors=True)
+            return None
+
+        # Marker is written last — its presence is the readiness contract.
+        (target / _COMPLETION_MARKER).write_text(f"model={model}\ntp={tp}\n", encoding="utf-8")
+        logger.info("[sharded] conversion complete: %s (%d shard files)", target, len(shards))
+        return target
+    finally:
+        lock.release()

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -293,6 +293,10 @@ class VllmProcessHandle:
         self._process_group_id: int | None = None
         self._max_concurrency: int | None = None
         self.hf_home_override: str | None = None
+        # Set by _maybe_prepare_sharded_checkpoint when a pre-sharded checkpoint
+        # is used for a TP>1 lane; _build_cmd then serves this directory with
+        # --load-format sharded_state instead of the full checkpoint.
+        self._sharded_model_dir: str | None = None
         # Consecutive liveness-probe failures observed by is_sleeping().
         # The lane manager reads this to escalate to a restart when the API
         # server is alive (/v1/models, /health) but the EngineCore RPC is
@@ -355,6 +359,10 @@ class VllmProcessHandle:
         """A single vLLM spawn attempt; raises on startup failure."""
         self._recent_logs.clear()
         self._lane_config = lane_config
+        # Resolve (and, if needed, build) a sharded checkpoint for TP>1 lanes
+        # BEFORE building the command — sets self._sharded_model_dir on success.
+        self._sharded_model_dir = None
+        await self._maybe_prepare_sharded_checkpoint(lane_config)
         cmd = self._build_cmd(lane_config)
         self._require_c_compiler()
         self._require_nvcc(lane_config)
@@ -1071,16 +1079,110 @@ class VllmProcessHandle:
             return None
         return int(value)
 
+    async def _maybe_prepare_sharded_checkpoint(self, lane_config: LaneConfig) -> None:
+        """Resolve (and, if missing, build) a sharded checkpoint for TP>1 lanes.
+
+        On success sets ``self._sharded_model_dir`` so ``_build_cmd`` serves the
+        pre-sharded directory with ``--load-format sharded_state`` — each rank
+        then reads only its own shard, keeping cold-start load time roughly
+        constant in TP instead of growing linearly. Any failure leaves it
+        ``None`` and the lane loads the full checkpoint exactly as before.
+
+        This is the spawn-time half of issue #615; the calibration trigger
+        (logos_bridge) pre-builds most checkpoints, so the common case here is
+        just the readiness check below.
+        """
+        vc = lane_config.vllm_config
+        if vc is None:
+            return
+        ec = self._vllm_engine_config
+        if not getattr(ec, "sharded_checkpoint_enabled", True):
+            return
+        tp = int(vc.tensor_parallel_size)
+        min_tp = max(2, int(getattr(ec, "sharded_checkpoint_min_tensor_parallel_size", 2)))
+        if tp < min_tp:
+            return
+        try:
+            from logos_worker_node import sharded_checkpoint as sc  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            logger.debug("[%s] sharded_checkpoint import failed", self.lane_id, exc_info=True)
+            return
+
+        cache_root = self._resolve_persistent_cache_root(self._global_config)
+        if not cache_root:
+            return
+        target = sc.sharded_checkpoint_dir(cache_root, lane_config.model, tp)
+        if sc.is_sharded_checkpoint_ready(target):
+            self._sharded_model_dir = str(target)
+            logger.info(
+                "[%s] using existing sharded checkpoint for %s (tp=%d): %s",
+                self.lane_id,
+                lane_config.model,
+                tp,
+                target,
+            )
+            return
+
+        if not getattr(ec, "sharded_checkpoint_convert_on_spawn", True):
+            return
+
+        hf_home = self.hf_home_override or self._resolve_hf_home(cache_root)
+        gpu_devices = lane_config.gpu_devices or self._global_config.gpu_devices
+        log_path = (
+            Path(cache_root) / ".cache" / "vllm" / "sharded_logs" / f"{lane_config.model.replace('/', '__')}_tp{tp}.log"
+        )
+        logger.info(
+            "[%s] no sharded checkpoint for %s (tp=%d) — converting before spawn",
+            self.lane_id,
+            lane_config.model,
+            tp,
+        )
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None,
+            lambda: sc.ensure_sharded_checkpoint(
+                model=lane_config.model,
+                tensor_parallel_size=tp,
+                cache_root=cache_root,
+                vllm_binary=vc.vllm_binary,
+                hf_home=hf_home,
+                gpu_devices=gpu_devices,
+                dtype=vc.dtype,
+                quantization=vc.quantization,
+                trust_remote_code=("--trust-remote-code" in (vc.extra_args or [])),
+                nccl_p2p_available=ec.nccl_p2p_available,
+                max_file_size_bytes=int(
+                    getattr(ec, "sharded_checkpoint_max_file_size_bytes", sc.DEFAULT_MAX_FILE_SIZE_BYTES)
+                ),
+                log_path=log_path,
+            ),
+        )
+        if result is not None:
+            self._sharded_model_dir = str(result)
+            logger.info("[%s] sharded checkpoint ready: %s", self.lane_id, result)
+        else:
+            logger.warning(
+                "[%s] sharded conversion failed/skipped for %s — loading full checkpoint",
+                self.lane_id,
+                lane_config.model,
+            )
+
     def _build_cmd(self, lane_config: LaneConfig) -> list[str]:
         """Build the vllm serve command."""
         if not lane_config.vllm_config:
             raise RuntimeError(f"[{self.lane_id}] Missing vllm_config for vLLM lane")
         vc = lane_config.vllm_config
         vllm_prefix = self._resolve_vllm_binary(vc.vllm_binary)
+        # For TP>1 lanes with a pre-sharded checkpoint, serve the sharded
+        # directory so each rank reads only its own shard (constant load time
+        # in TP) instead of the full checkpoint. Everything else keyed off the
+        # model name (tool parser, compile cache, profiles) still uses
+        # lane_config.model — only the served path and load-format change.
+        serve_target = self._sharded_model_dir or lane_config.model
         cmd = [
             *vllm_prefix,
             "serve",
-            lane_config.model,
+            serve_target,
             "--host",
             "0.0.0.0",
             "--port",
@@ -1090,6 +1192,8 @@ class VllmProcessHandle:
             "--dtype",
             vc.dtype,
         ]
+        if self._sharded_model_dir:
+            cmd.extend(["--load-format", "sharded_state"])
         # Resolve gpu_memory_utilization: explicit per-model override wins;
         # otherwise auto-derive from the calibrated profile so vLLM's startup
         # floor check (free_per_gpu >= gmu * total_per_gpu, raised by

--- a/logos/logos-workernode/tests/test_sharded_checkpoint.py
+++ b/logos/logos-workernode/tests/test_sharded_checkpoint.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from logos_worker_node import sharded_checkpoint as sc
+from logos_worker_node.models import LaneConfig, OllamaConfig, VllmConfig, VllmEngineConfig
+from logos_worker_node.vllm_process import VllmProcessHandle
+
+
+def test_sharded_checkpoint_dir_layout() -> None:
+    d = sc.sharded_checkpoint_dir("/cache", "org/Model-A", 4)
+    assert d == Path("/cache") / ".sharded_cache" / "org__Model-A" / "tp4"
+
+
+def test_is_ready_tracks_marker(tmp_path: Path) -> None:
+    d = sc.sharded_checkpoint_dir(str(tmp_path), "org/m", 2)
+    d.mkdir(parents=True)
+    assert sc.is_sharded_checkpoint_ready(d) is False
+    (d / sc._COMPLETION_MARKER).write_text("ok")
+    assert sc.is_sharded_checkpoint_ready(d) is True
+
+
+def test_resolve_cache_root_prefers_env(monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", "/override")
+    assert sc.resolve_cache_root("/models") == "/override"
+    monkeypatch.delenv("LOGOS_WORKER_CACHE_ROOT", raising=False)
+    assert sc.resolve_cache_root("/models") == "/models"
+
+
+def test_resolve_vllm_python_picks_sibling(monkeypatch, tmp_path: Path) -> None:
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    py = bin_dir / "python"
+    py.write_text("#!/bin/sh\nexit 0\n")
+    py.chmod(0o755)
+    vllm = bin_dir / "vllm"
+    vllm.write_text("#!/bin/sh\nexit 0\n")
+    vllm.chmod(0o755)
+    monkeypatch.setattr("logos_worker_node.sharded_checkpoint.shutil.which", lambda _c: None)
+    assert sc.resolve_vllm_python(str(vllm)) == str(py)
+
+
+def test_ensure_returns_none_for_tp1(tmp_path: Path) -> None:
+    assert sc.ensure_sharded_checkpoint(model="org/m", tensor_parallel_size=1, cache_root=str(tmp_path)) is None
+
+
+def test_ensure_returns_existing_without_converting(tmp_path: Path, monkeypatch) -> None:
+    d = sc.sharded_checkpoint_dir(str(tmp_path), "org/m", 2)
+    d.mkdir(parents=True)
+    (d / sc._COMPLETION_MARKER).write_text("ok")
+
+    def _boom(*_a, **_k):  # conversion must not run when already ready
+        raise AssertionError("should not convert an already-ready checkpoint")
+
+    monkeypatch.setattr(sc, "_run_conversion_subprocess", _boom)
+    out = sc.ensure_sharded_checkpoint(model="org/m", tensor_parallel_size=2, cache_root=str(tmp_path))
+    assert out == d
+
+
+def test_ensure_success_writes_marker(tmp_path: Path, monkeypatch) -> None:
+    def _fake_convert(cmd, env, log_path, timeout_s, cancel_event):
+        # Emulate the converter writing a shard file into --output.
+        out = Path(cmd[cmd.index("--output") + 1])
+        (out / "model-rank-0-part-0.safetensors").write_text("weights")
+        return True
+
+    monkeypatch.setattr(sc, "_run_conversion_subprocess", _fake_convert)
+    out = sc.ensure_sharded_checkpoint(model="org/m", tensor_parallel_size=2, cache_root=str(tmp_path))
+    assert out is not None
+    assert sc.is_sharded_checkpoint_ready(out)
+
+
+def test_ensure_failure_cleans_up(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sc, "_run_conversion_subprocess", lambda *a, **k: False)
+    out = sc.ensure_sharded_checkpoint(model="org/m", tensor_parallel_size=2, cache_root=str(tmp_path))
+    assert out is None
+    # Partial output directory must be removed so a retry starts clean.
+    assert not sc.sharded_checkpoint_dir(str(tmp_path), "org/m", 2).exists()
+
+
+def test_ensure_no_shard_files_is_failure(tmp_path: Path, monkeypatch) -> None:
+    # Subprocess reports success but produced no shards → treated as failure.
+    monkeypatch.setattr(sc, "_run_conversion_subprocess", lambda *a, **k: True)
+    out = sc.ensure_sharded_checkpoint(model="org/m", tensor_parallel_size=2, cache_root=str(tmp_path))
+    assert out is None
+
+
+def _lane(tp: int, tmp_path: Path) -> LaneConfig:
+    return LaneConfig(
+        model="org/Model-A",
+        vllm=True,
+        gpu_devices="0,1",
+        vllm_config=VllmConfig(tensor_parallel_size=tp, enable_sleep_mode=True),
+    )
+
+
+def test_build_cmd_uses_sharded_dir(tmp_path: Path, monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-x", 19010, OllamaConfig(), VllmEngineConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _c: ["/tmp/vllm"])
+    lane = _lane(2, tmp_path)
+    handle._sharded_model_dir = "/cache/.sharded_cache/org__Model-A/tp2"
+    cmd = handle._build_cmd(lane)
+    assert "/cache/.sharded_cache/org__Model-A/tp2" in cmd
+    assert "--load-format" in cmd
+    assert cmd[cmd.index("--load-format") + 1] == "sharded_state"
+    # The served target replaces the model id (not appended alongside it).
+    assert "org/Model-A" not in cmd
+
+
+def test_build_cmd_full_checkpoint_when_not_sharded(tmp_path: Path, monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-y", 19011, OllamaConfig(), VllmEngineConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _c: ["/tmp/vllm"])
+    lane = _lane(2, tmp_path)
+    cmd = handle._build_cmd(lane)
+    assert "org/Model-A" in cmd
+    assert "--load-format" not in cmd
+
+
+def test_maybe_prepare_uses_existing_checkpoint(tmp_path: Path) -> None:
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-z", 19012, gc, VllmEngineConfig())
+    lane = _lane(2, tmp_path)
+    ready = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    ready.mkdir(parents=True)
+    (ready / sc._COMPLETION_MARKER).write_text("ok")
+
+    asyncio.run(handle._maybe_prepare_sharded_checkpoint(lane))
+    assert handle._sharded_model_dir == str(ready)
+
+
+def test_maybe_prepare_skips_when_disabled(tmp_path: Path) -> None:
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-d", 19013, gc, VllmEngineConfig(sharded_checkpoint_enabled=False))
+    lane = _lane(2, tmp_path)
+    ready = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    ready.mkdir(parents=True)
+    (ready / sc._COMPLETION_MARKER).write_text("ok")
+
+    asyncio.run(handle._maybe_prepare_sharded_checkpoint(lane))
+    assert handle._sharded_model_dir is None
+
+
+def test_maybe_prepare_tp1_noop(tmp_path: Path) -> None:
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-1", 19014, gc, VllmEngineConfig())
+    lane = _lane(1, tmp_path)
+    asyncio.run(handle._maybe_prepare_sharded_checkpoint(lane))
+    assert handle._sharded_model_dir is None
+
+
+def test_maybe_prepare_convert_on_spawn_disabled(tmp_path: Path, monkeypatch) -> None:
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-c", 19015, gc, VllmEngineConfig(sharded_checkpoint_convert_on_spawn=False))
+    lane = _lane(2, tmp_path)
+
+    def _boom(*_a, **_k):
+        raise AssertionError("should not convert when convert_on_spawn is False")
+
+    monkeypatch.setattr(sc, "ensure_sharded_checkpoint", _boom)
+    asyncio.run(handle._maybe_prepare_sharded_checkpoint(lane))
+    assert handle._sharded_model_dir is None


### PR DESCRIPTION
Closes #615.

## Problem

With tensor parallelism enabled, each vLLM rank reads the **whole** model checkpoint and slices out its own shard, so cold-start load time grows with the tensor-parallel size (proportional to model size × TP of disk reads).

## Change

Automatically use [vLLM sharded-state checkpoints](https://docs.vllm.ai/en/latest/configuration/conserving_memory/#tensor-parallelism-tp) for `tensor_parallel_size > 1` lanes. The model is pre-converted to a sharded checkpoint (each rank then reads only its own shard → load time roughly constant in TP) and served with `--load-format sharded_state`.

Conversion is triggered in two places, per the issue:
1. **After calibration**, when the calibrated `tensor_parallel_size` is `>1` — the GPU is already free at that point, so it's the cheapest time to convert.
2. **Lazily, right before a TP>1 lane is spawned**, if no converted checkpoint exists yet.

Both paths go through an idempotent `ensure_sharded_checkpoint()`:
- keyed by `(model, tp)` under `<cache_root>/.sharded_cache/<model>/tp<N>/`,
- guarded by a completion marker (written last) + an in-process lock so the two triggers never collide,
- supports cancellation (wired to `stop_calibration_session`) and a timeout,
- cleans up partial output on failure, and falls back to loading the full checkpoint if anything goes wrong.

The converter (`_sharded_convert.py`) mirrors vLLM's official `save_sharded_state_offline.py` for the pinned `vllm==v0.23.0`, and runs as a subprocess under the vLLM-equipped interpreter (which may be a different venv than the worker).

## Config

New `engines.vllm` options (all default to the feature being **on**):

| key | default | meaning |
|---|---|---|
| `sharded_checkpoint_enabled` | `true` | master switch for both triggers |
| `sharded_checkpoint_convert_on_spawn` | `true` | allow the lazy pre-spawn fallback conversion |
| `sharded_checkpoint_min_tensor_parallel_size` | `2` | min TP that triggers conversion |
| `sharded_checkpoint_max_file_size_bytes` | `5 GiB` | shard file size cap |

## Testing

- New `tests/test_sharded_checkpoint.py` (15 tests): path layout, readiness marker, cache-root/python resolution, conversion success/failure/cleanup, and `_build_cmd` / `_maybe_prepare` integration.
- Full workernode suite: **386 passed, 2 pre-existing skips**. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for sharded checkpoints in tensor-parallel configurations to reduce cold-start time.
  * New configuration options to enable sharded checkpoint loading and control conversion timing.
  * Optional automatic checkpoint conversion during model calibration for tensor-parallel setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->