### PR TITLE
`Logos`: Workernode — alias sharded lane to its model id (fixes HTTP 404)

### DIFF
--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -1194,6 +1194,12 @@ class VllmProcessHandle:
         ]
         if self._sharded_model_dir:
             cmd.extend(["--load-format", "sharded_state"])
+            # The sharded checkpoint is served from a filesystem path, so vLLM
+            # would otherwise register the model under that path and return HTTP
+            # 404 for any request that addresses it by its real model id. Alias
+            # the served name back to lane_config.model so clients and the
+            # orchestrator's lane routing can reach it as usual.
+            cmd.extend(["--served-model-name", lane_config.model])
         # Resolve gpu_memory_utilization: explicit per-model override wins;
         # otherwise auto-derive from the calibrated profile so vLLM's startup
         # floor check (free_per_gpu >= gmu * total_per_gpu, raised by

--- a/logos/logos-workernode/tests/test_sharded_checkpoint.py
+++ b/logos/logos-workernode/tests/test_sharded_checkpoint.py
@@ -101,11 +101,14 @@ def test_build_cmd_uses_sharded_dir(tmp_path: Path, monkeypatch) -> None:
     lane = _lane(2, tmp_path)
     handle._sharded_model_dir = "/cache/.sharded_cache/org__Model-A/tp2"
     cmd = handle._build_cmd(lane)
-    assert "/cache/.sharded_cache/org__Model-A/tp2" in cmd
+    # The serve *target* is the sharded directory (so each rank reads its shard)...
+    assert cmd[cmd.index("serve") + 1] == "/cache/.sharded_cache/org__Model-A/tp2"
     assert "--load-format" in cmd
     assert cmd[cmd.index("--load-format") + 1] == "sharded_state"
-    # The served target replaces the model id (not appended alongside it).
-    assert "org/Model-A" not in cmd
+    # ...but the served *name* must alias back to the real model id, or every
+    # request addressing the model by name gets HTTP 404 from vLLM.
+    assert "--served-model-name" in cmd
+    assert cmd[cmd.index("--served-model-name") + 1] == "org/Model-A"
 
 
 def test_build_cmd_full_checkpoint_when_not_sharded(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem

The current benchmark run fails **every** request with:

```
[live] [P] sent=66/66 ok=0 err=65 ... avg_ttft=—
ERR=200 RemoteProtocolError: peer closed connection without sending complete message body
```

Root cause (introduced by #617, sharded checkpoints): TP>1 lanes are served from the pre-sharded checkpoint directory:

```
vllm serve /usr/.../.sharded_cache/google__gemma-3-12b-it/tp2 --load-format sharded_state
```

…but **no `--served-model-name`** is passed. vLLM registers the model under the *directory path*, so a request for `google/gemma-3-12b-it` returns **HTTP 404** ("model does not exist"). The orchestrator has already returned `200` and opened the SSE stream, so the client only ever sees `RemoteProtocolError: peer closed connection` with no first token (`ttft=—`).

Confirmed in the orchestrator logs:
```
LogosNodeCommandError: Lane 'planner-google_gemma-3-12b-it' returned HTTP 404
```

## Fix

Add `--served-model-name lane_config.model` whenever a sharded directory is served, so the lane answers to its real model id again. Non-sharded lanes are unchanged. Updates `test_build_cmd_uses_sharded_dir` (which previously asserted the buggy "model id absent" behaviour) to assert the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)