### PR TITLE
`Logos`: Add passkey login support

### DIFF
--- a/logos/.env.example
+++ b/logos/.env.example
@@ -39,6 +39,8 @@ LOGOS_INTERNAL_SECRET=
 LOGOS_NODE_DEV_ALLOW_INSECURE_HTTP=
 
 # ── Keycloak (Logos auth) ─────────────────────────────────────────────────────
+# Passkey (passwordless WebAuthn) login is configured in the realm itself
+# (logos/keycloak/tum-realm.json) — no env vars needed. See docs/passkey-login.md.
 # Production: https://keycloak.aet.cit.tum.de/realms/tum
 KEYCLOAK_ISSUER_URI=http://localhost:8085/realms/tum
 # Public OIDC client id that the UI uses to talk to Keycloak.

--- a/logos/docs/passkey-login.md
+++ b/logos/docs/passkey-login.md
@@ -1,0 +1,87 @@
+# Passkey login
+
+Logos supports **passwordless passkey (WebAuthn) login** in addition to the
+existing username/password sign-in. Like the rest of Logos auth, login is
+handled entirely by the **Keycloak-hosted login page** — the UI redirects to
+Keycloak via OIDC (`expo-auth-session`, see `logos-ui/components/main.tsx`), so
+there is no in-app WebAuthn code. Passkeys are enabled purely through Keycloak
+realm configuration (`logos/keycloak/tum-realm.json`).
+
+## How it works
+
+The realm binds a custom `browser-passkey` authentication flow:
+
+```
+browser-passkey
+├── Cookie                                  (ALTERNATIVE)  ← existing SSO session
+├── Identity Provider Redirector            (ALTERNATIVE)
+└── browser-passkey-forms                   (ALTERNATIVE)
+    ├── Username Form                        (REQUIRED)    ← enter username/email
+    └── browser-passkey-passwordless-or-password (REQUIRED)
+        ├── WebAuthn Passwordless Authenticator (ALTERNATIVE) ← passkey
+        └── browser-passkey-password         (ALTERNATIVE)
+            └── Password Form                (REQUIRED)    ← fallback
+```
+
+After entering their username, a user with a registered passkey is prompted for
+it; everyone else falls back to the password form. Existing password logins keep
+working unchanged.
+
+The passwordless WebAuthn policy is configured with
+`requireResidentKey: "Yes"` and `userVerification: "required"`, which makes the
+registered credentials true **discoverable passkeys** (synced via the platform
+authenticator / password manager). `signatureAlgorithms` allows `ES256` and
+`RS256`.
+
+`webAuthnPolicyPasswordlessRpId` is intentionally left **empty** so Keycloak
+derives the WebAuthn Relying Party ID from the request host. This works for both
+`localhost` in dev and the production Keycloak hostname
+(`keycloak.aet.cit.tum.de`) without per-environment overrides. A passkey is
+bound to the RP ID (the Keycloak host), so passkeys registered against dev do
+not work against prod and vice versa — this is expected WebAuthn behaviour.
+
+## Registering a passkey
+
+A user registers a passkey from the Keycloak **account console** → *Account
+security* → *Signing in* → *Passkey* → *Add*. This is driven by the
+`webauthn-register-passwordless` required action, which Keycloak provisions and
+enables by default.
+
+To force enrollment you can instead make it a default action (admin console →
+*Authentication* → *Required actions* → enable *Set as default action* for
+*Webauthn Register Passwordless*), which prompts every user to add a passkey on
+their next login. Logos ships it as opt-in (not a default action).
+
+## Testing locally
+
+1. Bring up the dev stack (includes Keycloak):
+   ```
+   cd logos && docker compose -f docker-compose.dev.yaml up --build
+   ```
+2. Open the UI (`http://localhost:18081`) and click **Sign in**.
+3. On the Keycloak page, enter a seed user (e.g. `tobias.wasner` /
+   `password`) and log in once with the password.
+4. Open the account console at
+   `http://localhost:8085/realms/tum/account` → *Signing in* → add a passkey
+   (Chrome/Safari offer a virtual or platform authenticator).
+5. Log out and sign in again — after entering the username you are now offered
+   the passkey instead of the password.
+
+> WebAuthn requires a secure context. `localhost` is treated as secure by
+> browsers, so dev works over plain HTTP; any other host needs HTTPS (prod is
+> behind Traefik TLS, so this is satisfied).
+
+## Verifying after a realm change
+
+Because Keycloak only imports the realm on first creation (`--import-realm`),
+changes to `tum-realm.json` need a fresh realm. In dev, recreate the Keycloak
+volume/container:
+
+```
+cd logos && docker compose -f docker-compose.dev.yaml up -d --force-recreate keycloak
+```
+
+Then confirm in the admin console (`admin` / `admin`):
+- *Authentication* → *Flows* → the bound browser flow is **browser-passkey**.
+- *Authentication* → *Policies* → *WebAuthn Passwordless Policy* shows the
+  passkey settings above.

--- a/logos/keycloak/tum-realm.json
+++ b/logos/keycloak/tum-realm.json
@@ -4,6 +4,21 @@
   "sslRequired": "none",
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
+
+  "browserFlow": "browser-passkey",
+  "webAuthnPolicyPasswordlessRpEntityName": "Logos",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256", "RS256"],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "Yes",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "required",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "webAuthnPolicyPasswordlessPasskeysEnabled": true,
+
   "roles": {
     "realm": [
       { "name": "itg-admin", "description": "Logos admin (maps to logos_admin)" },
@@ -96,6 +111,100 @@
       "clientRoles": {
         "realm-management": ["view-users", "query-users", "query-groups"]
       }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "browser-passkey",
+      "description": "Browser flow that offers a passwordless passkey alongside the password",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "browser-passkey-forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-passkey-forms",
+      "description": "Username first, then a passkey or password",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "browser-passkey-passwordless-or-password",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-passkey-passwordless-or-password",
+      "description": "Sign in with a registered passkey, otherwise fall back to the password form",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "webauthn-authenticator-passwordless",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "browser-passkey-password",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-passkey-password",
+      "description": "Password form",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation

Closes #628. Adds passwordless **passkey (WebAuthn)** login, following the passkey support added to [thesis-management#955](https://github.com/ls1intum/thesis-management/pull/955).

### Approach

Logos delegates login entirely to the **Keycloak-hosted login page** — the UI just redirects to Keycloak over OIDC (`expo-auth-session`, see `logos-ui/components/main.tsx`). Unlike thesis-management (a `keycloak-js` SPA with a custom in-page modal + custom provider JAR), the right fit for Logos is to enable passkeys in the **realm configuration** so the hosted login page offers them automatically. No in-app WebAuthn code and no custom Keycloak provider plugin are required.

### Changes

- **`logos/keycloak/tum-realm.json`**
  - New `browser-passkey` authentication flow, bound as the realm's `browserFlow`: **username first → passkey if registered, otherwise the existing password form**. Password login is unaffected.
  - Passwordless WebAuthn policy with `requireResidentKey: Yes` + `userVerification: required` (true discoverable passkeys), `ES256`/`RS256`. `RpId` left **empty** so Keycloak derives it from the request host — works for dev `localhost` and the prod Keycloak hostname without per-env overrides.
- **`logos/docs/passkey-login.md`** — how it works, local testing, registration, and prod RP-ID notes.
- **`logos/.env.example`** — pointer noting passkey config lives in the realm.

### How login flows now

```
browser-passkey
├── Cookie / IdP Redirector                  (ALTERNATIVE)
└── Username Form                             (REQUIRED)
    └── WebAuthn Passwordless  ── or ──  Password Form
```

### Testing

Realm config + docs only — no Python/TS code paths changed; `pre-commit` passes on the changed files. Keycloak only imports the realm on first creation, so to verify locally, recreate the Keycloak container (`docker compose -f docker-compose.dev.yaml up -d --force-recreate keycloak`), register a passkey via the account console, and sign in with it. Steps are in `docs/passkey-login.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey (passwordless WebAuthn) login support through the existing login page.
  * Improved the sign-in flow so users can choose passkey-based login or fall back to password login.

* **Documentation**
  * Added setup and usage guidance for passkey login, including registration steps and local testing instructions.
  * Clarified that passkey login is configured through the identity provider and does not require extra environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->