### PR TITLE
`Logos`: Fix CORS rejecting same-origin POST and WebSocket requests

### DIFF
--- a/logos/.env.example
+++ b/logos/.env.example
@@ -38,6 +38,18 @@ LOGOS_INTERNAL_SECRET=
 # Set to "true" for local development only. Never set in production.
 LOGOS_NODE_DEV_ALLOW_INSECURE_HTTP=
 
+# ── CORS ──────────────────────────────────────────────────────────────────────
+# Comma-separated browser origins the webservice accepts. Browsers attach an
+# Origin header to POST requests and WebSocket handshakes even when the UI and
+# API share an origin, so an EMPTY value makes Spring's CorsFilter reject every
+# POST/WS endpoint (get_models, get_providers, paginated_requests, billing,
+# /ws/stats, …) while same-origin GETs (/me, /users) still work. Must list the
+# exact origin the UI is served from, scheme + host + port. The compose files
+# default this to the UI origin derived from LOGOS_DOMAIN; override here only for
+# extra origins (e.g. a separate Expo dev server). Use exact origins (not `*`) so
+# credentialed requests are allowed.
+LOGOS_CORS_ALLOWED_ORIGINS=
+
 # ── Keycloak (Logos auth) ─────────────────────────────────────────────────────
 # Production: https://keycloak.aet.cit.tum.de/realms/tum
 KEYCLOAK_ISSUER_URI=http://localhost:8085/realms/tum

--- a/logos/docker-compose.dev.yaml
+++ b/logos/docker-compose.dev.yaml
@@ -178,7 +178,11 @@ services:
       KEYCLOAK_SYNC_ENABLED: "${KEYCLOAK_SYNC_ENABLED:-false}"
       KEYCLOAK_SYNC_CLIENT_ID: "${KEYCLOAK_SYNC_CLIENT_ID:-logos-sync}"
       KEYCLOAK_SYNC_CLIENT_SECRET: "${KEYCLOAK_SYNC_CLIENT_SECRET:-}"
-      LOGOS_CORS_ALLOWED_ORIGINS: "${LOGOS_CORS_ALLOWED_ORIGINS:-}"
+      # See prod docker-compose.yaml for why this must be set: browsers send an
+      # Origin on POST/WebSocket even same-origin, so an empty allowlist makes the
+      # CorsFilter reject every POST/WS. Default to the dev UI origin (Traefik UI
+      # port over plain HTTP).
+      LOGOS_CORS_ALLOWED_ORIGINS: "${LOGOS_CORS_ALLOWED_ORIGINS:-http://${LOGOS_DOMAIN:-localhost}:${LOGOS_TRAEFIK_UI_PORT:-18081}}"
     expose:
       - "8081"
     ports:

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -207,7 +207,13 @@ services:
       KEYCLOAK_SYNC_ENABLED: "${KEYCLOAK_SYNC_ENABLED:-false}"
       KEYCLOAK_SYNC_CLIENT_ID: "${KEYCLOAK_SYNC_CLIENT_ID:-logos-sync}"
       KEYCLOAK_SYNC_CLIENT_SECRET: "${KEYCLOAK_SYNC_CLIENT_SECRET:-}"
-      LOGOS_CORS_ALLOWED_ORIGINS: "${LOGOS_CORS_ALLOWED_ORIGINS:-}"
+      # Origins the webservice accepts browser requests from. Browsers attach an
+      # Origin header to POST requests and WebSocket handshakes even when the UI
+      # and API share an origin, so the Spring CorsFilter rejects every POST/WS
+      # (get_models, get_providers, paginated_requests, billing, /ws/stats, …)
+      # if this is empty — while same-origin GETs (/me, /users) slip through. The
+      # UI is served on the admin entrypoint, so default to that exact origin.
+      LOGOS_CORS_ALLOWED_ORIGINS: "${LOGOS_CORS_ALLOWED_ORIGINS:-https://${LOGOS_DOMAIN:-localhost}:${LOGOS_TRAEFIK_ADMIN_PORT:-9443}}"
     expose:
       - "8081"
     labels:

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/auth/SecurityConfig.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/auth/SecurityConfig.java
@@ -67,11 +67,16 @@ public class SecurityConfig {
     public CorsConfigurationSource logosCorsConfigurationSource(
             @Value("${logos.cors.allowed-origins:}") String allowedOrigins) {
         CorsConfiguration cfg = new CorsConfiguration();
-        // Default: no allowed origins. Browsers' same-origin policy applies — set
-        // `logos.cors.allowed-origins` explicitly (comma-separated) for any
-        // cross-origin browser client. The pattern form is permitted so that
-        // dev set-ups can use `*`, but credentialed `*` is rejected by Spring
-        // by design — use specific origins in production.
+        // Default: no allowed origins. NOTE: this is not "same-origin allowed" —
+        // browsers attach an Origin header to POST requests and WebSocket
+        // handshakes even when the UI and API share an origin, so with an empty
+        // allowlist the CorsFilter rejects every POST/WS (while same-origin GETs
+        // have no Origin and slip through). The deployment must therefore list
+        // the UI's own origin in `logos.cors.allowed-origins` (the compose files
+        // default it from LOGOS_DOMAIN); also add any cross-origin browser
+        // client. The pattern form is permitted so that dev set-ups can use `*`,
+        // but credentialed `*` is rejected by Spring by design — use specific
+        // origins in production.
         boolean credentialsSafe = true;
         for (String origin : allowedOrigins.split(",")) {
             String o = origin.strip();


### PR DESCRIPTION
### Problem

After the Keycloak integration (#609), logos admins could log in but every data/stats page was dead in prod: `get_models`, `get_providers`, `get_general_provider_stats`, `paginated_requests`, `billing/team_budget_history`, and `wss /ws/stats/v2` all failed, while login and the user/team admin pages worked.

### Root cause (confirmed on prod)

`SecurityConfig` (added in #609) enables a Spring `CorsFilter` driven by `LOGOS_CORS_ALLOWED_ORIGINS`, which **defaulted to empty** and was unset in the prod `.env`.

Browsers attach an `Origin` header to **POST** requests and **WebSocket** handshakes *even when the UI and API are same-origin*. With an empty allowlist, the CorsFilter rejected each of those at filter 5/15 — before auth ran:

```
DefaultCorsProcessor : Reject: 'https://logos.aet.cit.tum.de:9443' origin is not allowed
```

Same-origin **GET**s (`/me`, `/users`, `/teams`) carry no `Origin`, so they passed — which is exactly why login worked but the POST/WS data endpoints did not. JWT validation was never the issue (issuer/JWKS/signature/audience all verified fine); the requests never reached it.

### Fix

Default `LOGOS_CORS_ALLOWED_ORIGINS` to the UI's own origin, derived from `LOGOS_DOMAIN` + entrypoint port, in both compose files:
- prod: `https://${LOGOS_DOMAIN}:${LOGOS_TRAEFIK_ADMIN_PORT:-9443}`
- dev: `http://${LOGOS_DOMAIN}:${LOGOS_TRAEFIK_UI_PORT:-18081}`

Plus a `.env.example` entry and a `SecurityConfig` comment documenting the same-origin-POST footgun. An explicit `LOGOS_CORS_ALLOWED_ORIGINS` still overrides (e.g. to add a separate Expo dev server).

### Verification

Reproduced live on prod via TRACE logging (the CorsFilter reject above). Applied the origin to the prod `.env` and recreated the webservice: the previously-rejected POSTs now pass CORS (`Access-Control-Allow-Origin` returned, OPTIONS preflight `200`) and reach auth. This PR makes that default permanent so fresh deploys aren't affected.

> Note: prod `.env` was hotfixed directly to restore service; this PR is the durable equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser access to the web service by making allowed web origins configurable.
  * Updated default development and production settings so the UI/admin front end can connect without manual CORS setup.
  * Clarified setup guidance for browser-based requests, including POST and WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->