### PR TITLE
`Logos`: Add in-page passkey login

### DIFF
--- a/logos/docs/passkey-login.md
+++ b/logos/docs/passkey-login.md
@@ -1,0 +1,44 @@
+# Passkey login
+
+Logos supports **in-page passkey (WebAuthn) login** — no redirect to a hosted
+login page. The "Sign in with a passkey" button on the login screen runs the
+WebAuthn ceremony directly in the app and signs the user in.
+
+## How it works
+
+Login is handled by `logos-ui/lib/auth/passkey.ts` and surfaced in
+`components/main.tsx`. The flow:
+
+1. `GET {issuer}/passkey/{clientId}/challenge` — fetch a WebAuthn challenge.
+2. `navigator.credentials.get(...)` — the browser prompts for a discoverable
+   (usernameless) passkey and signs the challenge.
+3. `POST {issuer}/passkey/{clientId}/authenticate` — the assertion is verified by
+   the Keycloak passkey provider, which establishes a Keycloak SSO session.
+4. **Silent token retrieval** — because Logos uses authorization-code + PKCE
+   (not keycloak-js), a hidden `prompt=none` iframe pointed at
+   `silent-check-sso.html` obtains an authorization code against the fresh
+   session, which is exchanged for tokens. No login page is shown.
+
+Registration (`registerPasskey`) mirrors this with `challenge` →
+`navigator.credentials.create(...)` → `POST .../save`.
+
+## Keycloak prerequisites
+
+These live on the Keycloak side, not in this repo:
+
+- The **custom passkey provider** must be enabled for the `logos` client, exposing
+  `{issuer}/passkey/{logos}/{health|challenge|authenticate|save}`.
+- The `logos` client must allow the silent flow: the UI origin in **Web Origins**
+  and `{origin}/silent-check-sso.html` in **Valid Redirect URIs**.
+- The WebAuthn **passwordless policy** (resident key + user verification) must be
+  configured, and the passkey **rpId** must be a registrable suffix of the UI
+  origin. `passkey.ts` defaults `rpId` to the current hostname; override if the
+  shared provider scopes passkeys to a parent domain.
+
+## Notes / status
+
+- WebAuthn needs a secure context. `localhost` counts as secure for dev; all
+  other hosts need HTTPS (prod is behind Traefik TLS).
+- The silent `prompt=none` iframe depends on the Keycloak session cookie being
+  readable from the iframe; verify against the real Keycloak (third-party-cookie
+  behaviour varies by browser).

--- a/logos/logos-ui/components/main.tsx
+++ b/logos/logos-ui/components/main.tsx
@@ -26,6 +26,7 @@ import { VStack } from "@/components/ui/vstack";
 import { Center } from "@/components/ui/center";
 import { useAuth } from "@/components/auth-shell";
 import type { KeycloakConfig, StoredTokens } from "@/lib/auth/keycloak";
+import { isPasskeySupported, loginWithPasskey, passkeyErrorMessage } from "@/lib/auth/passkey";
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -80,6 +81,24 @@ function LoginView({
   const [hue, setHue] = useState(0);
   const [mounted, setMounted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
+  const passkeyAvailable = isPasskeySupported();
+
+  const handlePasskeyLogin = async () => {
+    setPasskeyLoading(true);
+    try {
+      const tokens = await loginWithPasskey(keycloak);
+      await completeLogin(tokens);
+      onAuthenticated?.(tokens.accessToken);
+      const target = redirectTo === null ? null : (redirectTo ?? "/dashboard");
+      hasNavigatedRef.current = true;
+      if (target && target !== pathname) router.replace(target);
+    } catch (err: unknown) {
+      Alert.alert("Passkey sign-in failed", passkeyErrorMessage(err));
+    } finally {
+      setPasskeyLoading(false);
+    }
+  };
 
   const redirectUri = makeRedirectUri({ scheme: "logos", path: "auth" });
 
@@ -194,16 +213,30 @@ function LoginView({
           Sign in to your account
         </Text>
         <Box className="w-1/2 min-w-[300px]">
-          <Button
-            onPress={() => {
-              setLoading(true);
-              void promptAsync();
-            }}
-            isDisabled={!request || loading}
-            className="w-full"
-          >
-            <ButtonText>{loading ? "Signing in…" : "Sign in with Keycloak"}</ButtonText>
-          </Button>
+          <VStack space="md">
+            <Button
+              onPress={() => {
+                setLoading(true);
+                void promptAsync();
+              }}
+              isDisabled={!request || loading || passkeyLoading}
+              className="w-full"
+            >
+              <ButtonText>{loading ? "Signing in…" : "Sign in with Keycloak"}</ButtonText>
+            </Button>
+            {passkeyAvailable && (
+              <Button
+                variant="outline"
+                onPress={() => void handlePasskeyLogin()}
+                isDisabled={loading || passkeyLoading}
+                className="w-full"
+              >
+                <ButtonText>
+                  {passkeyLoading ? "Waiting for passkey…" : "Sign in with a passkey"}
+                </ButtonText>
+              </Button>
+            )}
+          </VStack>
         </Box>
       </VStack>
     </Center>

--- a/logos/logos-ui/lib/auth/keycloak.ts
+++ b/logos/logos-ui/lib/auth/keycloak.ts
@@ -45,3 +45,11 @@ export async function fetchKeycloakConfig(): Promise<KeycloakConfig> {
     },
   };
 }
+
+// Endpoint of the custom Keycloak passkey provider, mounted per-client at
+// `{issuer}/passkey/{clientId}/{path}`, where `path` is one of:
+// health | challenge | authenticate | save.
+export function passkeyEndpoint(cfg: KeycloakConfig, path: string): string {
+  const base = cfg.issuer.replace(/\/+$/, "");
+  return `${base}/passkey/${encodeURIComponent(cfg.clientId)}/${path}`;
+}

--- a/logos/logos-ui/lib/auth/passkey.ts
+++ b/logos/logos-ui/lib/auth/passkey.ts
@@ -1,0 +1,333 @@
+// In-page passkey (WebAuthn) login for the Logos UI.
+//
+// Logos uses raw authorization-code + PKCE (not keycloak-js), so after the passkey
+// ceremony establishes a Keycloak SSO session we silently retrieve tokens via a
+// hidden `prompt=none` iframe (the classic Keycloak "check-sso" pattern).
+//
+// Keycloak-side prerequisite: the custom passkey provider must be enabled for the
+// `logos` client. Endpoints live at
+// `{issuer}/passkey/{clientId}/{health|challenge|authenticate|save}`.
+// See docs/passkey-login.md.
+
+import * as Crypto from "expo-crypto";
+
+import { KeycloakConfig, passkeyEndpoint, StoredTokens } from "./keycloak";
+
+const SILENT_REDIRECT_PATH = "/silent-check-sso.html";
+const CEREMONY_TIMEOUT_MS = 60_000;
+
+export function isPasskeySupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.isSecureContext &&
+    typeof window.PublicKeyCredential !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.credentials !== "undefined"
+  );
+}
+
+// WebAuthn rpId must be a registrable suffix of the page origin AND match what the
+// passkey was registered with in Keycloak. Default to the current host; override
+// via the optional argument if the shared provider scopes passkeys to a parent
+// domain (e.g. aet.cit.tum.de).
+export function defaultRpId(): string {
+  return typeof window !== "undefined" ? window.location.hostname : "";
+}
+
+// ── base64url <-> bytes ──────────────────────────────────────────────────────
+
+function toBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export function isPasskeyCancellation(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "NotAllowedError" || error.name === "AbortError")
+  );
+}
+
+export function passkeyErrorMessage(error: unknown, fallback = "Passkey sign-in failed."): string {
+  if (error instanceof DOMException) {
+    if (isPasskeyCancellation(error)) return "Passkey sign-in was cancelled.";
+    if (error.name === "InvalidStateError") return "This passkey is already registered.";
+    if (error.name === "SecurityError") return "Passkeys are not allowed on this site.";
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+// Best-effort human label saved with a newly registered passkey.
+export function getDeviceName(): string {
+  if (typeof navigator === "undefined") return "Unknown device";
+  const ua = navigator.userAgent;
+  const platform = /Mac/.test(ua)
+    ? "Mac"
+    : /Win/.test(ua)
+      ? "Windows"
+      : /Linux/.test(ua)
+        ? "Linux"
+        : /Android/.test(ua)
+          ? "Android"
+          : /iPhone|iPad/.test(ua)
+            ? "iOS"
+            : "Unknown";
+  const browser = /Firefox/.test(ua)
+    ? "Firefox"
+    : /Edg/.test(ua)
+      ? "Edge"
+      : /Chrome/.test(ua)
+        ? "Chrome"
+        : /Safari/.test(ua)
+          ? "Safari"
+          : "Browser";
+  return `${platform} - ${browser}`;
+}
+
+// ── Keycloak passkey provider calls ──────────────────────────────────────────
+
+export async function isPasskeyProviderAvailable(cfg: KeycloakConfig): Promise<boolean> {
+  try {
+    const res = await fetch(passkeyEndpoint(cfg, "health"), {
+      method: "GET",
+      credentials: "include",
+      cache: "no-store",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function requestChallenge(cfg: KeycloakConfig): Promise<string> {
+  const res = await fetch(passkeyEndpoint(cfg, "challenge"), {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`Passkey challenge failed (${res.status})`);
+  const data = (await res.json().catch(() => undefined)) as { challenge?: string } | undefined;
+  if (!data?.challenge) throw new Error("Passkey challenge response missing 'challenge'");
+  return data.challenge;
+}
+
+function jwtSubject(accessToken: string): string | undefined {
+  try {
+    const payload = accessToken.split(".")[1];
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    return (JSON.parse(json) as { sub?: string }).sub;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Authenticate with a discoverable (usernameless) passkey, then exchange the
+ * resulting Keycloak SSO session for OIDC tokens via a silent iframe.
+ */
+export async function loginWithPasskey(
+  cfg: KeycloakConfig,
+  rpId: string = defaultRpId()
+): Promise<StoredTokens> {
+  if (!isPasskeySupported()) throw new Error("This browser does not support passkeys.");
+
+  const challenge = await requestChallenge(cfg);
+  const credential = await navigator.credentials.get({
+    publicKey: {
+      challenge: fromBase64Url(challenge) as BufferSource,
+      rpId,
+      userVerification: "required",
+      timeout: CEREMONY_TIMEOUT_MS,
+    },
+  });
+
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("No passkey credential was returned.");
+  }
+  const response = credential.response;
+  if (!(response instanceof AuthenticatorAssertionResponse) || !response.userHandle) {
+    throw new Error("Unexpected passkey authentication response.");
+  }
+
+  const authRes = await fetch(passkeyEndpoint(cfg, "authenticate"), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      credentialId: toBase64Url(credential.rawId),
+      userHandle: toBase64Url(response.userHandle),
+      clientDataJSON: toBase64Url(response.clientDataJSON),
+      authenticatorData: toBase64Url(response.authenticatorData),
+      signature: toBase64Url(response.signature),
+      challenge,
+    }),
+  });
+  if (!authRes.ok) throw new Error(`Passkey authentication rejected (${authRes.status})`);
+
+  // The provider has now established a Keycloak SSO session (cookie). Pull tokens
+  // for the `logos` client silently, without showing the hosted login page.
+  return silentTokenExchange(cfg);
+}
+
+/**
+ * Register a new passkey for the currently logged-in user.
+ */
+export async function registerPasskey(
+  cfg: KeycloakConfig,
+  accessToken: string,
+  rpId: string = defaultRpId(),
+  rpName = "Logos"
+): Promise<void> {
+  if (!isPasskeySupported()) throw new Error("This browser does not support passkeys.");
+  const sub = jwtSubject(accessToken);
+  if (!sub) throw new Error("Cannot register a passkey: access token has no subject.");
+
+  const challenge = await requestChallenge(cfg);
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: fromBase64Url(challenge) as BufferSource,
+      rp: { name: rpName, id: rpId },
+      user: {
+        id: new TextEncoder().encode(sub) as BufferSource,
+        name: getDeviceName(),
+        displayName: getDeviceName(),
+      },
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 }, // ES256
+        { type: "public-key", alg: -257 }, // RS256
+      ],
+      authenticatorSelection: { residentKey: "required", userVerification: "required" },
+      timeout: CEREMONY_TIMEOUT_MS,
+    },
+  });
+
+  if (!(credential instanceof PublicKeyCredential)) {
+    throw new Error("No passkey credential was returned.");
+  }
+  const response = credential.response;
+  if (!(response instanceof AuthenticatorAttestationResponse)) {
+    throw new Error("Unexpected passkey registration response.");
+  }
+
+  const saveRes = await fetch(passkeyEndpoint(cfg, "save"), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({
+      credentialId: toBase64Url(credential.rawId),
+      clientDataJSON: toBase64Url(response.clientDataJSON),
+      attestationObject: toBase64Url(response.attestationObject),
+      challenge,
+      label: getDeviceName(),
+    }),
+  });
+  if (!saveRes.ok) throw new Error(`Passkey registration rejected (${saveRes.status})`);
+}
+
+// ── Silent token retrieval (prompt=none authorization-code + PKCE) ───────────
+
+async function pkcePair(): Promise<{ verifier: string; challenge: string }> {
+  const verifier = (Crypto.randomUUID() + Crypto.randomUUID()).replace(/-/g, "");
+  const digest = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    verifier,
+    { encoding: Crypto.CryptoEncoding.BASE64 }
+  );
+  const challenge = digest.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return { verifier, challenge };
+}
+
+async function silentTokenExchange(cfg: KeycloakConfig): Promise<StoredTokens> {
+  const redirectUri = `${window.location.origin}${SILENT_REDIRECT_PATH}`;
+  const { verifier, challenge } = await pkcePair();
+  const state = Crypto.randomUUID();
+  const nonce = Crypto.randomUUID();
+
+  const authUrl =
+    `${cfg.endpoints.authorizationEndpoint}?` +
+    new URLSearchParams({
+      client_id: cfg.clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope: "openid profile email",
+      prompt: "none",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      state,
+      nonce,
+    }).toString();
+
+  const code = await codeFromSilentIframe(authUrl, redirectUri, state);
+
+  const tokenRes = await fetch(cfg.endpoints.tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: cfg.clientId,
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirectUri,
+    }).toString(),
+  });
+  if (!tokenRes.ok) throw new Error(`Silent token exchange failed (${tokenRes.status})`);
+  const data = await tokenRes.json();
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+    expiresAt: Math.floor(Date.now() / 1000) + (data.expires_in ?? 300),
+  };
+}
+
+// Loads the prompt=none auth URL in a hidden iframe; silent-check-sso.html posts
+// the redirected URL (carrying ?code) back to us. Resolves with the auth code.
+function codeFromSilentIframe(authUrl: string, redirectUri: string, state: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    let settled = false;
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      clearTimeout(timer);
+      iframe.remove();
+    };
+    const fail = (msg: string) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(msg));
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (typeof event.data !== "string" || !event.data.startsWith(redirectUri)) return;
+      const params = new URL(event.data).searchParams;
+      if (params.get("state") !== state) return fail("Silent login state mismatch.");
+      const err = params.get("error");
+      if (err) return fail(`Silent login failed: ${err}`);
+      const code = params.get("code");
+      if (!code) return fail("Silent login returned no authorization code.");
+      settled = true;
+      cleanup();
+      resolve(code);
+    };
+
+    const timer = setTimeout(() => fail("Silent login timed out."), CEREMONY_TIMEOUT_MS);
+    window.addEventListener("message", onMessage);
+    iframe.src = authUrl;
+    document.body.appendChild(iframe);
+  });
+}

--- a/logos/logos-ui/public/silent-check-sso.html
+++ b/logos/logos-ui/public/silent-check-sso.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Logos silent auth</title>
+  </head>
+  <body>
+    <!--
+      Redirect target for the prompt=none passkey/silent login flow. Keycloak
+      redirects here (inside a hidden iframe) with ?code=... or ?error=...; we
+      hand the full URL back to the opener, which exchanges the code for tokens.
+      See lib/auth/passkey.ts.
+    -->
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### What

In-page passwordless **passkey (WebAuthn) login** integrated into the UI — **no redirect** to a hosted login page. The login screen gains a **"Sign in with a passkey"** button that runs the WebAuthn ceremony in-page and logs the user in. Built on the current (`main`) Expo UI.

### Flow

1. `GET {issuer}/passkey/{clientId}/challenge`
2. `navigator.credentials.get(...)` — browser prompts for a discoverable passkey
3. `POST {issuer}/passkey/{clientId}/authenticate` — Keycloak passkey provider verifies the assertion and establishes an SSO session
4. **Silent token retrieval** — since Logos uses authorization-code + PKCE (not keycloak-js), a hidden `prompt=none` iframe → `silent-check-sso.html` obtains a code that's exchanged for tokens. No login page shown.

`registerPasskey()` mirrors this (`challenge` → `navigator.credentials.create()` → `POST .../save`).

### Files

- `logos-ui/lib/auth/passkey.ts` — ceremony, silent token exchange, helpers
- `logos-ui/lib/auth/keycloak.ts` — passkey endpoint derivation from the issuer
- `logos-ui/components/main.tsx` — passkey button + handler
- `logos-ui/public/silent-check-sso.html` — silent redirect target
- `logos/docs/passkey-login.md` — flow + prerequisites

### Draft — needs before merge

This is the **frontend** integration. The Keycloak side (not in this repo) must be in place and verified end-to-end:
- The custom passkey provider enabled for the **`logos`** client (`{issuer}/passkey/logos/{health|challenge|authenticate|save}`).
- The `logos` client: UI origin in **Web Origins**, `{origin}/silent-check-sso.html` in **Valid Redirect URIs**.
- WebAuthn passwordless policy + correct **rpId** (`passkey.ts` defaults to the current hostname; override if passkeys are scoped to a parent domain).
- Verify the silent `prompt=none` iframe works against the real Keycloak (third-party-cookie behaviour varies by browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)