### PR TITLE
`Logos`: Make passkey RP ID configurable (parent domain on shared Keycloak)

### DIFF
--- a/logos/docker-compose.dev.yaml
+++ b/logos/docker-compose.dev.yaml
@@ -169,6 +169,10 @@ services:
       KEYCLOAK_ADMIN_BASE_URL: "${KEYCLOAK_ADMIN_BASE_URL:-http://keycloak:8080}"
       KEYCLOAK_REALM: "${KEYCLOAK_REALM:-tum}"
       KEYCLOAK_CLIENT_ID: "${KEYCLOAK_CLIENT_ID:-logos}"
+      # Passkey WebAuthn RP ID. Empty in dev => the UI falls back to its hostname
+      # (localhost), which is the correct RP ID for the local Keycloak.
+      KEYCLOAK_PASSKEY_RP_ID: "${KEYCLOAK_PASSKEY_RP_ID:-}"
+      KEYCLOAK_PASSKEY_RP_NAME: "${KEYCLOAK_PASSKEY_RP_NAME:-Logos}"
       # Empty default: KeycloakProperties auto-derives audience from client id.
       KEYCLOAK_AUDIENCE: "${KEYCLOAK_AUDIENCE:-}"
       KEYCLOAK_ROLES_LOGOS_ADMIN: "${KEYCLOAK_ROLES_LOGOS_ADMIN:-itg-admin}"

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -198,6 +198,11 @@ services:
       KEYCLOAK_ADMIN_BASE_URL: "${KEYCLOAK_ADMIN_BASE_URL:-}"
       KEYCLOAK_REALM: "${KEYCLOAK_REALM:-tum}"
       KEYCLOAK_CLIENT_ID: "${KEYCLOAK_CLIENT_ID:-logos}"
+      # Passkey WebAuthn Relying Party ID, served to the UI via /info. On the shared
+      # TUM Keycloak passkeys are scoped to the parent domain, so default to it
+      # rather than the full UI host (else the browser finds no matching passkey).
+      KEYCLOAK_PASSKEY_RP_ID: "${KEYCLOAK_PASSKEY_RP_ID:-aet.cit.tum.de}"
+      KEYCLOAK_PASSKEY_RP_NAME: "${KEYCLOAK_PASSKEY_RP_NAME:-Logos}"
       # Empty default: KeycloakProperties auto-derives audience from client id.
       KEYCLOAK_AUDIENCE: "${KEYCLOAK_AUDIENCE:-}"
       KEYCLOAK_ROLES_LOGOS_ADMIN: "${KEYCLOAK_ROLES_LOGOS_ADMIN:-itg-admin}"

--- a/logos/docs/passkey-login.md
+++ b/logos/docs/passkey-login.md
@@ -31,9 +31,15 @@ These live on the Keycloak side, not in this repo:
 - The `logos` client must allow the silent flow: the UI origin in **Web Origins**
   and `{origin}/silent-check-sso.html` in **Valid Redirect URIs**.
 - The WebAuthn **passwordless policy** (resident key + user verification) must be
-  configured, and the passkey **rpId** must be a registrable suffix of the UI
-  origin. `passkey.ts` defaults `rpId` to the current hostname; override if the
-  shared provider scopes passkeys to a parent domain.
+  configured, and the passkey **rpId** must match what the credential was
+  registered with. On the shared TUM Keycloak passkeys are scoped to the parent
+  domain, so the rpId must be `aet.cit.tum.de` (NOT `logos.aet.cit.tum.de`) — a
+  page on `logos.aet.cit.tum.de` is allowed to use the parent as rpId, and the
+  credential is then shared across `*.aet.cit.tum.de` apps.
+
+  The rpId is configured server-side via `KEYCLOAK_PASSKEY_RP_ID` (served to the
+  UI through `/info`); the compose default is `aet.cit.tum.de` for prod. When
+  blank (dev), `passkey.ts` falls back to the current hostname (e.g. `localhost`).
 
 ## Notes / status
 

--- a/logos/logos-ui/lib/auth/keycloak.ts
+++ b/logos/logos-ui/lib/auth/keycloak.ts
@@ -14,6 +14,13 @@ export type KeycloakConfig = {
   issuer: string;
   clientId: string;
   endpoints: OidcEndpoints;
+  // WebAuthn Relying Party ID for passkeys. Must be a registrable suffix of the
+  // UI origin AND match what the passkey was registered with in Keycloak. On the
+  // shared TUM Keycloak this is the parent domain (e.g. `aet.cit.tum.de`) so a
+  // passkey works across all `*.aet.cit.tum.de` apps — not the full UI host.
+  // Empty/undefined => fall back to the current hostname (fine for localhost).
+  passkeyRpId?: string;
+  passkeyRpName?: string;
 };
 
 export type StoredTokens = {
@@ -29,7 +36,14 @@ export async function fetchKeycloakConfig(): Promise<KeycloakConfig> {
   if (!res.ok) {
     throw new Error(`Failed to load runtime config from /info: ${res.status}`);
   }
-  const data = (await res.json()) as { keycloak?: { issuer?: string; client_id?: string } };
+  const data = (await res.json()) as {
+    keycloak?: {
+      issuer?: string;
+      client_id?: string;
+      passkey_rp_id?: string;
+      passkey_rp_name?: string;
+    };
+  };
   const issuer = data.keycloak?.issuer;
   const clientId = data.keycloak?.client_id;
   if (!issuer || !clientId) {
@@ -38,6 +52,8 @@ export async function fetchKeycloakConfig(): Promise<KeycloakConfig> {
   return {
     issuer,
     clientId,
+    passkeyRpId: data.keycloak?.passkey_rp_id || undefined,
+    passkeyRpName: data.keycloak?.passkey_rp_name || undefined,
     endpoints: {
       authorizationEndpoint: `${issuer}/protocol/openid-connect/auth`,
       tokenEndpoint: `${issuer}/protocol/openid-connect/token`,

--- a/logos/logos-ui/lib/auth/passkey.ts
+++ b/logos/logos-ui/lib/auth/passkey.ts
@@ -139,7 +139,7 @@ function jwtSubject(accessToken: string): string | undefined {
  */
 export async function loginWithPasskey(
   cfg: KeycloakConfig,
-  rpId: string = defaultRpId()
+  rpId: string = cfg.passkeyRpId || defaultRpId()
 ): Promise<StoredTokens> {
   if (!isPasskeySupported()) throw new Error("This browser does not support passkeys.");
 
@@ -187,8 +187,8 @@ export async function loginWithPasskey(
 export async function registerPasskey(
   cfg: KeycloakConfig,
   accessToken: string,
-  rpId: string = defaultRpId(),
-  rpName = "Logos"
+  rpId: string = cfg.passkeyRpId || defaultRpId(),
+  rpName: string = cfg.passkeyRpName || "Logos"
 ): Promise<void> {
   if (!isPasskeySupported()) throw new Error("This browser does not support passkeys.");
   const sub = jwtSubject(accessToken);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/auth/PublicConfigController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/auth/PublicConfigController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.logos.logoswebservice.auth;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -17,22 +18,31 @@ import org.springframework.web.bind.annotation.RestController;
 public class PublicConfigController {
 
     private final String issuer;
+    private final String passkeyRpId;
+    private final String passkeyRpName;
     private final KeycloakProperties props;
 
     public PublicConfigController(
             @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") String issuer,
+            @Value("${logos.auth.passkey.rp-id:}") String passkeyRpId,
+            @Value("${logos.auth.passkey.rp-name:Logos}") String passkeyRpName,
             KeycloakProperties props) {
         this.issuer = issuer;
+        this.passkeyRpId = passkeyRpId;
+        this.passkeyRpName = passkeyRpName;
         this.props = props;
     }
 
     @GetMapping("/info")
     public ResponseEntity<Map<String, Object>> info() {
-        return ResponseEntity.ok(Map.of(
-            "keycloak", Map.of(
-                "issuer", issuer,
-                "client_id", props.clientId()
-            )
-        ));
+        Map<String, Object> keycloak = new LinkedHashMap<>();
+        keycloak.put("issuer", issuer);
+        keycloak.put("client_id", props.clientId());
+        // WebAuthn Relying Party ID for passkeys. Blank => the UI falls back to the
+        // current hostname; on the shared TUM Keycloak this must be the parent
+        // domain (e.g. aet.cit.tum.de) so passkeys are shared across subdomains.
+        keycloak.put("passkey_rp_id", passkeyRpId);
+        keycloak.put("passkey_rp_name", passkeyRpName);
+        return ResponseEntity.ok(Map.of("keycloak", keycloak));
     }
 }

--- a/logos/logos-webservice/src/main/resources/application.properties
+++ b/logos/logos-webservice/src/main/resources/application.properties
@@ -26,6 +26,12 @@ logos.auth.client-id=${KEYCLOAK_CLIENT_ID:logos}
 # rejected. Leave empty to auto-derive from the client id (the usual case); override
 # only when an explicit aud mapper produces a different value.
 logos.auth.audience=${KEYCLOAK_AUDIENCE:}
+# Passkey (WebAuthn) Relying Party ID + display name, served to the UI via /info.
+# Leave rp-id blank to let the UI fall back to its own hostname (ok for localhost).
+# On the shared TUM Keycloak set it to the parent domain (e.g. aet.cit.tum.de) so a
+# passkey registered there is usable across all *.aet.cit.tum.de apps.
+logos.auth.passkey.rp-id=${KEYCLOAK_PASSKEY_RP_ID:}
+logos.auth.passkey.rp-name=${KEYCLOAK_PASSKEY_RP_NAME:Logos}
 logos.auth.roles.logos-admin=${KEYCLOAK_ROLES_LOGOS_ADMIN:itg-admin}
 logos.auth.roles.app-admin=${KEYCLOAK_ROLES_APP_ADMIN:chair-member}
 # Auto-create teams from suffix-matching Keycloak roles/groups. Off by default: a claim only maps


### PR DESCRIPTION
### Problem

Follow-up to the in-page passkey login (#631). On prod the passkey prompt showed **"You don't have any passwords or passkeys saved for this website."** The UI defaulted the WebAuthn **rpId** to the full host `logos.aet.cit.tum.de`, but on the shared TUM Keycloak passkeys are registered against the **parent domain** `aet.cit.tum.de` (so they're shared across `*.aet.cit.tum.de` apps like thesis-management). The rpIds didn't match, so the browser found no credential.

A page on `logos.aet.cit.tum.de` is allowed by WebAuthn to use `aet.cit.tum.de` as its rpId.

### Fix

Make the passkey RP ID/name **configurable** and serve them to the UI via `/info` (same channel as issuer/client_id):

- `PublicConfigController` adds `passkey_rp_id` / `passkey_rp_name` to `/info`, from `logos.auth.passkey.rp-id` / `rp-name`.
- `application.properties`: `KEYCLOAK_PASSKEY_RP_ID` / `KEYCLOAK_PASSKEY_RP_NAME` env knobs.
- Compose: prod defaults `KEYCLOAK_PASSKEY_RP_ID` to **`aet.cit.tum.de`**; dev leaves it blank.
- UI (`keycloak.ts`/`passkey.ts`): use the server-provided rpId, falling back to the current hostname when blank (correct for `localhost` dev).

### Deploy note

Needs the webservice **and** UI redeployed from this branch — the webservice must serve the new `/info` field and the UI bundle must read it. No prod `.env` change required (compose default covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey/WebAuthn configuration support so login and registration can use deployment-specific relying-party settings.
  * The public app config now exposes passkey RP ID and RP name, and the UI uses them when available.

* **Documentation**
  * Clarified passkey setup requirements, including the correct domain choice for shared passkeys and default behavior in development.

* **Bug Fixes**
  * Improved passkey compatibility across deployments by avoiding hardcoded relying-party values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->