### PR TITLE
`Logos`: Fix passkey button hydration mismatch (React #418)

### DIFF
--- a/logos/logos-ui/components/main.tsx
+++ b/logos/logos-ui/components/main.tsx
@@ -82,7 +82,9 @@ function LoginView({
   const [mounted, setMounted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [passkeyLoading, setPasskeyLoading] = useState(false);
-  const passkeyAvailable = isPasskeySupported();
+  // Guard against SSR/CSR hydration mismatch: isPasskeySupported() reads `window`
+  // and `navigator`, which are unavailable during SSR. Only consult it after mount.
+  const passkeyAvailable = mounted && isPasskeySupported();
 
   const handlePasskeyLogin = async () => {
     setPasskeyLoading(true);


### PR DESCRIPTION
### Problem

After enabling the passkey login in #631 / #632, the app crashed at boot with **React error #418** (hydration failed: server-rendered HTML doesn't match client).

Root cause: `LoginView` calls `isPasskeySupported()` directly during render. That helper reads `window` / `navigator` / `PublicKeyCredential`, so it returns:
- **SSR**: `false` (no `window`) — passkey button **not** rendered
- **First client render**: `true` — passkey button **rendered**

Different trees → hydration mismatch.

### Fix

Gate the check on the existing `mounted` flag (already used a few lines below for the hue filter, exactly to defer client-only state until after `useEffect` runs):

```tsx
const passkeyAvailable = mounted && isPasskeySupported();
```

Server and first client render now both see `mounted=false` → button absent → trees match. After mount the button appears.

### Test plan

- [ ] Reload `https://logos.aet.cit.tum.de:9443/` — no [React 418](https://react.dev/errors/418) in console
- [ ] Passkey button still appears once the page is interactive
- [ ] Sign-in with passkey still completes (depends on the Keycloak admin config from #632 being in place: `https://logos.aet.cit.tum.de:9443/*` in Valid Redirect URIs and `https://logos.aet.cit.tum.de:9443` in Web Origins on the `logos` client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in page rendering to avoid mismatches between server and browser views.
  * The “Sign in with a passkey” option now appears only after the app has loaded in the browser, preventing brief incorrect states during initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->