### PR TITLE
`Logos`: Fix silent-SSO query strip and SPA hydration mismatch

### DIFF
--- a/logos/logos-ui/Dockerfile
+++ b/logos/logos-ui/Dockerfile
@@ -17,6 +17,11 @@ COPY . ./
 # Build React app (defaults to production mode)
 RUN npx expo export --platform web --output-dir web-build
 
+# Ensure the `serve` config lands in the served root (expo export may skip
+# non-asset files from public/). cleanUrls must stay off so the silent-SSO
+# iframe at /silent-check-sso.html keeps its ?code=... query on response.
+RUN cp public/serve.json web-build/serve.json
+
 # 2. Serve Stage (no nginx needed)
 FROM node:alpine
 

--- a/logos/logos-ui/app/_layout.tsx
+++ b/logos/logos-ui/app/_layout.tsx
@@ -1,5 +1,5 @@
 import "../global.css";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { usePathname } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StyleSheet, View } from "react-native";
@@ -14,17 +14,27 @@ import Footer from "@/components/footer";
 
 export default function _layout() {
   const [colorMode, setColorMode] = useState<"light" | "dark">("light");
+  const [hydrated, setHydrated] = useState(false);
   const pathname = usePathname();
 
-  const isPublic = (() => {
-    const current = pathname || "/";
-    return (
-      current === "/" ||
-      current.startsWith("/about") ||
-      current.startsWith("/imprint") ||
-      current.startsWith("/privacy")
-    );
-  })();
+  useEffect(() => setHydrated(true), []);
+
+  // The web build is a single-page export: every route serves the same SSG HTML,
+  // which was pre-rendered with pathname === "/" (isPublic === true). Until React
+  // has finished hydrating, treat every route as public so the first client render
+  // matches the server HTML; otherwise we get React error #418 on direct loads of
+  // protected routes like /statistics.
+  const isPublic =
+    !hydrated ||
+    (() => {
+      const current = pathname || "/";
+      return (
+        current === "/" ||
+        current.startsWith("/about") ||
+        current.startsWith("/imprint") ||
+        current.startsWith("/privacy")
+      );
+    })();
 
   console.log(
     "[_layout] rendering, pathname:",

--- a/logos/logos-ui/public/serve.json
+++ b/logos/logos-ui/public/serve.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": false
+}


### PR DESCRIPTION
Follow-up to #631 / #632 / #633. The previous fix resolved the in-render hydration check on the passkey button, but the prod HAR for `/statistics` showed two further bugs that broke the in-page passkey login end-to-end.

### Bug 1 — silent-SSO iframe loses its `?code=...`

Repro (from the HAR):

```
GET 302 https://keycloak.aet.cit.tum.de/.../auth?...&prompt=none&redirect_uri=.../silent-check-sso.html
GET 301 https://logos.aet.cit.tum.de:9443/silent-check-sso.html?state=...&code=...
GET 200 https://logos.aet.cit.tum.de:9443/silent-check-sso        ← query lost
```

Cause: the prod container runs `serve web-build --single` and `serve-handler`'s `cleanUrls` default is `true`, which 301-redirects `/silent-check-sso.html` → `/silent-check-sso` and **drops the query** in the process. The bare path then `--single`-falls back to `index.html`, the iframe loads the Logos SPA shell instead of our redirect script, and the parent `loginWithPasskey()` waits forever for the never-arriving `postMessage`.

Fix: ship a `serve.json` next to the export with `cleanUrls: false`. `.html` URLs are served as-is, so `silent-check-sso.html?code=...` arrives intact. The Dockerfile copies the file into `web-build/` explicitly (belt-and-braces in case `expo export` skips non-asset files from `public/`).

This matches what thesis-management ([`client/serve.e2e.json`](https://github.com/ls1intum/thesis-management/blob/main/client/serve.e2e.json)) does for the same reason.

### Bug 2 — React #418 on direct loads of protected routes

Repro: hard-reload `/statistics` → `Uncaught Error: Minified React error #418` (hydration mismatch).

Cause: the export is single-page — `curl /` and `curl /statistics` return byte-identical HTML, pre-rendered with `pathname === "/"`. That makes the SSG `isPublic` resolve to `true`, so the static HTML contains `Main` (\"Checking login…\"). On the client at `/statistics`, `pathname === \"/statistics\"`, `isPublic` becomes `false`, and the tree switches to `AuthenticatedShell` (\"Checking authentication…\"). Different trees → #418.

Fix: defer the public/protected decision in `app/_layout.tsx` until after hydration, mirroring the `mounted`-gate pattern used elsewhere in the codebase (and applied to the passkey button in #633). The first client render now matches the SSG HTML; the real route takes over on the next render.

### Files

- `logos/logos-ui/app/_layout.tsx` — gate `isPublic` on `hydrated` flag.
- `logos/logos-ui/public/serve.json` — `{ \"cleanUrls\": false }`.
- `logos/logos-ui/Dockerfile` — explicit `cp public/serve.json web-build/serve.json` after export.

### Test plan

- [ ] Hard-reload `/statistics` (logged in) → no React #418 in console; spinner → dashboard, no flash.
- [ ] Hard-reload `/` (logged out) → login screen, no #418.
- [ ] Click \"Sign in with a passkey\" → ceremony completes, **iframe response is 200 with the `?code=` preserved (no 301 in network tab)** → tokens land → redirect to `/dashboard`.
- [ ] Check that `https://logos.aet.cit.tum.de:9443/serve.json` returns `{\"cleanUrls\": false}` after deploy (sanity-check that it ended up in `web-build/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)