### PR TITLE
`Logos`: Parallelity-aware lane placement (calibrated max_num_seqs)

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5454,6 +5454,48 @@ class CapacityPlanner:
         parsed.sort(key=lambda pair: pair[0])
         return parsed
 
+    # Minimum achievable concurrency (parallelity factor = kv_cache_tokens /
+    # max_model_len) we try to give a lane when GPU memory allows. Serving a
+    # single in-flight request (parallelity ~1) starves a model under any real
+    # load, so we size the KV cache for >=2 concurrent full-context requests
+    # when a fitting calibrated point provides it; otherwise we fall back to the
+    # smallest fitting KV. Replaces the old blunt 0.5 gpu_memory_utilization
+    # placement floor (see logos_worker_node.lane_manager).
+    _MIN_TARGET_PARALLELITY = 2.0
+
+    @staticmethod
+    def _parse_kv_parallelity_pairs(
+        profile: ModelProfile,
+    ) -> List[tuple[float, int, Optional[float]]]:
+        """Parse ``kv_cache_to_max_model_len_pairs`` as (kv_mb, max_model_len, parallelity).
+
+        ``parallelity`` is the calibrated achievable concurrency for that KV
+        point, or None for legacy profiles that predate parallelity capture.
+        """
+        raw_pairs = profile.kv_cache_to_max_model_len_pairs or []
+        parsed: List[tuple[float, int, Optional[float]]] = []
+        for item in raw_pairs:
+            if not isinstance(item, dict):
+                continue
+            try:
+                kv_mb = float(item.get("kv_mb"))
+                max_model_len = int(item.get("max_model_len"))
+            except (TypeError, ValueError):
+                continue
+            if kv_mb <= 0 or max_model_len <= 0:
+                continue
+            par: Optional[float]
+            try:
+                raw_par = item.get("parallelity")
+                par = float(raw_par) if raw_par is not None else None
+            except (TypeError, ValueError):
+                par = None
+            if par is not None and par <= 0:
+                par = None
+            parsed.append((kv_mb, max_model_len, par))
+        parsed.sort(key=lambda t: t[0])
+        return parsed
+
     @classmethod
     def _select_kv_mb_max_model_len_pair(
         cls,
@@ -5464,23 +5506,40 @@ class CapacityPlanner:
 
         Rule:
         1. keep fitting pairs (kv <= free)
-        2. pick highest max_model_len among fitting
-        3. among ties, pick smallest kv
+        2. pick highest max_model_len among fitting (never sacrifice context)
+        3. among pairs serving that context, prefer the SMALLEST kv whose
+           calibrated parallelity >= _MIN_TARGET_PARALLELITY so the lane can
+           serve >=2 concurrent full-context requests; if none reach the target
+           within budget, take the fitting pair with the HIGHEST parallelity;
+           if parallelity is unknown (legacy profile), fall back to smallest kv.
         """
         if profile is None:
             return None, None
-        parsed_pairs = cls._parse_kv_max_model_len_pairs(profile)
+        parsed_pairs = cls._parse_kv_parallelity_pairs(profile)
         if not parsed_pairs:
             return None, None
         if available_for_kv_mb is None:
             fitting = parsed_pairs
         else:
-            fitting = [pair for pair in parsed_pairs if pair[0] <= float(available_for_kv_mb)]
+            fitting = [t for t in parsed_pairs if t[0] <= float(available_for_kv_mb)]
         if not fitting:
             return None, None
-        best_max_model_len = max(max_model_len for _, max_model_len in fitting)
-        best_kv = min(kv_mb for kv_mb, max_model_len in fitting if max_model_len == best_max_model_len)
-        return best_kv, best_max_model_len
+        best_max_model_len = max(mml for _, mml, _ in fitting)
+        candidates = [t for t in fitting if t[1] == best_max_model_len]
+        # Points serving the chosen context, smallest KV first.
+        candidates.sort(key=lambda t: t[0])
+        # Prefer the smallest KV that meets the parallelity target.
+        for kv_mb, _mml, par in candidates:
+            if par is not None and par >= cls._MIN_TARGET_PARALLELITY:
+                return kv_mb, best_max_model_len
+        # No fitting point reaches the target. If any point carries parallelity
+        # info, take the one with the highest achievable concurrency; otherwise
+        # (legacy / unknown) fall back to the smallest KV (memory-minimal).
+        with_par = [t for t in candidates if t[2] is not None]
+        if with_par:
+            best = max(with_par, key=lambda t: t[2])
+            return best[0], best_max_model_len
+        return candidates[0][0], best_max_model_len
 
     @staticmethod
     def _select_kv_mb_from_envelope(

--- a/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_capacity_planner_kv_envelope.py
@@ -247,6 +247,56 @@ def test_select_kv_pair_ignores_zero_plateau_entries():
     assert (kv_mb, max_model_len) == (2048.0, 205920)
 
 
+def test_select_kv_pair_targets_parallelity_two():
+    """At the best context, pick the smallest KV whose parallelity reaches 2.
+
+    Pairs all serve max_model_len=2000 with rising KV/concurrency. With ample
+    free VRAM the planner must skip the parallelity~1 point (2G) and pick the
+    smallest point that reaches >=2x concurrency (3G), but not waste memory on
+    the 4G/3x point.
+    """
+    profile = ModelProfile(
+        model_name="pair/model",
+        engine="vllm",
+        kv_cache_to_max_model_len_pairs=[
+            {"kv_mb": 2048.0, "max_model_len": 2000, "parallelity": 1.0},
+            {"kv_mb": 3072.0, "max_model_len": 2000, "parallelity": 2.0},
+            {"kv_mb": 4096.0, "max_model_len": 2000, "parallelity": 3.0},
+        ],
+    )
+    kv_mb, max_model_len = CapacityPlanner._select_kv_mb_max_model_len_pair(profile, available_for_kv_mb=8192.0)
+    assert (kv_mb, max_model_len) == (3072.0, 2000)
+
+
+def test_select_kv_pair_parallelity_target_respects_budget():
+    """A parallelity>=2 point that does not fit is skipped; smallest fitting wins."""
+    profile = ModelProfile(
+        model_name="pair/model",
+        engine="vllm",
+        kv_cache_to_max_model_len_pairs=[
+            {"kv_mb": 2048.0, "max_model_len": 2000, "parallelity": 1.0},
+            {"kv_mb": 5120.0, "max_model_len": 2000, "parallelity": 2.0},
+        ],
+    )
+    # Only the 2G point fits — the 5G (parallelity 2) is out of budget.
+    kv_mb, max_model_len = CapacityPlanner._select_kv_mb_max_model_len_pair(profile, available_for_kv_mb=3000.0)
+    assert (kv_mb, max_model_len) == (2048.0, 2000)
+
+
+def test_select_kv_pair_falls_back_to_highest_parallelity_when_target_unreachable():
+    """When no fitting point reaches parallelity 2, take the highest available."""
+    profile = ModelProfile(
+        model_name="pair/model",
+        engine="vllm",
+        kv_cache_to_max_model_len_pairs=[
+            {"kv_mb": 2048.0, "max_model_len": 2000, "parallelity": 1.0},
+            {"kv_mb": 3072.0, "max_model_len": 2000, "parallelity": 1.5},
+        ],
+    )
+    kv_mb, max_model_len = CapacityPlanner._select_kv_mb_max_model_len_pair(profile, available_for_kv_mb=8192.0)
+    assert (kv_mb, max_model_len) == (3072.0, 2000)
+
+
 def _planner_for_kv_estimate(available_total_mb: float) -> CapacityPlanner:
     """A CapacityPlanner stub exposing just what _estimate_available_for_kv_mb needs."""
     from unittest.mock import MagicMock

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -644,6 +644,32 @@ def _extract_vllm_max_num_seqs_suggestion(log_tail: str) -> int | None:
     return value if value > 0 else None
 
 
+# vLLM prints the achievable concurrency at every engine init, e.g.
+#   "Maximum concurrency for 33,888 tokens per request: 2.00x"
+# This is total_kv_cache_tokens / max_model_len — i.e. how many simultaneous
+# full-context requests the KV pool can serve. We read it back (rather than
+# pinning --max-num-seqs) to record the "parallelity factor" of each KV point.
+_VLLM_MAX_CONCURRENCY_RE = re.compile(r"Maximum concurrency for [\d,]+ tokens per request:\s*([\d.]+)x")
+
+
+def _extract_vllm_max_concurrency(log_tail: str) -> float | None:
+    """Return vLLM's reported achievable concurrency (the ``X.XXx`` factor), else None.
+
+    Uses the LAST occurrence in the log so a re-probe at a different KV size
+    reflects the final successful load rather than an earlier attempt.
+    """
+    if not log_tail:
+        return None
+    matches = _VLLM_MAX_CONCURRENCY_RE.findall(log_tail)
+    if not matches:
+        return None
+    try:
+        value = float(matches[-1])
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 # ---------------------------------------------------------------------------
 # GPU VRAM helpers
 # ---------------------------------------------------------------------------
@@ -1119,6 +1145,13 @@ class CalibrationResult:
     # Each tuple is (kv_cache_mb, max_model_len) and represents one point on
     # the reachable context curve for this model on this hardware.
     kv_max_model_len_pairs: list[tuple[float, int]] | None = None
+    # Same sweep points annotated with the achievable concurrency (parallelity
+    # factor = kv_cache_tokens / max_model_len) vLLM reported at each KV size.
+    # Each tuple is (kv_cache_mb, max_model_len, parallelity). ``parallelity`` is
+    # None when neither a probed anchor nor the KV→context rate could supply it.
+    # The planner uses it to place lanes with enough KV for >=2 concurrent
+    # full-context requests when memory allows.
+    kv_max_model_len_parallelity_pairs: list[tuple[float, int, float | None]] | None = None
     # ``max_num_seqs`` actually used during the successful probe(s). Set when
     # calibration auto-injected --max-num-seqs because a hybrid Mamba/SSM
     # model's state-cache pool was smaller than the default 1024. Persisted so
@@ -1714,6 +1747,10 @@ def calibrate_model(
         model_default_max_len: int | None = None
         kv_needed_for_full_mb: float | None = None
         best_kv: float | None = None
+        # Achievable concurrency (parallelity factor) vLLM reported at each KV
+        # probe, keyed by kv_mb. Read back from the load log rather than pinning
+        # --max-num-seqs. Used to annotate the kv→max_model_len curve.
+        anchors_parallelity: dict[float, float] = {}
 
         def _probe_kv(kv_mb: float) -> int | None:
             nonlocal model_default_max_len, kv_needed_for_full_mb, best_kv, resolved_max_num_seqs
@@ -1728,6 +1765,9 @@ def calibrate_model(
                 return None
             _probes[kv_mb] = "ok"
             log_tail = _read_log_tail(log_path)
+            _conc = _extract_vllm_max_concurrency(log_tail)
+            if _conc is not None:
+                anchors_parallelity[kv_mb] = _conc
             suggested_mml = _extract_vllm_max_model_len_suggestion(log_tail)
             if model_default_max_len is None:
                 model_default_max_len = _extract_vllm_max_seq_len(log_tail)
@@ -1904,6 +1944,19 @@ def calibrate_model(
         partial.kv_max_model_len_pairs = kv_max_model_len_pairs
         if kv_max_model_len_pairs:
             partial.max_model_len = max(mml for _, mml in kv_max_model_len_pairs)
+            # Annotate every KV point with its achievable concurrency (parallelity
+            # factor = kv_cache_tokens / max_model_len). Prefer the value vLLM
+            # reported at a probed anchor; otherwise derive it from the calibrated
+            # KV→context rate (per_token_bytes). None when neither is available.
+            _anchor_par = {round(k, 1): v for k, v in anchors_parallelity.items()}
+            _triples: list[tuple[float, int, float | None]] = []
+            for kv_mb, mml in kv_max_model_len_pairs:
+                par = _anchor_par.get(round(kv_mb, 1))
+                if par is None and per_token_bytes and mml > 0:
+                    kv_tokens = (kv_mb * 1024.0 * 1024.0) / per_token_bytes
+                    par = kv_tokens / float(mml)
+                _triples.append((kv_mb, int(mml), (round(float(par), 3) if par and par > 0 else None)))
+            partial.kv_max_model_len_parallelity_pairs = _triples
 
         logger.info(
             "  KV sweep result: %s%sbest_working=%s%s (step=%.0f MB)",
@@ -2232,13 +2285,27 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
         # was passed. Mirrors ``calibration_kv_cache_memory_bytes`` — same
         # "value that the successful probe actually used" semantics.
         "calibration_max_model_len": int(r.max_model_len) if r.max_model_len else None,
-        # Per-KV max_model_len sweep captured during calibration.
+        # Per-KV max_model_len sweep captured during calibration, each point
+        # annotated with the achievable concurrency (``parallelity`` factor =
+        # kv_cache_tokens / max_model_len). Falls back to the un-annotated pairs
+        # for legacy results that predate parallelity capture.
         "kv_cache_to_max_model_len_pairs": (
             [
-                {"kv_mb": round(kv_mb, 1), "max_model_len": int(max_model_len)}
-                for kv_mb, max_model_len in (r.kv_max_model_len_pairs or [])
+                {
+                    "kv_mb": round(kv_mb, 1),
+                    "max_model_len": int(max_model_len),
+                    "parallelity": (round(float(parallelity), 3) if parallelity else None),
+                }
+                for kv_mb, max_model_len, parallelity in r.kv_max_model_len_parallelity_pairs
             ]
-            or None
+            if r.kv_max_model_len_parallelity_pairs
+            else (
+                [
+                    {"kv_mb": round(kv_mb, 1), "max_model_len": int(max_model_len)}
+                    for kv_mb, max_model_len in (r.kv_max_model_len_pairs or [])
+                ]
+                or None
+            )
         ),
         # --max-num-seqs that calibration auto-injected for a hybrid Mamba/SSM
         # model whose state-cache pool was smaller than vLLM's default 1024.

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -2224,6 +2224,7 @@ def calibrate_model(
             max_kv_cache_mb=max_kv_observed_mb,
             max_model_len=partial.max_model_len,
             kv_max_model_len_pairs=partial.kv_max_model_len_pairs,
+            kv_max_model_len_parallelity_pairs=partial.kv_max_model_len_parallelity_pairs,
             max_num_seqs=partial.max_num_seqs,
         )
 

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1614,13 +1614,22 @@ class LaneManager:
         per_gpu_required_mb = required_total_mb / float(tp_size)
         per_gpu_threshold_mb = per_gpu_required_mb * _GPU_PLACEMENT_SECURITY_RATIO + _GPU_PLACEMENT_HEADROOM_OFFSET_MB
 
-        # When the model's calibrated footprint is small, vLLM will clamp
-        # gpu_memory_utilization to _VLLM_GMU_FLOOR and pre-allocate that
-        # fraction of total GPU memory at startup. If we only check against
-        # the calibrated footprint, placement succeeds here but vLLM startup
-        # fails with "free memory < desired gpu_memory_utilization".
+        # When vLLM sizes its KV cache from gpu_memory_utilization, it clamps a
+        # small model's GMU up to _VLLM_GMU_FLOOR and pre-allocates that fraction
+        # of total GPU memory at startup; checking only the calibrated footprint
+        # would let placement succeed here but vLLM startup fail with
+        # "free memory < desired gpu_memory_utilization".
+        #
+        # BUT when the lane pins kv_cache_memory_bytes, vLLM skips memory
+        # profiling and ignores gpu_memory_utilization entirely (it logs exactly
+        # this), reserving only weights + the explicit KV. The floor would then
+        # demand free VRAM the lane never uses and wrongly reject small models
+        # (e.g. a 4B model needing ~6GB rejected for not having ~24GB free). KV
+        # size / concurrency is governed by the planner's calibrated
+        # parallelity-aware pair selection instead, so skip the floor here.
+        kv_pinned = bool(lane_config.vllm_config is not None and lane_config.vllm_config.kv_cache_memory_bytes)
         gpu_totals = [float(row.get("total_mb", 0.0)) for row in allowed_rows if row.get("total_mb", 0.0) > 0]
-        if gpu_totals:
+        if gpu_totals and not kv_pinned:
             min_gpu_total_mb = min(gpu_totals)
             vllm_floor_mb = _VLLM_GMU_FLOOR * min_gpu_total_mb
             if vllm_floor_mb > per_gpu_threshold_mb:

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1481,6 +1481,16 @@ class LaneManager:
         kv_mb = 0.0
         if lane_config.vllm_config and lane_config.vllm_config.kv_cache_memory_bytes:
             kv_mb = self._parse_memory_to_mb(lane_config.vllm_config.kv_cache_memory_bytes)
+            # With the GMU placement floor skipped for kv-pinned lanes, this
+            # estimate is the only placement guard. When the profile has no
+            # base residency, returning the KV size alone would understate the
+            # footprint (it omits the weights), letting placement pick a GPU
+            # that fits the KV cache but not the model. Prefer the observed
+            # loaded footprint (weights + KV) when it is known.
+            if base_mb <= 0:
+                observed_total_mb = float(profile.loaded_vram_mb or 0.0)
+                if observed_total_mb > 0:
+                    return max(observed_total_mb, kv_mb)
         elif profile.kv_budget_mb and profile.kv_budget_mb > 0:
             kv_mb = float(profile.kv_budget_mb)
         elif profile.loaded_vram_mb and profile.loaded_vram_mb > 0 and base_mb > 0:

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -334,7 +334,17 @@ class ModelProfileRegistry:
                         continue
                     if kv_mb <= 0 or max_model_len <= 0:
                         continue
-                    parsed_pairs.append({"kv_mb": kv_mb, "max_model_len": max_model_len})
+                    entry: dict[str, Any] = {"kv_mb": kv_mb, "max_model_len": max_model_len}
+                    # Preserve the achievable concurrency (parallelity factor) when present.
+                    raw_par = item.get("parallelity")
+                    if raw_par is not None:
+                        try:
+                            par = float(raw_par)
+                        except (TypeError, ValueError):
+                            par = 0.0
+                        if par > 0:
+                            entry["parallelity"] = par
+                    parsed_pairs.append(entry)
                 profile.kv_cache_to_max_model_len_pairs = parsed_pairs or None
                 applied.append(
                     "kv_cache_to_max_model_len_pairs=" f"{len(profile.kv_cache_to_max_model_len_pairs or [])}"

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -29,6 +29,7 @@ from logos_worker_node.calibration import (
     _build_vllm_cmd,
     _classify_fatal_load_error,
     _classify_node_transient_error,
+    _extract_vllm_max_concurrency,
     _extract_vllm_max_model_len_suggestion,
     _extract_vllm_max_num_seqs_suggestion,
     _format_kv_mb,
@@ -1004,6 +1005,65 @@ def test_extract_vllm_max_num_seqs_suggestion_ignores_unrelated_errors():
     assert _extract_vllm_max_num_seqs_suggestion("CUDA out of memory") is None
     assert _extract_vllm_max_num_seqs_suggestion("") is None
     assert _extract_vllm_max_num_seqs_suggestion(None) is None  # type: ignore[arg-type]
+
+
+def test_extract_vllm_max_concurrency_real_log_tail():
+    tail = (
+        "INFO 06-29 07:31:38 [kv_cache_utils.py:1744] GPU KV cache size: 67,786 tokens\n"
+        "INFO 06-29 07:31:38 [kv_cache_utils.py:1745] Maximum concurrency for 33,888 "
+        "tokens per request: 2.00x\n"
+    )
+    assert _extract_vllm_max_concurrency(tail) == 2.0
+
+
+def test_extract_vllm_max_concurrency_uses_last_occurrence():
+    # A re-probe at a larger KV should win over the earlier attempt.
+    tail = (
+        "Maximum concurrency for 8,192 tokens per request: 1.00x\n"
+        "Maximum concurrency for 8,192 tokens per request: 4.50x\n"
+    )
+    assert _extract_vllm_max_concurrency(tail) == 4.5
+
+
+def test_extract_vllm_max_concurrency_ignores_unrelated_errors():
+    assert _extract_vllm_max_concurrency("CUDA out of memory") is None
+    assert _extract_vllm_max_concurrency("") is None
+    assert _extract_vllm_max_concurrency(None) is None  # type: ignore[arg-type]
+
+
+def test_result_to_profile_dict_emits_parallelity_in_pairs():
+    result = CalibrationResult(
+        model="google/gemma-3-4b-it",
+        tensor_parallel_size=2,
+        gpu_devices="0,1",
+        kv_cache_sent_mb=1024.0,
+        success=True,
+        kv_max_model_len_pairs=[(1024.0, 33888), (2048.0, 33888)],
+        kv_max_model_len_parallelity_pairs=[
+            (1024.0, 33888, 2.0),
+            (2048.0, 33888, 4.0),
+        ],
+    )
+    out = result_to_profile_dict(result)
+    pairs = out["kv_cache_to_max_model_len_pairs"]
+    assert pairs == [
+        {"kv_mb": 1024.0, "max_model_len": 33888, "parallelity": 2.0},
+        {"kv_mb": 2048.0, "max_model_len": 33888, "parallelity": 4.0},
+    ]
+
+
+def test_result_to_profile_dict_legacy_pairs_without_parallelity():
+    result = CalibrationResult(
+        model="legacy/model",
+        tensor_parallel_size=1,
+        gpu_devices="0",
+        kv_cache_sent_mb=1024.0,
+        success=True,
+        kv_max_model_len_pairs=[(1024.0, 8192)],
+        kv_max_model_len_parallelity_pairs=None,
+    )
+    out = result_to_profile_dict(result)
+    assert out["kv_cache_to_max_model_len_pairs"] == [{"kv_mb": 1024.0, "max_model_len": 8192}]
 
 
 def test_result_to_profile_dict_includes_max_num_seqs():

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -665,7 +665,6 @@ async def test_auto_place_gpu_devices_picks_best_fit_single_gpu() -> None:
     assert placed.gpu_devices == "0"
 
 
-@pytest.mark.asyncio
 async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> None:
     """A kv-pinned lane must NOT be gated by the 0.5 GMU floor.
 

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -666,6 +666,75 @@ async def test_auto_place_gpu_devices_picks_best_fit_single_gpu() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> None:
+    """A kv-pinned lane must NOT be gated by the 0.5 GMU floor.
+
+    Same GPUs as the floor test: GPU 2 (7.6 GB free) was eliminated by the
+    12.3 GB floor. But when the lane pins kv_cache_memory_bytes, vLLM ignores
+    gpu_memory_utilization and only grabs weights + KV (~6 GB), so GPU 2 becomes
+    feasible — and best-fit (smallest leftover) now selects it. This is the fix
+    that lets small models (e.g. gemma-3-4b) place into tight free VRAM.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen2.5-0.5B-Instruct"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=6000.0,
+        engine="vllm",
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=16000.0,
+                    extra={"index": 0},
+                ),
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=12000.0,
+                    extra={"index": 1},
+                ),
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=7600.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 24576.0,
+            free_memory_mb=35600.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, kv_cache_memory_bytes="1G"),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
+    # Floor skipped → threshold ≈ footprint (~6 GB); GPU 2 (7600) fits and is the
+    # tightest best-fit, so it is chosen rather than being eliminated.
+    assert placed.gpu_devices == "2"
+
+
+@pytest.mark.asyncio
 async def test_auto_place_gpu_devices_avoids_collocating_with_tp2_lane() -> None:
     """A single-GPU lane must be placed on a GPU not already occupied by a
     TP=2 lane, even if those GPUs have more free memory than the isolated GPU.

--- a/logos/logos-workernode/tests/test_model_profiles.py
+++ b/logos/logos-workernode/tests/test_model_profiles.py
@@ -516,6 +516,30 @@ def test_kv_envelope_manual_override_applies():
     assert profile.max_kv_cache_mb == 8192.0
 
 
+def test_kv_pairs_override_preserves_parallelity():
+    """The parallelity factor on each kv pair survives the override merge."""
+    registry = ModelProfileRegistry(
+        model_profile_overrides={
+            "operator/pinned": {
+                "kv_cache_to_max_model_len_pairs": [
+                    {"kv_mb": 1024.0, "max_model_len": 33888, "parallelity": 2.0},
+                    {"kv_mb": 2048.0, "max_model_len": 33888, "parallelity": 4.0},
+                    {"kv_mb": 512.0, "max_model_len": 16944},  # legacy entry, no parallelity
+                ]
+            }
+        }
+    )
+    registry.seed_capabilities(["operator/pinned"], engine="vllm")
+    profile = registry.get_profile("operator/pinned")
+    assert profile is not None
+    pairs = profile.kv_cache_to_max_model_len_pairs
+    assert pairs is not None
+    by_kv = {p["kv_mb"]: p for p in pairs}
+    assert by_kv[1024.0]["parallelity"] == 2.0
+    assert by_kv[2048.0]["parallelity"] == 4.0
+    assert "parallelity" not in by_kv[512.0]
+
+
 def test_calibration_max_model_len_to_dict_round_trip():
     """The auto-shrunk --max-model-len appears in to_dict() so the YAML
     round-trip (and heartbeats) preserve it.


### PR DESCRIPTION
## Problem

The 5-model benchmark's **gemma-3-4b** (the *smallest* model, real footprint ~6 GB) never warmed up: worker auto-placement rejected its lane with `no feasible GPU subset … per-GPU threshold≈24570MB`. Root cause — the placement guard demands `_VLLM_GMU_FLOOR (0.5) × GPU-total (~49 GB) ≈ 24.5 GB free` for **every** lane.

That premise is false for our lanes: when a lane pins `kv_cache_memory_bytes`, vLLM **skips memory profiling and ignores `gpu_memory_utilization`** (it logs this verbatim), reserving only weights + the explicit KV. So the floor demanded ~24.5 GB the lane never uses, and starved the smallest model → warmup timeout → dropped requests.

## Fix

Replace the blunt 0.5 floor with a calibrated, *measured* signal — the **parallelity factor** (achievable concurrency = `kv_cache_tokens / max_model_len`, i.e. vLLM's `Maximum concurrency … X.XXx`):

- **Calibration** records parallelity at each KV sweep point, read back from vLLM's own load log (no need to pin `--max-num-seqs`). `kv_cache_to_max_model_len_pairs` entries gain a `parallelity` key; legacy profiles without it still work.
- **Planner** spawn-time KV selector targets **parallelity ≥ 2** (≥2 concurrent full-context requests) when a fitting calibrated point provides it; falls back to highest-available / smallest-KV under memory pressure.
- **Worker** GMU-floor guard is **skipped when `kv_cache_memory_bytes` is set**, so kv-pinned lanes place on their real footprint. The floor still applies to GMU-sized lanes.

## Tests

- Calibration: concurrency parsing + profile-dict emission (incl. legacy fallback).
- Schema: parallelity round-trips through the worker override-merge.
- Planner: targets parallelity ≥ 2, respects free-VRAM budget, falls back to highest available.
- Worker: floor skipped for kv-pinned lanes; still applied to GMU-sized lanes.

Requires full recalibration of all 5 models after deploy (to populate parallelity + lean footprints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calibration now captures achievable concurrency as an optional “parallelity” signal and includes it in generated KV→max context tuning.
  * Model profile overrides can preserve an optional parallelity value per KV entry.
* **Bug Fixes**
  * Capacity planning now selects KV settings using parallelity-aware logic when available, with sensible legacy fallback when it isn’t.
  * GPU auto-placement now correctly handles explicitly pinned KV cache memory without applying an overly strict memory floor.
* **Tests**
  * Added unit coverage for concurrency/parallelity parsing, profile serialization, override merging, parallelity-aware capacity selection, and KV-pinned GPU placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->