### PR TITLE
`Logos`: Update vLLM to 0.24.0

### DIFF
--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -37,7 +37,7 @@
 ARG BASE_IMAGE=python:3.12-slim
 ARG RUNTIME_IMAGE=${BASE_IMAGE}
 ARG INSTALL_VLLM=0
-ARG VLLM_PIP_SPEC="vllm==v0.23.0"
+ARG VLLM_PIP_SPEC="vllm==v0.24.0"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.


### PR DESCRIPTION
## Summary
Bumps the Logos workernode vLLM pin from `v0.23.0` to `v0.24.0`.

- `logos/logos-workernode/Dockerfile`: `VLLM_PIP_SPEC` → `vllm==v0.24.0`

This `ARG` is the canonical vLLM version source for the workernode image (CI does not override it), so the build arg is the only change required.

## Notes
- The benchmark exact-match references (`benchmarks/BENCHMARK_FRAMEWORKS.md`, `benchmark_logos.py` KServe `vllm/vllm-openai:v0.23.0`) are left at 0.23.0 — they document a historical comparison run and are not retroactively changed by this bump.

## Test plan
- CI `Build Logos *` jobs must build the workernode image against vLLM 0.24.0.
- Deploy to test workernode and smoke-test lane bring-up before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled vLLM version to a newer release for environments that install it during image build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->