### PR TITLE
`Iris`: Make health-check baseline variant configurable per pipeline

### DIFF
--- a/iris/src/iris/pipeline/pipeline.py
+++ b/iris/src/iris/pipeline/pipeline.py
@@ -43,6 +43,11 @@ class Pipeline(metaclass=ABCMeta):
     ROLES: ClassVar[set[str]] = set()
     VARIANT_DEFS: ClassVar[list[tuple[str, str, str]]] = []
     DEPENDENCIES: ClassVar[list[Dep]] = []
+    # Variant id the health checker treats as the baseline smoke test. Most
+    # pipelines have a literal "default" variant; pipelines whose variants are
+    # content-orthogonal (e.g. faq vs problem_statement in RewritingPipeline)
+    # override this to pick one of their existing variants.
+    HEALTH_BASELINE_VARIANT_ID: ClassVar[str] = "default"
 
     implementation_id: str
     tokens: List[TokenUsageDTO]

--- a/iris/src/iris/pipeline/rewriting_pipeline.py
+++ b/iris/src/iris/pipeline/rewriting_pipeline.py
@@ -51,6 +51,7 @@ class RewritingPipeline(Pipeline):
             "Default Problem statement rewriting variant.",
         ),
     ]
+    HEALTH_BASELINE_VARIANT_ID = "problem_statement"
 
     callback: RewritingCallback
     rewriting_handler: LlmRequestHandler

--- a/iris/src/iris/web/routers/health/Pipelines/checker.py
+++ b/iris/src/iris/web/routers/health/Pipelines/checker.py
@@ -10,16 +10,19 @@ from iris.web.routers.health.Pipelines.features import Features
 from iris.web.routers.health.Pipelines.registery import PIPELINE_BY_FEATURE
 
 
-def _get_default_variant(variants: Iterable) -> AbstractVariant | None:
-    variants = list(variants)
-    return next((v for v in variants if getattr(v, "id", None) == "default"), None)
+def _get_baseline_variant(
+    variants: Iterable[AbstractVariant], baseline_id: str
+) -> AbstractVariant | None:
+    return next((v for v in variants if getattr(v, "id", None) == baseline_id), None)
 
 
-def _get_advanced_required_models(variants: Iterable[AbstractVariant]) -> set[str]:
+def _get_non_baseline_required_models(
+    variants: Iterable[AbstractVariant], baseline_id: str
+) -> set[str]:
     return {
         m
         for v in variants
-        if "default" not in getattr(v, "id", "")
+        if getattr(v, "id", "") != baseline_id
         for m in v.required_models()
     }
 
@@ -72,30 +75,33 @@ def evaluate_feature(feature: Features, available_ids: Set[str]) -> FeatureResul
             feature, wired=True, has_default=False, missing_models=frozenset()
         )
 
-    default = _get_default_variant(variants)
-    if default is None:
-        # No default variant found. Return has_default=False.
-        # Per your request, we don't check advanced models if the default is missing.
+    baseline_id = getattr(pipeline_cls, "HEALTH_BASELINE_VARIANT_ID", "default")
+    baseline = _get_baseline_variant(variants, baseline_id)
+    if baseline is None:
+        # Baseline variant not declared on this pipeline. Skip non-baseline
+        # checks: we can't validate models for a baseline we don't have.
         return FeatureResult(
             feature,
             wired=True,
             has_default=False,
-            missing_models=frozenset({"No default variant found"}),
+            missing_models=frozenset(
+                {f"No baseline variant found (expected variant id: '{baseline_id}')"}
+            ),
         )
-    required_default = default.required_models()
-    required_advanced = _get_advanced_required_models(variants)
+    required_baseline = baseline.required_models()
+    required_non_baseline = _get_non_baseline_required_models(variants, baseline_id)
 
-    all_required = required_default.union(required_advanced)
+    all_required = required_baseline.union(required_non_baseline)
     all_missing = missing_llm_requirements(
         all_required,
         available_ids=set(available_ids),
     )
-    default_missing = missing_llm_requirements(
-        required_default,
+    baseline_missing = missing_llm_requirements(
+        required_baseline,
         available_ids=set(available_ids),
     )
-    default_available = not default_missing
-    if not default_available:
+    baseline_available = not baseline_missing
+    if not baseline_available:
         return FeatureResult(
             feature,
             wired=True,

--- a/iris/tests/test_pipeline_health_checker.py
+++ b/iris/tests/test_pipeline_health_checker.py
@@ -70,7 +70,7 @@ class _FakePipelineBase:
     """Fake pipeline whose get_variants() is controlled by class attributes."""
 
     HEALTH_BASELINE_VARIANT_ID = "default"
-    _VARIANTS: list[Variant] = []
+    _VARIANTS: tuple[Variant, ...] = ()
 
     @classmethod
     def get_variants(cls) -> list[Variant]:
@@ -91,10 +91,10 @@ def _evaluate_with_fake(
 def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("faq", {"m_faq"}),
             _make_variant("problem_statement", {"m_ps"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq", "m_ps"})
     assert result.wired is True
@@ -106,10 +106,10 @@ def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
 def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("faq", {"m_faq"}),
             _make_variant("problem_statement", {"m_ps"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
     assert result.wired is True
@@ -120,10 +120,10 @@ def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
 def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "default"
-        _VARIANTS = [
+        _VARIANTS = (
             _make_variant("default", {"m_default"}),
             _make_variant("advanced", {"m_advanced"}),
-        ]
+        )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_default"})
     assert result.wired is True
@@ -136,7 +136,7 @@ def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
 def test_evaluate_feature_missing_baseline_variant_reports_expected_id(monkeypatch):
     class P(_FakePipelineBase):
         HEALTH_BASELINE_VARIANT_ID = "problem_statement"
-        _VARIANTS = [_make_variant("faq", {"m_faq"})]
+        _VARIANTS = (_make_variant("faq", {"m_faq"}),)
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
     assert result.wired is True

--- a/iris/tests/test_pipeline_health_checker.py
+++ b/iris/tests/test_pipeline_health_checker.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+
+from iris.domain.variant.variant import Variant
+from iris.pipeline.rewriting_pipeline import RewritingPipeline
+from iris.web.routers.health.Pipelines import checker
+from iris.web.routers.health.Pipelines.checker import (
+    _get_baseline_variant,
+    _get_non_baseline_required_models,
+    evaluate_feature,
+)
+
+
+def test_rewriting_pipeline_health_baseline_is_problem_statement():
+    # Pin the specific override so accidentally removing it surfaces here
+    # rather than only in the health endpoint at deploy time.
+    assert RewritingPipeline.HEALTH_BASELINE_VARIANT_ID == "problem_statement"
+    declared_variant_ids = {vid for vid, _, _ in RewritingPipeline.VARIANT_DEFS}
+    assert (
+        RewritingPipeline.HEALTH_BASELINE_VARIANT_ID in declared_variant_ids
+    ), "HEALTH_BASELINE_VARIANT_ID must point at a declared variant"
+
+
+def _make_variant(variant_id: str, required: set[str]) -> Variant:
+    return Variant(
+        variant_id=variant_id,
+        name=variant_id,
+        description="",
+        role_models={},
+        required_model_ids=required,
+    )
+
+
+def test_get_baseline_variant_returns_match_for_custom_id():
+    variants = [
+        _make_variant("faq", {"m1"}),
+        _make_variant("problem_statement", {"m2"}),
+    ]
+    baseline = _get_baseline_variant(variants, "problem_statement")
+    assert baseline is not None
+    assert baseline.id == "problem_statement"
+
+
+def test_get_baseline_variant_returns_none_when_id_absent():
+    variants = [_make_variant("faq", {"m1"})]
+    assert _get_baseline_variant(variants, "default") is None
+
+
+def test_get_non_baseline_required_models_exact_equality():
+    # A variant id that *contains* the substring "default" but is not equal
+    # must be treated as non-baseline. The previous substring-based check
+    # would have wrongly excluded "default_v2" from the non-baseline set.
+    variants = [
+        _make_variant("default", {"m_baseline"}),
+        _make_variant("default_v2", {"m_v2"}),
+        _make_variant("advanced", {"m_advanced"}),
+    ]
+    non_baseline = _get_non_baseline_required_models(variants, "default")
+    assert non_baseline == {"m_v2", "m_advanced"}
+
+
+class _FakeFeature(str, Enum):
+    FAKE = "FAKE"
+
+
+class _FakePipelineBase:
+    """Fake pipeline whose get_variants() is controlled by class attributes."""
+
+    HEALTH_BASELINE_VARIANT_ID = "default"
+    _VARIANTS: list[Variant] = []
+
+    @classmethod
+    def get_variants(cls) -> list[Variant]:
+        return list(cls._VARIANTS)
+
+
+def _evaluate_with_fake(
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline_cls: type,
+    available: set[str],
+):
+    monkeypatch.setattr(
+        checker, "PIPELINE_BY_FEATURE", {_FakeFeature.FAKE: pipeline_cls}
+    )
+    return evaluate_feature(_FakeFeature.FAKE, available)
+
+
+def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [
+            _make_variant("faq", {"m_faq"}),
+            _make_variant("problem_statement", {"m_ps"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq", "m_ps"})
+    assert result.wired is True
+    assert result.has_default is True
+    assert result.missing_models == frozenset()
+    assert result.ok is True
+
+
+def test_evaluate_feature_baseline_model_missing_flips_has_default(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [
+            _make_variant("faq", {"m_faq"}),
+            _make_variant("problem_statement", {"m_ps"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
+    assert result.wired is True
+    assert result.has_default is False
+    assert "m_ps" in result.missing_models
+
+
+def test_evaluate_feature_non_baseline_missing_keeps_has_default(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "default"
+        _VARIANTS = [
+            _make_variant("default", {"m_default"}),
+            _make_variant("advanced", {"m_advanced"}),
+        ]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_default"})
+    assert result.wired is True
+    assert result.has_default is True
+    assert result.missing_models == frozenset({"m_advanced"})
+    # has_default is True but missing_models is non-empty → not "ok"
+    assert result.ok is False
+
+
+def test_evaluate_feature_missing_baseline_variant_reports_expected_id(monkeypatch):
+    class P(_FakePipelineBase):
+        HEALTH_BASELINE_VARIANT_ID = "problem_statement"
+        _VARIANTS = [_make_variant("faq", {"m_faq"})]
+
+    result = _evaluate_with_fake(monkeypatch, P, available={"m_faq"})
+    assert result.wired is True
+    assert result.has_default is False
+    assert result.missing_models == frozenset(
+        {"No baseline variant found (expected variant id: 'problem_statement')"}
+    )

--- a/iris/tests/test_pipeline_health_checker.py
+++ b/iris/tests/test_pipeline_health_checker.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import pytest
 
+from iris.config import settings
 from iris.domain.variant.variant import Variant
 from iris.pipeline.rewriting_pipeline import RewritingPipeline
 from iris.web.routers.health.Pipelines import checker
@@ -12,6 +13,7 @@ from iris.web.routers.health.Pipelines.checker import (
     _get_non_baseline_required_models,
     evaluate_feature,
 )
+from iris.web.routers.health.Pipelines.features import Features
 
 
 def test_rewriting_pipeline_health_baseline_is_problem_statement():
@@ -97,6 +99,33 @@ def test_evaluate_feature_with_custom_baseline_passes(monkeypatch):
         )
 
     result = _evaluate_with_fake(monkeypatch, P, available={"m_faq", "m_ps"})
+    assert result.wired is True
+    assert result.has_default is True
+    assert result.missing_models == frozenset()
+    assert result.ok is True
+
+
+def test_evaluate_feature_rewriting_uses_problem_statement_baseline(monkeypatch):
+    monkeypatch.setattr(settings, "local_llm_enabled", True)
+    monkeypatch.setattr(
+        settings,
+        "llm_configuration",
+        {
+            "rewriting_pipeline": {
+                "faq": {
+                    "rewriting": {"local": "m_faq", "cloud": "m_faq"},
+                    "consistency": {"local": "m_faq", "cloud": "m_faq"},
+                },
+                "problem_statement": {
+                    "rewriting": {"local": "m_ps", "cloud": "m_ps"},
+                    "consistency": {"local": "m_ps", "cloud": "m_ps"},
+                },
+            }
+        },
+    )
+
+    result = evaluate_feature(Features.REWRITING, {"m_faq", "m_ps"})
+
     assert result.wired is True
     assert result.has_default is True
     assert result.missing_models == frozenset()


### PR DESCRIPTION
## Summary

Reopens the intent of #560 on the original branch name, refreshed onto current `main`.

The Iris pipeline health checker previously treated only a variant with id `default` as the baseline. `RewritingPipeline` intentionally has content-specific variants (`faq`, `problem_statement`) and no `default` variant, so its health status could be falsely reported as missing a default variant even when its configured baseline models are available.

This PR:
- adds `Pipeline.HEALTH_BASELINE_VARIANT_ID`, defaulting to `default` for existing pipelines
- sets `RewritingPipeline.HEALTH_BASELINE_VARIANT_ID` to `problem_statement`
- updates health checking to compare against the configured baseline id exactly
- adds regression coverage, including a real `Features.REWRITING` health-check path

## Artemis compatibility

No Artemis update is required. The `/api/v1/health/` response contract is unchanged: `isHealthy`, `modules`, `status`, `error`, and `metaData` stay the same. This only changes Iris internal health classification.

## Validation

- `poetry run pytest tests/test_pipeline_health_checker.py -q` — 9 passed
- `poetry run pytest -q` — 133 passed
- `poetry run black --check src/iris/pipeline/pipeline.py src/iris/pipeline/rewriting_pipeline.py src/iris/web/routers/health/Pipelines/checker.py tests/test_pipeline_health_checker.py` — clean
- `poetry run pylint --rcfile=pylintrc src/iris/pipeline/pipeline.py src/iris/pipeline/rewriting_pipeline.py src/iris/web/routers/health/Pipelines/checker.py tests/test_pipeline_health_checker.py` — 10.00/10
- `git diff --check origin/main...HEAD` — clean

## Notes

GitHub refused to reopen #560 after the branch was force-pushed/recreated, so this PR keeps the original branch name and links the previous discussion instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now evaluate pipelines against a configurable baseline variant, instead of assuming a fixed `"default"` variant.
  * Pipelines without a literal default variant can now define their own baseline, improving check results for alternate variant setups.
  * Missing or mismatched baseline variants are now reported more clearly during health evaluation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->