### PR TITLE
`Iris`: Reduce chat first-answer latency

### DIFF
--- a/iris/src/iris/common/timing.py
+++ b/iris/src/iris/common/timing.py
@@ -1,0 +1,53 @@
+"""Lightweight wall-clock span logging for latency analysis.
+
+Emits one greppable log line per span so production logs can attribute
+end-to-end chat latency to individual phases:
+
+    Pipeline timing | pipeline=ChatPipeline span=agent_loop duration_ms=12345 elapsed_ms=13000
+
+``elapsed_ms`` is the time since the pipeline run started, so the log lines
+double as a timeline of the run.
+"""
+
+import time
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from iris.common.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@contextmanager
+def timed_span(
+    pipeline: str, span: str, run_start: Optional[float] = None
+) -> Iterator[None]:
+    """Log the wall-clock duration of the wrapped block.
+
+    Args:
+        pipeline: Name of the pipeline the span belongs to.
+        span: Name of the phase being measured.
+        run_start: ``time.perf_counter()`` value of the pipeline run start;
+            when given, the log line includes the total elapsed time as well.
+    """
+    span_start = time.perf_counter()
+    try:
+        yield
+    finally:
+        now = time.perf_counter()
+        duration_ms = (now - span_start) * 1000
+        if run_start is not None:
+            logger.info(
+                "Pipeline timing | pipeline=%s span=%s duration_ms=%.0f elapsed_ms=%.0f",
+                pipeline,
+                span,
+                duration_ms,
+                (now - run_start) * 1000,
+            )
+        else:
+            logger.info(
+                "Pipeline timing | pipeline=%s span=%s duration_ms=%.0f",
+                pipeline,
+                span,
+                duration_ms,
+            )

--- a/iris/src/iris/llm/external/openai_chat.py
+++ b/iris/src/iris/llm/external/openai_chat.py
@@ -43,6 +43,11 @@ from ...llm.external.model import ChatModel
 
 logger = get_logger(__name__)
 
+# Per-request cap for a single completion HTTP call. Artemis chat jobs expire
+# after 300s, so any response slower than this could never be delivered anyway
+# (the SDK default of 600s just burns the whole job on a hung connection).
+REQUEST_TIMEOUT_SECONDS = 300.0
+
 
 def convert_content_to_openai_format(content):
     """Convert a single content item to OpenAI format."""
@@ -236,94 +241,83 @@ class OpenAIChatModel(ChatModel):
         backoff_factor = 2
         initial_delay = 1
         client = self.get_client()
-        try:
-            # Maximum wait time: 1 + 2 + 4 + 8 + 16 = 31 seconds
+        # Maximum wait time: 1 + 2 + 4 + 8 + 16 = 31 seconds
 
-            messages = convert_to_open_ai_messages(messages)
+        messages = convert_to_open_ai_messages(messages)
 
-            for attempt in range(retries):
-                try:
-                    params: dict[str, Any] = {"model": self.model, "messages": messages}
+        for attempt in range(retries):
+            try:
+                params: dict[str, Any] = {"model": self.model, "messages": messages}
 
-                    # Reasoning models (GPT-5 / o-series) reject the
-                    # `temperature` parameter. Each model declares whether it
-                    # accepts temperature via `supports_temperature` in
-                    # llm_config.yml so we don't rely on name heuristics.
-                    if arguments.temperature is not None and self.supports_temperature:
-                        params["temperature"] = arguments.temperature
+                # Reasoning models (GPT-5 / o-series) reject the
+                # `temperature` parameter. Each model declares whether it
+                # accepts temperature via `supports_temperature` in
+                # llm_config.yml so we don't rely on name heuristics.
+                if arguments.temperature is not None and self.supports_temperature:
+                    params["temperature"] = arguments.temperature
 
-                    if arguments.reasoning_effort is not None:
-                        if self.supports_reasoning_effort:
-                            params["reasoning_effort"] = arguments.reasoning_effort
-                        else:
-                            logger.debug(
-                                "Ignoring reasoning_effort=%s for model id=%s "
-                                "(model=%s): set supports_reasoning_effort: true "
-                                "in llm_config.yml if this model actually supports it.",
-                                arguments.reasoning_effort,
-                                self.id,
-                                self.model,
-                            )
-
-                    if arguments.max_tokens is not None:
-                        params["max_completion_tokens"] = arguments.max_tokens
-
-                    if arguments.response_format == "JSON":
-                        params["response_format"] = ResponseFormatJSONObject(
-                            type="json_object"
+                if arguments.reasoning_effort is not None:
+                    if self.supports_reasoning_effort:
+                        params["reasoning_effort"] = arguments.reasoning_effort
+                    else:
+                        logger.debug(
+                            "Ignoring reasoning_effort=%s for model id=%s "
+                            "(model=%s): set supports_reasoning_effort: true "
+                            "in llm_config.yml if this model actually supports it.",
+                            arguments.reasoning_effort,
+                            self.id,
+                            self.model,
                         )
 
-                    if tools:
-                        params["tools"] = [
-                            convert_to_openai_tool(tool) for tool in tools
-                        ]
-                        logger.debug("Using tools: %s", [t.name for t in tools])
+                if arguments.max_tokens is not None:
+                    params["max_completion_tokens"] = arguments.max_tokens
 
-                    response = client.chat.completions.create(**params)
-                    choice = response.choices[0]
-                    usage = response.usage
-                    if choice.finish_reason == "content_filter":
-                        # I figured that an openai error would be automatically raised if the content filter activated,
-                        # but it seems that that is not the case.
-                        # We don't want to retry because the same message will likely be rejected again.
-                        # Raise an exception to trigger the global error handler and report a fatal error to the client.
-                        raise ContentFilterFinishReasonError()
+                if arguments.response_format == "JSON":
+                    params["response_format"] = ResponseFormatJSONObject(
+                        type="json_object"
+                    )
 
-                    if (
-                        choice.message is None
-                        or choice.message.content is None
-                        or len(choice.message.content) == 0
-                    ):
-                        logger.error("Model returned an empty message")
-                        logger.error("Finish reason: %s", choice.finish_reason)
-                        if (
-                            choice.message is not None
-                            and choice.message.refusal is not None
-                        ):
-                            logger.error("Refusal: %s", choice.message.refusal)
+                if tools:
+                    params["tools"] = [convert_to_openai_tool(tool) for tool in tools]
+                    logger.debug("Using tools: %s", [t.name for t in tools])
 
-                    return convert_to_iris_message(choice.message, usage, self.model)
-                except (
-                    APIError,
-                    APITimeoutError,
-                    APIConnectionError,  # Added to retry on connection errors
-                    RateLimitError,
+                response = client.chat.completions.create(**params)
+                choice = response.choices[0]
+                usage = response.usage
+                if choice.finish_reason == "content_filter":
+                    # I figured that an openai error would be automatically raised if the content filter activated,
+                    # but it seems that that is not the case.
+                    # We don't want to retry because the same message will likely be rejected again.
+                    # Raise an exception to trigger the global error handler and report a fatal error to the client.
+                    raise ContentFilterFinishReasonError()
+
+                if (
+                    choice.message is None
+                    or choice.message.content is None
+                    or len(choice.message.content) == 0
                 ):
-                    wait_time = initial_delay * (backoff_factor**attempt)
-                    logger.exception("OpenAI error on attempt %s:", attempt + 1)
-                    logger.info("Retrying in %s seconds...", wait_time)
-                    time.sleep(wait_time)
-            raise RuntimeError(
-                f"Failed to get response from OpenAI after {retries} retries"
-            )
-        finally:
-            # Ensure HTTP resources are released to avoid ResourceWarning on shutdown
-            close = getattr(client, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    logger.debug("Failed to close OpenAI client", exc_info=True)
+                    logger.error("Model returned an empty message")
+                    logger.error("Finish reason: %s", choice.finish_reason)
+                    if (
+                        choice.message is not None
+                        and choice.message.refusal is not None
+                    ):
+                        logger.error("Refusal: %s", choice.message.refusal)
+
+                return convert_to_iris_message(choice.message, usage, self.model)
+            except (
+                APIError,
+                APITimeoutError,
+                APIConnectionError,  # Added to retry on connection errors
+                RateLimitError,
+            ):
+                wait_time = initial_delay * (backoff_factor**attempt)
+                logger.exception("OpenAI error on attempt %s:", attempt + 1)
+                logger.info("Retrying in %s seconds...", wait_time)
+                time.sleep(wait_time)
+        raise RuntimeError(
+            f"Failed to get response from OpenAI after {retries} retries"
+        )
 
 
 class DirectOpenAIChatModel(OpenAIChatModel):
@@ -335,11 +329,30 @@ class DirectOpenAIChatModel(OpenAIChatModel):
 
     type: Literal["openai_chat"]
     base_url: Optional[str] = None
+    _client: OpenAI
+
+    def model_post_init(self, context) -> None:  # pylint: disable=unused-argument
+        # One client per model entry for the process lifetime: keeps the HTTP
+        # connection pool warm across requests instead of paying a new TCP+TLS
+        # handshake on every single completion call. max_retries=0 because the
+        # retry loop in chat() already handles retries with backoff; the SDK
+        # default of 2 would multiply attempts.
+        if self.base_url:
+            self._client = OpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                max_retries=0,
+            )
+        else:
+            self._client = OpenAI(
+                api_key=self.api_key,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                max_retries=0,
+            )
 
     def get_client(self) -> OpenAI:
-        if self.base_url:
-            return OpenAI(api_key=self.api_key, base_url=self.base_url)
-        return OpenAI(api_key=self.api_key)
+        return self._client
 
     def __str__(self):
         return f"OpenAIChat('{self.model}')"
@@ -352,14 +365,21 @@ class AzureOpenAIChatModel(OpenAIChatModel):
     endpoint: str
     azure_deployment: str
     api_version: str
+    _client: AzureOpenAI
 
-    def get_client(self) -> OpenAI:
-        return AzureOpenAI(
+    def model_post_init(self, context) -> None:  # pylint: disable=unused-argument
+        # See DirectOpenAIChatModel.model_post_init for the client-reuse rationale.
+        self._client = AzureOpenAI(
             azure_endpoint=self.endpoint,
             azure_deployment=self.azure_deployment,
             api_version=self.api_version,
             api_key=self.api_key,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            max_retries=0,
         )
+
+    def get_client(self) -> OpenAI:
+        return self._client
 
     def __str__(self):
         return f"AzureChat('{self.model}')"

--- a/iris/src/iris/pipeline/abstract_agent_pipeline.py
+++ b/iris/src/iris/pipeline/abstract_agent_pipeline.py
@@ -11,6 +11,7 @@ from iris.common.logging_config import get_logger
 from iris.common.memiris_setup import MemirisWrapper
 from iris.common.message_converters import convert_iris_message_to_langchain_message
 from iris.common.pyris_message import IrisMessageRole, PyrisMessage
+from iris.common.timing import timed_span
 from iris.common.token_usage_dto import TokenUsageDTO
 from iris.domain.data.text_message_content_dto import TextMessageContentDTO
 from iris.domain.variant.abstract_variant import AbstractVariant
@@ -62,6 +63,12 @@ class AgentPipelineExecutionState(Generic[DTO, VARIANT]):
     allow_lecture_tool: bool
     allow_faq_tool: bool
     allow_memiris_tool: bool
+    # perf_counter() timestamp of the run start, for latency span logging
+    start_time: float
+    # Session title generated after the final result was already delivered;
+    # it is sent to the client with the next outgoing status callback.
+    deferred_session_title: Optional[str]
+    deferred_session_title_delivered: bool
 
 
 def _filter_empty_messages(messages: list[PyrisMessage]) -> list[PyrisMessage]:
@@ -550,6 +557,9 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
         state.allow_lecture_tool = False
         state.allow_faq_tool = False
         state.allow_memiris_tool = False
+        state.start_time = start_time
+        state.deferred_session_title = None
+        state.deferred_session_title_delivered = False
         state.tracing_context = self.create_tracing_context(dto, variant)
         state.memiris_wrapper = MemirisWrapper(
             state.db.client, self.get_memiris_tenant(state.dto)
@@ -583,14 +593,17 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
                 completion_args=completion_args,
             )
 
-            self.prepare_state(state)
-            system_message = self.build_system_message(state)
+            with timed_span(pipeline_name, "prepare_state", start_time):
+                self.prepare_state(state)
+            with timed_span(pipeline_name, "build_system_message", start_time):
+                system_message = self.build_system_message(state)
             state.prompt = self.assemble_prompt_with_history(
                 state=state, system_prompt=system_message
             )
 
             # Load tools for both local and cloud models
-            state.tools = self.get_tools(state)
+            with timed_span(pipeline_name, "build_tools", start_time):
+                state.tools = self.get_tools(state)
 
             if local:
                 logger.info("Using local model with tool calling support")
@@ -613,10 +626,20 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
             self.pre_agent_hook(state)
 
             # 7.2. Run the agent with the provided DTO
-            state.result = self.execute_agent(state)
+            with timed_span(pipeline_name, "agent_loop", start_time):
+                state.result = self.execute_agent(state)
 
             # 7.3. Run post agent hook
-            self.post_agent_hook(state)
+            with timed_span(pipeline_name, "post_agent_hook", start_time):
+                self.post_agent_hook(state)
+
+            # A session title generated after the final result was sent still
+            # needs to reach the client; attach it to the trailing callback.
+            deferred_title = (
+                None
+                if state.deferred_session_title_delivered
+                else state.deferred_session_title
+            )
 
             # 8. Wait for the memory creation to finish if enabled
             if state.memiris_memory_creation_thread:
@@ -625,9 +648,13 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
                 state.callback.done(
                     "Memory creation finished.",
                     created_memories=state.memiris_memory_creation_storage,
+                    session_title=deferred_title,
                 )
             else:
-                state.callback.done("No memory creation thread started.")
+                state.callback.done(
+                    "No memory creation thread started.",
+                    session_title=deferred_title,
+                )
 
             duration_ms = (time.perf_counter() - start_time) * 1000
             logger.info(

--- a/iris/src/iris/pipeline/chat/chat_pipeline.py
+++ b/iris/src/iris/pipeline/chat/chat_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import time
 from datetime import datetime
 from typing import Any, Callable, Optional
 
@@ -9,13 +10,14 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from iris.common.logging_config import get_logger
+from iris.common.timing import timed_span
 from iris.domain.chat.chat_pipeline_execution_dto import ChatPipelineExecutionDTO
 from iris.pipeline.chat.iris_chat_mode import IrisChatMode
 from iris.pipeline.session_title_generation_pipeline import (
     SessionTitleGenerationPipeline,
 )
 from iris.tools.chat_tool_providers import CHAT_TOOL_PROVIDERS
-from iris.tracing import observe
+from iris.tracing import TracedThreadPoolExecutor, observe
 from iris.web.status.status_update import StatusCallback
 
 from ...common.memiris_setup import get_tenant_for_user
@@ -271,38 +273,62 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
 
             # If Programming Exercise, refine response using guide prompt
             if self.chat_mode == IrisChatMode.EXERCISE:
-                result = self._refine_response(state)
+                with timed_span("ChatPipeline", "refine_response", state.start_time):
+                    result = self._refine_response(state)
 
             # Add citations if applicable
-            result = self._add_citations(state, result)
+            with timed_span("ChatPipeline", "citations", state.start_time):
+                result = self._add_citations(state, result)
             state.result = result
-            # Generate title
-            session_title = self._generate_session_title(state, result, state.dto)
+            # Snapshot for title generation: the same post-citation, pre-MCQ
+            # text the title was generated from before the deferral (the MCQ
+            # JSON blob appended below must not leak into the title prompt).
+            result_for_title = result
 
             # Handle MCQ placeholder replacement and parallel thread joining
-            mcq_post_agent_hook(
-                state=state,
-                mcq_pipeline=self.mcq_pipeline,
-                track_tokens=self._track_tokens,
-            )
+            with timed_span("ChatPipeline", "mcq_join", state.start_time):
+                mcq_post_agent_hook(
+                    state=state,
+                    mcq_pipeline=self.mcq_pipeline,
+                    track_tokens=self._track_tokens,
+                )
 
             result = state.result
 
             # Send the result first so the user sees the message immediately
-            state.callback.done(
-                "Response created",
-                final_result=result,
-                tokens=state.tokens,
-                session_title=session_title,
-                accessed_memories=state.accessed_memory_storage,
+            with timed_span("ChatPipeline", "final_result_callback", state.start_time):
+                state.callback.done(
+                    "Response created",
+                    final_result=result,
+                    tokens=state.tokens,
+                    accessed_memories=state.accessed_memory_storage,
+                )
+            logger.info(
+                "Chat first result delivered | mode=%s elapsed_ms=%.0f",
+                self.chat_mode.value,
+                (time.perf_counter() - state.start_time) * 1000,
             )
+
+            # The session title is not part of the answer, so it is generated
+            # only after the final result was delivered. It reaches the client
+            # with the next outgoing callback: the suggestions callback for
+            # course/exercise chat, or the trailing callback sent by
+            # AbstractAgentPipeline for the other modes.
+            try:
+                with timed_span("ChatPipeline", "session_title", state.start_time):
+                    state.deferred_session_title = self._generate_session_title(
+                        state, result_for_title, state.dto
+                    )
+            except Exception as e:
+                logger.error("Error generating deferred session title", exc_info=e)
 
             # Generate and send suggestions separately (async from user's perspective)
             if self.chat_mode in [
                 IrisChatMode.COURSE,
                 IrisChatMode.EXERCISE,
             ]:
-                self._generate_suggestions(state, result)
+                with timed_span("ChatPipeline", "suggestions", state.start_time):
+                    self._generate_suggestions(state, result)
 
             return result
 
@@ -322,8 +348,17 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         """
         dto = state.dto
         course_id = dto.course.id
-        state.allow_lecture_tool = should_allow_lecture_tool(state.db, course_id)
-        state.allow_faq_tool = should_allow_faq_tool(state.db, course_id)
+        # The two availability checks are independent Weaviate round trips;
+        # run them concurrently so the agent can start sooner.
+        with TracedThreadPoolExecutor(max_workers=2) as executor:
+            lecture_tool_future = executor.submit(
+                should_allow_lecture_tool, state.db, course_id
+            )
+            faq_tool_future = executor.submit(
+                should_allow_faq_tool, state.db, course_id
+            )
+            state.allow_lecture_tool = lecture_tool_future.result()
+            state.allow_faq_tool = faq_tool_future.result()
         state.allow_memiris_tool = bool(
             dto.user
             and dto.user.memiris_enabled
@@ -817,7 +852,9 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
                     final_result=None,
                     suggestions=suggestions,
                     tokens=state.tokens,
+                    session_title=state.deferred_session_title,
                 )
+                state.deferred_session_title_delivered = True
             else:
                 state.callback.skip(
                     "Skipping suggestion generation as no output was generated."
@@ -825,7 +862,14 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
 
         except Exception as e:
             logger.error("Error generating suggestions", exc_info=e)
-            state.callback.error("Generating interaction suggestions failed.")
+            # The error callback terminates the job on the Artemis side, so a
+            # later callback could not deliver the deferred title anymore —
+            # attach it here so it is not lost.
+            state.callback.error(
+                "Generating interaction suggestions failed.",
+                session_title=state.deferred_session_title,
+            )
+            state.deferred_session_title_delivered = True
 
     @observe(name="Chat Pipeline")
     def __call__(

--- a/iris/src/iris/pipeline/chat/mcq_chat_mixin.py
+++ b/iris/src/iris/pipeline/chat/mcq_chat_mixin.py
@@ -83,6 +83,7 @@ def retrieve_lecture_content_for_mcq(
     db: Any,
     course_id: int,
     lecture_id: Optional[int] = None,
+    allow_lecture_tool: Optional[bool] = None,
 ) -> tuple[Optional[str], list[dict]]:
     """Fetch lecture unit page text directly from Weaviate for MCQ generation.
 
@@ -93,11 +94,15 @@ def retrieve_lecture_content_for_mcq(
         db: The Weaviate database client wrapper.
         course_id: ID of the course.
         lecture_id: Optional lecture ID to narrow results.
+        allow_lecture_tool: Pre-computed lecture availability flag (e.g. from
+            ``prepare_state``). Pass it to skip the redundant Weaviate check.
 
     Returns:
         Tuple of (formatted content string, list of lecture unit metadata dicts).
     """
-    if not should_allow_lecture_tool(db, course_id):
+    if allow_lecture_tool is None:
+        allow_lecture_tool = should_allow_lecture_tool(db, course_id)
+    if not allow_lecture_tool:
         return None, []
     try:
         chunk_filter = Filter.by_property(
@@ -248,7 +253,10 @@ def mcq_pre_agent_hook(
     count = getattr(state, "mcq_count", 1)
 
     lecture_content, _ = retrieve_lecture_content_for_mcq(
-        db, course_id, lecture_id=lecture_id
+        db,
+        course_id,
+        lecture_id=lecture_id,
+        allow_lecture_tool=getattr(state, "allow_lecture_tool", None),
     )
 
     setattr(

--- a/iris/src/iris/retrieval/lecture/lecture_page_chunk_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_page_chunk_retrieval.py
@@ -24,7 +24,7 @@ from iris.llm.request_handler.rerank_request_handler import (
     RerankRequestHandler,
 )
 from iris.pipeline.sub_pipeline import SubPipeline
-from iris.tracing import observe
+from iris.tracing import TracedThreadPoolExecutor, observe
 from iris.vector_database.lecture_unit_page_chunk_schema import (
     LectureUnitPageChunkSchema,
     init_lecture_unit_page_chunk_schema,
@@ -88,6 +88,10 @@ class LecturePageChunkRetrieval(SubPipeline):
         self.lecture_unit_collection = init_lecture_unit_schema(client)
 
         self.tokens = []
+        # Per-request cache of lecture unit metadata, keyed by
+        # (course_id, lecture_id, lecture_unit_id, base_url). Hits from the
+        # same unit would otherwise trigger one identical Weaviate lookup each.
+        self._lecture_unit_cache: dict = {}
 
     @observe(name="Full Lecture Retrieval")
     def __call__(
@@ -104,19 +108,25 @@ class LecturePageChunkRetrieval(SubPipeline):
         Retrieve lecture data from the database.
         """
 
-        basic_lecture_chunks = self.search_in_db(
-            query=rewritten_student_query,
-            hybrid_factor=0.9,
-            result_limit=result_limit,
-            lecture_unit_dto=lecture_unit,
-        )
-
-        hyde_lecture_chunks = self.search_in_db(
-            query=hypothetical_answer,
-            hybrid_factor=0.9,
-            result_limit=result_limit,
-            lecture_unit_dto=lecture_unit,
-        )
+        # The two searches (embed + hybrid search each) are independent;
+        # run them concurrently.
+        with TracedThreadPoolExecutor(max_workers=2) as executor:
+            basic_future = executor.submit(
+                self.search_in_db,
+                query=rewritten_student_query,
+                hybrid_factor=0.9,
+                result_limit=result_limit,
+                lecture_unit_dto=lecture_unit,
+            )
+            hyde_future = executor.submit(
+                self.search_in_db,
+                query=hypothetical_answer,
+                hybrid_factor=0.9,
+                result_limit=result_limit,
+                lecture_unit_dto=lecture_unit,
+            )
+            basic_lecture_chunks = basic_future.result()
+            hyde_lecture_chunks = hyde_future.result()
 
         unique = {}
         for segment in basic_lecture_chunks + hyde_lecture_chunks:
@@ -181,26 +191,41 @@ class LecturePageChunkRetrieval(SubPipeline):
         return return_value.objects
 
     def generate_retrieval_dtos(self, lecture_page_chunk, uuid):
-        lecture_unit_filter = Filter.by_property(
-            LectureUnitSchema.COURSE_ID.value
-        ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.COURSE_ID.value])
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_ID.value
-        ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_ID.value])
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_UNIT_ID.value
-        ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_UNIT_ID.value])
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.BASE_URL.value
-        ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.BASE_URL.value])
+        cache_key = (
+            lecture_page_chunk[LectureUnitPageChunkSchema.COURSE_ID.value],
+            lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_ID.value],
+            lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_UNIT_ID.value],
+            lecture_page_chunk[LectureUnitPageChunkSchema.BASE_URL.value],
+        )
+        if cache_key in self._lecture_unit_cache:
+            lecture_unit = self._lecture_unit_cache[cache_key]
+        else:
+            lecture_unit_filter = Filter.by_property(
+                LectureUnitSchema.COURSE_ID.value
+            ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.COURSE_ID.value])
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_ID.value
+            ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_ID.value])
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_UNIT_ID.value
+            ).equal(
+                lecture_page_chunk[LectureUnitPageChunkSchema.LECTURE_UNIT_ID.value]
+            )
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.BASE_URL.value
+            ).equal(lecture_page_chunk[LectureUnitPageChunkSchema.BASE_URL.value])
 
-        lecture_units = self.lecture_unit_collection.query.fetch_objects(
-            filters=lecture_unit_filter
-        ).objects
-        if len(lecture_units) == 0:
+            lecture_units = self.lecture_unit_collection.query.fetch_objects(
+                filters=lecture_unit_filter
+            ).objects
+            lecture_unit = (
+                lecture_units[0].properties if len(lecture_units) > 0 else None
+            )
+            self._lecture_unit_cache[cache_key] = lecture_unit
+
+        if lecture_unit is None:
             return None
         else:
-            lecture_unit = lecture_units[0].properties
             lecture_transcription_dto = LectureUnitPageChunkRetrievalDTO(
                 uuid=uuid,
                 course_id=lecture_unit[LectureUnitSchema.COURSE_ID.value],

--- a/iris/src/iris/retrieval/lecture/lecture_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_retrieval.py
@@ -15,6 +15,7 @@ from iris.common.message_converters import (
 )
 from iris.common.pipeline_enum import PipelineEnum
 from iris.common.pyris_message import PyrisMessage
+from iris.common.timing import timed_span
 from iris.domain.retrieval.lecture.lecture_retrieval_dto import (
     LectureRetrievalDTO,
     LectureTranscriptionRetrievalDTO,
@@ -132,7 +133,8 @@ class LectureRetrieval(SubPipeline):
         lecture_unit_id: int = None,
         base_url: str = None,
     ) -> LectureRetrievalDTO:
-        lecture_unit = self.get_lecture_unit(course_id, lecture_id, lecture_unit_id)
+        with timed_span("LectureRetrieval", "get_lecture_unit"):
+            lecture_unit = self.get_lecture_unit(course_id, lecture_id, lecture_unit_id)
         if lecture_unit is None:
             return LectureRetrievalDTO(
                 lecture_transcriptions=[],
@@ -140,40 +142,57 @@ class LectureRetrieval(SubPipeline):
                 lecture_unit_segments=[],
             )
 
-        (
-            rewritten_lecture_pages_query,
-            rewritten_lecture_transcriptions_query,
-            hypothetical_lecture_pages_answer_query,
-            hypothetical_lecture_transcriptions_answer_query,
-        ) = self.run_parallel_rewrite_tasks(
-            chat_history,
-            query,
-            lecture_unit.course_language,
-            lecture_unit.course_name,
-            problem_statement,
-            exercise_title,
-        )
-
-        (
-            lecture_unit_segments,
-            lecture_transcriptions,
-            lecture_unit_page_chunks,
-        ) = self.call_lecture_pipelines(
-            lecture_unit,
-            query,
-            rewritten_lecture_pages_query,
-            rewritten_lecture_transcriptions_query,
-            hypothetical_lecture_pages_answer_query,
-            hypothetical_lecture_transcriptions_answer_query,
-        )
-
-        for lecture_unit_segment in lecture_unit_segments:
-            lecture_transcriptions += self.get_lecture_transcription_of_lecture_unit(
-                lecture_unit_segment
+        with timed_span("LectureRetrieval", "query_rewrites"):
+            (
+                rewritten_lecture_pages_query,
+                rewritten_lecture_transcriptions_query,
+                hypothetical_lecture_pages_answer_query,
+                hypothetical_lecture_transcriptions_answer_query,
+            ) = self.run_parallel_rewrite_tasks(
+                chat_history,
+                query,
+                lecture_unit.course_language,
+                lecture_unit.course_name,
+                problem_statement,
+                exercise_title,
             )
-            lecture_unit_page_chunks += self.get_lecture_page_chunks_of_lecture_unit(
-                lecture_unit_segment
+
+        with timed_span("LectureRetrieval", "search_pipelines"):
+            (
+                lecture_unit_segments,
+                lecture_transcriptions,
+                lecture_unit_page_chunks,
+            ) = self.call_lecture_pipelines(
+                lecture_unit,
+                query,
+                rewritten_lecture_pages_query,
+                rewritten_lecture_transcriptions_query,
+                hypothetical_lecture_pages_answer_query,
+                hypothetical_lecture_transcriptions_answer_query,
             )
+
+        # Fetch the segments' surrounding transcriptions/page chunks
+        # concurrently: these are independent Weaviate lookups (two per
+        # segment) that used to run sequentially.
+        if lecture_unit_segments:
+            with timed_span("LectureRetrieval", "segment_content_fetch"):
+                with TracedThreadPoolExecutor(max_workers=8) as executor:
+                    transcription_futures = [
+                        executor.submit(
+                            self.get_lecture_transcription_of_lecture_unit, segment
+                        )
+                        for segment in lecture_unit_segments
+                    ]
+                    page_chunk_futures = [
+                        executor.submit(
+                            self.get_lecture_page_chunks_of_lecture_unit, segment
+                        )
+                        for segment in lecture_unit_segments
+                    ]
+                    for future in transcription_futures:
+                        lecture_transcriptions += future.result()
+                    for future in page_chunk_futures:
+                        lecture_unit_page_chunks += future.result()
 
         # Remove duplicate lecture transcriptions
         unique_transcriptions = {}
@@ -187,18 +206,19 @@ class LectureRetrieval(SubPipeline):
             unique_page_chunks[page_chunk.uuid] = page_chunk
         lecture_unit_page_chunks = list(unique_page_chunks.values())
 
-        lecture_transcriptions = self.cohere_client.rerank(
-            query,
-            lecture_transcriptions,
-            top_n=7,
-            content_field_name="segment_text",
-        )
-        lecture_unit_page_chunks = self.cohere_client.rerank(
-            query,
-            lecture_unit_page_chunks,
-            top_n=7,
-            content_field_name="page_text_content",
-        )
+        with timed_span("LectureRetrieval", "final_rerank"):
+            lecture_transcriptions = self.cohere_client.rerank(
+                query,
+                lecture_transcriptions,
+                top_n=7,
+                content_field_name="segment_text",
+            )
+            lecture_unit_page_chunks = self.cohere_client.rerank(
+                query,
+                lecture_unit_page_chunks,
+                top_n=7,
+                content_field_name="page_text_content",
+            )
 
         return LectureRetrievalDTO(
             lecture_unit_segments=lecture_unit_segments,

--- a/iris/src/iris/retrieval/lecture/lecture_transcription_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_transcription_retrieval.py
@@ -19,7 +19,7 @@ from iris.llm.request_handler.rerank_request_handler import (
     RerankRequestHandler,
 )
 from iris.pipeline.sub_pipeline import SubPipeline
-from iris.tracing import observe
+from iris.tracing import TracedThreadPoolExecutor, observe
 from iris.vector_database.lecture_transcription_schema import (
     LectureTranscriptionSchema,
     init_lecture_transcription_schema,
@@ -55,6 +55,10 @@ class LectureTranscriptionRetrieval(SubPipeline):
         reranker_id = resolve_model(pipeline_id, "default", "reranker", local=False)
         self.cohere_client = RerankRequestHandler(reranker_id)
         self.tokens = []
+        # Per-request cache of lecture unit metadata, keyed by
+        # (course_id, lecture_id, lecture_unit_id, base_url). Hits from the
+        # same unit would otherwise trigger one identical Weaviate lookup each.
+        self._lecture_unit_cache: dict = {}
 
     @observe(name="Lecture Transcription Retrieval")
     def __call__(
@@ -67,12 +71,25 @@ class LectureTranscriptionRetrieval(SubPipeline):
         hybrid_factor: float = 0.9,
         top_n_reranked_results: int = 7,
     ):
-        results_rewritten_query = self.search_in_db(
-            lecture_unit_dto, rewritten_query, hybrid_factor, result_limit
-        )
-        results_hypothetical_answer = self.search_in_db(
-            lecture_unit_dto, hypothetical_answer, hybrid_factor, result_limit
-        )
+        # The two searches (embed + hybrid search each) are independent;
+        # run them concurrently.
+        with TracedThreadPoolExecutor(max_workers=2) as executor:
+            rewritten_future = executor.submit(
+                self.search_in_db,
+                lecture_unit_dto,
+                rewritten_query,
+                hybrid_factor,
+                result_limit,
+            )
+            hypothetical_future = executor.submit(
+                self.search_in_db,
+                lecture_unit_dto,
+                hypothetical_answer,
+                hybrid_factor,
+                result_limit,
+            )
+            results_rewritten_query = rewritten_future.result()
+            results_hypothetical_answer = hypothetical_future.result()
 
         unique = {}
         for segment in results_hypothetical_answer + results_rewritten_query:
@@ -142,36 +159,55 @@ class LectureTranscriptionRetrieval(SubPipeline):
         return return_value.objects
 
     def generate_retrieval_dtos(self, lecture_transcription_segment, uuid):
-        lecture_unit_filter = Filter.by_property(
-            LectureUnitSchema.COURSE_ID.value
-        ).equal(
-            lecture_transcription_segment[LectureTranscriptionSchema.COURSE_ID.value]
-        )
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_ID.value
-        ).equal(
-            lecture_transcription_segment[LectureTranscriptionSchema.LECTURE_ID.value]
-        )
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_UNIT_ID.value
-        ).equal(
+        cache_key = (
+            lecture_transcription_segment[LectureTranscriptionSchema.COURSE_ID.value],
+            lecture_transcription_segment[LectureTranscriptionSchema.LECTURE_ID.value],
             lecture_transcription_segment[
                 LectureTranscriptionSchema.LECTURE_UNIT_ID.value
-            ]
+            ],
+            lecture_transcription_segment[LectureTranscriptionSchema.BASE_URL.value],
         )
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.BASE_URL.value
-        ).equal(
-            lecture_transcription_segment[LectureTranscriptionSchema.BASE_URL.value]
-        )
+        if cache_key in self._lecture_unit_cache:
+            lecture_unit = self._lecture_unit_cache[cache_key]
+        else:
+            lecture_unit_filter = Filter.by_property(
+                LectureUnitSchema.COURSE_ID.value
+            ).equal(
+                lecture_transcription_segment[
+                    LectureTranscriptionSchema.COURSE_ID.value
+                ]
+            )
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_ID.value
+            ).equal(
+                lecture_transcription_segment[
+                    LectureTranscriptionSchema.LECTURE_ID.value
+                ]
+            )
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_UNIT_ID.value
+            ).equal(
+                lecture_transcription_segment[
+                    LectureTranscriptionSchema.LECTURE_UNIT_ID.value
+                ]
+            )
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.BASE_URL.value
+            ).equal(
+                lecture_transcription_segment[LectureTranscriptionSchema.BASE_URL.value]
+            )
 
-        lecture_units = self.lecture_unit_collection.query.fetch_objects(
-            filters=lecture_unit_filter
-        ).objects
-        if len(lecture_units) == 0:
+            lecture_units = self.lecture_unit_collection.query.fetch_objects(
+                filters=lecture_unit_filter
+            ).objects
+            lecture_unit = (
+                lecture_units[0].properties if len(lecture_units) > 0 else None
+            )
+            self._lecture_unit_cache[cache_key] = lecture_unit
+
+        if lecture_unit is None:
             return None
         else:
-            lecture_unit = lecture_units[0].properties
             lecture_transcription_dto = LectureTranscriptionRetrievalDTO(
                 uuid=uuid,
                 course_id=lecture_unit[LectureUnitSchema.COURSE_ID.value],

--- a/iris/src/iris/retrieval/lecture/lecture_unit_segment_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_unit_segment_retrieval.py
@@ -19,7 +19,7 @@ from iris.llm.request_handler.rerank_request_handler import (
     RerankRequestHandler,
 )
 from iris.pipeline.sub_pipeline import SubPipeline
-from iris.tracing import observe
+from iris.tracing import TracedThreadPoolExecutor, observe
 from iris.vector_database.lecture_unit_schema import (
     LectureUnitSchema,
     init_lecture_unit_schema,
@@ -55,6 +55,10 @@ class LectureUnitSegmentRetrieval(SubPipeline):
         reranker_id = resolve_model(pipeline_id, "default", "reranker", local=False)
         self.cohere_client = RerankRequestHandler(reranker_id)
         self.tokens = []
+        # Per-request cache of lecture unit metadata, keyed by
+        # (course_id, lecture_id, lecture_unit_id). Hits from the same unit
+        # would otherwise trigger one identical Weaviate lookup each.
+        self._lecture_unit_cache: dict = {}
 
     @observe(name="Lecture Unit Segment Retrieval")
     def __call__(
@@ -67,12 +71,25 @@ class LectureUnitSegmentRetrieval(SubPipeline):
         hybrid_factor: float = 0.9,
         top_n_reranked_results: int = 7,
     ):
-        results_rewritten_query = self.search_in_db(
-            lecture_unit_dto, rewritten_query, hybrid_factor, result_limit
-        )
-        results_hypothetical_answer = self.search_in_db(
-            lecture_unit_dto, hypothetical_answer, hybrid_factor, result_limit
-        )
+        # The two searches (embed + hybrid search each) are independent;
+        # run them concurrently.
+        with TracedThreadPoolExecutor(max_workers=2) as executor:
+            rewritten_future = executor.submit(
+                self.search_in_db,
+                lecture_unit_dto,
+                rewritten_query,
+                hybrid_factor,
+                result_limit,
+            )
+            hypothetical_future = executor.submit(
+                self.search_in_db,
+                lecture_unit_dto,
+                hypothetical_answer,
+                hybrid_factor,
+                result_limit,
+            )
+            results_rewritten_query = rewritten_future.result()
+            results_hypothetical_answer = hypothetical_future.result()
         unique = {}
         for segment in results_hypothetical_answer + results_rewritten_query:
             unique[segment.uuid] = segment
@@ -142,23 +159,36 @@ class LectureUnitSegmentRetrieval(SubPipeline):
         return return_value.objects
 
     def generate_retrieval_dtos(self, lecture_unit_segment, uuid: str):
-        lecture_unit_filter = Filter.by_property(
-            LectureUnitSchema.COURSE_ID.value
-        ).equal(lecture_unit_segment[LectureUnitSegmentSchema.COURSE_ID.value])
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_ID.value
-        ).equal(lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_ID.value])
-        lecture_unit_filter &= Filter.by_property(
-            LectureUnitSchema.LECTURE_UNIT_ID.value
-        ).equal(lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_UNIT_ID.value])
+        cache_key = (
+            lecture_unit_segment[LectureUnitSegmentSchema.COURSE_ID.value],
+            lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_ID.value],
+            lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_UNIT_ID.value],
+        )
+        if cache_key in self._lecture_unit_cache:
+            lecture_unit = self._lecture_unit_cache[cache_key]
+        else:
+            lecture_unit_filter = Filter.by_property(
+                LectureUnitSchema.COURSE_ID.value
+            ).equal(lecture_unit_segment[LectureUnitSegmentSchema.COURSE_ID.value])
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_ID.value
+            ).equal(lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_ID.value])
+            lecture_unit_filter &= Filter.by_property(
+                LectureUnitSchema.LECTURE_UNIT_ID.value
+            ).equal(
+                lecture_unit_segment[LectureUnitSegmentSchema.LECTURE_UNIT_ID.value]
+            )
 
-        lecture_units = self.lecture_unit_collection.query.fetch_objects(
-            filters=lecture_unit_filter
-        ).objects
-        if len(lecture_units) == 0:
+            lecture_units = self.lecture_unit_collection.query.fetch_objects(
+                filters=lecture_unit_filter
+            ).objects
+            lecture_unit = (
+                lecture_units[0].properties if len(lecture_units) > 0 else None
+            )
+            self._lecture_unit_cache[cache_key] = lecture_unit
+
+        if lecture_unit is None:
             return None
-
-        lecture_unit = lecture_units[0].properties
         lecture_unit_segment_retrieval_dto = LectureUnitSegmentRetrievalDTO(
             uuid=uuid,
             course_id=lecture_unit_segment[LectureUnitSegmentSchema.COURSE_ID.value],

--- a/iris/src/iris/tools/chat_tool_providers.py
+++ b/iris/src/iris/tools/chat_tool_providers.py
@@ -202,9 +202,17 @@ def provide_mcq_generation(state: State) -> Optional[Callable]:
     lecture_id = (
         state.dto.lecture.id if state.dto.lecture and state.dto.lecture.id else None
     )
-    lecture_content, _ = retrieve_lecture_content_for_mcq(
-        state.db, course_id, lecture_id=lecture_id
-    )
+
+    # Fetch the (potentially large) grounding content only when the agent
+    # actually calls the MCQ tool, not on every course/lecture chat turn.
+    def lecture_content_supplier() -> Optional[str]:
+        lecture_content, _ = retrieve_lecture_content_for_mcq(
+            state.db,
+            course_id,
+            lecture_id=lecture_id,
+            allow_lecture_tool=state.allow_lecture_tool,
+        )
+        return lecture_content
 
     return create_tool_generate_mcq_questions(
         state.mcq_pipeline,
@@ -212,7 +220,7 @@ def provide_mcq_generation(state: State) -> Optional[Callable]:
         state.callback,
         state.mcq_result_storage,
         state.dto.user.lang_key,
-        lecture_content=lecture_content,
+        lecture_content_supplier=lecture_content_supplier,
     )
 
 

--- a/iris/src/iris/tools/mcq_generation.py
+++ b/iris/src/iris/tools/mcq_generation.py
@@ -13,7 +13,7 @@ def create_tool_generate_mcq_questions(
     callback: StatusCallback,
     mcq_result_storage: Dict[str, str],
     user_language: str = "en",
-    lecture_content: Optional[str] = None,
+    lecture_content_supplier: Optional[Callable[[], Optional[str]]] = None,
 ) -> Callable[[str], str]:
     """
     Create a tool that generates MCQ questions using the MCQ subpipeline.
@@ -24,7 +24,9 @@ def create_tool_generate_mcq_questions(
         callback: Callback for status updates.
         mcq_result_storage: Shared dict to store the generated MCQ JSON.
         user_language: The user's preferred language ("en" or "de").
-        lecture_content: Pre-fetched lecture content to ground MCQ generation.
+        lecture_content_supplier: Lazily fetches lecture content to ground MCQ
+            generation. Only invoked when the tool is actually called, so the
+            (potentially large) content fetch is not paid on every chat turn.
 
     Returns:
         Callable[[str], str]: Function that generates MCQ questions.
@@ -45,6 +47,9 @@ def create_tool_generate_mcq_questions(
         Returns:
             str: A placeholder that will be replaced with the MCQ widget.
         """
+        lecture_content = (
+            lecture_content_supplier() if lecture_content_supplier else None
+        )
         result_json = mcq_pipeline(
             command=command,
             chat_history=chat_history,

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC
 from typing import List, Optional
 
@@ -75,6 +76,7 @@ class StatusCallback(ABC):
         Returns:
             True if the status update was sent successfully, False otherwise.
         """
+        post_start = time.perf_counter()
         try:
             resp = requests.post(
                 self.url,
@@ -85,7 +87,12 @@ class StatusCallback(ABC):
                 json=self.status.model_dump(by_alias=True),
                 timeout=200,
             )
-            logger.info("Status callback to %s returned %d", self.url, resp.status_code)
+            logger.info(
+                "Status callback to %s returned %d | duration_ms=%.0f",
+                self.url,
+                resp.status_code,
+                (time.perf_counter() - post_start) * 1000,
+            )
             resp.raise_for_status()
             return True
         except requests.exceptions.RequestException as e:
@@ -217,10 +224,16 @@ class StatusCallback(ABC):
         exception=None,
         tokens: Optional[List[TokenUsageDTO]] = None,
         error_code: Optional[str] = None,
+        session_title: Optional[str] = None,
     ):
         """
         Transition the current stage to ERROR and update the status.
         Set all later stages to SKIPPED if an error occurs.
+
+        A ``session_title`` may be attached so that a title generated after the
+        final result was already delivered still reaches the client: an error
+        callback terminates the job on the Artemis side, so a later callback
+        could not deliver it anymore.
         """
         self.stage.state = StageStateEnum.ERROR
         self.stage.message = message
@@ -229,6 +242,8 @@ class StatusCallback(ABC):
             self.status.display_page_numbers = None
         if hasattr(self.status, "suggestions"):
             self.status.suggestions = None
+        if session_title is not None and hasattr(self.status, "session_title"):
+            self.status.session_title = session_title
         self.status.tokens = tokens or self.status.tokens
         if error_code is not None and hasattr(self.status, "error_code"):
             self.status.error_code = error_code

--- a/iris/tests/test_chat_latency_ordering.py
+++ b/iris/tests/test_chat_latency_ordering.py
@@ -1,0 +1,244 @@
+"""Latency-critical ordering tests for the unified chat pipeline.
+
+The first ``done(final_result=...)`` callback is what the user perceives as
+the answer arriving. These tests pin down that deferrable work (session title
+generation, suggestion generation, MCQ grounding-content fetch) does not run
+before that callback, and that deferred results still reach Artemis via the
+subsequent callbacks.
+"""
+
+# pylint: skip-file
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Bootstrap the iris package: importing iris.llm directly hits a pre-existing
+# circular import between iris.common.pyris_message and iris.domain. Loading
+# iris.pipeline.pipeline first establishes the right module init order.
+import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.llm.external.openai_chat import (  # noqa: E402
+    AzureOpenAIChatModel,
+    DirectOpenAIChatModel,
+)
+from iris.pipeline.chat.chat_pipeline import ChatPipeline  # noqa: E402
+from iris.pipeline.chat.iris_chat_mode import IrisChatMode  # noqa: E402
+from iris.tools.chat_tool_providers import provide_mcq_generation  # noqa: E402
+
+
+def _make_dto():
+    return SimpleNamespace(
+        chat_history=[],
+        user=SimpleNamespace(id=1, lang_key="en", memiris_enabled=False),
+        course=SimpleNamespace(
+            id=7,
+            name="Test Course",
+            competencies=[],
+            exercises=[],
+            student_analytics_dashboard_enabled=False,
+        ),
+        lecture=None,
+        programming_exercise=None,
+        text_exercise=None,
+        settings=None,
+        session_title=None,
+        metrics=None,
+        context=None,
+        custom_instructions="",
+    )
+
+
+def _make_pipeline(chat_mode: IrisChatMode) -> ChatPipeline:
+    """Create a ChatPipeline without running its heavy __init__."""
+    pipeline = ChatPipeline.__new__(ChatPipeline)
+    pipeline.chat_mode = chat_mode
+    pipeline.event = None
+
+    title_pipeline = MagicMock(return_value="UPDATE: Fancy Title")
+    title_pipeline.tokens = None
+    pipeline.session_title_pipeline = title_pipeline
+
+    citation_pipeline = MagicMock()
+    citation_pipeline.tokens = []
+    pipeline.citation_pipeline = citation_pipeline
+
+    suggestion_pipeline = MagicMock(return_value=["suggestion 1"])
+    suggestion_pipeline.tokens = None
+    pipeline.suggestion_pipeline = suggestion_pipeline
+
+    pipeline.mcq_pipeline = MagicMock()
+
+    # Stub out everything before the agent loop; these tests only assert the
+    # post-agent callback ordering.
+    pipeline.prepare_state = lambda state: None
+    pipeline.build_system_message = lambda state: "system prompt"
+    pipeline.get_tools = lambda state: []
+    pipeline.execute_agent = lambda state: "agent answer"
+    pipeline.create_tracing_context = lambda dto, variant: None
+    return pipeline
+
+
+def _run_pipeline(pipeline: ChatPipeline, callback: MagicMock) -> None:
+    variant = MagicMock()
+    variant.id = "default"
+    variant.model.return_value = "some-model-id"
+    with (
+        patch("iris.pipeline.abstract_agent_pipeline.VectorDatabase"),
+        patch("iris.pipeline.abstract_agent_pipeline.MemirisWrapper"),
+        patch("iris.pipeline.abstract_agent_pipeline.LlmRequestHandler"),
+        patch("iris.pipeline.abstract_agent_pipeline.IrisLangchainChatModel"),
+    ):
+        pipeline(_make_dto(), variant, callback)
+
+
+def test_first_result_callback_is_sent_before_title_generation():
+    """The final-result callback must not wait for the session title LLM call."""
+    pipeline = _make_pipeline(IrisChatMode.LECTURE)
+    callback = MagicMock()
+
+    order_tracker = MagicMock()
+    order_tracker.attach_mock(callback, "callback")
+    order_tracker.attach_mock(pipeline.session_title_pipeline, "title_pipeline")
+
+    _run_pipeline(pipeline, callback)
+
+    call_names = [name for name, _, _ in order_tracker.mock_calls]
+    first_result_index = call_names.index("callback.done")
+    title_index = call_names.index("title_pipeline")
+    assert first_result_index < title_index
+
+    first_done = callback.done.call_args_list[0]
+    assert first_done.kwargs["final_result"] == "agent answer"
+    assert "session_title" not in first_done.kwargs
+
+
+def test_deferred_title_is_delivered_with_trailing_callback():
+    """Lecture chat has no suggestions callback, so the trailing callback
+    (memory-creation stage) must carry the deferred session title."""
+    pipeline = _make_pipeline(IrisChatMode.LECTURE)
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    assert callback.done.call_count == 2
+    trailing_done = callback.done.call_args_list[1]
+    assert trailing_done.kwargs["session_title"] == "Fancy Title"
+
+
+def test_deferred_title_is_delivered_with_suggestions_callback():
+    """Course chat delivers the deferred title with the suggestions callback,
+    and the trailing callback must not deliver it again."""
+    pipeline = _make_pipeline(IrisChatMode.COURSE)
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    assert callback.done.call_count == 3
+    result_done, suggestions_done, trailing_done = callback.done.call_args_list
+
+    assert result_done.kwargs["final_result"] == "agent answer"
+    assert "session_title" not in result_done.kwargs
+
+    assert suggestions_done.kwargs["suggestions"] == ["suggestion 1"]
+    assert suggestions_done.kwargs["session_title"] == "Fancy Title"
+
+    assert trailing_done.kwargs["session_title"] is None
+
+
+def test_suggestions_are_generated_after_first_result_callback():
+    pipeline = _make_pipeline(IrisChatMode.COURSE)
+    callback = MagicMock()
+
+    order_tracker = MagicMock()
+    order_tracker.attach_mock(callback, "callback")
+    order_tracker.attach_mock(pipeline.suggestion_pipeline, "suggestion_pipeline")
+
+    _run_pipeline(pipeline, callback)
+
+    call_names = [name for name, _, _ in order_tracker.mock_calls]
+    assert call_names.index("callback.done") < call_names.index("suggestion_pipeline")
+
+
+def test_deferred_title_rides_error_callback_when_suggestions_fail():
+    """A suggestions failure sends callback.error(), which terminates the job
+    on the Artemis side — the deferred title must ride that error callback
+    because no later callback can deliver it."""
+    pipeline = _make_pipeline(IrisChatMode.COURSE)
+    pipeline.suggestion_pipeline.side_effect = RuntimeError("suggestions down")
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    callback.error.assert_called_once()
+    assert callback.error.call_args.kwargs["session_title"] == "Fancy Title"
+    # The trailing callback must not try to deliver the title again.
+    trailing_done = callback.done.call_args_list[-1]
+    assert trailing_done.kwargs["session_title"] is None
+
+
+def test_title_failure_does_not_break_the_run():
+    """A failing title generation after the answer was sent must neither raise
+    nor emit an error callback."""
+    pipeline = _make_pipeline(IrisChatMode.LECTURE)
+    pipeline.session_title_pipeline.side_effect = RuntimeError("title model down")
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    callback.error.assert_not_called()
+    assert callback.done.call_count == 2
+    assert callback.done.call_args_list[1].kwargs["session_title"] is None
+
+
+def test_mcq_provider_defers_lecture_content_fetch():
+    """Constructing the MCQ tool must not hit Weaviate; only invoking it may."""
+    state = SimpleNamespace(
+        dto=SimpleNamespace(
+            programming_exercise=None,
+            text_exercise=None,
+            course=SimpleNamespace(id=7),
+            lecture=None,
+            chat_history=[],
+            user=SimpleNamespace(lang_key="en"),
+        ),
+        db=MagicMock(),
+        callback=MagicMock(),
+        mcq_pipeline=MagicMock(return_value='{"type": "mcq"}'),
+        allow_lecture_tool=True,
+    )
+
+    with patch(
+        "iris.tools.chat_tool_providers.retrieve_lecture_content_for_mcq",
+        return_value=("LECTURE CONTENT", []),
+    ) as fetch:
+        tool = provide_mcq_generation(state)
+        assert fetch.call_count == 0
+
+        result = tool("generate a question about sorting")
+
+    assert result == "[MCQ_RESULT]"
+    fetch.assert_called_once_with(state.db, 7, lecture_id=None, allow_lecture_tool=True)
+    assert state.mcq_pipeline.call_args.kwargs["lecture_content"] == "LECTURE CONTENT"
+
+
+def test_openai_chat_client_is_reused():
+    """The completion client must be created once per model entry, not per call."""
+    model = DirectOpenAIChatModel(
+        id="m",
+        type="openai_chat",
+        model="gpt-test",
+        api_key="sk-test",  # pragma: allowlist secret
+    )
+    assert model.get_client() is model.get_client()
+
+
+def test_azure_chat_client_is_reused():
+    model = AzureOpenAIChatModel(
+        id="m",
+        type="azure_chat",
+        model="gpt-test",
+        api_key="sk-test",  # pragma: allowlist secret
+        endpoint="https://example.openai.azure.com",
+        azure_deployment="gpt-test",
+        api_version="2024-02-01",
+    )
+    assert model.get_client() is model.get_client()

--- a/iris/tests/test_lecture_retrieval_unit_cache.py
+++ b/iris/tests/test_lecture_retrieval_unit_cache.py
@@ -1,0 +1,98 @@
+"""Tests for the per-request lecture unit metadata cache in the sub-retrievals.
+
+``generate_retrieval_dtos`` used to look up the same lecture unit metadata in
+Weaviate once per search hit (an N+1 pattern that dominated lecture retrieval
+latency). The cache must collapse identical lookups while keeping negative
+results (unknown units are skipped, not retried).
+"""
+
+# pylint: skip-file
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.retrieval.lecture.lecture_unit_segment_retrieval import (  # noqa: E402
+    LectureUnitSegmentRetrieval,
+)
+from iris.vector_database.lecture_unit_schema import LectureUnitSchema  # noqa: E402
+from iris.vector_database.lecture_unit_segment_schema import (  # noqa: E402
+    LectureUnitSegmentSchema,
+)
+
+
+def _make_retrieval() -> LectureUnitSegmentRetrieval:
+    retrieval = LectureUnitSegmentRetrieval.__new__(LectureUnitSegmentRetrieval)
+    retrieval._lecture_unit_cache = {}
+    retrieval.lecture_unit_collection = MagicMock()
+    return retrieval
+
+
+def _segment_properties(course_id=1, lecture_id=2, lecture_unit_id=3):
+    return {
+        LectureUnitSegmentSchema.COURSE_ID.value: course_id,
+        LectureUnitSegmentSchema.LECTURE_ID.value: lecture_id,
+        LectureUnitSegmentSchema.LECTURE_UNIT_ID.value: lecture_unit_id,
+        LectureUnitSegmentSchema.PAGE_NUMBER.value: 4,
+        LectureUnitSegmentSchema.SEGMENT_SUMMARY.value: "summary",
+        LectureUnitSegmentSchema.BASE_URL.value: "http://example.com",
+    }
+
+
+def _unit_fetch_result():
+    unit_properties = {
+        LectureUnitSchema.COURSE_ID.value: 1,
+        LectureUnitSchema.COURSE_NAME.value: "Course",
+        LectureUnitSchema.COURSE_DESCRIPTION.value: "Description",
+        LectureUnitSchema.LECTURE_ID.value: 2,
+        LectureUnitSchema.LECTURE_NAME.value: "Lecture",
+        LectureUnitSchema.LECTURE_UNIT_ID.value: 3,
+        LectureUnitSchema.LECTURE_UNIT_NAME.value: "Unit",
+        LectureUnitSchema.LECTURE_UNIT_LINK.value: "http://example.com/unit",
+        LectureUnitSchema.VIDEO_LINK.value: None,
+    }
+    return SimpleNamespace(
+        objects=[SimpleNamespace(properties=unit_properties, uuid=uuid4())]
+    )
+
+
+def test_repeated_hits_from_same_unit_fetch_metadata_once():
+    retrieval = _make_retrieval()
+    retrieval.lecture_unit_collection.query.fetch_objects.return_value = (
+        _unit_fetch_result()
+    )
+
+    first = retrieval.generate_retrieval_dtos(_segment_properties(), str(uuid4()))
+    second = retrieval.generate_retrieval_dtos(_segment_properties(), str(uuid4()))
+
+    assert retrieval.lecture_unit_collection.query.fetch_objects.call_count == 1
+    assert first is not None and second is not None
+    assert first.lecture_unit_name == second.lecture_unit_name == "Unit"
+
+
+def test_different_units_fetch_metadata_separately():
+    retrieval = _make_retrieval()
+    retrieval.lecture_unit_collection.query.fetch_objects.return_value = (
+        _unit_fetch_result()
+    )
+
+    retrieval.generate_retrieval_dtos(_segment_properties(), str(uuid4()))
+    retrieval.generate_retrieval_dtos(
+        _segment_properties(lecture_unit_id=99), str(uuid4())
+    )
+
+    assert retrieval.lecture_unit_collection.query.fetch_objects.call_count == 2
+
+
+def test_missing_unit_is_cached_as_negative_result():
+    retrieval = _make_retrieval()
+    retrieval.lecture_unit_collection.query.fetch_objects.return_value = (
+        SimpleNamespace(objects=[])
+    )
+
+    first = retrieval.generate_retrieval_dtos(_segment_properties(), str(uuid4()))
+    second = retrieval.generate_retrieval_dtos(_segment_properties(), str(uuid4()))
+
+    assert first is None and second is None
+    assert retrieval.lecture_unit_collection.query.fetch_objects.call_count == 1


### PR DESCRIPTION
## Summary

Production Iris chat averages ~39s of user-visible response time. This PR reduces the time to the **first assistant answer** across all chat modes (`COURSE_CHAT`, `LECTURE_CHAT`, `PROGRAMMING_EXERCISE_CHAT`, `TEXT_EXERCISE_CHAT`) by removing blocking work from the critical path and parallelizing Weaviate round trips. No observable behavior changes: first-callback payload semantics, stage bookkeeping per mode, current-view prompt injection, citation content, retrieval result sets, and Memiris paths are all explicitly preserved.

## Description

1. **Deferred session title generation.** Session title generation (an LLM call on every turn, in all modes) no longer blocks the first `done(final_result=...)` callback. It now runs *after* the answer is delivered and rides the next outgoing callback: the suggestions callback for course/exercise chat, the trailing memory-stage callback otherwise, or the error callback if suggestion generation fails (an error callback terminates the Artemis job, so a later delivery would be rejected).
2. **Lazy MCQ tool data fetch.** The MCQ generation tool no longer eagerly fetches *all* course page chunks from Weaviate at tool construction time on every course/lecture message. The fetch is deferred into the tool closure so it only runs if the agent actually calls the tool, and it reuses the precomputed lecture-tool availability flag instead of a redundant Weaviate check.
3. **Reused OpenAI/Azure SDK clients.** SDK clients are now created once per model entry (via pydantic `model_post_init`, mirroring the existing embeddings pattern) instead of once per LLM call — saving a TCP+TLS handshake on every call. Clients get an explicit 300s timeout (matching the Artemis job lifetime) and `max_retries=0` so only the existing manual backoff loop retries (the SDK's default of 2 internal retries was silently multiplying attempts).
4. **Lecture retrieval N+1 fix.** The three lecture sub-retrievals now cache lecture-unit metadata per request in `generate_retrieval_dtos` (previously issued one identical Weaviate lookup per search hit, up to ~60 per tool call). The two hybrid searches per sub-retrieval now run concurrently, and the per-segment transcription/page-chunk fetch loop (up to 14 sequential round trips) is now parallel.
5. **Concurrent tool-availability checks.** `prepare_state` now runs the two tool-availability Weaviate checks concurrently instead of sequentially.
6. **Timing instrumentation.** Added greppable `Pipeline timing | pipeline=... span=... duration_ms=... elapsed_ms=...` spans around every phase (`prepare_state`, `build_system_message`, `build_tools`, `agent_loop`, `refine`, `citations`, `mcq_join`, `final_result_callback`, `session_title`, `suggestions`, retrieval phases), per-callback POST duration, and a `Chat first result delivered | mode=... elapsed_ms=...` line to measure time-to-first-answer in production.

### Artemis companion PR

A companion Artemis PR (being opened in parallel) removes redundant session reloads on the callback path. The two PRs are independent — each works correctly without the other; the Artemis PR is a further latency improvement on top of this one.

## Validation

- `poetry run pytest` — 145 passed (includes 12 new focused tests pinning callback ordering, deferred-title delivery on all paths, MCQ laziness, client reuse, and the retrieval metadata cache)
- `poetry run pylint --rcfile=pylintrc <changed files>` — 10.00/10
- `poetry run black --check <changed files>` — clean
- `poetry run isort --check-only <changed files>` — clean
- Cross-vendor code review (OpenAI Codex, gpt-5.5, `xhigh` reasoning effort) — explicitly approved; its one High-severity finding (deferred title lost when suggestion generation fails) was fixed and regression-tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end timing for key pipeline and retrieval steps to improve observability.
  * Deferred session title delivery so the first response can return sooner, with title details attached later when available.
  * Made some content generation and retrieval work happen only when needed, reducing unnecessary processing.

* **Performance Improvements**
  * Parallelized several independent retrieval and validation tasks to speed up responses.
  * Reused cached API clients and metadata lookups to avoid repeated setup and database calls.

* **Bug Fixes**
  * Improved handling of filtered or empty model responses.
  * Preserved session titles even when follow-up suggestion generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
