### PR TITLE
`Iris`: Make reasoning effort configurable per task and upgrade advanced chat to GPT-5.5

### DIFF
--- a/iris/application.example.yml
+++ b/iris/application.example.yml
@@ -59,7 +59,9 @@ env_vars:
 
 # Values are LLM entry IDs (the "id" field in llm_config.yml).
 llm_configuration:
-  exercise_chat_pipeline:
+  # Unified chat pipeline (COURSE_CHAT, LECTURE_CHAT, PROGRAMMING_EXERCISE_CHAT,
+  # TEXT_EXERCISE_CHAT all resolve through this single pipeline id).
+  chat_pipeline:
     default:
       chat:
         local: oai-gpt-5-mini
@@ -67,37 +69,7 @@ llm_configuration:
     advanced:
       chat:
         local: oai-gpt-52
-        cloud: oai-gpt-52
-
-  course_chat_pipeline:
-    default:
-      chat:
-        local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
-    advanced:
-      chat:
-        local: oai-gpt-52
-        cloud: oai-gpt-52
-
-  lecture_chat_pipeline:
-    default:
-      chat:
-        local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
-    advanced:
-      chat:
-        local: oai-gpt-52
-        cloud: oai-gpt-52
-
-  text_exercise_chat_pipeline:
-    default:
-      chat:
-        local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
-    advanced:
-      chat:
-        local: oai-gpt-52
-        cloud: oai-gpt-52
+        cloud: oai-gpt-5.5
 
   autonomous_tutor_pipeline:
     default:
@@ -199,7 +171,7 @@ llm_configuration:
     default:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
+        cloud: oai-gpt-5-mini-minimal
       embedding: oai-embedding-small
       reranker: cohere
 
@@ -223,37 +195,37 @@ llm_configuration:
     default:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
+        cloud: oai-gpt-5-mini-minimal
       embedding: oai-embedding-small
 
   citation_pipeline:
     default:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-mini-minimal
       keyword_summary:
         local: oai-gpt-5-nano
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-nano-minimal
     advanced:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-mini
+        cloud: oai-gpt-5-mini-minimal
 
   interaction_suggestion_pipeline:
     course:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-nano-minimal
     exercise:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-nano-minimal
 
   session_title_generation_pipeline:
     default:
       chat:
         local: oai-gpt-5-mini
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-nano-minimal
 
   code_feedback_pipeline:
     default:
@@ -271,14 +243,14 @@ llm_configuration:
     default:
       hyde:
         local: gpt-oss
-        cloud: oai-gpt-5.4-nano
+        cloud: oai-gpt-5-nano-minimal
       answer:
         local: gpt-oss
-        cloud: oai-gpt-5.4-mini
+        cloud: oai-gpt-5-mini-minimal
       embedding: oai-embedding-small
 
   mcq_generation_pipeline:
     default:
       chat:
         local: gpt-oss
-        cloud: oai-gpt-5-nano
+        cloud: oai-gpt-5-nano-low

--- a/iris/llm_config.example.yml
+++ b/iris/llm_config.example.yml
@@ -13,6 +13,9 @@
   model: gpt-5.2
   api_key:
   supports_temperature: false
+  supports_reasoning_effort: true
+  reasoning_effort: none
+  reasoning_effort_values: [none, low, medium, high, xhigh]
   cost_per_million_input_token: 3.0
   cost_per_million_output_token: 12.0
 - id: oai-gpt-5-mini
@@ -20,6 +23,19 @@
   model: gpt-5-mini
   api_key:
   supports_temperature: false
+  supports_reasoning_effort: true
+  reasoning_effort: medium
+  reasoning_effort_values: [minimal, low, medium, high]
+  cost_per_million_input_token: 0.4
+  cost_per_million_output_token: 1.6
+- id: oai-gpt-5-mini-minimal
+  type: openai_chat
+  model: gpt-5-mini
+  api_key:
+  supports_temperature: false
+  supports_reasoning_effort: true
+  reasoning_effort: minimal
+  reasoning_effort_values: [minimal, low, medium, high]
   cost_per_million_input_token: 0.4
   cost_per_million_output_token: 1.6
 - id: oai-gpt-5-nano
@@ -28,24 +44,40 @@
   api_key:
   supports_temperature: false
   supports_reasoning_effort: true
+  reasoning_effort: medium
+  reasoning_effort_values: [minimal, low, medium, high]
   cost_per_million_input_token: 0.1
   cost_per_million_output_token: 0.4
-- id: oai-gpt-5.4-mini
+- id: oai-gpt-5-nano-minimal
   type: openai_chat
-  model: gpt-5.4-mini
+  model: gpt-5-nano
   api_key:
   supports_temperature: false
   supports_reasoning_effort: true
-  cost_per_million_input_token: 0.75
-  cost_per_million_output_token: 4.50
-- id: oai-gpt-5.4-nano
+  reasoning_effort: minimal
+  reasoning_effort_values: [minimal, low, medium, high]
+  cost_per_million_input_token: 0.1
+  cost_per_million_output_token: 0.4
+- id: oai-gpt-5-nano-low
   type: openai_chat
-  model: gpt-5.4-nano
+  model: gpt-5-nano
   api_key:
   supports_temperature: false
   supports_reasoning_effort: true
-  cost_per_million_input_token: 0.15
-  cost_per_million_output_token: 0.60
+  reasoning_effort: low
+  reasoning_effort_values: [minimal, low, medium, high]
+  cost_per_million_input_token: 0.1
+  cost_per_million_output_token: 0.4
+- id: oai-gpt-5.5
+  type: openai_chat
+  model: gpt-5.5
+  api_key:
+  supports_temperature: false
+  supports_reasoning_effort: true
+  reasoning_effort: medium
+  reasoning_effort_values: [none, low, medium, high, xhigh]
+  cost_per_million_input_token: 5.00
+  cost_per_million_output_token: 30.00
 
 # ── Azure example (GPT 5 Mini) ──────────────────────────────────────────────
 - id: azure-gpt-5-mini
@@ -56,19 +88,24 @@
   azure_deployment: gpt-5-mini
   endpoint: "<your-endpoint>"
   supports_temperature: false
+  supports_reasoning_effort: true
+  reasoning_effort: medium
+  reasoning_effort_values: [minimal, low, medium, high]
   cost_per_million_input_token: 0.4
   cost_per_million_output_token: 1.6
 
-# ── Azure example (GPT 5.4 — supports reasoning effort) ─────────────────────
-- id: azure-gpt-5.4
+# ── Azure example (GPT 5.5 — supports reasoning effort) ─────────────────────
+- id: azure-gpt-5.5
   type: azure_chat
-  model: gpt-5.4
+  model: gpt-5.5
   api_key:
   api_version: 2025-04-01-preview
-  azure_deployment: gpt-5.4
+  azure_deployment: gpt-5.5
   endpoint: "<your-endpoint>"
   supports_temperature: false
   supports_reasoning_effort: true
+  reasoning_effort: medium
+  reasoning_effort_values: [none, low, medium, high, xhigh]
 
 # ── Embedding models ─────────────────────────────────────────────────────────
 - id: azure-embedding-large
@@ -125,6 +162,10 @@
   api_key: ""
   cost_per_million_input_token: 0
   cost_per_million_output_token: 0
+# Logos/vLLM-served gpt-oss accepts ONLY low|medium|high for reasoning_effort;
+# any other value is a hard 400. For an OpenAI-compatible gpt-oss entry, use:
+# type: openai_chat, base_url: <logos-url>, supports_reasoning_effort: true,
+# reasoning_effort: medium, reasoning_effort_values: [low, medium, high].
 - id: mxbai-embed-large
   type: ollama
   model: mxbai-embed-large:latest

--- a/iris/llm_config.example.yml
+++ b/iris/llm_config.example.yml
@@ -76,6 +76,8 @@
   supports_reasoning_effort: true
   reasoning_effort: medium
   reasoning_effort_values: [none, low, medium, high, xhigh]
+  # GPT-5.5 rejects reasoning_effort+tools on chat completions; /responses is supported.
+  use_responses_api: true
   cost_per_million_input_token: 5.00
   cost_per_million_output_token: 30.00
 
@@ -106,6 +108,8 @@
   supports_reasoning_effort: true
   reasoning_effort: medium
   reasoning_effort_values: [none, low, medium, high, xhigh]
+  # GPT-5.5 rejects reasoning_effort+tools on chat completions; /responses is supported.
+  use_responses_api: true
 
 # ── Embedding models ─────────────────────────────────────────────────────────
 - id: azure-embedding-large

--- a/iris/src/iris/llm/external/openai_chat.py
+++ b/iris/src/iris/llm/external/openai_chat.py
@@ -5,27 +5,31 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Literal,
     Optional,
     Sequence,
     Type,
     Union,
+    cast,
 )
 
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langfuse.openai import AzureOpenAI, OpenAI
-from openai import APIConnectionError  # Added for retry logic
 from openai import (
+    APIConnectionError,
     APIError,
-    APITimeoutError,
+    APIStatusError,
     ContentFilterFinishReasonError,
+    InternalServerError,
     RateLimitError,
 )
 from openai.types import CompletionUsage
 from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
+from openai.types.shared import ReasoningEffort
 from openai.types.shared_params import ResponseFormatJSONObject
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from iris.domain.data.text_message_content_dto import TextMessageContentDTO
 from iris.tracing import observe
@@ -47,6 +51,23 @@ logger = get_logger(__name__)
 # after 300s, so any response slower than this could never be delivered anyway
 # (the SDK default of 600s just burns the whole job on a hung connection).
 REQUEST_TIMEOUT_SECONDS = 300.0
+
+_REASONING_EFFORT_ORDER = ("none", "minimal", "low", "medium", "high", "xhigh")
+ReasoningEffortValue = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+_REASONING_EFFORT_INDEX = {
+    effort: index for index, effort in enumerate(_REASONING_EFFORT_ORDER)
+}
+
+
+def _retry_after_openai_error(
+    attempt: int,
+    initial_delay: int,
+    backoff_factor: int,
+) -> None:
+    wait_time = initial_delay * (backoff_factor**attempt)
+    logger.exception("OpenAI error on attempt %s:", attempt + 1)
+    logger.info("Retrying in %s seconds...", wait_time)
+    time.sleep(wait_time)
 
 
 def convert_content_to_openai_format(content):
@@ -226,6 +247,87 @@ class OpenAIChatModel(ChatModel):
     api_key: str
     supports_temperature: bool = True
     supports_reasoning_effort: bool = False
+    reasoning_effort: Optional[ReasoningEffort] = None
+    reasoning_effort_values: Optional[List[ReasoningEffortValue]] = None
+
+    @model_validator(mode="after")
+    def validate_reasoning_effort_config(self):
+        if not self.supports_reasoning_effort and (
+            self.reasoning_effort is not None
+            or self.reasoning_effort_values is not None
+        ):
+            raise ValueError(
+                "supports_reasoning_effort must be true when reasoning_effort "
+                "or reasoning_effort_values is configured"
+            )
+
+        allowed_reasoning_efforts = self.reasoning_effort_values
+        if allowed_reasoning_efforts is not None and not allowed_reasoning_efforts:
+            raise ValueError(
+                "reasoning_effort_values must not be empty when configured"
+            )
+        if self.reasoning_effort is not None and allowed_reasoning_efforts is not None:
+            allowed_values = cast(list[str], allowed_reasoning_efforts)
+            try:
+                allowed_values.index(self.reasoning_effort)
+            except ValueError as error:
+                raise ValueError(
+                    f"reasoning_effort={self.reasoning_effort} must be one of "
+                    f"reasoning_effort_values={allowed_reasoning_efforts}"
+                ) from error
+
+        return self
+
+    def _effective_reasoning_effort(
+        self,
+        arguments: CompletionArguments,
+    ) -> Optional[str]:
+        effective = (
+            arguments.reasoning_effort
+            if arguments.reasoning_effort is not None
+            else self.reasoning_effort
+        )
+
+        if effective is None:
+            return None
+
+        if not self.supports_reasoning_effort:
+            logger.debug(
+                "Ignoring reasoning_effort=%s for model id=%s "
+                "(model=%s): set supports_reasoning_effort: true "
+                "in llm_config.yml if this model actually supports it.",
+                effective,
+                self.id,
+                self.model,
+            )
+            return None
+
+        allowed_values = cast(list[str], self.reasoning_effort_values or [])
+        if allowed_values and effective not in allowed_values:
+            clamped = self._nearest_reasoning_effort(effective, allowed_values)
+            logger.warning(
+                "Clamping reasoning_effort=%s to %s for model id=%s "
+                "(model=%s): requested value is not in reasoning_effort_values=%s.",
+                effective,
+                clamped,
+                self.id,
+                self.model,
+                allowed_values,
+            )
+            return clamped
+
+        return effective
+
+    @staticmethod
+    def _nearest_reasoning_effort(requested: str, allowed_values: list[str]) -> str:
+        requested_index = _REASONING_EFFORT_INDEX[requested]
+        return min(
+            allowed_values,
+            key=lambda value: (
+                abs(_REASONING_EFFORT_INDEX[value] - requested_index),
+                _REASONING_EFFORT_INDEX[value],
+            ),
+        )
 
     @observe(name="OpenAI Chat Completion")
     def chat(
@@ -256,18 +358,9 @@ class OpenAIChatModel(ChatModel):
                 if arguments.temperature is not None and self.supports_temperature:
                     params["temperature"] = arguments.temperature
 
-                if arguments.reasoning_effort is not None:
-                    if self.supports_reasoning_effort:
-                        params["reasoning_effort"] = arguments.reasoning_effort
-                    else:
-                        logger.debug(
-                            "Ignoring reasoning_effort=%s for model id=%s "
-                            "(model=%s): set supports_reasoning_effort: true "
-                            "in llm_config.yml if this model actually supports it.",
-                            arguments.reasoning_effort,
-                            self.id,
-                            self.model,
-                        )
+                effective_reasoning_effort = self._effective_reasoning_effort(arguments)
+                if effective_reasoning_effort is not None:
+                    params["reasoning_effort"] = effective_reasoning_effort
 
                 if arguments.max_tokens is not None:
                     params["max_completion_tokens"] = arguments.max_tokens
@@ -305,16 +398,30 @@ class OpenAIChatModel(ChatModel):
                         logger.error("Refusal: %s", choice.message.refusal)
 
                 return convert_to_iris_message(choice.message, usage, self.model)
-            except (
-                APIError,
-                APITimeoutError,
-                APIConnectionError,  # Added to retry on connection errors
-                RateLimitError,
-            ):
-                wait_time = initial_delay * (backoff_factor**attempt)
-                logger.exception("OpenAI error on attempt %s:", attempt + 1)
-                logger.info("Retrying in %s seconds...", wait_time)
-                time.sleep(wait_time)
+            except (RateLimitError, APIConnectionError, InternalServerError):
+                _retry_after_openai_error(attempt, initial_delay, backoff_factor)
+            except APIStatusError as error:
+                # 408/409 are transient (the SDK's own retry predicate retries
+                # them); since the client runs with max_retries=0, this loop is
+                # the only retry layer.
+                if error.status_code >= 500 or error.status_code in (408, 409):
+                    _retry_after_openai_error(attempt, initial_delay, backoff_factor)
+                else:
+                    logger.exception(
+                        "Non-retryable OpenAI API status error for model id=%s "
+                        "(model=%s, status_code=%s):",
+                        self.id,
+                        self.model,
+                        error.status_code,
+                    )
+                    raise
+            except APIError:
+                logger.exception(
+                    "Non-retryable OpenAI API error for model id=%s (model=%s):",
+                    self.id,
+                    self.model,
+                )
+                raise
         raise RuntimeError(
             f"Failed to get response from OpenAI after {retries} retries"
         )

--- a/iris/src/iris/llm/external/openai_chat.py
+++ b/iris/src/iris/llm/external/openai_chat.py
@@ -165,6 +165,151 @@ def convert_to_open_ai_messages(
     return openai_messages
 
 
+def convert_content_to_responses_format(content):
+    """Convert a single content item to OpenAI Responses format."""
+    content_type_mapping = {
+        ImageMessageContentDTO: lambda c: {
+            "type": "input_image",
+            "image_url": f"data:image/jpeg;base64,{c.base64}",
+            "detail": "high",
+        },
+        TextMessageContentDTO: lambda c: {
+            "type": "input_text",
+            "text": c.text_content,
+        },
+        JsonMessageContentDTO: lambda c: {
+            "type": "input_text",
+            "text": json.dumps(c.json_content),
+        },
+    }
+
+    converter = content_type_mapping.get(type(content))
+    return converter(content) if converter else None
+
+
+def create_responses_message_content(contents):
+    """Convert Pyris message content to a Responses message content field."""
+    text_parts = []
+    formatted_content = []
+    has_non_text_content = False
+
+    for content in contents:
+        if isinstance(content, TextMessageContentDTO):
+            text_parts.append(content.text_content)
+            continue
+
+        formatted = convert_content_to_responses_format(content)
+        if formatted:
+            has_non_text_content = True
+            formatted_content.append(formatted)
+
+    if not has_non_text_content:
+        return "".join(text_parts)
+
+    return [
+        {"type": "input_text", "text": text_part}
+        for text_part in text_parts
+        if text_part
+    ] + formatted_content
+
+
+def has_responses_message_content(content) -> bool:
+    """Return whether a Responses message content field carries visible content."""
+    if isinstance(content, str):
+        return bool(content)
+    return bool(content)
+
+
+def create_responses_tool_calls(tool_calls):
+    """Convert tool calls to Responses function_call input items."""
+    return [
+        {
+            "type": "function_call",
+            "call_id": tool.id,
+            "name": tool.function.name,
+            "arguments": json.dumps(tool.function.arguments),
+        }
+        for tool in tool_calls
+    ]
+
+
+def handle_responses_tool_message(content):
+    """Handle tool result conversion for Responses input."""
+    if isinstance(content, ToolMessageContentDTO):
+        return {
+            "type": "function_call_output",
+            "call_id": content.tool_call_id,
+            "output": content.tool_content,
+        }
+    return None
+
+
+def convert_to_responses_input(messages: list[PyrisMessage]) -> list[dict[str, Any]]:
+    """
+    Convert a list of PyrisMessage to a Responses API input array.
+
+    Args:
+        messages: List of PyrisMessage objects to convert
+
+    Returns:
+        List of Responses input items
+    """
+    responses_input = []
+
+    for message in messages:
+        if message.sender == "TOOL":
+            for content in message.contents:
+                tool_message = handle_responses_tool_message(content)
+                if tool_message:
+                    responses_input.append(tool_message)
+            continue
+
+        message_content = create_responses_message_content(message.contents)
+        if has_responses_message_content(message_content):
+            responses_input.append(
+                {
+                    "role": map_role_to_str(message.sender),
+                    "content": message_content,
+                }
+            )
+
+        if isinstance(message, PyrisAIMessage) and message.tool_calls:
+            responses_input.extend(create_responses_tool_calls(message.tool_calls))
+
+    return responses_input
+
+
+def convert_to_responses_tool(tool) -> dict[str, Any]:
+    """Convert a LangChain/OpenAI tool definition to Responses tool format."""
+    openai_tool = convert_to_openai_tool(tool)
+    if openai_tool.get("type") != "function":
+        return openai_tool
+
+    function = openai_tool["function"]
+    responses_tool = {
+        "type": "function",
+        "name": function["name"],
+        "parameters": function.get("parameters"),
+    }
+    if "description" in function:
+        responses_tool["description"] = function["description"]
+    if "strict" in function:
+        responses_tool["strict"] = function["strict"]
+    return responses_tool
+
+
+def get_tool_names(tools) -> list[str]:
+    """Extract tool names for debug logging without constraining tool shape."""
+    names = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            function = tool.get("function", {})
+            names.append(function.get("name", str(tool)))
+            continue
+        names.append(getattr(tool, "name", getattr(tool, "__name__", str(tool))))
+    return names
+
+
 def create_token_usage(usage: Optional[CompletionUsage], model: str) -> TokenUsageDTO:
     """
     Create a TokenUsageDTO from CompletionUsage data.
@@ -180,6 +325,20 @@ def create_token_usage(usage: Optional[CompletionUsage], model: str) -> TokenUsa
         model=model,
         numInputTokens=getattr(usage, "prompt_tokens", 0),
         numOutputTokens=getattr(usage, "completion_tokens", 0),
+    )
+
+
+def create_completion_usage_from_responses_usage(usage) -> Optional[CompletionUsage]:
+    """Create CompletionUsage from Responses usage data."""
+    if usage is None:
+        return None
+
+    input_tokens = getattr(usage, "input_tokens", 0)
+    output_tokens = getattr(usage, "output_tokens", 0)
+    return CompletionUsage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
     )
 
 
@@ -204,6 +363,57 @@ def create_iris_tool_calls(message_tool_calls) -> list[ToolCallDTO]:
         )
         for tc in message_tool_calls
     ]
+
+
+def create_iris_tool_calls_from_responses(output_items) -> list[ToolCallDTO]:
+    """
+    Convert Responses function_call output items to Iris format.
+
+    Args:
+        output_items: List of output items from a Responses API response
+
+    Returns:
+        List of ToolCallDTO objects
+    """
+    return [
+        ToolCallDTO(
+            id=item.call_id,
+            type="function",
+            function={
+                "name": item.name,
+                "arguments": item.arguments,
+            },
+        )
+        for item in output_items
+        if getattr(item, "type", None) == "function_call"
+    ]
+
+
+def response_has_refusal(output_items) -> bool:
+    """Return whether a Responses output contains a refusal content item."""
+    for item in output_items:
+        if getattr(item, "type", None) != "message":
+            continue
+        for content in getattr(item, "content", []):
+            if getattr(content, "type", None) == "refusal":
+                return True
+    return False
+
+
+def extract_response_output_text(response) -> str:
+    """Extract visible text from a Responses API response."""
+    output_text = getattr(response, "output_text", None)
+    if output_text:
+        return output_text
+
+    texts = []
+    for item in getattr(response, "output", []):
+        if getattr(item, "type", None) != "message":
+            continue
+        for content in getattr(item, "content", []):
+            if getattr(content, "type", None) == "output_text":
+                texts.append(content.text)
+    return "".join(texts)
 
 
 def convert_to_iris_message(
@@ -241,6 +451,49 @@ def convert_to_iris_message(
     )
 
 
+def convert_responses_to_iris_message(response, model: str) -> PyrisMessage:
+    """
+    Convert a Responses API response to a PyrisMessage.
+
+    Args:
+        response: The Responses API response to convert
+        model: The model name used for the completion
+
+    Returns:
+        PyrisMessage or PyrisAIMessage depending on presence of function calls
+    """
+    output_items = getattr(response, "output", [])
+    if response_has_refusal(output_items):
+        raise ContentFilterFinishReasonError()
+
+    status = getattr(response, "status", None)
+    if status is not None and status != "completed":
+        logger.warning("Responses API returned non-completed status: %s", status)
+
+    token_usage = create_token_usage(
+        create_completion_usage_from_responses_usage(getattr(response, "usage", None)),
+        model,
+    )
+    current_time = datetime.now()
+    output_text = extract_response_output_text(response)
+    tool_calls = create_iris_tool_calls_from_responses(output_items)
+
+    if tool_calls:
+        return PyrisAIMessage(
+            tool_calls=tool_calls,
+            contents=[TextMessageContentDTO(textContent=output_text)],
+            sendAt=current_time,
+            token_usage=token_usage,
+        )
+
+    return PyrisMessage(
+        sender=map_str_to_role("assistant"),
+        contents=[TextMessageContentDTO(textContent=output_text)],
+        sendAt=current_time,
+        token_usage=token_usage,
+    )
+
+
 class OpenAIChatModel(ChatModel):
     """A chat model implementation that uses the OpenAI API for generating completions."""
 
@@ -249,6 +502,9 @@ class OpenAIChatModel(ChatModel):
     supports_reasoning_effort: bool = False
     reasoning_effort: Optional[ReasoningEffort] = None
     reasoning_effort_values: Optional[List[ReasoningEffortValue]] = None
+    # Only enable for native OpenAI/Azure endpoints that support /responses.
+    # OpenAI-compatible base_url gateways such as vLLM should keep this false.
+    use_responses_api: bool = False
 
     @model_validator(mode="after")
     def validate_reasoning_effort_config(self):
@@ -329,6 +585,43 @@ class OpenAIChatModel(ChatModel):
             ),
         )
 
+    def _responses_model_name(self) -> str:
+        return self.model
+
+    def _create_responses_completion(
+        self,
+        client: OpenAI,
+        responses_input: list[dict[str, Any]],
+        arguments: CompletionArguments,
+        tools: Optional[
+            Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]]
+        ],
+    ):
+        params: dict[str, Any] = {
+            "model": self._responses_model_name(),
+            "input": responses_input,
+            "store": False,
+        }
+
+        if arguments.temperature is not None and self.supports_temperature:
+            params["temperature"] = arguments.temperature
+
+        effective_reasoning_effort = self._effective_reasoning_effort(arguments)
+        if effective_reasoning_effort is not None:
+            params["reasoning"] = {"effort": effective_reasoning_effort}
+
+        if arguments.max_tokens is not None:
+            params["max_output_tokens"] = arguments.max_tokens
+
+        if arguments.response_format == "JSON":
+            params["text"] = {"format": {"type": "json_object"}}
+
+        if tools:
+            params["tools"] = [convert_to_responses_tool(tool) for tool in tools]
+            logger.debug("Using tools: %s", get_tool_names(tools))
+
+        return client.responses.create(**params)
+
     @observe(name="OpenAI Chat Completion")
     def chat(
         self,
@@ -345,10 +638,25 @@ class OpenAIChatModel(ChatModel):
         client = self.get_client()
         # Maximum wait time: 1 + 2 + 4 + 8 + 16 = 31 seconds
 
-        messages = convert_to_open_ai_messages(messages)
+        if self.use_responses_api:
+            responses_input = convert_to_responses_input(messages)
+        else:
+            messages = convert_to_open_ai_messages(messages)
 
         for attempt in range(retries):
             try:
+                if self.use_responses_api:
+                    response = self._create_responses_completion(
+                        client,
+                        responses_input,
+                        arguments,
+                        tools,
+                    )
+                    return convert_responses_to_iris_message(
+                        response,
+                        self._responses_model_name(),
+                    )
+
                 params: dict[str, Any] = {"model": self.model, "messages": messages}
 
                 # Reasoning models (GPT-5 / o-series) reject the
@@ -372,7 +680,7 @@ class OpenAIChatModel(ChatModel):
 
                 if tools:
                     params["tools"] = [convert_to_openai_tool(tool) for tool in tools]
-                    logger.debug("Using tools: %s", [t.name for t in tools])
+                    logger.debug("Using tools: %s", get_tool_names(tools))
 
                 response = client.chat.completions.create(**params)
                 choice = response.choices[0]
@@ -472,10 +780,20 @@ class AzureOpenAIChatModel(OpenAIChatModel):
     endpoint: str
     azure_deployment: str
     api_version: str
-    _client: AzureOpenAI
+    _client: OpenAI
 
     def model_post_init(self, context) -> None:  # pylint: disable=unused-argument
         # See DirectOpenAIChatModel.model_post_init for the client-reuse rationale.
+        if self.use_responses_api:
+            self._client = OpenAI(
+                base_url=self.endpoint.rstrip("/") + "/openai/v1",
+                api_key=self.api_key,
+                default_headers={"api-key": self.api_key},
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                max_retries=0,
+            )
+            return
+
         self._client = AzureOpenAI(
             azure_endpoint=self.endpoint,
             azure_deployment=self.azure_deployment,
@@ -487,6 +805,9 @@ class AzureOpenAIChatModel(OpenAIChatModel):
 
     def get_client(self) -> OpenAI:
         return self._client
+
+    def _responses_model_name(self) -> str:
+        return self.azure_deployment
 
     def __str__(self):
         return f"AzureChat('{self.model}')"

--- a/iris/src/iris/llm/llm_configuration.py
+++ b/iris/src/iris/llm/llm_configuration.py
@@ -12,7 +12,8 @@ class LlmConfigurationError(ValueError):
 
 
 def validate_llm_configuration(
-    config: Mapping[str, Mapping[str, Mapping[str, Mapping[str, str]]]] | None = None,
+    config: Mapping[str, Mapping[str, Mapping[str, object]]] | None = None,
+    known_model_ids: set[str] | None = None,
 ) -> None:
     """
     Validate structural completeness of llm_configuration.
@@ -23,6 +24,7 @@ def validate_llm_configuration(
     """
     cfg = config if config is not None else settings.llm_configuration
     missing: list[str] = []
+    unknown: list[str] = []
 
     for pipeline_id, variants in cfg.items():
         if not isinstance(variants, dict):
@@ -43,6 +45,13 @@ def validate_llm_configuration(
                         missing.append(
                             f"llm_configuration.{pipeline_id}.{variant_id}.{role} (empty)"
                         )
+                    elif (
+                        known_model_ids is not None and role_cfg not in known_model_ids
+                    ):
+                        unknown.append(
+                            f"llm_configuration.{pipeline_id}.{variant_id}.{role} "
+                            f"references unknown model id '{role_cfg}'"
+                        )
                     continue
 
                 if not isinstance(role_cfg, dict):
@@ -61,10 +70,27 @@ def validate_llm_configuration(
                             f"llm_configuration.{pipeline_id}.{variant_id}.{role}.{env}"
                         )
 
-    if missing:
-        raise LlmConfigurationError(
-            "Missing llm configuration entries:\n" + "\n".join(missing)
-        )
+                if known_model_ids is not None:
+                    for env, value in role_cfg.items():
+                        if (
+                            isinstance(value, str)
+                            and value
+                            and value not in known_model_ids
+                        ):
+                            unknown.append(
+                                f"llm_configuration.{pipeline_id}.{variant_id}.{role}.{env} "
+                                f"references unknown model id '{value}'"
+                            )
+
+    if missing or unknown:
+        details = []
+        if missing:
+            details.append("Missing llm configuration entries:\n" + "\n".join(missing))
+        if unknown:
+            details.append(
+                "Unknown llm configuration model IDs:\n" + "\n".join(unknown)
+            )
+        raise LlmConfigurationError("\n".join(details))
 
 
 def resolve_model(pipeline_id: str, variant_id: str, role: str, *, local: bool) -> str:

--- a/iris/src/iris/llm/llm_configuration.py
+++ b/iris/src/iris/llm/llm_configuration.py
@@ -71,7 +71,8 @@ def validate_llm_configuration(
                         )
 
                 if known_model_ids is not None:
-                    for env, value in role_cfg.items():
+                    for env in environments:
+                        value = role_cfg.get(env)
                         if (
                             isinstance(value, str)
                             and value

--- a/iris/src/iris/main.py
+++ b/iris/src/iris/main.py
@@ -160,5 +160,7 @@ app.include_router(search_router)
 from iris.llm.llm_configuration import validate_llm_configuration  # noqa: E402
 from iris.llm.llm_manager import LlmManager  # noqa: E402
 
-LlmManager()
-validate_llm_configuration()
+llm_manager = LlmManager()
+validate_llm_configuration(
+    known_model_ids={entry.id for entry in llm_manager.entries},
+)

--- a/iris/src/iris/pipeline/global_search_pipeline.py
+++ b/iris/src/iris/pipeline/global_search_pipeline.py
@@ -66,11 +66,9 @@ class GlobalSearchPipeline(SubPipeline):
             embedding_model,
         )
 
-        hyde_completion_args = CompletionArguments(
-            reasoning_effort="none", max_tokens=150
-        )
+        hyde_completion_args = CompletionArguments(max_tokens=150)
         answer_completion_args = CompletionArguments(
-            response_format="JSON", reasoning_effort="none", max_tokens=600
+            response_format="JSON", max_tokens=600
         )
         self.hyde_llm = IrisLangchainChatModel(
             request_handler=LlmRequestHandler(model_id=hyde_model),

--- a/iris/tests/test_openai_chat_retry.py
+++ b/iris/tests/test_openai_chat_retry.py
@@ -1,0 +1,161 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.llm import CompletionArguments  # noqa: E402
+from iris.llm.external.openai_chat import DirectOpenAIChatModel  # noqa: E402
+
+
+def _mock_openai_response():
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    role="assistant",
+                    content="ok",
+                    tool_calls=None,
+                    refusal=None,
+                ),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def _build_model():
+    return DirectOpenAIChatModel(
+        id="test-model",
+        type="openai_chat",
+        model="gpt-test",
+        api_key="sk-test",  # pragma: allowlist secret
+    )
+
+
+def _http_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+
+
+def test_bad_request_is_not_retried():
+    model = _build_model()
+    mock_client = MagicMock()
+    error = openai.BadRequestError(
+        "bad request",
+        response=_http_response(400),
+        body=None,
+    )
+    mock_client.chat.completions.create.side_effect = error
+
+    with (
+        patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client),
+        patch("time.sleep") as sleep,
+        pytest.raises(openai.BadRequestError),
+    ):
+        model.chat([], CompletionArguments(), tools=None)
+
+    assert mock_client.chat.completions.create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_rate_limit_retries_until_success():
+    model = _build_model()
+    mock_client = MagicMock()
+    rate_limit_error = openai.RateLimitError(
+        "rate limited",
+        response=_http_response(429),
+        body=None,
+    )
+    mock_client.chat.completions.create.side_effect = [
+        rate_limit_error,
+        rate_limit_error,
+        _mock_openai_response(),
+    ]
+
+    with (
+        patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client),
+        patch("time.sleep") as sleep,
+    ):
+        result = model.chat([], CompletionArguments(), tools=None)
+
+    assert result.contents[0].text_content == "ok"
+    assert mock_client.chat.completions.create.call_count == 3
+    assert sleep.call_count == 2
+
+
+def test_internal_server_error_retries_until_success():
+    model = _build_model()
+    mock_client = MagicMock()
+    server_error = openai.InternalServerError(
+        "server error",
+        response=_http_response(503),
+        body=None,
+    )
+    mock_client.chat.completions.create.side_effect = [
+        server_error,
+        _mock_openai_response(),
+    ]
+
+    with (
+        patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client),
+        patch("time.sleep") as sleep,
+    ):
+        result = model.chat([], CompletionArguments(), tools=None)
+
+    assert result.contents[0].text_content == "ok"
+    assert mock_client.chat.completions.create.call_count == 2
+    sleep.assert_called_once()
+
+
+def test_request_timeout_408_is_retried():
+    model = _build_model()
+    mock_client = MagicMock()
+    timeout_error = openai.APIStatusError(
+        "request timeout",
+        response=_http_response(408),
+        body=None,
+    )
+    mock_client.chat.completions.create.side_effect = [
+        timeout_error,
+        _mock_openai_response(),
+    ]
+
+    with (
+        patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client),
+        patch("time.sleep") as sleep,
+    ):
+        result = model.chat([], CompletionArguments(), tools=None)
+
+    assert result.contents[0].text_content == "ok"
+    assert mock_client.chat.completions.create.call_count == 2
+    sleep.assert_called_once()
+
+
+def test_conflict_409_is_retried():
+    model = _build_model()
+    mock_client = MagicMock()
+    conflict_error = openai.ConflictError(
+        "lock timeout",
+        response=_http_response(409),
+        body=None,
+    )
+    mock_client.chat.completions.create.side_effect = [
+        conflict_error,
+        _mock_openai_response(),
+    ]
+
+    with (
+        patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client),
+        patch("time.sleep") as sleep,
+    ):
+        result = model.chat([], CompletionArguments(), tools=None)
+
+    assert result.contents[0].text_content == "ok"
+    assert mock_client.chat.completions.create.call_count == 2
+    sleep.assert_called_once()

--- a/iris/tests/test_reasoning_effort_config.py
+++ b/iris/tests/test_reasoning_effort_config.py
@@ -1,0 +1,201 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.llm import CompletionArguments  # noqa: E402
+from iris.llm.external.openai_chat import DirectOpenAIChatModel  # noqa: E402
+from iris.llm.llm_configuration import (  # noqa: E402
+    LlmConfigurationError,
+    validate_llm_configuration,
+)
+
+
+def _mock_openai_response():
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(
+                    role="assistant",
+                    content="ok",
+                    tool_calls=None,
+                    refusal=None,
+                ),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def _build_model(**overrides):
+    base = {
+        "id": "test-model",
+        "type": "openai_chat",
+        "model": "gpt-test",
+        "api_key": "sk-test",  # pragma: allowlist secret
+        "supports_reasoning_effort": True,
+    }
+    base.update(overrides)
+    return DirectOpenAIChatModel(**base)
+
+
+def _invoke_chat(model, **completion_kwargs):
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_openai_response()
+    with patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client):
+        model.chat([], CompletionArguments(**completion_kwargs), tools=None)
+    return mock_client.chat.completions.create.call_args.kwargs
+
+
+def test_per_call_reasoning_effort_wins_over_entry_default():
+    model = _build_model(reasoning_effort="low")
+    params = _invoke_chat(model, reasoning_effort="high")
+    assert params["reasoning_effort"] == "high"
+
+
+def test_entry_default_reasoning_effort_is_used_when_per_call_is_none():
+    model = _build_model(reasoning_effort="medium")
+    params = _invoke_chat(model)
+    assert params["reasoning_effort"] == "medium"
+
+
+def test_reasoning_effort_is_omitted_when_call_and_entry_default_are_none():
+    model = _build_model()
+    params = _invoke_chat(model)
+    assert "reasoning_effort" not in params
+
+
+def test_reasoning_effort_is_clamped_to_nearest_allowed_value():
+    model = _build_model(reasoning_effort_values=["low", "medium", "high"])
+
+    assert _invoke_chat(model, reasoning_effort="none")["reasoning_effort"] == "low"
+    assert _invoke_chat(model, reasoning_effort="xhigh")["reasoning_effort"] == "high"
+    assert _invoke_chat(model, reasoning_effort="minimal")["reasoning_effort"] == "low"
+
+
+def test_reasoning_effort_in_allowed_values_passes_through():
+    model = _build_model(reasoning_effort_values=["low", "medium", "high"])
+    params = _invoke_chat(model, reasoning_effort="medium")
+    assert params["reasoning_effort"] == "medium"
+
+
+def test_reasoning_effort_argument_is_dropped_when_model_does_not_support_it():
+    model = _build_model(supports_reasoning_effort=False)
+    params = _invoke_chat(model, reasoning_effort="high")
+    assert "reasoning_effort" not in params
+
+
+def test_reasoning_effort_clamp_logs_warning(caplog):
+    model = _build_model(reasoning_effort_values=["low", "medium", "high"])
+
+    with caplog.at_level(logging.WARNING, logger="iris.llm.external.openai_chat"):
+        params = _invoke_chat(model, reasoning_effort="xhigh")
+
+    assert params["reasoning_effort"] == "high"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "Clamping reasoning_effort=xhigh to high for model id=test-model" in message
+        for message in messages
+    ), f"expected clamp warning; got: {messages}"
+
+
+def test_missing_llm_catalog_id_raises_with_pipeline_variant_role_and_id():
+    config = {
+        "chat_pipeline": {
+            "default": {
+                "chat": {
+                    "local": "known-model",
+                    "cloud": "missing-model",
+                },
+            },
+        },
+    }
+
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        validate_llm_configuration(config, known_model_ids={"known-model"})
+
+    message = str(exc_info.value)
+    assert "llm_configuration.chat_pipeline.default.chat.cloud" in message
+    assert "missing-model" in message
+
+
+def test_flat_missing_llm_catalog_id_raises_with_pipeline_variant_role_and_id():
+    config = {
+        "retrieval_pipeline": {
+            "default": {
+                "embedding": "missing-embedding",
+            },
+        },
+    }
+
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        validate_llm_configuration(config, known_model_ids={"known-model"})
+
+    message = str(exc_info.value)
+    assert "llm_configuration.retrieval_pipeline.default.embedding" in message
+    assert "missing-embedding" in message
+
+
+def test_bare_llm_configuration_validation_skips_catalog_cross_reference():
+    config = {
+        "chat_pipeline": {
+            "default": {
+                "chat": {
+                    "local": "missing-model",
+                    "cloud": "missing-model",
+                },
+            },
+        },
+    }
+
+    validate_llm_configuration(config)
+
+
+def test_reasoning_effort_default_must_be_in_declared_allowed_values():
+    with pytest.raises(ValueError) as exc_info:
+        _build_model(
+            reasoning_effort="xhigh",
+            reasoning_effort_values=["low", "medium", "high"],
+        )
+
+    assert "reasoning_effort=xhigh must be one of" in str(exc_info.value)
+
+
+def test_reasoning_effort_default_requires_support_flag():
+    with pytest.raises(ValueError) as exc_info:
+        _build_model(supports_reasoning_effort=False, reasoning_effort="high")
+
+    assert "supports_reasoning_effort must be true" in str(exc_info.value)
+
+
+def test_reasoning_effort_values_require_support_flag():
+    with pytest.raises(ValueError) as exc_info:
+        _build_model(
+            supports_reasoning_effort=False,
+            reasoning_effort_values=["low", "medium", "high"],
+        )
+
+    assert "supports_reasoning_effort must be true" in str(exc_info.value)
+
+
+def test_valid_reasoning_effort_model_entry_passes_validation():
+    model = _build_model(
+        reasoning_effort="medium",
+        reasoning_effort_values=["low", "medium", "high"],
+    )
+
+    assert model.reasoning_effort == "medium"
+
+
+def test_empty_reasoning_effort_values_is_rejected():
+    with pytest.raises(ValidationError, match="must not be empty"):
+        _build_model(reasoning_effort_values=[])
+
+
+def test_null_entry_in_reasoning_effort_values_is_rejected():
+    with pytest.raises(ValidationError):
+        _build_model(reasoning_effort_values=["low", None])

--- a/iris/tests/test_reasoning_effort_config.py
+++ b/iris/tests/test_reasoning_effort_config.py
@@ -3,11 +3,20 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain_core.tools import tool
 from pydantic import ValidationError
 
 import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.common.pyris_message import PyrisAIMessage, PyrisToolMessage
+from iris.domain.data.text_message_content_dto import TextMessageContentDTO
+from iris.domain.data.tool_call_dto import ToolCallDTO
+from iris.domain.data.tool_message_content_dto import ToolMessageContentDTO
 from iris.llm import CompletionArguments  # noqa: E402
-from iris.llm.external.openai_chat import DirectOpenAIChatModel  # noqa: E402
+from iris.llm.external.openai_chat import (  # noqa: E402
+    AzureOpenAIChatModel,
+    DirectOpenAIChatModel,
+    convert_to_iris_message,
+)
 from iris.llm.llm_configuration import (  # noqa: E402
     LlmConfigurationError,
     validate_llm_configuration,
@@ -31,6 +40,40 @@ def _mock_openai_response():
     )
 
 
+def _mock_responses_response(
+    *,
+    output=None,
+    output_text="ok",
+    input_tokens=1,
+    output_tokens=1,
+    status="completed",
+):
+    return SimpleNamespace(
+        status=status,
+        output=(
+            output
+            if output is not None
+            else [
+                SimpleNamespace(
+                    type="message",
+                    content=[
+                        SimpleNamespace(
+                            type="output_text",
+                            text=output_text,
+                        )
+                    ],
+                )
+            ]
+        ),
+        output_text=output_text,
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            output_tokens_details=SimpleNamespace(reasoning_tokens=0),
+        ),
+    )
+
+
 def _build_model(**overrides):
     base = {
         "id": "test-model",
@@ -43,12 +86,74 @@ def _build_model(**overrides):
     return DirectOpenAIChatModel(**base)
 
 
+def _build_azure_model(**overrides):
+    base = {
+        "id": "azure-test-model",
+        "type": "azure_chat",
+        "model": "gpt-test",
+        "api_key": "sk-test",  # pragma: allowlist secret
+        "api_version": "2025-04-01-preview",
+        "azure_deployment": "gpt-test-deployment",
+        "endpoint": "https://example.openai.azure.com",
+        "supports_reasoning_effort": True,
+    }
+    base.update(overrides)
+    return AzureOpenAIChatModel(**base)
+
+
 def _invoke_chat(model, **completion_kwargs):
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = _mock_openai_response()
     with patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client):
         model.chat([], CompletionArguments(**completion_kwargs), tools=None)
     return mock_client.chat.completions.create.call_args.kwargs
+
+
+@tool("lookup")
+def _lookup(query: str) -> str:
+    """Lookup data."""
+    return query
+
+
+def _sample_tool():
+    return _lookup
+
+
+def _sample_tool_schema():
+    return {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Lookup data.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _tool_call(call_id="call-1", query="weather"):
+    return ToolCallDTO(
+        id=call_id,
+        function={
+            "name": "lookup",
+            "arguments": f'{{"query": "{query}"}}',
+        },
+    )
+
+
+def _invoke_responses_chat(model, messages=None, tools=None, **completion_kwargs):
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _mock_responses_response()
+    with patch.object(type(model), "get_client", lambda self: mock_client):
+        result = model.chat(
+            messages or [],
+            CompletionArguments(**completion_kwargs),
+            tools=tools if tools is not None else [_sample_tool()],
+        )
+    return mock_client, result
 
 
 def test_per_call_reasoning_effort_wins_over_entry_default():
@@ -101,6 +206,146 @@ def test_reasoning_effort_clamp_logs_warning(caplog):
         "Clamping reasoning_effort=xhigh to high for model id=test-model" in message
         for message in messages
     ), f"expected clamp warning; got: {messages}"
+
+
+def test_responses_api_azure_uses_flattened_tools_reasoning_and_deployment_model():
+    model = _build_azure_model(use_responses_api=True, reasoning_effort="medium")
+    mock_client, _ = _invoke_responses_chat(
+        model,
+        tools=[_sample_tool_schema()],
+        max_tokens=42,
+        response_format="JSON",
+    )
+
+    mock_client.responses.create.assert_called_once()
+    mock_client.chat.completions.create.assert_not_called()
+    params = mock_client.responses.create.call_args.kwargs
+    assert params["model"] == "gpt-test-deployment"
+    assert params["reasoning"] == {"effort": "medium"}
+    assert params["store"] is False
+    assert params["max_output_tokens"] == 42
+    assert params["text"] == {"format": {"type": "json_object"}}
+    assert params["tools"] == [
+        {
+            "type": "function",
+            "name": "lookup",
+            "description": "Lookup data.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]
+
+
+def test_responses_api_tool_call_round_trip_matches_chat_shape():
+    response_tool_call = SimpleNamespace(
+        type="function_call",
+        call_id="call-2",
+        name="lookup",
+        arguments='{"query": "next"}',
+    )
+    model = _build_model(use_responses_api=True, reasoning_effort="medium")
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _mock_responses_response(
+        output=[response_tool_call],
+        output_text="",
+    )
+    assistant_message = PyrisAIMessage(
+        toolCalls=[_tool_call()],
+        contents=[TextMessageContentDTO(textContent="")],
+    )
+    tool_message = PyrisToolMessage(
+        contents=[
+            ToolMessageContentDTO(
+                toolName="lookup",
+                toolContent='{"result": "sunny"}',
+                toolCallId="call-1",
+            )
+        ]
+    )
+
+    with patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client):
+        result = model.chat(
+            [assistant_message, tool_message],
+            CompletionArguments(),
+            tools=[_sample_tool()],
+        )
+
+    params = mock_client.responses.create.call_args.kwargs
+    assert params["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "lookup",
+            "arguments": '{"query": "weather"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": '{"result": "sunny"}',
+        },
+    ]
+    expected = convert_to_iris_message(
+        SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call-2",
+                    type="function",
+                    function=SimpleNamespace(
+                        name="lookup",
+                        arguments='{"query": "next"}',
+                    ),
+                )
+            ],
+        ),
+        SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        model.model,
+    )
+    assert isinstance(result, PyrisAIMessage)
+    assert result.tool_calls == expected.tool_calls
+
+
+def test_responses_api_usage_maps_to_token_usage_fields():
+    model = _build_model(use_responses_api=True, reasoning_effort="medium")
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _mock_responses_response(
+        input_tokens=11,
+        output_tokens=22,
+    )
+
+    with patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client):
+        result = model.chat([], CompletionArguments(), tools=None)
+
+    assert result.token_usage.model_info == "gpt-test"
+    assert result.token_usage.num_input_tokens == 11
+    assert result.token_usage.num_output_tokens == 22
+
+
+def test_responses_api_is_not_called_when_flag_is_off():
+    model = _build_model(reasoning_effort="medium")
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_openai_response()
+
+    with patch.object(DirectOpenAIChatModel, "get_client", lambda self: mock_client):
+        model.chat([], CompletionArguments(), tools=[_sample_tool()])
+
+    mock_client.responses.create.assert_not_called()
+    mock_client.chat.completions.create.assert_called_once()
+
+
+def test_responses_api_reasoning_effort_is_clamped_to_nearest_allowed_value():
+    model = _build_model(
+        use_responses_api=True,
+        reasoning_effort_values=["low", "medium", "high"],
+    )
+    mock_client, _ = _invoke_responses_chat(model, reasoning_effort="xhigh")
+
+    params = mock_client.responses.create.call_args.kwargs
+    assert params["reasoning"] == {"effort": "high"}
 
 
 def test_missing_llm_catalog_id_raises_with_pipeline_variant_role_and_id():

--- a/iris/tests/test_reasoning_effort_config.py
+++ b/iris/tests/test_reasoning_effort_config.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
 from iris.common.pyris_message import PyrisAIMessage, PyrisToolMessage
+from iris.config import settings
 from iris.domain.data.text_message_content_dto import TextMessageContentDTO
 from iris.domain.data.tool_call_dto import ToolCallDTO
 from iris.domain.data.tool_message_content_dto import ToolMessageContentDTO
@@ -398,6 +399,73 @@ def test_bare_llm_configuration_validation_skips_catalog_cross_reference():
     }
 
     validate_llm_configuration(config)
+
+
+def test_disabled_local_llm_ignores_stale_local_catalog_entry(monkeypatch):
+    # Cloud-only deployment (local_llm_enabled: false) with a "local" entry
+    # that references a model intentionally absent from llm_config.yml. The
+    # catalog cross-check must be scoped the same way as the structural
+    # "missing entry" check, which already skips "local" in this mode.
+    monkeypatch.setattr(settings, "local_llm_enabled", False)
+    config = {
+        "chat_pipeline": {
+            "default": {
+                "chat": {
+                    "local": "stale-local-only-model",
+                    "cloud": "known-model",
+                },
+            },
+        },
+    }
+
+    validate_llm_configuration(config, known_model_ids={"known-model"})
+
+
+def test_disabled_local_llm_still_validates_cloud_catalog_entry(monkeypatch):
+    # A cloud-only deployment must still fail if the *cloud* entry it
+    # actually uses references an unknown model id.
+    monkeypatch.setattr(settings, "local_llm_enabled", False)
+    config = {
+        "chat_pipeline": {
+            "default": {
+                "chat": {
+                    "local": "stale-local-only-model",
+                    "cloud": "missing-model",
+                },
+            },
+        },
+    }
+
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        validate_llm_configuration(config, known_model_ids={"known-model"})
+
+    message = str(exc_info.value)
+    assert "llm_configuration.chat_pipeline.default.chat.cloud" in message
+    assert "missing-model" in message
+    assert "chat.local" not in message
+
+
+def test_enabled_local_llm_still_validates_both_environments(monkeypatch):
+    # Behavior must stay unchanged when local_llm_enabled is true: both
+    # "local" and "cloud" entries are cross-checked against the catalog.
+    monkeypatch.setattr(settings, "local_llm_enabled", True)
+    config = {
+        "chat_pipeline": {
+            "default": {
+                "chat": {
+                    "local": "missing-local-model",
+                    "cloud": "known-model",
+                },
+            },
+        },
+    }
+
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        validate_llm_configuration(config, known_model_ids={"known-model"})
+
+    message = str(exc_info.value)
+    assert "llm_configuration.chat_pipeline.default.chat.local" in message
+    assert "missing-local-model" in message
 
 
 def test_reasoning_effort_default_must_be_in_declared_allowed_values():


### PR DESCRIPTION
> [!NOTE]
> Stacked on #652 (`iris/perf/chat-first-answer-latency`) — the base retargets to `main` automatically once #652 merges. Review only the last commit.

## Summary

Second slice of the chat-latency work: every LLM call in the chat path currently runs at the provider's *default* reasoning effort — for `gpt-5-mini`/`-nano` that is `medium`, which burns 64–128+ hidden reasoning tokens even on trivial calls like session-title generation or query rewrites. This PR makes reasoning effort a YAML-configured, per-model-entry setting so mechanical tasks run at `minimal`/`low` while the main chat agent keeps full reasoning, and upgrades the advanced chat variant from GPT-5.4 to GPT-5.5.

## Description

- **Per-entry effort config**: `llm_config.yml` chat entries gain `reasoning_effort` (default applied when the call doesn't set one) and `reasoning_effort_values` (what the backend actually accepts). Values outside the list are clamped to the nearest allowed value with a warning. Allowed sets differ per backend and are hard 400s when violated: gpt-5/-mini/-nano = `minimal|low|medium|high`; gpt-5.2/5.4/5.5 = `none|low|medium|high|xhigh` (`minimal` rejected on 5.5, verified live); Logos/vLLM gpt-oss = `low|medium|high` only.
- **Fail fast on 4xx**: the retry loop caught broad `APIError`, so a deterministic 400 was retried 5× with 31s of pointless backoff. Now only 429, connection/timeouts, 5xx, and 408/409 retry (408/409 are transient per the OpenAI SDK's own retry predicate; the cached client runs `max_retries=0`).
- **Startup validation hard-fails** on: `llm_configuration` roles referencing model ids missing from the catalog (previously only surfaced per-request), entry defaults outside their own `reasoning_effort_values`, effort fields without `supports_reasoning_effort`, and empty/null-bearing value lists. Ops edits these YAMLs on live servers — misconfigurations should fail at boot, not at request time.
- **global_search** hyde/answer efforts move from hardcoded Python (`reasoning_effort="none"`) to YAML-pinned `*-minimal` entries (same-rollout config update required, included in the deployment runbook).
- **Example configs**: effort-suffixed entries (`oai-gpt-5-mini-minimal`, `oai-gpt-5-nano-minimal`, `oai-gpt-5-nano-low`), per-role mapping (main chat pinned `medium`, citations/rewrites/title/suggestions `minimal`, MCQ `low`), `gpt-5.4` → `gpt-5.5` ($5/$30 per 1M tokens), and the four dead legacy per-mode chat blocks replaced with the unified `chat_pipeline` block the code actually resolves — a fresh install following the example could not run chat at all.

## Validation

- `poetry run pytest`: **166 passed** (10 new tests: retry classification incl. 408/409, effort resolution/clamping, config validation)
- `poetry run pylint src/iris`: **10.00/10**; `black`/`isort` clean
- **Live end-to-end**: local Pyris (this branch) against real Azure deployments with a stub Artemis callback receiver — identical COURSE_CHAT prompts with the main chat entry pinned at `minimal` vs `high` produced **63 vs 504 output tokens** (same 2646 input tokens), confirming the YAML → resolution → clamp → API chain end to end; title/suggestions ran on `gpt-5-nano-minimal` (11/52 output tokens); all callbacks delivered in order.
- Effort value sets verified against OpenAI model cards, Azure docs, and the vLLM 0.24.0 source (gpt-oss harmony path), plus live probes of every `ase-se01` deployment and Logos.
- Cross-vendor review: implemented by Codex (GPT-5.5, xhigh), reviewed by Claude; final diff re-reviewed by Codex — explicit approval after 408/409 and validator-hardening fixes.

---
**Update (live-testing follow-up):** Azure gpt-5.5 rejects `reasoning_effort` combined with function tools on `/chat/completions` (hard 400 telling you to use `/v1/responses`). Added a per-entry `use_responses_api` switch with full Responses-API mapping (input items incl. tool calls/results, flattened tool schemas, `reasoning.effort`, JSON mode, `store: false`, usage mapping, Azure `/openai/v1` client) so the effort pin keeps working on the flagship agent loop. Live-verified against Azure gpt-5.5: tools + pinned `medium` → clean tool call. 171 tests on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for newer chat model configuration options, including reasoning-effort settings and Responses API usage.
  * Expanded cloud model presets across several pipelines for more consistent model selection.

* **Bug Fixes**
  * Improved LLM configuration validation to catch invalid or unknown model references earlier.
  * Updated chat handling to better support retries, tool calls, usage reporting, and refusal detection.
  * Refined Azure and OpenAI model behavior for compatible Responses API support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->