### PR TITLE
`Iris`: Speed up lecture retrieval with transcription skipping, shared embeddings, and parallel reranks

### DIFF
--- a/iris/src/iris/pipeline/prompts/lecture_retrieval_prompts.py
+++ b/iris/src/iris/pipeline/prompts/lecture_retrieval_prompts.py
@@ -91,7 +91,7 @@ The chat history between the AI tutor and the student is provided to you in the 
 Please provide a response in {course_language}.
 You should create a response that looks like a lecture slide.
 Craft your response to closely reflect the style and content of typical university lecture materials.
-Do not exceed 350 words. Add keywords and phrases that are relevant to student intent.
+Do not exceed 120 words. Add keywords and phrases that are relevant to student intent.
 """
 
 write_hypothetical_lecture_transcriptions_answer_prompt = """
@@ -100,7 +100,7 @@ The chat history between the AI tutor and the student is provided to you in the 
 Please provide a response in {course_language}.
 You should create a response that looks like spoken content from a lecture video transcription.
 Answer just with the spoken text.
-Do not exceed 350 words. Add keywords and phrases that are relevant to student intent.
+Do not exceed 120 words. Add keywords and phrases that are relevant to student intent.
 """
 
 

--- a/iris/src/iris/retrieval/lecture/lecture_page_chunk_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_page_chunk_retrieval.py
@@ -103,6 +103,8 @@ class LecturePageChunkRetrieval(SubPipeline):
         result_limit: int = 10,
         hybrid_factor: float = 0.9,
         top_n_reranked_results: int = 7,
+        rewritten_query_vector=None,
+        hypothetical_answer_vector=None,
     ) -> list[LectureUnitPageChunkRetrievalDTO]:
         """
         Retrieve lecture data from the database.
@@ -117,6 +119,7 @@ class LecturePageChunkRetrieval(SubPipeline):
                 hybrid_factor=0.9,
                 result_limit=result_limit,
                 lecture_unit_dto=lecture_unit,
+                query_vector=rewritten_query_vector,
             )
             hyde_future = executor.submit(
                 self.search_in_db,
@@ -124,6 +127,7 @@ class LecturePageChunkRetrieval(SubPipeline):
                 hybrid_factor=0.9,
                 result_limit=result_limit,
                 lecture_unit_dto=lecture_unit,
+                query_vector=hypothetical_answer_vector,
             )
             basic_lecture_chunks = basic_future.result()
             hyde_lecture_chunks = hyde_future.result()
@@ -155,6 +159,7 @@ class LecturePageChunkRetrieval(SubPipeline):
         hybrid_factor: float,
         result_limit: int,
         lecture_unit_dto: LectureUnitRetrievalDTO,
+        query_vector=None,
     ):
         """
         Search the database for the given query.
@@ -180,7 +185,11 @@ class LecturePageChunkRetrieval(SubPipeline):
                 LectureUnitPageChunkSchema.BASE_URL.value
             ).equal(lecture_unit_dto.base_url)
 
-        vec = self.llm_embedding.embed(query)
+        vec = (
+            query_vector
+            if query_vector is not None
+            else self.llm_embedding.embed(query)
+        )
         return_value = self.lecture_unit_page_chunk_collection.query.hybrid(
             query=query,
             alpha=hybrid_factor,

--- a/iris/src/iris/retrieval/lecture/lecture_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_retrieval.py
@@ -91,7 +91,7 @@ class LectureRetrieval(SubPipeline):
             pipeline_id, "default", "embedding", local=False
         )
         request_handler = LlmRequestHandler(model_id=chat_model)
-        completion_args = CompletionArguments(temperature=0, max_tokens=2000)
+        completion_args = CompletionArguments(temperature=0, max_tokens=400)
         self.llm = IrisLangchainChatModel(
             request_handler=request_handler, completion_args=completion_args
         )
@@ -107,6 +107,7 @@ class LectureRetrieval(SubPipeline):
         )
 
         self.tokens = []
+        self._transcription_presence_cache: dict = {}
 
         self.lecture_unit_segment_pipeline = LectureUnitSegmentRetrieval(
             client, local=local
@@ -134,12 +135,27 @@ class LectureRetrieval(SubPipeline):
         base_url: str = None,
     ) -> LectureRetrievalDTO:
         with timed_span("LectureRetrieval", "get_lecture_unit"):
-            lecture_unit = self.get_lecture_unit(course_id, lecture_id, lecture_unit_id)
+            with TracedThreadPoolExecutor(max_workers=2) as executor:
+                lecture_unit_future = executor.submit(
+                    self.get_lecture_unit, course_id, lecture_id, lecture_unit_id
+                )
+                transcriptions_exist_future = executor.submit(
+                    self.lecture_unit_has_transcriptions,
+                    course_id,
+                    lecture_id,
+                    lecture_unit_id,
+                )
+                lecture_unit = lecture_unit_future.result()
+                transcriptions_exist = transcriptions_exist_future.result()
         if lecture_unit is None:
             return LectureRetrievalDTO(
                 lecture_transcriptions=[],
                 lecture_unit_page_chunks=[],
                 lecture_unit_segments=[],
+            )
+        if not transcriptions_exist:
+            logger.info(
+                "Lecture retrieval: no transcriptions for unit — skipping transcription domain"
             )
 
         with timed_span("LectureRetrieval", "query_rewrites"):
@@ -155,7 +171,22 @@ class LectureRetrieval(SubPipeline):
                 lecture_unit.course_name,
                 problem_statement,
                 exercise_title,
+                include_transcriptions=transcriptions_exist,
             )
+
+        with timed_span("LectureRetrieval", "query_embeddings"):
+            queries_to_embed = [
+                rewritten_lecture_pages_query,
+                hypothetical_lecture_pages_answer_query,
+            ]
+            if transcriptions_exist:
+                queries_to_embed.extend(
+                    [
+                        rewritten_lecture_transcriptions_query,
+                        hypothetical_lecture_transcriptions_answer_query,
+                    ]
+                )
+            query_vectors = self.embed_distinct_queries(queries_to_embed)
 
         with timed_span("LectureRetrieval", "search_pipelines"):
             (
@@ -169,6 +200,8 @@ class LectureRetrieval(SubPipeline):
                 rewritten_lecture_transcriptions_query,
                 hypothetical_lecture_pages_answer_query,
                 hypothetical_lecture_transcriptions_answer_query,
+                transcriptions_exist,
+                query_vectors,
             )
 
         # Fetch the segments' surrounding transcriptions/page chunks
@@ -177,12 +210,15 @@ class LectureRetrieval(SubPipeline):
         if lecture_unit_segments:
             with timed_span("LectureRetrieval", "segment_content_fetch"):
                 with TracedThreadPoolExecutor(max_workers=8) as executor:
-                    transcription_futures = [
-                        executor.submit(
-                            self.get_lecture_transcription_of_lecture_unit, segment
-                        )
-                        for segment in lecture_unit_segments
-                    ]
+                    transcription_futures = []
+                    if transcriptions_exist:
+                        transcription_futures = [
+                            executor.submit(
+                                self.get_lecture_transcription_of_lecture_unit,
+                                segment,
+                            )
+                            for segment in lecture_unit_segments
+                        ]
                     page_chunk_futures = [
                         executor.submit(
                             self.get_lecture_page_chunks_of_lecture_unit, segment
@@ -207,23 +243,89 @@ class LectureRetrieval(SubPipeline):
         lecture_unit_page_chunks = list(unique_page_chunks.values())
 
         with timed_span("LectureRetrieval", "final_rerank"):
-            lecture_transcriptions = self.cohere_client.rerank(
-                query,
-                lecture_transcriptions,
-                top_n=7,
-                content_field_name="segment_text",
-            )
-            lecture_unit_page_chunks = self.cohere_client.rerank(
-                query,
-                lecture_unit_page_chunks,
-                top_n=7,
-                content_field_name="page_text_content",
-            )
+            with TracedThreadPoolExecutor(max_workers=2) as executor:
+                transcriptions_future = executor.submit(
+                    self.rerank_or_empty,
+                    query,
+                    lecture_transcriptions,
+                    7,
+                    "segment_text",
+                )
+                page_chunks_future = executor.submit(
+                    self.rerank_or_empty,
+                    query,
+                    lecture_unit_page_chunks,
+                    7,
+                    "page_text_content",
+                )
+                lecture_transcriptions = transcriptions_future.result()
+                lecture_unit_page_chunks = page_chunks_future.result()
 
         return LectureRetrievalDTO(
             lecture_unit_segments=lecture_unit_segments,
             lecture_transcriptions=lecture_transcriptions,
             lecture_unit_page_chunks=lecture_unit_page_chunks,
+        )
+
+    def lecture_unit_has_transcriptions(
+        self,
+        course_id: int,
+        lecture_id: int = None,
+        lecture_unit_id: int = None,
+    ) -> bool:
+        cache_key = (course_id, lecture_id, lecture_unit_id)
+        if not hasattr(self, "_transcription_presence_cache"):
+            self._transcription_presence_cache = {}
+        if cache_key in self._transcription_presence_cache:
+            return self._transcription_presence_cache[cache_key]
+
+        transcription_filter = Filter.by_property(
+            LectureTranscriptionSchema.COURSE_ID.value
+        ).equal(course_id)
+        if lecture_id is not None:
+            transcription_filter &= Filter.by_property(
+                LectureTranscriptionSchema.LECTURE_ID.value
+            ).equal(lecture_id)
+        if lecture_unit_id is not None:
+            transcription_filter &= Filter.by_property(
+                LectureTranscriptionSchema.LECTURE_UNIT_ID.value
+            ).equal(lecture_unit_id)
+
+        transcriptions = self.lecture_transcription_collection.query.fetch_objects(
+            filters=transcription_filter,
+            limit=1,
+        ).objects
+        transcriptions_exist = len(transcriptions) > 0
+        self._transcription_presence_cache[cache_key] = transcriptions_exist
+        return transcriptions_exist
+
+    def embed_distinct_queries(self, queries: List[str]) -> Dict[str, List[float]]:
+        distinct_queries = list(dict.fromkeys(query for query in queries if query))
+        if not distinct_queries:
+            return {}
+
+        with TracedThreadPoolExecutor(max_workers=len(distinct_queries)) as executor:
+            futures = {
+                query: executor.submit(self.llm_embedding.embed, query)
+                for query in distinct_queries
+            }
+            return {query: future.result() for query, future in futures.items()}
+
+    def rerank_or_empty(
+        self,
+        query: str,
+        documents: List[Any],
+        top_n: int,
+        content_field_name: str,
+    ) -> List[Any]:
+        if not documents:
+            return []
+
+        return self.cohere_client.rerank(
+            query,
+            documents,
+            top_n=top_n,
+            content_field_name=content_field_name,
         )
 
     def fetch_context_content(
@@ -491,13 +593,13 @@ class LectureRetrieval(SubPipeline):
         course_name: str = None,
         problem_statement: str = None,
         exercise_title: str = None,
+        include_transcriptions: bool = True,
     ):
         """
         Run the rewrite tasks in parallel.
         """
         if problem_statement:
             with TracedThreadPoolExecutor() as executor:
-                # Schedule the rewrite tasks to run in parallel
                 rewritten_lecture_pages_query_future = executor.submit(
                     self.rewrite_student_query_with_exercise_context,
                     chat_history,
@@ -507,16 +609,6 @@ class LectureRetrieval(SubPipeline):
                     exercise_title,
                     problem_statement,
                     QueryRewriteMode.LECTURE_PAGES,
-                )
-                rewritten_lecture_transcriptions_query_future = executor.submit(
-                    self.rewrite_student_query_with_exercise_context,
-                    chat_history,
-                    student_query,
-                    course_language,
-                    course_name,
-                    exercise_title,
-                    problem_statement,
-                    QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
                 )
                 hypothetical_lecture_pages_answer_query_future = executor.submit(
                     self.rewrite_elaborated_query_with_exercise_context,
@@ -528,9 +620,11 @@ class LectureRetrieval(SubPipeline):
                     problem_statement,
                     QueryRewriteMode.LECTURE_PAGES,
                 )
-                hypothetical_lecture_transcriptions_answer_query_future = (
-                    executor.submit(
-                        self.rewrite_elaborated_query_with_exercise_context,
+                rewritten_lecture_transcriptions_query_future = None
+                hypothetical_lecture_transcriptions_answer_query_future = None
+                if include_transcriptions:
+                    rewritten_lecture_transcriptions_query_future = executor.submit(
+                        self.rewrite_student_query_with_exercise_context,
                         chat_history,
                         student_query,
                         course_language,
@@ -539,24 +633,37 @@ class LectureRetrieval(SubPipeline):
                         problem_statement,
                         QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
                     )
-                )
+                    hypothetical_lecture_transcriptions_answer_query_future = (
+                        executor.submit(
+                            self.rewrite_elaborated_query_with_exercise_context,
+                            chat_history,
+                            student_query,
+                            course_language,
+                            course_name,
+                            exercise_title,
+                            problem_statement,
+                            QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
+                        )
+                    )
 
-                # Get the results once both tasks are complete
                 rewritten_lecture_pages_query: str = (
                     rewritten_lecture_pages_query_future.result()
-                )
-                rewritten_lecture_transcriptions_query: str = (
-                    rewritten_lecture_transcriptions_query_future.result()
                 )
                 hypothetical_lecture_pages_answer_query: str = (
                     hypothetical_lecture_pages_answer_query_future.result()
                 )
-                hypothetical_lecture_transcriptions_answer_query: str = (
-                    hypothetical_lecture_transcriptions_answer_query_future.result()
-                )
+                if include_transcriptions:
+                    rewritten_lecture_transcriptions_query: str = (
+                        rewritten_lecture_transcriptions_query_future.result()
+                    )
+                    hypothetical_lecture_transcriptions_answer_query: str = (
+                        hypothetical_lecture_transcriptions_answer_query_future.result()
+                    )
+                else:
+                    rewritten_lecture_transcriptions_query = None
+                    hypothetical_lecture_transcriptions_answer_query = None
         else:
             with TracedThreadPoolExecutor() as executor:
-                # Schedule the rewrite tasks to run in parallel
                 rewritten_lecture_pages_query_future = executor.submit(
                     self.rewrite_student_query,
                     chat_history,
@@ -564,14 +671,6 @@ class LectureRetrieval(SubPipeline):
                     course_language,
                     course_name,
                     QueryRewriteMode.LECTURE_PAGES,
-                )
-                rewritten_lecture_transcriptions_query_future = executor.submit(
-                    self.rewrite_student_query,
-                    chat_history,
-                    student_query,
-                    course_language,
-                    course_name,
-                    QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
                 )
                 hypothetical_lecture_pages_answer_query_future = executor.submit(
                     self.rewrite_elaborated_query,
@@ -581,30 +680,44 @@ class LectureRetrieval(SubPipeline):
                     course_name,
                     QueryRewriteMode.LECTURE_PAGES,
                 )
-                hypothetical_lecture_transcriptions_answer_query_future = (
-                    executor.submit(
-                        self.rewrite_elaborated_query,
+                rewritten_lecture_transcriptions_query_future = None
+                hypothetical_lecture_transcriptions_answer_query_future = None
+                if include_transcriptions:
+                    rewritten_lecture_transcriptions_query_future = executor.submit(
+                        self.rewrite_student_query,
                         chat_history,
                         student_query,
                         course_language,
                         course_name,
                         QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
                     )
-                )
+                    hypothetical_lecture_transcriptions_answer_query_future = (
+                        executor.submit(
+                            self.rewrite_elaborated_query,
+                            chat_history,
+                            student_query,
+                            course_language,
+                            course_name,
+                            QueryRewriteMode.LECTURE_TRANSCRIPTIONS,
+                        )
+                    )
 
-                # Get the results once both tasks are complete
                 rewritten_lecture_pages_query: str = (
                     rewritten_lecture_pages_query_future.result()
-                )
-                rewritten_lecture_transcriptions_query: str = (
-                    rewritten_lecture_transcriptions_query_future.result()
                 )
                 hypothetical_lecture_pages_answer_query: str = (
                     hypothetical_lecture_pages_answer_query_future.result()
                 )
-                hypothetical_lecture_transcriptions_answer_query: str = (
-                    hypothetical_lecture_transcriptions_answer_query_future.result()
-                )
+                if include_transcriptions:
+                    rewritten_lecture_transcriptions_query: str = (
+                        rewritten_lecture_transcriptions_query_future.result()
+                    )
+                    hypothetical_lecture_transcriptions_answer_query: str = (
+                        hypothetical_lecture_transcriptions_answer_query_future.result()
+                    )
+                else:
+                    rewritten_lecture_transcriptions_query = None
+                    hypothetical_lecture_transcriptions_answer_query = None
 
         return (
             rewritten_lecture_pages_query,
@@ -837,39 +950,64 @@ class LectureRetrieval(SubPipeline):
         lecture_transcriptions_query: str,
         hypothetical_lecture_pages_answer_query: str,
         hypothetical_lecture_transcriptions_answer_query: str,
+        transcriptions_exist: bool,
+        query_vectors: Dict[str, List[float]],
     ):
         """
         Call the different pipelines for lecture content retrieval.
         """
-        with TracedThreadPoolExecutor() as executor:
+        segment_query = lecture_transcriptions_query
+        segment_hypothetical_answer = hypothetical_lecture_transcriptions_answer_query
+        if not transcriptions_exist:
+            segment_query = lecture_pages_query
+            segment_hypothetical_answer = hypothetical_lecture_pages_answer_query
+
+        worker_count = 3 if transcriptions_exist else 2
+        with TracedThreadPoolExecutor(max_workers=worker_count) as executor:
             lecture_unit_segments_future = executor.submit(
                 self.lecture_unit_segment_pipeline,
                 student_query,
-                lecture_transcriptions_query,
-                hypothetical_lecture_transcriptions_answer_query,
+                segment_query,
+                segment_hypothetical_answer,
                 lecture_unit,
+                rewritten_query_vector=query_vectors.get(segment_query),
+                hypothetical_answer_vector=query_vectors.get(
+                    segment_hypothetical_answer
+                ),
             )
-            lecture_transcriptions_future = executor.submit(
-                self.lecture_transcription_pipeline,
-                student_query,
-                lecture_transcriptions_query,
-                hypothetical_lecture_transcriptions_answer_query,
-                lecture_unit,
-            )
+            lecture_transcriptions_future = None
+            if transcriptions_exist:
+                lecture_transcriptions_future = executor.submit(
+                    self.lecture_transcription_pipeline,
+                    student_query,
+                    lecture_transcriptions_query,
+                    hypothetical_lecture_transcriptions_answer_query,
+                    lecture_unit,
+                    rewritten_query_vector=query_vectors.get(
+                        lecture_transcriptions_query
+                    ),
+                    hypothetical_answer_vector=query_vectors.get(
+                        hypothetical_lecture_transcriptions_answer_query
+                    ),
+                )
             lecture_unit_page_chunks_future = executor.submit(
                 self.lecture_unit_page_chunk_pipeline,
                 student_query,
                 lecture_pages_query,
                 hypothetical_lecture_pages_answer_query,
                 lecture_unit,
+                rewritten_query_vector=query_vectors.get(lecture_pages_query),
+                hypothetical_answer_vector=query_vectors.get(
+                    hypothetical_lecture_pages_answer_query
+                ),
             )
 
             lecture_unit_segments: List[LectureUnitSegmentRetrievalDTO] = (
                 lecture_unit_segments_future.result()
             )
-            lecture_transcriptions: List[LectureTranscriptionRetrievalDTO] = (
-                lecture_transcriptions_future.result()
-            )
+            lecture_transcriptions: List[LectureTranscriptionRetrievalDTO] = []
+            if lecture_transcriptions_future is not None:
+                lecture_transcriptions = lecture_transcriptions_future.result()
             lecture_unit_page_chunks: List[LectureUnitPageChunkRetrievalDTO] = (
                 lecture_unit_page_chunks_future.result()
             )

--- a/iris/src/iris/retrieval/lecture/lecture_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_retrieval.py
@@ -27,7 +27,7 @@ from iris.llm import (
     CompletionArguments,
 )
 from iris.llm.langchain import IrisLangchainChatModel
-from iris.llm.llm_configuration import resolve_model
+from iris.llm.llm_configuration import LlmConfigurationError, resolve_model
 from iris.llm.request_handler.llm_request_handler import (
     LlmRequestHandler,
 )
@@ -121,6 +121,56 @@ class LectureRetrieval(SubPipeline):
 
         reranker_id = resolve_model(pipeline_id, "default", "reranker", local=False)
         self.cohere_client = RerankRequestHandler(reranker_id)
+
+        # The shared-embedding optimization only holds if every sub-pipeline
+        # that receives the pre-embedded vectors uses the same embedding model.
+        self._assert_shared_embedding_model()
+
+    def _assert_shared_embedding_model(self) -> None:
+        """Guard the shared-embedding optimization against misconfiguration.
+
+        ``call_lecture_pipelines`` embeds every query exactly once (with this
+        orchestrator's embedding model) and reuses those vectors across the
+        segment, transcription, and page-chunk sub-pipelines. A hybrid search
+        only returns meaningful results when the query vector comes from the
+        same embedding model — hence the same vector space and dimension — the
+        sub-pipeline would have used itself. These three pipelines are
+        independent ``llm_configuration`` entries
+        (``lecture_retrieval_pipeline``,
+        ``lecture_unit_segment_retrieval_pipeline`` and
+        ``lecture_transcriptions_retrieval_pipeline``), so a deployment could
+        point them at different embedding models. Rather than silently searching
+        with mismatched vectors (bad results, or a dimension error raised deep
+        inside Weaviate), fail fast at construction with an actionable message.
+        """
+        shared_model_id = self.llm_embedding.model_id
+        mismatches = {
+            consumer: sub_pipeline.llm_embedding.model_id
+            for consumer, sub_pipeline in (
+                (
+                    "segment retrieval (lecture_unit_segment_retrieval_pipeline)",
+                    self.lecture_unit_segment_pipeline,
+                ),
+                (
+                    "transcription retrieval (lecture_transcriptions_retrieval_pipeline)",
+                    self.lecture_transcription_pipeline,
+                ),
+                (
+                    "page-chunk retrieval (lecture_retrieval_pipeline)",
+                    self.lecture_unit_page_chunk_pipeline,
+                ),
+            )
+            if sub_pipeline.llm_embedding.model_id != shared_model_id
+        }
+        if mismatches:
+            raise LlmConfigurationError(
+                "Lecture retrieval reuses one set of query embeddings across the "
+                "segment, transcription and page-chunk sub-pipelines, so they must "
+                "all share the embedding model configured for "
+                f"'lecture_retrieval_pipeline' ('{shared_model_id}'). Mismatched "
+                f"embedding models: {mismatches}. Align the 'embedding' entries in "
+                "llm_configuration for these pipelines."
+            )
 
     @observe(name="Lecture Retrieval")
     def __call__(

--- a/iris/src/iris/retrieval/lecture/lecture_transcription_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_transcription_retrieval.py
@@ -70,6 +70,8 @@ class LectureTranscriptionRetrieval(SubPipeline):
         result_limit: int = 10,
         hybrid_factor: float = 0.9,
         top_n_reranked_results: int = 7,
+        rewritten_query_vector=None,
+        hypothetical_answer_vector=None,
     ):
         # The two searches (embed + hybrid search each) are independent;
         # run them concurrently.
@@ -80,6 +82,7 @@ class LectureTranscriptionRetrieval(SubPipeline):
                 rewritten_query,
                 hybrid_factor,
                 result_limit,
+                query_vector=rewritten_query_vector,
             )
             hypothetical_future = executor.submit(
                 self.search_in_db,
@@ -87,6 +90,7 @@ class LectureTranscriptionRetrieval(SubPipeline):
                 hypothetical_answer,
                 hybrid_factor,
                 result_limit,
+                query_vector=hypothetical_answer_vector,
             )
             results_rewritten_query = rewritten_future.result()
             results_hypothetical_answer = hypothetical_future.result()
@@ -122,6 +126,7 @@ class LectureTranscriptionRetrieval(SubPipeline):
         query: str,
         hybrid_factor: float,
         result_limit: int,
+        query_vector=None,
     ):
         """
         Search the database for the given query.
@@ -148,7 +153,11 @@ class LectureTranscriptionRetrieval(SubPipeline):
                 LectureTranscriptionSchema.BASE_URL.value
             ).equal(lecture_unit_dto.base_url)
 
-        vec = self.llm_embedding.embed(query)
+        vec = (
+            query_vector
+            if query_vector is not None
+            else self.llm_embedding.embed(query)
+        )
         return_value = self.collection.query.hybrid(
             query=query,
             alpha=hybrid_factor,

--- a/iris/src/iris/retrieval/lecture/lecture_unit_segment_retrieval.py
+++ b/iris/src/iris/retrieval/lecture/lecture_unit_segment_retrieval.py
@@ -70,6 +70,8 @@ class LectureUnitSegmentRetrieval(SubPipeline):
         result_limit: int = 10,
         hybrid_factor: float = 0.9,
         top_n_reranked_results: int = 7,
+        rewritten_query_vector=None,
+        hypothetical_answer_vector=None,
     ):
         # The two searches (embed + hybrid search each) are independent;
         # run them concurrently.
@@ -80,6 +82,7 @@ class LectureUnitSegmentRetrieval(SubPipeline):
                 rewritten_query,
                 hybrid_factor,
                 result_limit,
+                query_vector=rewritten_query_vector,
             )
             hypothetical_future = executor.submit(
                 self.search_in_db,
@@ -87,6 +90,7 @@ class LectureUnitSegmentRetrieval(SubPipeline):
                 hypothetical_answer,
                 hybrid_factor,
                 result_limit,
+                query_vector=hypothetical_answer_vector,
             )
             results_rewritten_query = rewritten_future.result()
             results_hypothetical_answer = hypothetical_future.result()
@@ -122,6 +126,7 @@ class LectureUnitSegmentRetrieval(SubPipeline):
         query: str,
         hybrid_factor: float,
         result_limit: int,
+        query_vector=None,
     ):
         """
         Search the database for the given query.
@@ -148,7 +153,11 @@ class LectureUnitSegmentRetrieval(SubPipeline):
                 LectureUnitSegmentSchema.BASE_URL.value
             ).equal(lecture_unit_dto.base_url)
 
-        vec = self.llm_embedding.embed(query)
+        vec = (
+            query_vector
+            if query_vector is not None
+            else self.llm_embedding.embed(query)
+        )
         return_value = self.collection.query.hybrid(
             query=query,
             alpha=hybrid_factor,

--- a/iris/tests/test_lecture_retrieval_speedups.py
+++ b/iris/tests/test_lecture_retrieval_speedups.py
@@ -1,0 +1,308 @@
+"""Tests for lecture retrieval latency optimizations."""
+
+# pylint: skip-file
+
+from threading import Barrier
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
+from iris.domain.retrieval.lecture.lecture_retrieval_dto import (  # noqa: E402
+    LectureTranscriptionRetrievalDTO,
+    LectureUnitPageChunkRetrievalDTO,
+    LectureUnitRetrievalDTO,
+    LectureUnitSegmentRetrievalDTO,
+)
+from iris.retrieval.lecture.lecture_page_chunk_retrieval import (  # noqa: E402
+    LecturePageChunkRetrieval,
+)
+from iris.retrieval.lecture.lecture_retrieval import (  # noqa: E402
+    LectureRetrieval,
+    QueryRewriteMode,
+)
+from iris.retrieval.lecture.lecture_unit_segment_retrieval import (  # noqa: E402
+    LectureUnitSegmentRetrieval,
+)
+
+
+def _lecture_unit() -> LectureUnitRetrievalDTO:
+    return LectureUnitRetrievalDTO(
+        uuid=str(uuid4()),
+        course_id=1,
+        course_name="Course",
+        course_description="Description",
+        course_language="en",
+        lecture_id=2,
+        lecture_name="Lecture",
+        lecture_unit_id=3,
+        lecture_unit_name="Unit",
+        lecture_unit_link="http://example.com/unit",
+        video_link="http://example.com/video",
+        base_url="http://example.com",
+        lecture_unit_summary="Unit summary",
+    )
+
+
+def _segment() -> LectureUnitSegmentRetrievalDTO:
+    return LectureUnitSegmentRetrievalDTO(
+        uuid=str(uuid4()),
+        course_id=1,
+        course_name="Course",
+        course_description="Description",
+        lecture_id=2,
+        lecture_name="Lecture",
+        lecture_unit_id=3,
+        lecture_unit_name="Unit",
+        lecture_unit_link="http://example.com/unit",
+        video_link="http://example.com/video",
+        page_number=4,
+        display_page_number=4,
+        segment_summary="Segment summary",
+        base_url="http://example.com",
+    )
+
+
+def _transcription(text: str = "Transcript") -> LectureTranscriptionRetrievalDTO:
+    return LectureTranscriptionRetrievalDTO(
+        uuid=str(uuid4()),
+        course_id=1,
+        course_name="Course",
+        course_description="Description",
+        lecture_id=2,
+        lecture_name="Lecture",
+        lecture_unit_id=3,
+        lecture_unit_name="Unit",
+        video_link="http://example.com/video",
+        language="en",
+        segment_start_time=0.0,
+        segment_end_time=10.0,
+        page_number=4,
+        segment_summary="Summary",
+        segment_text=text,
+        base_url="http://example.com",
+    )
+
+
+def _page_chunk(text: str = "Slide") -> LectureUnitPageChunkRetrievalDTO:
+    return LectureUnitPageChunkRetrievalDTO(
+        uuid=str(uuid4()),
+        course_id=1,
+        course_name="Course",
+        course_description="Description",
+        lecture_id=2,
+        lecture_name="Lecture",
+        lecture_unit_id=3,
+        lecture_unit_name="Unit",
+        lecture_unit_link="http://example.com/unit",
+        course_language="en",
+        page_number=4,
+        display_page_number=4,
+        page_text_content=text,
+        base_url="http://example.com",
+    )
+
+
+def _make_retrieval(probe_objects=None) -> LectureRetrieval:
+    retrieval = LectureRetrieval.__new__(LectureRetrieval)
+    retrieval.get_lecture_unit = MagicMock(return_value=_lecture_unit())
+    retrieval._transcription_presence_cache = {}
+
+    retrieval.lecture_transcription_collection = MagicMock()
+    retrieval.lecture_transcription_collection.query.fetch_objects.return_value = (
+        SimpleNamespace(objects=probe_objects if probe_objects is not None else [])
+    )
+
+    retrieval.rewrite_student_query = MagicMock(
+        side_effect=lambda _history, _query, _language, _course, mode: (
+            f"rewrite-{mode.value}"
+        )
+    )
+    retrieval.rewrite_elaborated_query = MagicMock(
+        side_effect=lambda _history, _query, _language, _course, mode: (
+            f"hyde-{mode.value}"
+        )
+    )
+
+    retrieval.llm_embedding = MagicMock()
+    retrieval.llm_embedding.embed.side_effect = lambda query: [len(query)]
+
+    retrieval.lecture_unit_segment_pipeline = MagicMock(return_value=[])
+    retrieval.lecture_transcription_pipeline = MagicMock(return_value=[])
+    retrieval.lecture_unit_page_chunk_pipeline = MagicMock(return_value=[])
+    retrieval.get_lecture_transcription_of_lecture_unit = MagicMock(return_value=[])
+    retrieval.get_lecture_page_chunks_of_lecture_unit = MagicMock(return_value=[])
+
+    retrieval.cohere_client = MagicMock()
+    retrieval.cohere_client.rerank.side_effect = (
+        lambda _query, documents, *_args, **_kwargs: documents
+    )
+    return retrieval
+
+
+def test_no_transcriptions_skips_transcription_domain_and_caches_probe():
+    retrieval = _make_retrieval(probe_objects=[])
+    retrieval.lecture_unit_segment_pipeline.return_value = [_segment()]
+    retrieval.get_lecture_transcription_of_lecture_unit.return_value = [
+        _transcription("Should not be fetched")
+    ]
+
+    result = retrieval(
+        "student query",
+        course_id=1,
+        chat_history=[],
+        lecture_id=2,
+        lecture_unit_id=3,
+    )
+
+    assert retrieval.rewrite_student_query.call_count == 1
+    assert retrieval.rewrite_elaborated_query.call_count == 1
+    assert retrieval.rewrite_student_query.call_args.args[-1] == (
+        QueryRewriteMode.LECTURE_PAGES
+    )
+    assert retrieval.rewrite_elaborated_query.call_args.args[-1] == (
+        QueryRewriteMode.LECTURE_PAGES
+    )
+    retrieval.lecture_transcription_pipeline.assert_not_called()
+    retrieval.get_lecture_transcription_of_lecture_unit.assert_not_called()
+    assert result.lecture_transcriptions == []
+
+    segment_call = retrieval.lecture_unit_segment_pipeline.call_args
+    assert segment_call.args[1] == "rewrite-lecture_pages"
+    assert segment_call.args[2] == "hyde-lecture_pages"
+
+    retrieval(
+        "student query",
+        course_id=1,
+        chat_history=[],
+        lecture_id=2,
+        lecture_unit_id=3,
+    )
+
+    assert (
+        retrieval.lecture_transcription_collection.query.fetch_objects.call_count == 1
+    )
+
+
+def test_existing_transcriptions_keep_all_rewrites_and_pipelines():
+    retrieval = _make_retrieval(probe_objects=[SimpleNamespace(uuid=uuid4())])
+    retrieval.lecture_unit_segment_pipeline.return_value = [_segment()]
+    retrieval.lecture_transcription_pipeline.return_value = [_transcription()]
+    retrieval.lecture_unit_page_chunk_pipeline.return_value = [_page_chunk()]
+
+    result = retrieval(
+        "student query",
+        course_id=1,
+        chat_history=[],
+        lecture_id=2,
+        lecture_unit_id=3,
+    )
+
+    assert retrieval.rewrite_student_query.call_count == 2
+    assert retrieval.rewrite_elaborated_query.call_count == 2
+    retrieval.lecture_unit_segment_pipeline.assert_called_once()
+    retrieval.lecture_transcription_pipeline.assert_called_once()
+    retrieval.lecture_unit_page_chunk_pipeline.assert_called_once()
+    assert result.lecture_transcriptions
+    assert (
+        retrieval.lecture_transcription_collection.query.fetch_objects.call_count == 1
+    )
+
+
+def test_final_reranks_run_concurrently_and_preserve_results():
+    retrieval = _make_retrieval(probe_objects=[SimpleNamespace(uuid=uuid4())])
+    transcription = _transcription("Original transcript")
+    page_chunk = _page_chunk("Original page")
+    reranked_transcription = _transcription("Reranked transcript")
+    reranked_page_chunk = _page_chunk("Reranked page")
+
+    retrieval.run_parallel_rewrite_tasks = MagicMock(
+        return_value=(
+            "page rewrite",
+            "transcription rewrite",
+            "page hyde",
+            "trans hyde",
+        )
+    )
+    retrieval.lecture_unit_segment_pipeline.return_value = []
+    retrieval.lecture_transcription_pipeline.return_value = [transcription]
+    retrieval.lecture_unit_page_chunk_pipeline.return_value = [page_chunk]
+
+    barrier = Barrier(2, timeout=1.0)
+
+    def rerank(_query, documents, *_args, **kwargs):
+        barrier.wait()
+        if kwargs["content_field_name"] == "segment_text":
+            assert documents == [transcription]
+            return [reranked_transcription]
+        assert kwargs["content_field_name"] == "page_text_content"
+        assert documents == [page_chunk]
+        return [reranked_page_chunk]
+
+    retrieval.cohere_client.rerank.side_effect = rerank
+
+    result = retrieval(
+        "student query",
+        course_id=1,
+        chat_history=[],
+        lecture_id=2,
+        lecture_unit_id=3,
+    )
+
+    assert result.lecture_transcriptions == [reranked_transcription]
+    assert result.lecture_unit_page_chunks == [reranked_page_chunk]
+    assert {
+        call.kwargs["content_field_name"]
+        for call in retrieval.cohere_client.rerank.call_args_list
+    } == {"segment_text", "page_text_content"}
+
+
+def test_distinct_queries_embed_once_and_subpipeline_fallback_still_embeds():
+    retrieval = _make_retrieval(probe_objects=[SimpleNamespace(uuid=uuid4())])
+    retrieval.run_parallel_rewrite_tasks = MagicMock(
+        return_value=("same query", "same query", "same query", "same query")
+    )
+    retrieval.lecture_unit_segment_pipeline.return_value = []
+    retrieval.lecture_transcription_pipeline.return_value = []
+    retrieval.lecture_unit_page_chunk_pipeline.return_value = []
+
+    retrieval(
+        "student query",
+        course_id=1,
+        chat_history=[],
+        lecture_id=2,
+        lecture_unit_id=3,
+    )
+
+    retrieval.llm_embedding.embed.assert_called_once_with("same query")
+
+    segment_call = retrieval.lecture_unit_segment_pipeline.call_args
+    transcription_call = retrieval.lecture_transcription_pipeline.call_args
+    page_chunk_call = retrieval.lecture_unit_page_chunk_pipeline.call_args
+    assert segment_call.kwargs["rewritten_query_vector"] == [len("same query")]
+    assert transcription_call.kwargs["hypothetical_answer_vector"] == [
+        len("same query")
+    ]
+    assert page_chunk_call.kwargs["rewritten_query_vector"] == [len("same query")]
+
+    segment_retrieval = LectureUnitSegmentRetrieval.__new__(LectureUnitSegmentRetrieval)
+    segment_retrieval.llm_embedding = MagicMock()
+    segment_retrieval.llm_embedding.embed.return_value = [1, 2, 3]
+    segment_retrieval.collection = MagicMock()
+    segment_retrieval.collection.query.hybrid.return_value = SimpleNamespace(objects=[])
+
+    segment_retrieval.search_in_db(_lecture_unit(), "standalone", 0.9, 10)
+
+    segment_retrieval.llm_embedding.embed.assert_called_once_with("standalone")
+
+    page_retrieval = LecturePageChunkRetrieval.__new__(LecturePageChunkRetrieval)
+    page_retrieval.llm_embedding = MagicMock()
+    page_retrieval.llm_embedding.embed.return_value = [4, 5, 6]
+    page_retrieval.lecture_unit_page_chunk_collection = MagicMock()
+    page_retrieval.lecture_unit_page_chunk_collection.query.hybrid.return_value = (
+        SimpleNamespace(objects=[])
+    )
+
+    page_retrieval.search_in_db("standalone", 0.9, 10, _lecture_unit())
+
+    page_retrieval.llm_embedding.embed.assert_called_once_with("standalone")

--- a/iris/tests/test_lecture_retrieval_speedups.py
+++ b/iris/tests/test_lecture_retrieval_speedups.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 import iris.pipeline.pipeline  # noqa: F401  pylint: disable=unused-import
 from iris.domain.retrieval.lecture.lecture_retrieval_dto import (  # noqa: E402
     LectureTranscriptionRetrievalDTO,
@@ -14,6 +16,7 @@ from iris.domain.retrieval.lecture.lecture_retrieval_dto import (  # noqa: E402
     LectureUnitRetrievalDTO,
     LectureUnitSegmentRetrievalDTO,
 )
+from iris.llm.llm_configuration import LlmConfigurationError  # noqa: E402
 from iris.retrieval.lecture.lecture_page_chunk_retrieval import (  # noqa: E402
     LecturePageChunkRetrieval,
 )
@@ -306,3 +309,62 @@ def test_distinct_queries_embed_once_and_subpipeline_fallback_still_embeds():
     page_retrieval.search_in_db("standalone", 0.9, 10, _lecture_unit())
 
     page_retrieval.llm_embedding.embed.assert_called_once_with("standalone")
+
+
+def _embedding_guard_retrieval(
+    parent_model, segment_model, transcription_model, page_model
+) -> LectureRetrieval:
+    """Build a bare LectureRetrieval wired only with the attributes the shared
+    embedding-model guard inspects."""
+    retrieval = LectureRetrieval.__new__(LectureRetrieval)
+    retrieval.llm_embedding = SimpleNamespace(model_id=parent_model)
+    retrieval.lecture_unit_segment_pipeline = SimpleNamespace(
+        llm_embedding=SimpleNamespace(model_id=segment_model)
+    )
+    retrieval.lecture_transcription_pipeline = SimpleNamespace(
+        llm_embedding=SimpleNamespace(model_id=transcription_model)
+    )
+    retrieval.lecture_unit_page_chunk_pipeline = SimpleNamespace(
+        llm_embedding=SimpleNamespace(model_id=page_model)
+    )
+    return retrieval
+
+
+def test_shared_embedding_guard_passes_when_all_models_match():
+    retrieval = _embedding_guard_retrieval(
+        "oai-embedding-small",
+        "oai-embedding-small",
+        "oai-embedding-small",
+        "oai-embedding-small",
+    )
+    # Should not raise: reusing the shared query vectors is safe here.
+    retrieval._assert_shared_embedding_model()
+
+
+def test_shared_embedding_guard_raises_when_segment_model_differs():
+    retrieval = _embedding_guard_retrieval(
+        "oai-embedding-small",
+        "oai-embedding-large",
+        "oai-embedding-small",
+        "oai-embedding-small",
+    )
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        retrieval._assert_shared_embedding_model()
+
+    message = str(exc_info.value)
+    assert "lecture_unit_segment_retrieval_pipeline" in message
+    assert "oai-embedding-large" in message
+    assert "oai-embedding-small" in message
+
+
+def test_shared_embedding_guard_raises_when_transcription_model_differs():
+    retrieval = _embedding_guard_retrieval(
+        "oai-embedding-small",
+        "oai-embedding-small",
+        "voyage-3",
+        "oai-embedding-small",
+    )
+    with pytest.raises(LlmConfigurationError) as exc_info:
+        retrieval._assert_shared_embedding_model()
+
+    assert "lecture_transcriptions_retrieval_pipeline" in str(exc_info.value)


### PR DESCRIPTION
> [!NOTE]
> Stacked on #654 (`iris/perf/per-role-reasoning-effort`); base retargets automatically as the stack merges. Review only the last commit.

## Summary

Third slice of the chat-latency work: cuts the lecture-retrieval critical path without changing what content can be found. The retrieval currently runs 4 LLM query rewrites (2 of them ≤350-word HyDE generations — the dominant cost), 6 embeddings (2 duplicated), 6 hybrid searches, and 5 Cohere reranks (2 sequential at the end) — even for slide-only courses with no transcriptions at all.

## Description

- **Transcription-domain skip**: a `limit=1` filtered existence probe (concurrent with the lecture-unit lookup, cached per unit including negative results) gates the whole transcription domain *before* the rewrite phase. Slide-only courses save 2 of 4 rewrite LLM calls (including one HyDE), the full transcription sub-pipeline, and up to 7 per-segment transcription fetches. The segment pipeline falls back to pages-domain queries (segments carry slide summaries). The probe is fail-safe: an over-broad match only disables the skip, never skips real content.
- **HyDE 350→120 words, rewrite `max_tokens` 2000→400**: the HyDE decode is the critical-path item; a keyword-dense short pseudo-document serves the embedding just as well.
- **Embed once**: distinct query strings are embedded once in the orchestrator (parallel) and vectors passed down; previously the segment and transcription pipelines each embedded the same two strings. Sub-pipelines keep internal embedding as fallback for standalone use.
- **Parallel final reranks**: the two final Cohere reranks ran sequentially; now concurrent with an empty-safe wrapper.

Expected effect: several seconds on retrieval-bearing turns; largest for slide-only courses. Follow-ups deliberately *not* included pending a retrieval-quality eval harness (dropping the 2 intermediate sub-pipeline reranks, `top_n` 7→5): those change the candidate set and need overlap + known-answer gates first.

## Validation

- `poetry run pytest`: **170 passed** — 4 new tests written red-first (transcription skip incl. cache and query fallback, no-skip path, parallel rerank preservation, embed-once counting)
- `poetry run pylint src/iris`: **10.00/10**; `black`/`isort` clean
- Implemented by Codex (GPT-5.5, xhigh) from a written spec; full diff reviewed by Claude
