### PR TITLE
`Iris`: Keep exercise guide refinement blocking on the guide model

### DIFF
--- a/iris/application.example.yml
+++ b/iris/application.example.yml
@@ -36,6 +36,15 @@ memiris:
 
 local_llm_enabled: true # Set to false to disable local LLM support entirely
 
+# Programming-exercise guide refinement:
+# - blocking: run the guide rewrite before the answer is sent; this is the
+#   default and reflects production behavior.
+# - shadow: send the answer first, then run guide refinement for evidence collection.
+# - off: disable guide refinement entirely.
+exercise_guide_refinement: blocking
+# Shadow sampling rate, only used when exercise_guide_refinement is shadow.
+exercise_guide_refinement_shadow_sample: 1.0
+
 langfuse:
   enabled: false # Set to true to enable LangFuse tracing
   public_key: "pk-lf-..." # Your LangFuse public key
@@ -66,10 +75,18 @@ llm_configuration:
       chat:
         local: oai-gpt-5-mini
         cloud: oai-gpt-5-mini
+      # Guard detection quality requires medium reasoning effort (eval-backed).
+      guide:
+        local: oai-gpt-5-mini
+        cloud: oai-gpt-5-mini
     advanced:
       chat:
         local: oai-gpt-52
         cloud: oai-gpt-5.5
+      # Guard detection quality requires medium reasoning effort (eval-backed).
+      guide:
+        local: oai-gpt-52
+        cloud: oai-gpt-5-mini
 
   autonomous_tutor_pipeline:
     default:

--- a/iris/application.example.yml
+++ b/iris/application.example.yml
@@ -36,15 +36,6 @@ memiris:
 
 local_llm_enabled: true # Set to false to disable local LLM support entirely
 
-# Programming-exercise guide refinement:
-# - blocking: run the guide rewrite before the answer is sent; this is the
-#   default and reflects production behavior.
-# - shadow: send the answer first, then run guide refinement for evidence collection.
-# - off: disable guide refinement entirely.
-exercise_guide_refinement: blocking
-# Shadow sampling rate, only used when exercise_guide_refinement is shadow.
-exercise_guide_refinement_shadow_sample: 1.0
-
 langfuse:
   enabled: false # Set to true to enable LangFuse tracing
   public_key: "pk-lf-..." # Your LangFuse public key

--- a/iris/application.example.yml
+++ b/iris/application.example.yml
@@ -85,7 +85,7 @@ llm_configuration:
         cloud: oai-gpt-5.5
       # Guard detection quality requires medium reasoning effort (eval-backed).
       guide:
-        local: oai-gpt-52
+        local: oai-gpt-5-mini
         cloud: oai-gpt-5-mini
 
   autonomous_tutor_pipeline:

--- a/iris/src/iris/config.py
+++ b/iris/src/iris/config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -160,10 +160,6 @@ class Settings(BaseModel):
     memiris: MemirisSettings
     langfuse: LangfuseSettings = Field(default_factory=LangfuseSettings)
     local_llm_enabled: bool = Field(default=True)
-    exercise_guide_refinement: Literal["blocking", "shadow", "off"] = Field(
-        default="blocking"
-    )
-    exercise_guide_refinement_shadow_sample: float = Field(default=1.0, ge=0.0, le=1.0)
     llm_configuration: dict[str, LlmVariantConfiguration] = Field(default_factory=dict)
     transcription: TranscriptionSettings = Field(default_factory=TranscriptionSettings)
 

--- a/iris/src/iris/config.py
+++ b/iris/src/iris/config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import yaml
 from pydantic import BaseModel, Field, model_validator
@@ -160,6 +160,10 @@ class Settings(BaseModel):
     memiris: MemirisSettings
     langfuse: LangfuseSettings = Field(default_factory=LangfuseSettings)
     local_llm_enabled: bool = Field(default=True)
+    exercise_guide_refinement: Literal["blocking", "shadow", "off"] = Field(
+        default="blocking"
+    )
+    exercise_guide_refinement_shadow_sample: float = Field(default=1.0, ge=0.0, le=1.0)
     llm_configuration: dict[str, LlmVariantConfiguration] = Field(default_factory=dict)
     transcription: TranscriptionSettings = Field(default_factory=TranscriptionSettings)
 

--- a/iris/src/iris/pipeline/chat/chat_pipeline.py
+++ b/iris/src/iris/pipeline/chat/chat_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import random
 import time
 from datetime import datetime
 from typing import Any, Callable, Optional
@@ -11,6 +12,7 @@ from langchain_core.prompts import ChatPromptTemplate
 
 from iris.common.logging_config import get_logger
 from iris.common.timing import timed_span
+from iris.config import settings
 from iris.domain.chat.chat_pipeline_execution_dto import ChatPipelineExecutionDTO
 from iris.pipeline.chat.iris_chat_mode import IrisChatMode
 from iris.pipeline.session_title_generation_pipeline import (
@@ -32,6 +34,7 @@ from ...llm import (
     LlmRequestHandler,
 )
 from ...llm.langchain import IrisLangchainChatModel
+from ...llm.llm_configuration import LlmConfigurationError, resolve_model
 from ...retrieval.faq_retrieval_utils import should_allow_faq_tool
 from ...retrieval.lecture.lecture_retrieval import LectureRetrieval
 from ...retrieval.lecture.lecture_retrieval_utils import should_allow_lecture_tool
@@ -134,6 +137,7 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
     jinja_env: Environment
     system_prompt_template: Any
     guide_prompt_template: Any
+    _guide_model_cache: dict[tuple[str, bool], str]
 
     def __init__(self, chat_mode: IrisChatMode, local: bool = False):
         """
@@ -171,6 +175,7 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         self.guide_prompt_template = self.jinja_env.get_template(
             "exercise_chat_guide_prompt.j2"
         )
+        self._guide_model_cache = {}
 
     def __repr__(self):
         return f"{self.__class__.__name__}(context={self.chat_mode.value})"
@@ -270,11 +275,18 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         """
         try:
             result = state.result
+            refinement_mode = settings.exercise_guide_refinement
+            shadow_input: Optional[str] = None
 
             # If Programming Exercise, refine response using guide prompt
             if self.chat_mode == IrisChatMode.EXERCISE:
-                with timed_span("ChatPipeline", "refine_response", state.start_time):
-                    result = self._refine_response(state)
+                if refinement_mode == "blocking":
+                    with timed_span(
+                        "ChatPipeline", "refine_response", state.start_time
+                    ):
+                        result = self._refine_response(state)
+                elif refinement_mode == "shadow":
+                    shadow_input = result
 
             # Add citations if applicable
             with timed_span("ChatPipeline", "citations", state.start_time):
@@ -329,6 +341,13 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
             ]:
                 with timed_span("ChatPipeline", "suggestions", state.start_time):
                     self._generate_suggestions(state, result)
+
+            if (
+                self.chat_mode == IrisChatMode.EXERCISE
+                and refinement_mode == "shadow"
+                and shadow_input is not None
+            ):
+                self._shadow_guide_refinement(state, shadow_input)
 
             return result
 
@@ -760,6 +779,78 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         """
         return self.update_session_title(state, output, dto.session_title)
 
+    def _run_guide_refinement(
+        self,
+        state: AgentPipelineExecutionState[ChatPipelineExecutionDTO, Variant],
+        response: str,
+    ) -> tuple[str, str]:
+        """
+        Run the exercise guide refinement chain for a response.
+
+        Args:
+            state: The current pipeline execution state.
+            response: The response text to check with the guide prompt.
+
+        Returns:
+            A tuple of the raw guide response and the response to use.
+        """
+        exercise = state.dto.programming_exercise or state.dto.text_exercise
+        problem_statement = exercise.problem_statement if exercise else ""
+        guide_prompt_rendered = self.guide_prompt_template.render(
+            {
+                "problem_statement": problem_statement,
+                "support_level": _support_level(state.dto),
+            }
+        )
+
+        completion_args = CompletionArguments(temperature=0.5, max_tokens=2000)
+        refinement_model = self._resolve_guide_model(state)
+        llm_small = IrisLangchainChatModel(
+            request_handler=LlmRequestHandler(model_id=refinement_model),
+            completion_args=completion_args,
+        )
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                SystemMessage(content=guide_prompt_rendered),
+                HumanMessage(content=response),
+            ]
+        )
+
+        guide_response = (prompt | llm_small | StrOutputParser()).invoke({})
+        self._track_tokens(state, llm_small.tokens)
+
+        if "!ok!" in guide_response:
+            return guide_response, response
+        return guide_response, guide_response
+
+    def _resolve_guide_model(
+        self,
+        state: AgentPipelineExecutionState[ChatPipelineExecutionDTO, Variant],
+    ) -> str:
+        """
+        Resolve the optional guide role model, falling back to chat for old configs.
+        """
+        cache = getattr(self, "_guide_model_cache", None)
+        if cache is None:
+            cache = {}
+            self._guide_model_cache = cache
+
+        cache_key = (state.variant.id, state.local)
+        if cache_key in cache:
+            return cache[cache_key]
+
+        try:
+            guide_model = resolve_model(
+                self.PIPELINE_ID, state.variant.id, "guide", local=state.local
+            )
+        except LlmConfigurationError:
+            guide_model = state.variant.model("chat", state.local)
+            logger.info("guide role not configured — falling back to chat model")
+
+        cache[cache_key] = guide_model
+        return guide_model
+
     @observe(name="Response Refinement")
     def _refine_response(
         self,
@@ -781,45 +872,61 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
 
             state.callback.in_progress("Refining response ...")
 
-            exercise = state.dto.programming_exercise or state.dto.text_exercise
-            problem_statement = exercise.problem_statement if exercise else ""
-            guide_prompt_rendered = self.guide_prompt_template.render(
-                {
-                    "problem_statement": problem_statement,
-                    "support_level": _support_level(state.dto),
-                }
+            guide_response, refined_response = self._run_guide_refinement(
+                state, state.result
             )
-
-            # Create small LLM for refinement
-            completion_args = CompletionArguments(temperature=0.5, max_tokens=2000)
-            refinement_model = state.variant.model("chat", state.local)
-            llm_small = IrisLangchainChatModel(
-                request_handler=LlmRequestHandler(model_id=refinement_model),
-                completion_args=completion_args,
-            )
-
-            prompt = ChatPromptTemplate.from_messages(
-                [
-                    SystemMessage(content=guide_prompt_rendered),
-                    HumanMessage(content=state.result),
-                ]
-            )
-
-            guide_response = (prompt | llm_small | StrOutputParser()).invoke({})
-
-            self._track_tokens(state, llm_small.tokens)
-
             if "!ok!" in guide_response:
                 logger.info("Response is ok and not rewritten")
-                return state.result
-            else:
-                logger.info("Response is rewritten")
-                return guide_response
+                return refined_response
+            logger.info("Response is rewritten")
+            return refined_response
 
         except Exception as e:
-            logger.error("Error in refining response", exc_info=e)
-            state.callback.error("Error in refining response")
+            logger.warning("Error in refining response", exc_info=e)
             return state.result
+
+    def _shadow_guide_refinement(
+        self,
+        state: AgentPipelineExecutionState[ChatPipelineExecutionDTO, Variant],
+        response: str,
+    ) -> None:
+        """
+        Run exercise guide refinement after user-visible callbacks for logging only.
+
+        Args:
+            state: The current pipeline execution state.
+            response: The pre-citation response that blocking mode would refine.
+        """
+        try:
+            with timed_span(
+                "ChatPipeline", "shadow_guide_refinement", state.start_time
+            ):
+                if self.chat_mode is not IrisChatMode.EXERCISE:
+                    return
+                # Sampling gate, not security-relevant randomness.
+                if (
+                    random.random()  # nosec B311
+                    >= settings.exercise_guide_refinement_shadow_sample
+                ):
+                    return
+
+                shadow_start = time.perf_counter()
+                guide_response, refined_response = self._run_guide_refinement(
+                    state, response
+                )
+                would_have_rewritten = "!ok!" not in guide_response
+                rewrite_chars = len(refined_response) if would_have_rewritten else 0
+                elapsed_ms = (time.perf_counter() - shadow_start) * 1000
+                logger.info(
+                    "Guide refinement shadow | would_have_rewritten=%s "
+                    "response_chars=%d rewrite_chars=%d elapsed_ms=%.0f",
+                    would_have_rewritten,
+                    len(response),
+                    rewrite_chars,
+                    elapsed_ms,
+                )
+        except Exception as e:
+            logger.warning("Error in shadow guide refinement", exc_info=e)
 
     def _generate_suggestions(
         self,

--- a/iris/src/iris/pipeline/chat/chat_pipeline.py
+++ b/iris/src/iris/pipeline/chat/chat_pipeline.py
@@ -1,5 +1,4 @@
 import os
-import random
 import time
 from datetime import datetime
 from typing import Any, Callable, Optional
@@ -12,7 +11,6 @@ from langchain_core.prompts import ChatPromptTemplate
 
 from iris.common.logging_config import get_logger
 from iris.common.timing import timed_span
-from iris.config import settings
 from iris.domain.chat.chat_pipeline_execution_dto import ChatPipelineExecutionDTO
 from iris.pipeline.chat.iris_chat_mode import IrisChatMode
 from iris.pipeline.session_title_generation_pipeline import (
@@ -275,18 +273,11 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         """
         try:
             result = state.result
-            refinement_mode = settings.exercise_guide_refinement
-            shadow_input: Optional[str] = None
 
             # If Programming Exercise, refine response using guide prompt
             if self.chat_mode == IrisChatMode.EXERCISE:
-                if refinement_mode == "blocking":
-                    with timed_span(
-                        "ChatPipeline", "refine_response", state.start_time
-                    ):
-                        result = self._refine_response(state)
-                elif refinement_mode == "shadow":
-                    shadow_input = result
+                with timed_span("ChatPipeline", "refine_response", state.start_time):
+                    result = self._refine_response(state)
 
             # Add citations if applicable
             with timed_span("ChatPipeline", "citations", state.start_time):
@@ -341,13 +332,6 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
             ]:
                 with timed_span("ChatPipeline", "suggestions", state.start_time):
                     self._generate_suggestions(state, result)
-
-            if (
-                self.chat_mode == IrisChatMode.EXERCISE
-                and refinement_mode == "shadow"
-                and shadow_input is not None
-            ):
-                self._shadow_guide_refinement(state, shadow_input)
 
             return result
 
@@ -884,49 +868,6 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         except Exception as e:
             logger.warning("Error in refining response", exc_info=e)
             return state.result
-
-    def _shadow_guide_refinement(
-        self,
-        state: AgentPipelineExecutionState[ChatPipelineExecutionDTO, Variant],
-        response: str,
-    ) -> None:
-        """
-        Run exercise guide refinement after user-visible callbacks for logging only.
-
-        Args:
-            state: The current pipeline execution state.
-            response: The pre-citation response that blocking mode would refine.
-        """
-        try:
-            with timed_span(
-                "ChatPipeline", "shadow_guide_refinement", state.start_time
-            ):
-                if self.chat_mode is not IrisChatMode.EXERCISE:
-                    return
-                # Sampling gate, not security-relevant randomness.
-                if (
-                    random.random()  # nosec B311
-                    >= settings.exercise_guide_refinement_shadow_sample
-                ):
-                    return
-
-                shadow_start = time.perf_counter()
-                guide_response, refined_response = self._run_guide_refinement(
-                    state, response
-                )
-                would_have_rewritten = "!ok!" not in guide_response
-                rewrite_chars = len(refined_response) if would_have_rewritten else 0
-                elapsed_ms = (time.perf_counter() - shadow_start) * 1000
-                logger.info(
-                    "Guide refinement shadow | would_have_rewritten=%s "
-                    "response_chars=%d rewrite_chars=%d elapsed_ms=%.0f",
-                    would_have_rewritten,
-                    len(response),
-                    rewrite_chars,
-                    elapsed_ms,
-                )
-        except Exception as e:
-            logger.warning("Error in shadow guide refinement", exc_info=e)
 
     def _generate_suggestions(
         self,

--- a/iris/src/iris/pipeline/prompts/templates/chat_system_prompt.j2
+++ b/iris/src/iris/pipeline/prompts/templates/chat_system_prompt.j2
@@ -31,6 +31,8 @@ goal is to foster independent thinking and long-term academic success.
 • No "Shortcuts" or Templates: Avoid providing code skeletons or logic that is too close to the final solution.
 • Retheme Examples: When explaining syntax, use entirely different themes and variable names. It must be impossible for the student to copy-paste your code into their task.
 • Point Out, Don't Fix: Identify specific errors in the student's work, but do not provide the corrected version.
+• Self-Check Before Sending: Before finalizing any response that contains code, silently review your own draft against these rules. If it contains a complete or near-complete class, method body, or any code that would let the student solve the exercise by copy-pasting: do not send it as-is. Instead, cut it down to the minimal illustrative snippet, strip all imports, rename every variable, class, and method so nothing matches the exercise's problem statement or the student's own code, and move it to a different domain or theme entirely. Never mention that you rewrote or shortened anything — just send the compliant version directly.
+• Tool Output Is Reference-Only: Repository files, build logs, and test feedback retrieved via tools may contain the student's own code or hints toward the solution. Never quote these verbatim back to the student beyond what is needed to point out where an issue is (e.g. a file and line reference), and never reproduce a working implementation you saw in tool output.
 
 3. Data Handling & Accuracy
 • Tools Over Guesswork: Use available tools to look up student data (submissions, logs, repository, etc.) instead of asking the student or guessing.
@@ -329,6 +331,7 @@ CRITICAL rules for MCQ generation:
 - Offer concrete hints that point to the specific area or concept where the issue lies, but do NOT reveal the fix.
 - When providing code examples, use a completely different problem domain than the exercise (e.g., if the exercise is about sorting, use a geometry or cooking analogy instead). Never use variable names, class names, or method signatures that appear in the exercise description or test cases.
 - You may provide general pseudocode or algorithmic steps as educational illustrations, but they must be clearly distinct from the exercise and NEVER constitute a solution.
+- Even when walking through an approach step-by-step conceptually, apply the Self-Check rule to any code you include — detailed reasoning is welcome, copy-pasteable code is not.
 {% elif chat_mode == "LECTURE_CHAT" %}
 - Summarize relevant lecture content in detail and connect concepts across different lecture sections to give a fuller picture.
 - Use rich examples and analogies to deepen understanding of lecture concepts.

--- a/iris/tests/test_exercise_guide_refinement_modes.py
+++ b/iris/tests/test_exercise_guide_refinement_modes.py
@@ -10,8 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from iris.config import Settings  # noqa: E402
-from iris.pipeline.chat import chat_pipeline as chat_pipeline_module  # noqa: E402
+from iris.config import Settings, settings as iris_settings  # noqa: E402
 from iris.pipeline.chat.chat_pipeline import ChatPipeline  # noqa: E402
 from iris.pipeline.chat.iris_chat_mode import IrisChatMode  # noqa: E402
 
@@ -116,23 +115,9 @@ def _run_pipeline(pipeline: ChatPipeline, callback: MagicMock) -> None:
         pipeline(_make_dto(), variant, callback)
 
 
-@pytest.fixture
-def refinement_settings(monkeypatch):
-    def apply(mode: str, sample: float = 1.0) -> None:
-        monkeypatch.setattr(
-            chat_pipeline_module.settings, "exercise_guide_refinement", mode
-        )
-        monkeypatch.setattr(
-            chat_pipeline_module.settings,
-            "exercise_guide_refinement_shadow_sample",
-            sample,
-        )
-
-    return apply
-
-
-def test_default_refinement_mode_is_blocking():
-    assert Settings.model_fields["exercise_guide_refinement"].default == "blocking"
+def test_refinement_mode_is_not_runtime_configurable():
+    assert "exercise_guide_refinement" not in Settings.model_fields
+    assert "exercise_guide_refinement_shadow_sample" not in Settings.model_fields
 
 
 def test_guide_role_configured_uses_guide_model(monkeypatch):
@@ -141,14 +126,12 @@ def test_guide_role_configured_uses_guide_model(monkeypatch):
     state = _make_refinement_state(variant)
     captured_model_ids = []
 
-    llm_configuration = copy.deepcopy(chat_pipeline_module.settings.llm_configuration)
+    llm_configuration = copy.deepcopy(iris_settings.llm_configuration)
     llm_configuration["chat_pipeline"]["default"]["guide"] = {
         "local": "guide-local-model-id",
         "cloud": "guide-cloud-model-id",
     }
-    monkeypatch.setattr(
-        chat_pipeline_module.settings, "llm_configuration", llm_configuration
-    )
+    monkeypatch.setattr(iris_settings, "llm_configuration", llm_configuration)
 
     class FakeGuideChain:
         def __or__(self, _other):
@@ -198,11 +181,9 @@ def test_guide_role_missing_falls_back_to_chat_model_and_logs_once(monkeypatch, 
     state = _make_refinement_state(variant)
     captured_model_ids = []
 
-    llm_configuration = copy.deepcopy(chat_pipeline_module.settings.llm_configuration)
+    llm_configuration = copy.deepcopy(iris_settings.llm_configuration)
     llm_configuration["chat_pipeline"]["default"].pop("guide", None)
-    monkeypatch.setattr(
-        chat_pipeline_module.settings, "llm_configuration", llm_configuration
-    )
+    monkeypatch.setattr(iris_settings, "llm_configuration", llm_configuration)
 
     class FakeGuideChain:
         def __or__(self, _other):
@@ -255,9 +236,8 @@ def test_guide_role_missing_falls_back_to_chat_model_and_logs_once(monkeypatch, 
     ],
 )
 def test_blocking_invokes_guide_before_done_and_uses_guide_result(
-    refinement_settings, guide_response, expected_final_result
+    guide_response, expected_final_result
 ):
-    refinement_settings("blocking")
     pipeline = _make_pipeline(IrisChatMode.EXERCISE)
     pipeline._run_guide_refinement = MagicMock(
         return_value=(guide_response, expected_final_result)
@@ -278,10 +258,7 @@ def test_blocking_invokes_guide_before_done_and_uses_guide_result(
     assert pipeline._captured_state.result == expected_final_result
 
 
-def test_blocking_failure_delivers_original_without_error_callback(
-    refinement_settings,
-):
-    refinement_settings("blocking")
+def test_blocking_failure_delivers_original_without_error_callback():
     pipeline = _make_pipeline(IrisChatMode.EXERCISE)
     pipeline._run_guide_refinement = MagicMock(side_effect=RuntimeError("guide down"))
     callback = MagicMock()
@@ -294,80 +271,10 @@ def test_blocking_failure_delivers_original_without_error_callback(
 
 
 @pytest.mark.parametrize(
-    ("guide_response", "would_have_rewritten"),
-    [
-        ("Please use a smaller hint.", True),
-        ("!ok!", False),
-    ],
-)
-def test_shadow_invokes_guide_after_user_callbacks_and_keeps_original_result(
-    refinement_settings, caplog, guide_response, would_have_rewritten
-):
-    refinement_settings("shadow")
-    caplog.set_level(logging.INFO)
-    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
-    rewrite = "Please use a smaller hint." if would_have_rewritten else "agent answer"
-    pipeline._run_guide_refinement = MagicMock(return_value=(guide_response, rewrite))
-    callback = MagicMock()
-
-    order_tracker = MagicMock()
-    order_tracker.attach_mock(callback, "callback")
-    order_tracker.attach_mock(pipeline._run_guide_refinement, "guide")
-
-    _run_pipeline(pipeline, callback)
-
-    call_names = [name for name, _, _ in order_tracker.mock_calls]
-    guide_index = call_names.index("guide")
-    done_indices = [
-        index
-        for index, call_name in enumerate(call_names)
-        if call_name == "callback.done"
-    ]
-    assert done_indices[0] < guide_index
-    assert done_indices[1] < guide_index
-    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
-    assert pipeline._captured_state.result == "agent answer"
-    assert (
-        "Guide refinement shadow | " f"would_have_rewritten={would_have_rewritten}"
-    ) in caplog.text
-
-
-def test_shadow_sampling_zero_never_invokes_guide(refinement_settings):
-    refinement_settings("shadow", sample=0.0)
-    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
-    pipeline._run_guide_refinement = MagicMock(
-        return_value=("Please use a smaller hint.", "Please use a smaller hint.")
-    )
-    callback = MagicMock()
-
-    with patch("iris.pipeline.chat.chat_pipeline.random.random", return_value=0.0):
-        _run_pipeline(pipeline, callback)
-
-    pipeline._run_guide_refinement.assert_not_called()
-    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
-
-
-def test_off_never_invokes_guide(refinement_settings):
-    refinement_settings("off")
-    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
-    pipeline._run_guide_refinement = MagicMock(
-        return_value=("Please use a smaller hint.", "Please use a smaller hint.")
-    )
-    callback = MagicMock()
-
-    _run_pipeline(pipeline, callback)
-
-    pipeline._run_guide_refinement.assert_not_called()
-    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
-
-
-@pytest.mark.parametrize(
     "chat_mode",
     [IrisChatMode.COURSE, IrisChatMode.LECTURE, IrisChatMode.TEXT_EXERCISE],
 )
-@pytest.mark.parametrize("mode", ["blocking", "shadow", "off"])
-def test_non_exercise_modes_never_invoke_guide(refinement_settings, chat_mode, mode):
-    refinement_settings(mode)
+def test_non_exercise_modes_never_invoke_guide(chat_mode):
     pipeline = _make_pipeline(chat_mode)
     pipeline._run_guide_refinement = MagicMock(
         return_value=("Please use a smaller hint.", "Please use a smaller hint.")

--- a/iris/tests/test_exercise_guide_refinement_modes.py
+++ b/iris/tests/test_exercise_guide_refinement_modes.py
@@ -1,0 +1,379 @@
+import iris.pipeline.pipeline  # noqa: F401
+
+# isort: skip_file
+# pylint: skip-file
+
+import copy
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from iris.config import Settings  # noqa: E402
+from iris.pipeline.chat import chat_pipeline as chat_pipeline_module  # noqa: E402
+from iris.pipeline.chat.chat_pipeline import ChatPipeline  # noqa: E402
+from iris.pipeline.chat.iris_chat_mode import IrisChatMode  # noqa: E402
+
+
+def _make_dto():
+    return SimpleNamespace(
+        chat_history=[],
+        user=SimpleNamespace(id=1, lang_key="en", memiris_enabled=False),
+        course=SimpleNamespace(
+            id=7,
+            name="Test Course",
+            competencies=[],
+            exercises=[],
+            student_analytics_dashboard_enabled=False,
+        ),
+        lecture=None,
+        programming_exercise=SimpleNamespace(
+            title="Exercise",
+            problem_statement="Implement the exercise.",
+            programming_language="Python",
+        ),
+        text_exercise=None,
+        settings=None,
+        session_title=None,
+        metrics=None,
+        context=None,
+        custom_instructions="",
+        text_exercise_submission="",
+    )
+
+
+def _make_pipeline(chat_mode: IrisChatMode) -> ChatPipeline:
+    pipeline = ChatPipeline.__new__(ChatPipeline)
+    pipeline.chat_mode = chat_mode
+    pipeline.event = None
+
+    title_pipeline = MagicMock(return_value="UPDATE: Fancy Title")
+    title_pipeline.tokens = None
+    pipeline.session_title_pipeline = title_pipeline
+
+    citation_pipeline = MagicMock()
+    citation_pipeline.tokens = []
+    pipeline.citation_pipeline = citation_pipeline
+
+    suggestion_pipeline = MagicMock(return_value=["suggestion 1"])
+    suggestion_pipeline.tokens = None
+    pipeline.suggestion_pipeline = suggestion_pipeline
+
+    pipeline.mcq_pipeline = MagicMock()
+
+    pipeline.prepare_state = lambda state: None
+    pipeline.build_system_message = lambda state: "system prompt"
+    pipeline.get_tools = lambda state: []
+    pipeline.pre_agent_hook = lambda state: None
+
+    def execute_agent(state):
+        pipeline._captured_state = state
+        return "agent answer"
+
+    pipeline.execute_agent = execute_agent
+    pipeline.create_tracing_context = lambda dto, variant: None
+    pipeline._track_tokens = MagicMock()
+    return pipeline
+
+
+def _make_refinement_pipeline() -> ChatPipeline:
+    pipeline = ChatPipeline.__new__(ChatPipeline)
+    pipeline.chat_mode = IrisChatMode.EXERCISE
+    pipeline.guide_prompt_template = MagicMock()
+    pipeline.guide_prompt_template.render.return_value = "guide prompt"
+    pipeline._track_tokens = MagicMock()
+    return pipeline
+
+
+def _make_refinement_state(variant):
+    return SimpleNamespace(
+        dto=_make_dto(),
+        variant=variant,
+        local=False,
+        callback=MagicMock(),
+    )
+
+
+def _make_variant(chat_model_id: str = "chat-model-id"):
+    variant = MagicMock()
+    variant.id = "default"
+    variant.model.return_value = chat_model_id
+    return variant
+
+
+def _run_pipeline(pipeline: ChatPipeline, callback: MagicMock) -> None:
+    variant = MagicMock()
+    variant.id = "default"
+    variant.model.return_value = "some-model-id"
+    with (
+        patch("iris.pipeline.abstract_agent_pipeline.VectorDatabase"),
+        patch("iris.pipeline.abstract_agent_pipeline.MemirisWrapper"),
+        patch("iris.pipeline.abstract_agent_pipeline.LlmRequestHandler"),
+        patch("iris.pipeline.abstract_agent_pipeline.IrisLangchainChatModel"),
+        patch("iris.pipeline.chat.chat_pipeline.mcq_post_agent_hook"),
+    ):
+        pipeline(_make_dto(), variant, callback)
+
+
+@pytest.fixture
+def refinement_settings(monkeypatch):
+    def apply(mode: str, sample: float = 1.0) -> None:
+        monkeypatch.setattr(
+            chat_pipeline_module.settings, "exercise_guide_refinement", mode
+        )
+        monkeypatch.setattr(
+            chat_pipeline_module.settings,
+            "exercise_guide_refinement_shadow_sample",
+            sample,
+        )
+
+    return apply
+
+
+def test_default_refinement_mode_is_blocking():
+    assert Settings.model_fields["exercise_guide_refinement"].default == "blocking"
+
+
+def test_guide_role_configured_uses_guide_model(monkeypatch):
+    pipeline = _make_refinement_pipeline()
+    variant = _make_variant()
+    state = _make_refinement_state(variant)
+    captured_model_ids = []
+
+    llm_configuration = copy.deepcopy(chat_pipeline_module.settings.llm_configuration)
+    llm_configuration["chat_pipeline"]["default"]["guide"] = {
+        "local": "guide-local-model-id",
+        "cloud": "guide-cloud-model-id",
+    }
+    monkeypatch.setattr(
+        chat_pipeline_module.settings, "llm_configuration", llm_configuration
+    )
+
+    class FakeGuideChain:
+        def __or__(self, _other):
+            return self
+
+        def invoke(self, _arguments):
+            return "Guide rewrite"
+
+    def fake_request_handler(*args, **kwargs):
+        captured_model_ids.append(kwargs.get("model_id", args[0] if args else None))
+        return MagicMock()
+
+    def fake_chat_model(request_handler, completion_args):
+        assert request_handler is not None
+        assert completion_args.temperature == 0.5
+        assert completion_args.max_tokens == 2000
+        return SimpleNamespace(tokens=["guide-token"])
+
+    with (
+        patch(
+            "iris.pipeline.chat.chat_pipeline.ChatPromptTemplate.from_messages",
+            return_value=FakeGuideChain(),
+        ),
+        patch(
+            "iris.pipeline.chat.chat_pipeline.LlmRequestHandler",
+            side_effect=fake_request_handler,
+        ),
+        patch(
+            "iris.pipeline.chat.chat_pipeline.IrisLangchainChatModel",
+            side_effect=fake_chat_model,
+        ),
+    ):
+        guide_response, refined_response = pipeline._run_guide_refinement(
+            state, "Original answer"
+        )
+
+    assert guide_response == "Guide rewrite"
+    assert refined_response == "Guide rewrite"
+    assert captured_model_ids == ["guide-cloud-model-id"]
+    variant.model.assert_not_called()
+    pipeline._track_tokens.assert_called_once_with(state, ["guide-token"])
+
+
+def test_guide_role_missing_falls_back_to_chat_model_and_logs_once(monkeypatch, caplog):
+    pipeline = _make_refinement_pipeline()
+    variant = _make_variant()
+    state = _make_refinement_state(variant)
+    captured_model_ids = []
+
+    llm_configuration = copy.deepcopy(chat_pipeline_module.settings.llm_configuration)
+    llm_configuration["chat_pipeline"]["default"].pop("guide", None)
+    monkeypatch.setattr(
+        chat_pipeline_module.settings, "llm_configuration", llm_configuration
+    )
+
+    class FakeGuideChain:
+        def __or__(self, _other):
+            return self
+
+        def invoke(self, _arguments):
+            return "!ok!"
+
+    def fake_request_handler(*args, **kwargs):
+        captured_model_ids.append(kwargs.get("model_id", args[0] if args else None))
+        return MagicMock()
+
+    with (
+        patch(
+            "iris.pipeline.chat.chat_pipeline.ChatPromptTemplate.from_messages",
+            return_value=FakeGuideChain(),
+        ),
+        patch(
+            "iris.pipeline.chat.chat_pipeline.LlmRequestHandler",
+            side_effect=fake_request_handler,
+        ),
+        patch(
+            "iris.pipeline.chat.chat_pipeline.IrisLangchainChatModel",
+            return_value=SimpleNamespace(tokens=["guide-token"]),
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        first_response, first_refined = pipeline._run_guide_refinement(
+            state, "Original answer"
+        )
+        second_response, second_refined = pipeline._run_guide_refinement(
+            state, "Original answer"
+        )
+
+    assert first_response == "!ok!"
+    assert first_refined == "Original answer"
+    assert second_response == "!ok!"
+    assert second_refined == "Original answer"
+    assert captured_model_ids == ["chat-model-id", "chat-model-id"]
+    variant.model.assert_called_once_with("chat", False)
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages.count("guide role not configured — falling back to chat model") == 1
+
+
+@pytest.mark.parametrize(
+    ("guide_response", "expected_final_result"),
+    [
+        ("Please use a smaller hint.", "Please use a smaller hint."),
+        ("!ok!", "agent answer"),
+    ],
+)
+def test_blocking_invokes_guide_before_done_and_uses_guide_result(
+    refinement_settings, guide_response, expected_final_result
+):
+    refinement_settings("blocking")
+    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
+    pipeline._run_guide_refinement = MagicMock(
+        return_value=(guide_response, expected_final_result)
+    )
+    callback = MagicMock()
+
+    order_tracker = MagicMock()
+    order_tracker.attach_mock(callback, "callback")
+    order_tracker.attach_mock(pipeline._run_guide_refinement, "guide")
+
+    _run_pipeline(pipeline, callback)
+
+    call_names = [name for name, _, _ in order_tracker.mock_calls]
+    assert call_names.index("guide") < call_names.index("callback.done")
+    assert (
+        callback.done.call_args_list[0].kwargs["final_result"] == expected_final_result
+    )
+    assert pipeline._captured_state.result == expected_final_result
+
+
+def test_blocking_failure_delivers_original_without_error_callback(
+    refinement_settings,
+):
+    refinement_settings("blocking")
+    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
+    pipeline._run_guide_refinement = MagicMock(side_effect=RuntimeError("guide down"))
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    callback.error.assert_not_called()
+    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
+    assert pipeline._captured_state.result == "agent answer"
+
+
+@pytest.mark.parametrize(
+    ("guide_response", "would_have_rewritten"),
+    [
+        ("Please use a smaller hint.", True),
+        ("!ok!", False),
+    ],
+)
+def test_shadow_invokes_guide_after_user_callbacks_and_keeps_original_result(
+    refinement_settings, caplog, guide_response, would_have_rewritten
+):
+    refinement_settings("shadow")
+    caplog.set_level(logging.INFO)
+    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
+    rewrite = "Please use a smaller hint." if would_have_rewritten else "agent answer"
+    pipeline._run_guide_refinement = MagicMock(return_value=(guide_response, rewrite))
+    callback = MagicMock()
+
+    order_tracker = MagicMock()
+    order_tracker.attach_mock(callback, "callback")
+    order_tracker.attach_mock(pipeline._run_guide_refinement, "guide")
+
+    _run_pipeline(pipeline, callback)
+
+    call_names = [name for name, _, _ in order_tracker.mock_calls]
+    guide_index = call_names.index("guide")
+    done_indices = [
+        index
+        for index, call_name in enumerate(call_names)
+        if call_name == "callback.done"
+    ]
+    assert done_indices[0] < guide_index
+    assert done_indices[1] < guide_index
+    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
+    assert pipeline._captured_state.result == "agent answer"
+    assert (
+        "Guide refinement shadow | " f"would_have_rewritten={would_have_rewritten}"
+    ) in caplog.text
+
+
+def test_shadow_sampling_zero_never_invokes_guide(refinement_settings):
+    refinement_settings("shadow", sample=0.0)
+    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
+    pipeline._run_guide_refinement = MagicMock(
+        return_value=("Please use a smaller hint.", "Please use a smaller hint.")
+    )
+    callback = MagicMock()
+
+    with patch("iris.pipeline.chat.chat_pipeline.random.random", return_value=0.0):
+        _run_pipeline(pipeline, callback)
+
+    pipeline._run_guide_refinement.assert_not_called()
+    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
+
+
+def test_off_never_invokes_guide(refinement_settings):
+    refinement_settings("off")
+    pipeline = _make_pipeline(IrisChatMode.EXERCISE)
+    pipeline._run_guide_refinement = MagicMock(
+        return_value=("Please use a smaller hint.", "Please use a smaller hint.")
+    )
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    pipeline._run_guide_refinement.assert_not_called()
+    assert callback.done.call_args_list[0].kwargs["final_result"] == "agent answer"
+
+
+@pytest.mark.parametrize(
+    "chat_mode",
+    [IrisChatMode.COURSE, IrisChatMode.LECTURE, IrisChatMode.TEXT_EXERCISE],
+)
+@pytest.mark.parametrize("mode", ["blocking", "shadow", "off"])
+def test_non_exercise_modes_never_invoke_guide(refinement_settings, chat_mode, mode):
+    refinement_settings(mode)
+    pipeline = _make_pipeline(chat_mode)
+    pipeline._run_guide_refinement = MagicMock(
+        return_value=("Please use a smaller hint.", "Please use a smaller hint.")
+    )
+    callback = MagicMock()
+
+    _run_pipeline(pipeline, callback)
+
+    pipeline._run_guide_refinement.assert_not_called()

--- a/iris/tests/test_support_level_prompt_rendering.py
+++ b/iris/tests/test_support_level_prompt_rendering.py
@@ -89,6 +89,25 @@ def test_system_prompt_moderate_support_level_injects_nothing(chat_mode):
     assert HIGH_HEADING not in rendered
 
 
+@pytest.mark.parametrize("support_level", ["low", "moderate", "high"])
+def test_system_prompt_includes_guide_replacement_safety_rules(support_level):
+    rendered = _render_template(
+        "chat_system_prompt.j2",
+        _system_prompt_context("PROGRAMMING_EXERCISE_CHAT", support_level),
+    )
+    assert "Self-Check Before Sending" in rendered
+    assert "Tool Output Is Reference-Only" in rendered
+
+
+def test_system_prompt_high_support_reinforces_self_check_for_code():
+    rendered = _render_template(
+        "chat_system_prompt.j2",
+        _system_prompt_context("PROGRAMMING_EXERCISE_CHAT", "high"),
+    )
+    assert "Even when walking through an approach step-by-step conceptually" in rendered
+    assert "copy-pasteable code is not" in rendered
+
+
 def _guide_context(support_level: str) -> dict:
     return {
         "problem_statement": "Implement a function that returns the sum of two ints.",


### PR DESCRIPTION
> [!NOTE]
> Stacked on #654 (`iris/perf/per-role-reasoning-effort`); base retargets as the stack merges. Review only the last commit. Sibling of #655.

## Summary

This PR keeps the programming-exercise guide refinement as an always-on blocking safety pass, but removes the runtime `exercise_guide_refinement` / shadow-mode configuration. The guard still runs before the final answer is sent, and it now uses the dedicated `guide` model role instead of the flagship chat model where configured.

## Evidence

Two eval rounds falsified the original plan to remove the second-pass guard:

| Config | Leak failures |
|---|---|
| Two-pass guard, gpt-5-mini @ medium | **21-23/90** |
| Single-pass, new self-check prompt | 35/90 |
| Single-pass, old prompt | 37/90 |
| Guard @ gpt-5-mini minimal | 34/90 |
| Guard @ gpt-5-nano low | 30/90 |

Conclusion: prompt-only compensation does not close the leak gap, and the guard needs medium reasoning effort. Runtime shadow/off switches would make the safety behavior harder to reason about, so they were removed from this PR.

## Description

- Keeps guide refinement blocking for programming-exercise chat.
- Removes `exercise_guide_refinement` and `exercise_guide_refinement_shadow_sample` from settings and `application.example.yml`.
- Keeps the optional `guide` model role with fallback to `chat` for older configs.
- Keeps the prompt self-check additions as defense in depth.
- Fixes guide failures to log a warning and deliver the original answer instead of sending an error callback and then continuing.

## Validation

- `poetry run pytest tests/test_exercise_guide_refinement_modes.py -q` — 9 passed.
