### PR TITLE
`Logos`: Fix status update in Statistics Page

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
@@ -53,7 +53,7 @@ export class RecentRequests implements OnInit, OnChanges, OnDestroy {
   now = signal(Date.now());
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
-  private prevLiveCount = 0;
+  private prevLiveSignature = '';
 
   displayItems = computed((): PaginatedRequestItem[] => {
     const data = this.pageData();
@@ -73,10 +73,19 @@ export class RecentRequests implements OnInit, OnChanges, OnDestroy {
     this.scheduleTicker();
   }
 
+  private static liveSignature(items: RequestItem[]): string {
+    return items
+      .map((r) => `${r.request_id}:${r.status}:${r.scheduled_ts ?? ''}:${r.request_complete_ts ?? ''}`)
+      .join(',');
+  }
+
   ngOnChanges(): void {
-    if (this.page() === 1 && this.liveRequests.length !== this.prevLiveCount) {
-      this.prevLiveCount = this.liveRequests.length;
-      this.silentRefresh();
+    if (this.page() === 1) {
+      const sig = RecentRequests.liveSignature(this.liveRequests);
+      if (sig !== this.prevLiveSignature) {
+        this.prevLiveSignature = sig;
+        this.silentRefresh();
+      }
     }
     // Re-schedule ticker whenever inputs change so cadence stays correct.
     this.scheduleTicker();


### PR DESCRIPTION
This PR resolves an update bug in the statistics page, where a finished model was still shown as running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic refresh behavior in the recent requests view so updates are triggered more reliably when request details change, not just when the number of items changes.
  * Reduced missed refreshes and unnecessary refreshes by making change detection more precise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->