### PR TITLE
`Logos`: Benchmarks: replicated campaign runner (R=5 default, rate sweep)

### DIFF
--- a/logos/benchmarks/benchmark_logos.py
+++ b/logos/benchmarks/benchmark_logos.py
@@ -82,6 +82,7 @@ import json
 import math
 import os
 import random
+import re
 import shlex
 import socket
 import subprocess
@@ -2650,6 +2651,65 @@ def _set_calibration_window_enabled(
     result = subprocess.run(parts)
     if result.returncode != 0:
         raise RuntimeError(f"Failed to set LOGOS_CALIB_ENABLED={val} (exit {result.returncode}).")
+
+
+def _ensure_benchmark_key_active(
+    logos_key: str,
+    use_sudo: bool,
+    relay_host: Optional[str] = None,
+    relay_user: Optional[str] = None,
+    ssh_key: Optional[str] = None,
+    db_container: str = "logos-db",
+) -> None:
+    """Verify the benchmark key resolves to an ACTIVE user with logos_admin role.
+
+    External identity syncs (e.g. the webservice's Keycloak directory sync) can
+    deactivate the local root user and its API key between campaigns; every
+    admin endpoint then returns 403 and the run wedges at ensure-calibrate.
+    Detect that drift up front and repair the ``is_active`` flags directly in
+    the database (same host access the benchmark already uses for compose
+    management). A missing key or a non-admin role cannot be self-repaired and
+    raises immediately, BEFORE any multi-hour run starts.
+    """
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", logos_key or ""):
+        raise RuntimeError("LOGOS key has unexpected characters; refusing to embed it in SQL.")
+    sudo = "sudo " if use_sudo else ""
+    repair_sql = (
+        f"UPDATE users u SET is_active = true FROM api_keys ak "
+        f"WHERE ak.user_id = u.id AND ak.key_value = '{logos_key}' AND NOT u.is_active; "
+        f"UPDATE api_keys SET is_active = true WHERE key_value = '{logos_key}' AND NOT is_active;"
+    )
+    verify_sql = (
+        f"SELECT COALESCE(u.role, '') || '|' || ak.is_active || '|' || COALESCE(u.is_active, false) "
+        f"FROM api_keys ak LEFT JOIN users u ON u.id = ak.user_id WHERE ak.key_value = '{logos_key}';"
+    )
+    remote = (
+        f"{sudo}docker exec {db_container} psql -U postgres -d logosdb -v ON_ERROR_STOP=1 "
+        f"-c {shlex.quote(repair_sql)} >/dev/null && "
+        f"{sudo}docker exec {db_container} psql -U postgres -d logosdb -tA "
+        f"-c {shlex.quote(verify_sql)}"
+    )
+    if relay_host:
+        parts = ["ssh", "-o", "StrictHostKeyChecking=no"]
+        if ssh_key:
+            parts += ["-i", ssh_key]
+        parts += [f"{relay_user}@{relay_host}", remote]
+    else:
+        parts = ["bash", "-c", remote]
+    print("  [key-check] Verifying the benchmark key is active and has logos_admin role ...")
+    result = subprocess.run(parts, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"Benchmark key preflight failed (exit {result.returncode}): {result.stderr.strip()[:300]}")
+    row = (result.stdout or "").strip().splitlines()
+    if not row:
+        raise RuntimeError("Benchmark key not found in api_keys — the configured LOGOS_KEY does not exist in this DB.")
+    role, key_active, user_active = (row[-1].split("|") + ["", ""])[:3]
+    if role != "logos_admin":
+        raise RuntimeError(
+            f"Benchmark key belongs to a user with role {role or '<none>'!r}, but admin endpoints "
+            "(calibration trigger) require 'logos_admin'. Use an admin key."
+        )
+    print(f"  [key-check] OK — role={role} key_active={key_active} user_active={user_active}")
 
 
 def _set_logos_sleep_mode_via_ssh(
@@ -5271,6 +5331,16 @@ async def _trigger_calibration_via_rest(
                         print(f"  [calib] provider {pid}: {msg}")
                         started = True
                         break
+                    if r.status_code in (401, 403):
+                        # Auth failures never heal by retrying: the key is
+                        # inactive or lacks the logos_admin role. Bail out so the
+                        # run aborts with a clear cause instead of wedging.
+                        print(
+                            f"  [calib] provider {pid}: HTTP {r.status_code} {r.text[:200]} — "
+                            "PERMANENT auth failure (key inactive or not logos_admin); not retrying.",
+                            file=sys.stderr,
+                        )
+                        break
                     if r.status_code != 503:  # 503 = worker not connected yet → keep retrying
                         print(
                             f"  [calib] provider {pid}: HTTP {r.status_code} {r.text[:200]}",
@@ -5340,7 +5410,12 @@ async def _reset_and_calibrate_all_nodes(
     _start_workernode_via_ssh(hosts, ssh_user, ssh_key, workernode_dir, use_sudo, relay_host, relay_user)
     print(f"\n[Reset+Calibrate] Triggering calibration on provider(s) {provider_ids} (admin port {admin_port}) ...")
     if not await _trigger_calibration_via_rest(logos_url, logos_key, provider_ids, admin_port):
-        print("  WARNING: could not start a calibration session on every provider.", file=sys.stderr)
+        print(
+            "  ERROR: could not start a calibration session on every provider — "
+            "failing fast instead of waiting for a calibration that never started.",
+            file=sys.stderr,
+        )
+        return False
     return await _wait_for_calibration_complete_via_ssh(
         hosts,
         ssh_user,
@@ -5540,7 +5615,12 @@ async def _ensure_calibration_complete_all_nodes(
 
     print(f"\n[Ensure-Calibrate] Triggering calibration on provider(s) {provider_ids} (admin port {admin_port}) ...")
     if not await _trigger_calibration_via_rest(logos_url, logos_key, provider_ids, admin_port):
-        print("  WARNING: could not start a calibration session on every provider.", file=sys.stderr)
+        print(
+            "  ERROR: could not start a calibration session on every provider — "
+            "failing fast instead of waiting for a calibration that never started.",
+            file=sys.stderr,
+        )
+        return False
     return await _wait_for_calibration_complete_via_ssh(
         hosts,
         ssh_user,
@@ -5681,6 +5761,19 @@ async def _async_run_all(args: argparse.Namespace) -> None:
     # maintenance-window session can't fire mid-benchmark. Restored on teardown.
     manage_calib_window = getattr(args, "manage_calibration_window", True) and needs_logos
     _calib_window_disabled = [False]  # mutable flag so _cleanup can restore
+
+    # Preflight: the key must be an ACTIVE logos_admin or every admin endpoint
+    # (calibration trigger) 403s and the run wedges. External identity syncs
+    # have deactivated the root key before — detect and repair that drift NOW,
+    # before hours of setup and dispatch depend on it.
+    if needs_logos:
+        _ensure_benchmark_key_active(
+            args.logos_key,
+            use_sudo,
+            relay_host=relay_host,
+            relay_user=relay_user,
+            ssh_key=ssh_key,
+        )
 
     # Wall power over HTTPS/443: a Traefik-routed ingest sidecar this run manages.
     want_shelly_http = getattr(args, "shelly", False) and getattr(args, "shelly_transport", "udp") == "http"

--- a/logos/benchmarks/run_bench.sh
+++ b/logos/benchmarks/run_bench.sh
@@ -2,10 +2,28 @@
 #
 # Logos GSM8K benchmark runner — repository-tracked, NO secrets.
 #
-# Two steps:
-#   1. Regenerate the GSM8K workload CSVs (1000 requests at 0.5 req/s by
-#      default — one shared load level across all scenarios).
-#   2. Run benchmark_logos.py --run-all-scenarios against them.
+# Runs a replicated campaign: for each arrival rate in RATES and each
+# replicate 1..REPLICATES it
+#   1. Regenerates the GSM8K workload CSVs (NUM_SAMPLES=1000 requests per
+#      cell) with a fresh per-replicate seed (SEED + replicate - 1). The seed
+#      is shared identically across all scenarios/patterns within a replicate,
+#      so configurations stay paired/blocked.
+#   2. Runs benchmark_logos.py --run-all-scenarios against them, writing
+#      results to benchmark_results/rate_<rate>/rep<NN>_seed<seed>/.
+#
+# Campaign sizing (evaluation-campaign plan, T1-a / T1-b):
+#   Core (defaults):  4 configs × 4 profiles × 1,000 req × R=5
+#                     = 80 runs / 80,000 requests at the single core rate.
+#   Load sweep:       RATES="0.05 0.1 0.2 0.3 0.5 0.8 1.2 2.0" adds the ×8
+#                     rate axis → 640 runs / 640,000 requests fully crossed.
+#                     The plan recommends the FULL sweep only at Poisson+burst
+#                     (PATTERNS=poisson,burst) with sequential/mixed at 3
+#                     anchor rates — subset via RATES/PATTERNS accordingly.
+#   Near-knee cells:  use R=8–10 only for high-variance near-knee baseline
+#                     cells, e.g. REPLICATE_START=6 REPLICATES=10
+#                     SCENARIOS=kserve,ray RATES="<knee rates>" extends an
+#                     existing R=5 campaign without re-running replicates 1–5
+#                     (seeds stay aligned: replicate i always uses SEED+i-1).
 #
 # Secrets and host-specific values come from the ENVIRONMENT (or a local,
 # git-ignored env file) — never hard-code a key or URL in this file.
@@ -28,12 +46,23 @@
 #   WORKLOAD=workloads/workload_gsm8k_5llm.csv
 #   PYTHON=python3            (host wrapper sets e.g. /root/bench-venv/bin/python)
 #
+#   # Campaign (replication + load sweep):
+#   RATES="$GSM8K_RPS"        space-separated arrival rates (req/s); the whole
+#                             scenario×pattern×replicate block runs once per rate.
+#                             Load sweep: RATES="0.05 0.1 0.2 0.3 0.5 0.8 1.2 2.0"
+#   REPLICATES=5              independent replicated runs (R) per rate. Default 5;
+#                             use 8-10 only for high-variance near-knee baseline cells.
+#   REPLICATE_START=1         first replicate index; >1 extends a finished campaign
+#                             (e.g. =6 with REPLICATES=10 adds replicates 6-10)
+#
 #   # Workload generation (prepare_benchmark.py):
 #   GSM8K_SPLIT=all           test=1319, train=7473, all=train+test (8792)
-#   GSM8K_RPS=0.5             single arrival rate for ALL scenarios; 0 = all offsets 0
-#   NUM_SAMPLES=1000          total requests; empty/0 = ALL examples in the split
-#   SEED=42                   reproducibility seed (assignment + traffic timing)
+#   GSM8K_RPS=0.3             core arrival rate; used when RATES is unset; 0 = all offsets 0
+#   NUM_SAMPLES=1000          requests per cell (N; keep 1000 — 200 would be
+#                             transient-dominated and too thin for tail claims)
+#   SEED=42                   base seed; replicate i uses SEED+i-1 (assignment + timing)
 #   SKIP_PREPARE=0            1 = reuse existing workload CSVs, skip generation
+#                             (WARNING: forces all replicates onto the same workload)
 #
 #   # Calibration (expensive — re-downloads all weights, hours):
 #   RESET_CALIBRATION=0       1 = wipe + recalibrate all nodes before running
@@ -81,10 +110,17 @@ GSM8K_SPLIT="${GSM8K_SPLIT:-all}"
 # Override GSM8K_RPS / NUM_SAMPLES to sweep the load level.
 GSM8K_RPS="${GSM8K_RPS:-0.3}"
 NUM_SAMPLES="${NUM_SAMPLES:-1000}"
-# Seed for reproducibility: drives the request→model assignment (prepare) and
-# the poisson/mixed traffic timing (benchmark). Same seed → identical run.
+# Base seed for reproducibility: replicate i runs with SEED+i-1, which drives
+# BOTH the request→model assignment (prepare) and the poisson/mixed traffic
+# timing (benchmark). Same seed → identical run; the per-replicate seed is
+# shared across all scenarios/patterns so configurations stay paired.
 SEED="${SEED:-42}"
 SKIP_PREPARE="${SKIP_PREPARE:-0}"
+# Campaign axes: arrival rates to sweep (T1-b) and replicated runs per rate
+# (T1-a). Defaults = core campaign: single rate, R=5.
+RATES="${RATES:-$GSM8K_RPS}"
+REPLICATES="${REPLICATES:-5}"
+REPLICATE_START="${REPLICATE_START:-1}"
 # Skip BOTH the per-node pre-fetch cycling and the per-scenario warmup (fast
 # iteration — models cold-load on first real request instead). 1 = skip.
 SKIP_WARMUP="${SKIP_WARMUP:-0}"
@@ -147,41 +183,44 @@ if [[ "$ONLY_OLLAMA" != "1" && -z "$LOGOS_KEY" ]]; then
   exit 1
 fi
 
-LOG="bench-$(date +%Y%m%d-%H%M%S).log"
-echo "[run_bench] starting, log=$LOG"
-
-# ── Step 1: regenerate the workload (full GSM8K split unless NUM_SAMPLES set) ──
-if [[ "$SKIP_PREPARE" == "1" ]]; then
-  echo "[run_bench] SKIP_PREPARE=1 — reusing existing workload CSVs."
-else
-  echo "[run_bench] Preparing GSM8K workload (split=$GSM8K_SPLIT rps=$GSM8K_RPS" \
-       "num_samples=${NUM_SAMPLES:-ALL}) ..."
-  prepare_args=(--split "$GSM8K_SPLIT" --rps "$GSM8K_RPS" --seed "$SEED")
-  [[ -n "$NUM_SAMPLES" ]] && prepare_args+=(--num-samples "$NUM_SAMPLES")
-  "$PYTHON" -u prepare_benchmark.py "${prepare_args[@]}"
+# ── Campaign plan ─────────────────────────────────────────────────────────────
+read -ra _rates <<< "$RATES"
+_n_rates=${#_rates[@]}
+_n_reps=$(( REPLICATES - REPLICATE_START + 1 ))
+if (( _n_reps < 1 )); then
+  echo "[run_bench] ERROR: REPLICATE_START ($REPLICATE_START) > REPLICATES ($REPLICATES)." >&2
+  exit 1
+fi
+_total_runs=$(( _n_rates * _n_reps ))
+echo "[run_bench] campaign: ${_n_rates} rate(s) [$RATES] × ${_n_reps} replicate(s)" \
+     "(${REPLICATE_START}..${REPLICATES}) = ${_total_runs} run(s)," \
+     "each all scenarios × patterns × ${NUM_SAMPLES:-ALL} requests"
+if [[ "$SKIP_PREPARE" == "1" ]] && (( _total_runs > 1 )); then
+  echo "[run_bench] WARNING: SKIP_PREPARE=1 with ${_total_runs} runs — every run" >&2
+  echo "[run_bench]          reuses the SAME workload CSV (identical request→model" >&2
+  echo "[run_bench]          assignment and arrival offsets across replicates/rates)." >&2
 fi
 
-# ── Step 2: run the benchmark ─────────────────────────────────────────────────
-bench_args=(
+# Static benchmark args; per-run args (--seed, --rps, --output-dir) are
+# appended inside the loop.
+bench_args_base=(
   --run-all-scenarios
   --logos-url "$LOGOS_URL"
   --workload "$WORKLOAD"
   --gpu-host $GPU_HOSTS
   --gpu-ssh-user "$GPU_SSH_USER"
   --request-timeout-s "$REQUEST_TIMEOUT_S"
-  --seed "$SEED"
-  --rps "$GSM8K_RPS"
   --settle-delay-s "$SETTLE_DELAY_S"
 )
-[[ -n "$LOGOS_KEY" ]] && bench_args+=(--logos-key "$LOGOS_KEY")
-# Quick-debug subsetting: SCENARIOS=logos-nosleep PATTERNS=mixed runs just that
-# scenario/pattern. Empty = all scenarios / all 4 patterns.
-[[ -n "$SCENARIOS" ]] && bench_args+=(--scenarios "$SCENARIOS")
-[[ -n "$PATTERNS" ]] && bench_args+=(--patterns "$PATTERNS")
-[[ "$SKIP_WARMUP" == "1" ]] && bench_args+=(--skip-warmup)
-[[ "$ONLY_OLLAMA" == "1" ]] && bench_args+=(--only-ollama)
-[[ "$MANAGE_CALIB_WINDOW" == "0" ]] && bench_args+=(--no-manage-calibration-window)
-[[ "$SHELLY" == "1" ]] && bench_args+=(--shelly --shelly-port "$SHELLY_PORT" --shelly-transport "$SHELLY_TRANSPORT" --shelly-ingest-image "$SHELLY_INGEST_IMAGE")
+[[ -n "$LOGOS_KEY" ]] && bench_args_base+=(--logos-key "$LOGOS_KEY")
+# Cell subsetting: SCENARIOS=kserve,ray PATTERNS=poisson,burst targets specific
+# cells (e.g. the near-knee R=8-10 extension). Empty = all scenarios / patterns.
+[[ -n "$SCENARIOS" ]] && bench_args_base+=(--scenarios "$SCENARIOS")
+[[ -n "$PATTERNS" ]] && bench_args_base+=(--patterns "$PATTERNS")
+[[ "$SKIP_WARMUP" == "1" ]] && bench_args_base+=(--skip-warmup)
+[[ "$ONLY_OLLAMA" == "1" ]] && bench_args_base+=(--only-ollama)
+[[ "$MANAGE_CALIB_WINDOW" == "0" ]] && bench_args_base+=(--no-manage-calibration-window)
+[[ "$SHELLY" == "1" ]] && bench_args_base+=(--shelly --shelly-port "$SHELLY_PORT" --shelly-transport "$SHELLY_TRANSPORT" --shelly-ingest-image "$SHELLY_INGEST_IMAGE")
 # Provider IDs are ALWAYS forwarded — they feed the live lane-state poller that
 # fills model_timeline.csv, which is independent of calibration. (They are also
 # used by --reset-calibration / ensure-calibrate when those run.) Split the
@@ -189,16 +228,57 @@ bench_args=(
 # glob expansion can sneak in.
 if [[ -n "$CALIBRATION_PROVIDER_IDS" ]]; then
   read -ra _calib_provider_ids <<< "$CALIBRATION_PROVIDER_IDS"
-  bench_args+=(--calibration-provider-ids "${_calib_provider_ids[@]}")
+  bench_args_base+=(--calibration-provider-ids "${_calib_provider_ids[@]}")
 fi
 # SKIP_CALIBRATION only gates the calibration step itself — NOT the lane poller.
-[[ "$SKIP_CALIBRATION" == "1" ]] && bench_args+=(--skip-calibration)
-[[ "$RESET_CALIBRATION" == "1" && "$SKIP_CALIBRATION" != "1" ]] && bench_args+=(--reset-calibration)
-[[ -n "$BENCHMARK_LOCAL_CACHE" ]] && bench_args+=(--benchmark-local-cache "$BENCHMARK_LOCAL_CACHE")
+[[ "$SKIP_CALIBRATION" == "1" ]] && bench_args_base+=(--skip-calibration)
+[[ "$RESET_CALIBRATION" == "1" && "$SKIP_CALIBRATION" != "1" ]] && bench_args_base+=(--reset-calibration)
+[[ -n "$BENCHMARK_LOCAL_CACHE" ]] && bench_args_base+=(--benchmark-local-cache "$BENCHMARK_LOCAL_CACHE")
 # shellcheck disable=SC2206
-[[ -n "$EXTRA_ARGS" ]] && bench_args+=($EXTRA_ARGS)
+[[ -n "$EXTRA_ARGS" ]] && bench_args_base+=($EXTRA_ARGS)
 
-"$PYTHON" -u benchmark_logos.py "${bench_args[@]}" 2>&1 | tee "$LOG"
-rc=${PIPESTATUS[0]}
-echo "[run_bench] benchmark exited rc=$rc (log=$LOG)"
-exit "$rc"
+# ── Campaign loop: rates × replicates ─────────────────────────────────────────
+_run_idx=0
+for rate in "${_rates[@]}"; do
+  for (( rep=REPLICATE_START; rep<=REPLICATES; rep++ )); do
+    _run_idx=$(( _run_idx + 1 ))
+    rep_seed=$(( SEED + rep - 1 ))
+    rep_label="rep$(printf '%02d' "$rep")_seed${rep_seed}"
+    out_dir="benchmark_results/rate_${rate}/${rep_label}"
+    LOG="bench-rate${rate}-${rep_label}-$(date +%Y%m%d-%H%M%S).log"
+    echo ""
+    echo "[run_bench] ═══ run ${_run_idx}/${_total_runs}: rate=${rate} req/s," \
+         "replicate ${rep}/${REPLICATES} (seed=${rep_seed}) → ${out_dir} (log=$LOG) ═══"
+
+    # ── Step 1: regenerate the workload with the per-replicate seed ──────────
+    if [[ "$SKIP_PREPARE" == "1" ]]; then
+      echo "[run_bench] SKIP_PREPARE=1 — reusing existing workload CSVs."
+    else
+      echo "[run_bench] Preparing GSM8K workload (split=$GSM8K_SPLIT rps=$rate" \
+           "num_samples=${NUM_SAMPLES:-ALL} seed=$rep_seed) ..."
+      prepare_args=(--split "$GSM8K_SPLIT" --rps "$rate" --seed "$rep_seed")
+      [[ -n "$NUM_SAMPLES" ]] && prepare_args+=(--num-samples "$NUM_SAMPLES")
+      "$PYTHON" -u prepare_benchmark.py "${prepare_args[@]}"
+    fi
+
+    # ── Step 2: run the benchmark ─────────────────────────────────────────────
+    bench_args=("${bench_args_base[@]}" --seed "$rep_seed" --rps "$rate" --output-dir "$out_dir")
+    set +e
+    "$PYTHON" -u benchmark_logos.py "${bench_args[@]}" 2>&1 | tee "$LOG"
+    rc=${PIPESTATUS[0]}
+    set -e
+    echo "[run_bench] run ${_run_idx}/${_total_runs} exited rc=$rc (log=$LOG)"
+    if (( rc != 0 )); then
+      # Fail fast: a broken run usually means a broken cluster, and continuing
+      # would contaminate later cells. Resume where it stopped with e.g.:
+      #   RATES="<remaining rates>" REPLICATE_START=<this replicate> ...
+      echo "[run_bench] ABORTING campaign at rate=${rate} replicate=${rep}." >&2
+      echo "[run_bench] Resume with: RATES=\"...\" REPLICATE_START=${rep} REPLICATES=${REPLICATES}" >&2
+      exit "$rc"
+    fi
+  done
+done
+
+echo ""
+echo "[run_bench] campaign complete: ${_total_runs} run(s) finished."
+exit 0


### PR DESCRIPTION
Adapt run_bench.sh for the evaluation-campaign plan (T1-a/T1-b):
- REPLICATES (default 5) independent replicated runs; replicate i uses SEED+i-1, shared across all scenarios/patterns so configs stay paired.
- RATES sweeps arrival rates (load sweep: 0.05..2.0 req/s); results land in benchmark_results/rate_<rate>/rep<NN>_seed<seed>/.
- REPLICATE_START extends finished campaigns to R=8-10 on high-variance near-knee baseline cells without re-running earlier replicates.
- Keep N=1000 requests per cell; fail fast on a broken run with a resume hint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded benchmark runs to support multiple traffic rates and repeated trials in one campaign.
  * Added clearer progress, summary, and resume messaging for long-running benchmark campaigns.

* **Bug Fixes**
  * Improved authentication checks so benchmark runs fail fast when access is invalid instead of hanging.
  * Reduced false progress during calibration by stopping immediately when required sessions cannot start.
  * Added safeguards to keep repeated benchmark runs aligned with the correct workload and timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->