### PR TITLE
`Logos`: Improve webapp contrast, show requesting team, and add dev deploy environment

### DIFF
--- a/.github/workflows/logos_deploy-dev.yml
+++ b/.github/workflows/logos_deploy-dev.yml
@@ -24,7 +24,7 @@ jobs:
           - environment: "Logos - Dev"
             compose-file: ./logos/docker-compose.yaml
             base-path: /opt/logos
-          - environment: "Logos Worker - Dev - hochbruegge"
+          - environment: "Logos Worker - Test - hochbruegge"
             compose-file: ./logos/logos-workernode/docker-compose.yml
             base-path: /opt/logos-workernode
     environment:

--- a/.github/workflows/logos_deploy-dev.yml
+++ b/.github/workflows/logos_deploy-dev.yml
@@ -1,0 +1,147 @@
+name: Logos - Deploy to Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        type: string
+        description: "Image tag to deploy (default: latest)"
+        default: "latest"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      # Deploy each node independently: one unreachable host must not cancel
+      # the in-flight deploys of the other (healthy) nodes.
+      fail-fast: false
+      matrix:
+        include:
+          - environment: "Logos - Dev"
+            compose-file: ./logos/docker-compose.yaml
+            base-path: /opt/logos
+          - environment: "Logos Worker - Dev - hochbruegge"
+            compose-file: ./logos/logos-workernode/docker-compose.yml
+            base-path: /opt/logos-workernode
+    environment:
+      name: ${{ matrix.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract compose file basename
+        id: extract-basename
+        run: |
+          BASENAME=$(basename "${{ matrix.compose-file }}")
+          echo "basename=$BASENAME" >> $GITHUB_OUTPUT
+          cp "${{ matrix.compose-file }}" "$BASENAME"
+
+      - name: Copy docker compose file to VM
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          source: ${{ steps.extract-basename.outputs.basename }}
+          target: ${{ matrix.base-path }}
+
+      - name: Create .env file
+        run: |
+          echo "ENVIRONMENT=${{ matrix.environment }}" > .env
+          echo "IMAGE_TAG=${{ inputs.image-tag }}" >> .env
+          echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
+
+          echo "$SECRETS_CONTEXT" | jq -r '
+            del(
+              .github_token,
+              .DOCKER_USERNAME,
+              .DOCKER_PASSWORD,
+              .DEPLOYMENT_GATEWAY_SSH_KEY,
+              .VM_SSH_PRIVATE_KEY,
+              .LOGOS_HARBOR_PASSWORD
+            )
+            | to_entries[]
+            | "\(.key)=\(.value | @json)"
+          ' >> .env
+
+          echo "$VARS_CONTEXT" | jq -r '
+            del(
+              .DEPLOYMENT_GATEWAY_PORT,
+              .DEPLOYMENT_GATEWAY_USER,
+              .DEPLOYMENT_GATEWAY_HOST,
+              .VM_USERNAME,
+              .VM_HOST,
+              .LOGOS_HARBOR_REGISTRY,
+              .LOGOS_HARBOR_USER
+            )
+            | to_entries[]
+            | "\(.key)=\(.value | @json)"
+          ' >> .env
+        env:
+          VARS_CONTEXT: ${{ toJson(vars) }}
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+
+      - name: Copy .env file to VM
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          source: .env
+          target: ${{ matrix.base-path }}
+
+      - name: Pull new images
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          LOGOS_HARBOR_PASSWORD: ${{ secrets.LOGOS_HARBOR_PASSWORD }}
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          command_timeout: 30m
+          envs: LOGOS_HARBOR_PASSWORD
+          script: |
+            printf '%s' "$LOGOS_HARBOR_PASSWORD" | docker login ${{ vars.LOGOS_HARBOR_REGISTRY }} -u '${{ vars.LOGOS_HARBOR_USER }}' --password-stdin
+            docker compose -f ${{ matrix.base-path }}/${{ steps.extract-basename.outputs.basename }} --env-file=${{ matrix.base-path }}/.env pull
+
+      - name: Deploy with docker compose
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            docker compose -f ${{ matrix.base-path }}/${{ steps.extract-basename.outputs.basename }} --env-file=${{ matrix.base-path }}/.env up -d --remove-orphans
+
+      - name: Clean up old images
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            docker image prune -af

--- a/logos/docs/deployment.md
+++ b/logos/docs/deployment.md
@@ -1,0 +1,55 @@
+# Logos deployment environments
+
+Logos images are built by the `Logos - Build` workflow and pushed to the Harbor
+registry (`${LOGOS_HARBOR_REGISTRY}/logos`). PR builds are tagged `pr-<number>`,
+builds on `main` are tagged `latest`.
+
+| Environment | Workflow | Trigger | Nodes (GitHub environments) |
+|---|---|---|---|
+| Prod | `Logos - Deploy to Prod` | auto after `Logos - Build` on `main`, or manual | `Logos - Prod`, `Logos Worker - Prod - deioma` |
+| Test | `Logos - Deploy to Test` | manual (`workflow_dispatch`, image-tag input) | `Logos - Test`, `Logos Worker - Prod - deimama`, `Logos Worker - Prod - deipapa` |
+| Dev | `Logos - Deploy to Dev` | manual (`workflow_dispatch`, image-tag input) | `Logos - Dev`, `Logos Worker - Dev - hochbruegge` |
+
+Each deploy job copies the docker compose file and a generated `.env` (all
+environment vars/secrets except the SSH/registry plumbing) to the node and runs
+`docker compose up -d` there. Core nodes use `logos/docker-compose.yaml` under
+`/opt/logos`; worker nodes use `logos/logos-workernode/docker-compose.yml` under
+`/opt/logos-workernode`.
+
+## Required configuration per GitHub environment
+
+Repository-level (already configured): `LOGOS_HARBOR_REGISTRY`,
+`LOGOS_HARBOR_USER` (vars), `LOGOS_HARBOR_PASSWORD` (secret), and the
+`DEPLOYMENT_GATEWAY_*` vars/secrets inherited from the organization.
+
+### Core node (e.g. `Logos - Dev`)
+
+Variables:
+
+- `VM_HOST`, `VM_USERNAME` — target VM and SSH user
+- `LOGOS_DOMAIN`, `LOGOS_CERT_RESOLVER`, `LOGOS_CORS_ALLOWED_ORIGINS`, `ACME_EMAIL`
+- `KEYCLOAK_ADMIN_BASE_URL`, `KEYCLOAK_AUDIENCE`, `KEYCLOAK_CLIENT_ID`,
+  `KEYCLOAK_ISSUER_URI`, `KEYCLOAK_JWKS_URI`, `KEYCLOAK_ROLES_APP_ADMIN`,
+  `KEYCLOAK_ROLES_LOGOS_ADMIN`, `KEYCLOAK_SYNC_CLIENT_ID`,
+  `KEYCLOAK_SYNC_ENABLED`, `KEYCLOAK_TEAM_ROLE_SUFFIXES`
+
+Secrets:
+
+- `VM_SSH_PRIVATE_KEY`
+- `LOGOS_INTERNAL_SECRET`
+- `KEYCLOAK_SYNC_CLIENT_SECRET`
+- `PROMETHEUS_API_KEY`
+
+### Worker node (e.g. `Logos Worker - Dev - hochbruegge`)
+
+Variables:
+
+- `VM_HOST`, `VM_USERNAME` — target GPU node and SSH user
+- `LOGOS_URL` — URL of the core node's orchestrator this worker registers with
+- `LOGOS_TMPFS_CACHE_PATH`, `TMPFS_SIZE`, `OLLAMA_MODELS_MOUNT`
+
+Secrets:
+
+- `VM_SSH_PRIVATE_KEY`
+- `LOGOS_API_KEY` — key the worker uses to authenticate against the orchestrator
+- `HF_TOKEN`

--- a/logos/docs/deployment.md
+++ b/logos/docs/deployment.md
@@ -8,7 +8,7 @@ builds on `main` are tagged `latest`.
 |---|---|---|---|
 | Prod | `Logos - Deploy to Prod` | auto after `Logos - Build` on `main`, or manual | `Logos - Prod`, `Logos Worker - Prod - deioma` |
 | Test | `Logos - Deploy to Test` | manual (`workflow_dispatch`, image-tag input) | `Logos - Test`, `Logos Worker - Prod - deimama`, `Logos Worker - Prod - deipapa` |
-| Dev | `Logos - Deploy to Dev` | manual (`workflow_dispatch`, image-tag input) | `Logos - Dev`, `Logos Worker - Dev - hochbruegge` |
+| Dev | `Logos - Deploy to Dev` | manual (`workflow_dispatch`, image-tag input) | `Logos - Dev`, `Logos Worker - Test - hochbruegge` |
 
 Each deploy job copies the docker compose file and a generated `.env` (all
 environment vars/secrets except the SSH/registry plumbing) to the node and runs
@@ -40,7 +40,7 @@ Secrets:
 - `KEYCLOAK_SYNC_CLIENT_SECRET`
 - `PROMETHEUS_API_KEY`
 
-### Worker node (e.g. `Logos Worker - Dev - hochbruegge`)
+### Worker node (e.g. `Logos Worker - Test - hochbruegge`)
 
 Variables:
 

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
@@ -40,6 +40,11 @@
                 [class.rr-badge--cloud]="item.is_cloud"
                 [class.rr-badge--local]="!item.is_cloud"
               >{{ item.is_cloud ? 'Cloud' : 'Local' }}</span>
+              @if (item.team_name) {
+                <span class="rr-card__team" title="Requesting team">
+                  <i class="pi pi-users" aria-hidden="true"></i>{{ item.team_name }}
+                </span>
+              }
             </div>
             @if (stageOf(item) === 'complete' && item.status === 'error' && item.error_message) {
               <div class="rr-card__error-snippet">{{ errorSnippet(item.error_message) }}</div>

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.scss
@@ -118,6 +118,21 @@
   text-overflow: ellipsis;
 }
 
+.rr-card__team {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  color: rgb(var(--color-typography-300));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  .pi {
+    font-size: var(--font-size-xs);
+  }
+}
+
 .rr-card__error-snippet {
   font-size: var(--font-size-sm);
   color: rgb(var(--color-error));

--- a/logos/logos-ui/src/app/features/statistics/components/request-volume-chart/request-volume-chart.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/request-volume-chart/request-volume-chart.scss
@@ -127,7 +127,7 @@
 
 // ── Crosshair vertical guide ──────────────────────────────────────────────────
 .rvc-crosshair {
-  stroke: rgb(var(--color-typography-500) / var(--opacity-stroke));
+  stroke: rgb(var(--color-typography-500) / var(--opacity-guide));
   stroke-width: 1;
   pointer-events: none;
 }

--- a/logos/logos-ui/src/app/features/statistics/components/vram-remaining-chart/vram-remaining-chart.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/vram-remaining-chart/vram-remaining-chart.scss
@@ -42,7 +42,7 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: rgb(var(--nav-item-text)  / var(--opacity-stroke));
+  color: rgb(var(--nav-item-text)  / var(--opacity-subdued));
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease;
 
@@ -171,7 +171,7 @@
 
 .vram-area {
   // fill set dynamically via url(#vram-grad-N)
-  opacity: var(--opacity-stroke);
+  opacity: var(--opacity-chart-minor);
 }
 
 .vram-line {
@@ -185,7 +185,7 @@
 
 // ── Crosshair vertical guide ──────────────────────────────────────────────────
 .rvc-crosshair {
-  stroke: rgb(var(--color-typography-500) / var(--opacity-stroke));
+  stroke: rgb(var(--color-typography-500) / var(--opacity-guide));
   stroke-width: 1;
   pointer-events: none;
 }
@@ -195,8 +195,8 @@
   position: absolute;
   top: 8px;
   transform: translateX(-50%);
-  background: rgb(var(--glass-fill) / var(--opacity-stroke));
-  border: 1px solid rgb(var(--glass-stroke) / var(--opacity-stroke));
+  background: rgb(var(--color-surface-0) / var(--opacity-semi));
+  border: 1px solid rgb(var(--glass-stroke) / var(--glass-stroke-opacity));
   border-radius: 8px;
   padding: 8px 12px;
   pointer-events: none;
@@ -247,7 +247,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  color: rgb(var(--nav-item-text) / var(--opacity-stroke));
+  color: rgb(var(--nav-item-text) / var(--opacity-subdued));
   font-size: var(--font-size-sm);
   padding: 4px 8px;
   border-radius: 6px;

--- a/logos/logos-ui/src/app/features/statistics/statistics.models.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.models.ts
@@ -133,6 +133,7 @@ export type PaginatedRequestItem = {
   priority_when_scheduled: string | null;
   queue_depth_at_enqueue: number | null;
   error_message: string | null;
+  team_name: string | null;
 };
 
 // PaginatedRequestResponse from logos-ui-old/components/statistics/types.ts

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -68,6 +68,8 @@ export function mergeWithLive(
     priority_when_scheduled: r.priority_when_scheduled,
     queue_depth_at_enqueue: r.queue_depth_at_enqueue,
     error_message: r.error_message,
+    // the live WS payload carries no team info — pageData does.
+    team_name: null,
   });
 
   const liveById = new Map<string, PaginatedRequestItem>();
@@ -80,10 +82,14 @@ export function mergeWithLive(
   for (const p of pageItems) {
     const overlay = liveById.get(p.request_id);
     if (overlay) {
-      // Preserve the paginated `is_cloud` flag (the WS payload has to
-      // infer it from the provider name); take everything else from
+      // Preserve the paginated `is_cloud` flag and `team_name` (the WS
+      // payload has to infer/omit them); take everything else from
       // the live row so state transitions render immediately.
-      merged.push({ ...overlay, is_cloud: p.is_cloud ?? overlay.is_cloud });
+      merged.push({
+        ...overlay,
+        is_cloud: p.is_cloud ?? overlay.is_cloud,
+        team_name: p.team_name ?? overlay.team_name,
+      });
     } else {
       merged.push(p);
     }

--- a/logos/logos-ui/src/styles/_tokens.scss
+++ b/logos/logos-ui/src/styles/_tokens.scss
@@ -202,13 +202,13 @@
   --color-surface-50:  30  20  58;
   --color-surface-100: 39  27  75;
 
-  // ── Neutrals: typography (unchanged — already violet) ──
+  // ── Neutrals: typography (violet; 700/900 lifted for contrast on dark) ──
   --color-typography-0:   245 243 255;
   --color-typography-100: 237 233 254;
   --color-typography-300: 221 214 254;
   --color-typography-500: 196 181 253;
-  --color-typography-700: 139 127 170;
-  --color-typography-900: 88  78  120;
+  --color-typography-700: 158 148 194;  // #9E94C2
+  --color-typography-900: 122 111 158;  // #7A6F9E
 
   // ── Neutrals: outlines ──
   --color-outline-100: 255 255 255;
@@ -229,15 +229,16 @@
   --orb-primary: 139 92 246;
   --orb-accent:  99 102 241;
 
-  // ── Opacities (dark values) ──
-  --opacity-faint:         0.04;
+  // ── Opacities (dark values; kept above legibility floor — muted text and
+  //    borders compound with the already-muted violet tones on dark) ──
+  --opacity-faint:         0.06;
   --opacity-soft:          0.12;
-  --opacity-border:        0.18;
-  --opacity-strong:        0.30;
-  --opacity-muted:         0.50;
-  --opacity-surface:       0.05;
-  --opacity-surface-hover: 0.08;
-  --opacity-stroke:        0.10;
+  --opacity-border:        0.25;
+  --opacity-strong:        0.38;
+  --opacity-muted:         0.68;
+  --opacity-surface:       0.08;
+  --opacity-surface-hover: 0.12;
+  --opacity-stroke:        0.16;
   --opacity-overlay:       0.45;
 
   // ── Glass ──

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -190,10 +190,12 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.initial_priority AS initialPriority,
                le.priority_when_scheduled AS priorityWhenScheduled,
                le.queue_depth_at_enqueue AS queueDepthAtEnqueue,
-               le.error_message AS errorMessage
+               le.error_message AS errorMessage,
+               t.name AS teamName
         FROM log_entry le
         LEFT JOIN models m ON m.id = le.model_id
         LEFT JOIN providers p ON p.id = le.provider_id
+        LEFT JOIN teams t ON t.id = le.team_id
         WHERE le.request_id IS NOT NULL
           AND (CAST(:apiKeyId AS INTEGER) IS NULL OR le.api_key_id = CAST(:apiKeyId AS INTEGER))
         ORDER BY le.timestamp_request DESC NULLS LAST
@@ -289,10 +291,12 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.initial_priority AS initialPriority,
                le.priority_when_scheduled AS priorityWhenScheduled,
                le.queue_depth_at_enqueue AS queueDepthAtEnqueue,
-               le.error_message AS errorMessage
+               le.error_message AS errorMessage,
+               t.name AS teamName
         FROM log_entry le
         LEFT JOIN models m ON m.id = le.model_id
         LEFT JOIN providers p ON p.id = le.provider_id
+        LEFT JOIN teams t ON t.id = le.team_id
         WHERE le.request_id IS NOT NULL
           AND le.api_key_id IN (SELECT id FROM api_keys WHERE user_id = :userId)
         ORDER BY le.timestamp_request DESC NULLS LAST

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/PaginatedRequestProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/PaginatedRequestProjection.java
@@ -19,4 +19,5 @@ public interface PaginatedRequestProjection {
     String getPriorityWhenScheduled();
     Integer getQueueDepthAtEnqueue();
     String getErrorMessage();
+    String getTeamName();
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
@@ -148,6 +148,7 @@ public class RequestLogService {
                 m.put("priority_when_scheduled", p.getPriorityWhenScheduled());
                 m.put("queue_depth_at_enqueue", p.getQueueDepthAtEnqueue());
                 m.put("error_message", p.getErrorMessage());
+                m.put("team_name", p.getTeamName());
                 return m;
             })
             .toList();


### PR DESCRIPTION
## Motivation

Closes #668, closes #670. Additionally sets up the deploy pipeline for the new `logos-dev` environment.

## Description

### Statistics page shows who requested (#670)
- The `paginated_requests` query now left-joins `teams` via the denormalized `log_entry.team_id` and returns `team_name` (both the admin and the per-user variant).
- The recent-requests card displays the team next to the provider/cloud badge (with a `pi-users` icon, hidden when no team is attached).
- Live WebSocket overlay rows carry no team info, so `mergeWithLive` preserves the paginated `team_name` the same way it already preserves `is_cloud`.

### Dark mode contrast (#668)
Two root causes:
1. **Compounded muted tokens**: dark mode paired already-muted violet text tones with opacities lower than light mode's, dropping secondary text/labels to ~2:1 contrast. Fix: lift dark `--color-typography-700/900` and the dark opacity floor (`muted` 0.50→0.68, `border` 0.18→0.25, `strong` 0.30→0.38, `faint` 0.04→0.06, glass `surface` 0.05→0.08, `stroke` 0.10→0.16).
2. **`--opacity-stroke` misuse**: it is 0.85 in light but 0.10 (glass border) in dark. The VRAM/request-volume charts used it for nav buttons, the reset button, the area fill, the crosshair, and the tooltip background — all near-invisible in dark mode. These now use the semantically correct theme-stable tokens (`subdued`, `guide`, `chart-minor`, `semi` on `surface-0`).

Light mode is visually unchanged except the chart crosshair (0.85→0.55, intended guide strength).

### Dev deploy environment
- New manual workflow **Logos - Deploy to Dev** (mirror of the test deploy) targeting the GitHub environments `Logos - Dev` (core stack on the logos-dev VM) and `Logos Worker - Dev - hochbruegge`.
- New `logos/docs/deployment.md` documenting all three deploy targets and the vars/secrets each environment needs.
- The two GitHub environments have been created; invariant variables are pre-set, remaining env-specific variables and secrets still need to be configured (see the doc).

## Verification
- `ng build` succeeds (only pre-existing budget warnings); webservice `mvn compile` succeeds.
- Orchestrator pytest suite: 438 passed, 1 xfailed.
- `pre-commit` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request history and statistics now show the team associated with each request when available.
  * Deployment to development environments can now be triggered manually with a selectable image tag.

* **Bug Fixes**
  * Improved live request merging so team information is retained in paginated views.
  * Refined several chart and UI theme values for clearer contrast and smoother readability.

* **Documentation**
  * Added deployment documentation covering environment setup and deployment flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->