### PR TITLE
`Development`: Bump release metadata to v2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ EduTelligence maintains compatibility with different versions of [Artemis](https
 | 9.3.x           | 2.3.x                 | ✅ Stable |
 | 9.4.x           | 2.4.x                 | ✅ Stable |
 | 9.5.x           | 2.5.x                 | ✅ Stable |
+| 9.6.x           | 2.6.x                 | ✅ Stable |
 
 > **Note:** Always ensure you're using compatible versions for optimal integration and functionality.
 

--- a/athena/assessment_module_manager/poetry.lock
+++ b/athena/assessment_module_manager/poetry.lock
@@ -100,7 +100,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/assessment_module_manager/pyproject.toml
+++ b/athena/assessment_module_manager/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "assessment-module-manager"
-version = "2.5"
+version = "2.6"
 description = "The interface between the Athena modules and external systems. It manages, which modules will be used for incoming submissions and feedback."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/athena/pyproject.toml
+++ b/athena/athena/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/docs/package-lock.json
+++ b/athena/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "athena-docs",
-  "version": "2.5",
+  "version": "2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "athena-docs",
-      "version": "2.5",
+      "version": "2.6",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/athena/docs/package.json
+++ b/athena/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-docs",
-  "version": "2.5",
+  "version": "2.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/athena/evaluation/pyproject.toml
+++ b/athena/evaluation/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evaluation"
-version = "2.5"
+version = "2.6"
 description = ""
 authors = ["Dominik Remo <47261058+DominikRemo@users.noreply.github.com>"]
 package-mode = false

--- a/athena/llm_core/poetry.lock
+++ b/athena/llm_core/poetry.lock
@@ -270,7 +270,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/llm_core/pyproject.toml
+++ b/athena/llm_core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llm_core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/log_viewer/pyproject.toml
+++ b/athena/log_viewer/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "log-viewer"
-version = "2.5"
+version = "2.6"
 description = "Shows the logs of the assessment module manager and all modules in a web interface."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/modeling/module_modeling_llm/poetry.lock
+++ b/athena/modules/modeling/module_modeling_llm/poetry.lock
@@ -270,7 +270,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"
@@ -1490,7 +1490,7 @@ files = [
 
 [[package]]
 name = "llm-core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/modeling/module_modeling_llm/pyproject.toml
+++ b/athena/modules/modeling/module_modeling_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_modeling_llm"
-version = "2.5"
+version = "2.6"
 description = "Modeling assessment LLM module."
 authors = ["Matthias Lehner <ga59bip@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_example/poetry.lock
+++ b/athena/modules/programming/module_example/poetry.lock
@@ -100,7 +100,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_example/pyproject.toml
+++ b/athena/modules/programming/module_example/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_example"
-version = "2.5"
+version = "2.6"
 description = "An example module to demonstrate how to create new modules for Athena."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_apted/poetry.lock
+++ b/athena/modules/programming/module_programming_apted/poetry.lock
@@ -124,7 +124,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_programming_apted/pyproject.toml
+++ b/athena/modules/programming/module_programming_apted/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_apted"
-version = "2.5"
+version = "2.6"
 description = "Programming assessment AP-TED module."
 authors = ["Marlon Bucciarelli <marlon.bucciarelli@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_llm/poetry.lock
+++ b/athena/modules/programming/module_programming_llm/poetry.lock
@@ -270,7 +270,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"
@@ -1490,7 +1490,7 @@ files = [
 
 [[package]]
 name = "llm-core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_programming_llm/pyproject.toml
+++ b/athena/modules/programming/module_programming_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_llm"
-version = "2.5"
+version = "2.6"
 description = "Programming assessment LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_quality_llm/poetry.lock
+++ b/athena/modules/programming/module_programming_quality_llm/poetry.lock
@@ -270,7 +270,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"
@@ -1490,7 +1490,7 @@ files = [
 
 [[package]]
 name = "llm-core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_programming_quality_llm/pyproject.toml
+++ b/athena/modules/programming/module_programming_quality_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_quality_llm"
-version = "2.5"
+version = "2.6"
 description = "Programming quality LLM module."
 authors = ["Aniruddh Zaveri <aniruddh.zaveri@tum.de>", "Konrad Weiß <konrad2002.weiss@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_themisml/poetry.lock
+++ b/athena/modules/programming/module_programming_themisml/poetry.lock
@@ -112,7 +112,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_programming_themisml/pyproject.toml
+++ b/athena/modules/programming/module_programming_themisml/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_themisml"
-version = "2.5"
+version = "2.6"
 description = "A module generating feedback suggestions somewhat similar to CoFee, but for programming submissions and by using CodeBERT."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/programming/module_programming_winnowing/poetry.lock
+++ b/athena/modules/programming/module_programming_winnowing/poetry.lock
@@ -112,7 +112,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/programming/module_programming_winnowing/pyproject.toml
+++ b/athena/modules/programming/module_programming_winnowing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_programming_winnowing"
-version = "2.5"
+version = "2.6"
 description = "Programming assessment Winnowing module."
 authors = ["Marlon Bucciarelli <marlon.bucciarelli@tum.de>"]
 license = "MIT"

--- a/athena/modules/text/module_text_cofee/poetry.lock
+++ b/athena/modules/text/module_text_cofee/poetry.lock
@@ -100,7 +100,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/text/module_text_cofee/pyproject.toml
+++ b/athena/modules/text/module_text_cofee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_text_cofee"
-version = "2.5"
+version = "2.6"
 description = "An adapter to the original [Athena](https://github.com/ls1intum/Athena), an implementation of CoFee (text exercise assessment)."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 license = "MIT"

--- a/athena/modules/text/module_text_llm/poetry.lock
+++ b/athena/modules/text/module_text_llm/poetry.lock
@@ -270,7 +270,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"
@@ -1490,7 +1490,7 @@ files = [
 
 [[package]]
 name = "llm-core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 optional = false
 python-versions = "3.11.*"

--- a/athena/modules/text/module_text_llm/pyproject.toml
+++ b/athena/modules/text/module_text_llm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "module_text_llm"
-version = "2.5"
+version = "2.6"
 description = "Text assessment LLM module."
 authors = ["Felix Dietrich <felixtj.dietrich@tum.de>"]
 license = "MIT"

--- a/athena/playground/package-lock.json
+++ b/athena/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playground",
-  "version": "2.5",
+  "version": "2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playground",
-      "version": "2.5",
+      "version": "2.6",
       "dependencies": {
         "@blueprintjs/core": "5.5.1",
         "@fortawesome/fontawesome-svg-core": "6.6.0",

--- a/athena/playground/package.json
+++ b/athena/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playground",
-  "version": "2.5",
+  "version": "2.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/athena/pyproject.toml
+++ b/athena/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 authors = ["Paul Schwind <paul.schwind@tum.de>"]
 package-mode = true

--- a/athena/tests/poetry.lock
+++ b/athena/tests/poetry.lock
@@ -215,7 +215,7 @@ trio = ["trio (>=0.32.0)"]
 
 [[package]]
 name = "assessment-module-manager"
-version = "2.5"
+version = "2.6"
 description = "The interface between the Athena modules and external systems. It manages, which modules will be used for incoming submissions and feedback."
 optional = false
 python-versions = "3.11.*"
@@ -290,7 +290,7 @@ files = [
 
 [[package]]
 name = "athena"
-version = "2.5"
+version = "2.6"
 description = "This is a helper module for easier development of Athena modules. It provides communication functionality with the Assessment Module manager, as well as helper functions for storage."
 optional = false
 python-versions = "3.11.*"
@@ -1510,7 +1510,7 @@ files = [
 
 [[package]]
 name = "llm-core"
-version = "2.5"
+version = "2.6"
 description = "SHared LLM module."
 optional = false
 python-versions = "3.11.*"
@@ -1566,7 +1566,7 @@ files = [
 
 [[package]]
 name = "module-modeling-llm"
-version = "2.5"
+version = "2.6"
 description = "Modeling assessment LLM module."
 optional = false
 python-versions = "3.11.*"
@@ -1586,7 +1586,7 @@ url = "../modules/modeling/module_modeling_llm"
 
 [[package]]
 name = "module-text-llm"
-version = "2.5"
+version = "2.6"
 description = "Text assessment LLM module."
 optional = false
 python-versions = "3.11.*"

--- a/athena/tests/pyproject.toml
+++ b/athena/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "athena-tests"
-version = "2.5"
+version = "2.6"
 description = "Testing environment for the Athena project, orchestrating tests for all modules."
 license = "MIT"
 package-mode = false

--- a/atlas/AtlasMl/pyproject.toml
+++ b/atlas/AtlasMl/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atlasml"
-version = "2.5"
+version = "2.6"
 description = ""
 authors = ["Maximilian Anzinger <anzinger@cit.tum.de>"]
 readme = "README.md"

--- a/atlas/docs/package-lock.json
+++ b/atlas/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs-new",
-  "version": "2.5",
+  "version": "2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs-new",
-      "version": "2.5",
+      "version": "2.6",
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/preset-classic": "3.9.1",

--- a/atlas/docs/package.json
+++ b/atlas/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-new",
-  "version": "2.5",
+  "version": "2.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/iris/docs/package-lock.json
+++ b/iris/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-docs",
-  "version": "2.5",
+  "version": "2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-docs",
-      "version": "2.5",
+      "version": "2.6",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",

--- a/iris/docs/package.json
+++ b/iris/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-docs",
-  "version": "2.5",
+  "version": "2.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/iris/poetry.lock
+++ b/iris/poetry.lock
@@ -2365,7 +2365,7 @@ files = [
 
 [[package]]
 name = "memiris"
-version = "2.5"
+version = "2.6"
 description = ""
 optional = false
 python-versions = ">=3.13,<4.0.0"

--- a/iris/pyproject.toml
+++ b/iris/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iris"
-version = "2.5"
+version = "2.6"
 description = "An LLM microservice for the learning platform Artemis"
 authors = ["Timor Morrien <timor.morrien@tum.de>", "Patrick Bassner <patrick.bassner@tum.de>"]
 readme = "README.md"

--- a/logos/logos-orchestrator/pyproject.toml
+++ b/logos/logos-orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logos"
-version = "2.5"
+version = "2.6"
 description = "Logos is an LLM Engineering Platform that includes usage logging, billing, central resouce management, policy-based model selection, scheduling, and monitoring."
 authors = [
     {name = "Tobias Wasner",email = "tobias.wasner@tum.de"}

--- a/logos/logos-orchestrator/src/logos/sdi/__init__.py
+++ b/logos/logos-orchestrator/src/logos/sdi/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "RequestMetrics",
 ]
 
-__version__ = "2.5"
+__version__ = "2.6"

--- a/logos/logos-orchestrator/uv.lock
+++ b/logos/logos-orchestrator/uv.lock
@@ -1128,7 +1128,7 @@ wheels = [
 
 [[package]]
 name = "logos"
-version = "2.5"
+version = "2.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2421,7 +2421,7 @@ wheels = [
 
 [[package]]
 name = "shared"
-version = "2.5"
+version = "2.6"
 source = { directory = "/Users/tobiaswasner/git/edutelligence/shared" }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },

--- a/logos/logos-ui/package-lock.json
+++ b/logos/logos-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "logos-ui",
-  "version": "2.5",
+  "version": "2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "logos-ui",
-      "version": "2.5",
+      "version": "2.6",
       "dependencies": {
         "@angular/animations": "^21.2.17",
         "@angular/cdk": "^21.2.14",

--- a/logos/logos-ui/package.json
+++ b/logos/logos-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logos-ui",
-  "version": "2.5",
+  "version": "2.6",
   "main": "expo-router/entry",
   "scripts": {
     "ng": "ng",

--- a/memiris/pyproject.toml
+++ b/memiris/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "memiris"
-version = "2.5"
+version = "2.6"
 description = ""
 authors = ["Timor Morrien <timor.morrien@tum.de>"]
 readme = "README.MD"

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shared"
-version = "2.5"
+version = "2.6"
 description = "Shared python library for EduTelligence"
 authors = [
     { name = "Felix T.J. Dietrich", email = "felixtj.dietrich@tum.de" },


### PR DESCRIPTION
## Summary

- add the Artemis 9.6.x to EduTelligence 2.6.x compatibility mapping
- bump repository-local package and lock metadata from 2.5 to 2.6
- keep the historical v2.6 tag fixed at the Artemis 9.6 compatibility cutoff

Release: https://github.com/ls1intum/edutelligence/releases/tag/v2.6

## Validation

- all repository pre-commit hooks passed for Iris, Athena, Memiris, and Logos
- all changed TOML and JSON files parse successfully
- Poetry lock checks passed for every changed Poetry lock
- npm package-lock dry runs passed for all five changed npm packages
- package manifests and lock roots agree on version 2.6
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the platform release to version **2.6** across its components and packages.
  - Added stable compatibility information for **Artemis 9.6.x** with **EduTelligence 2.6.x**.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->