### PR TITLE
`Logos`: Update vLLM to v0.25.1

### DIFF
--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -37,7 +37,7 @@
 ARG BASE_IMAGE=python:3.12-slim
 ARG RUNTIME_IMAGE=${BASE_IMAGE}
 ARG INSTALL_VLLM=0
-ARG VLLM_PIP_SPEC="vllm==v0.24.0"
+ARG VLLM_PIP_SPEC="vllm==v0.25.1"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.


### PR DESCRIPTION
## Motivation

Keep the workernode's inference stack current: bump the default vLLM pin from v0.24.0 to v0.25.1 (latest PyPI release).

## Description

Updates the `VLLM_PIP_SPEC` build arg default in `logos/logos-workernode/Dockerfile` from `vllm==v0.24.0` to `vllm==v0.25.1`. This is the only place the version is pinned; torch and FlashInfer are resolved from vLLM's own dependency pins at build time, so no other changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled vLLM version to 0.25.1.
  * No other build or runtime behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->