### PR TITLE
`Logos`: Show requesting user or application environment in recent requests

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
@@ -45,6 +45,15 @@
                   <i class="pi pi-users" aria-hidden="true"></i>{{ item.team_name }}
                 </span>
               }
+              @if (item.username) {
+                <span class="rr-card__requester" title="Requesting user">
+                  <i class="pi pi-user" aria-hidden="true"></i>{{ item.username }}
+                </span>
+              } @else if (item.environment) {
+                <span class="rr-card__requester" title="Application environment">
+                  <i class="pi pi-tag" aria-hidden="true"></i>{{ item.environment }}
+                </span>
+              }
             </div>
             @if (stageOf(item) === 'complete' && item.status === 'error' && item.error_message) {
               <div class="rr-card__error-snippet">{{ errorSnippet(item.error_message) }}</div>

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.scss
@@ -118,7 +118,8 @@
   text-overflow: ellipsis;
 }
 
-.rr-card__team {
+.rr-card__team,
+.rr-card__requester {
   display: inline-flex;
   align-items: center;
   gap: 4px;

--- a/logos/logos-ui/src/app/features/statistics/statistics.models.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.models.ts
@@ -134,6 +134,8 @@ export type PaginatedRequestItem = {
   queue_depth_at_enqueue: number | null;
   error_message: string | null;
   team_name: string | null;
+  username: string | null;
+  environment: string | null;
 };
 
 // PaginatedRequestResponse from logos-ui-old/components/statistics/types.ts

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -68,8 +68,10 @@ export function mergeWithLive(
     priority_when_scheduled: r.priority_when_scheduled,
     queue_depth_at_enqueue: r.queue_depth_at_enqueue,
     error_message: r.error_message,
-    // the live WS payload carries no team info — pageData does.
+    // the live WS payload carries no requester info — pageData does.
     team_name: null,
+    username: null,
+    environment: null,
   });
 
   const liveById = new Map<string, PaginatedRequestItem>();
@@ -82,13 +84,15 @@ export function mergeWithLive(
   for (const p of pageItems) {
     const overlay = liveById.get(p.request_id);
     if (overlay) {
-      // Preserve the paginated `is_cloud` flag and `team_name` (the WS
-      // payload has to infer/omit them); take everything else from
-      // the live row so state transitions render immediately.
+      // Preserve the paginated `is_cloud` flag and the requester fields
+      // (the WS payload has to infer/omit them); take everything else
+      // from the live row so state transitions render immediately.
       merged.push({
         ...overlay,
         is_cloud: p.is_cloud ?? overlay.is_cloud,
         team_name: p.team_name ?? overlay.team_name,
+        username: p.username ?? overlay.username,
+        environment: p.environment ?? overlay.environment,
       });
     } else {
       merged.push(p);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -191,11 +191,14 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.priority_when_scheduled AS priorityWhenScheduled,
                le.queue_depth_at_enqueue AS queueDepthAtEnqueue,
                le.error_message AS errorMessage,
-               t.name AS teamName
+               t.name AS teamName,
+               u.username AS username,
+               le.environment AS environment
         FROM log_entry le
         LEFT JOIN models m ON m.id = le.model_id
         LEFT JOIN providers p ON p.id = le.provider_id
         LEFT JOIN teams t ON t.id = le.team_id
+        LEFT JOIN users u ON u.id = le.user_id
         WHERE le.request_id IS NOT NULL
           AND (CAST(:apiKeyId AS INTEGER) IS NULL OR le.api_key_id = CAST(:apiKeyId AS INTEGER))
         ORDER BY le.timestamp_request DESC NULLS LAST
@@ -292,11 +295,14 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.priority_when_scheduled AS priorityWhenScheduled,
                le.queue_depth_at_enqueue AS queueDepthAtEnqueue,
                le.error_message AS errorMessage,
-               t.name AS teamName
+               t.name AS teamName,
+               u.username AS username,
+               le.environment AS environment
         FROM log_entry le
         LEFT JOIN models m ON m.id = le.model_id
         LEFT JOIN providers p ON p.id = le.provider_id
         LEFT JOIN teams t ON t.id = le.team_id
+        LEFT JOIN users u ON u.id = le.user_id
         WHERE le.request_id IS NOT NULL
           AND le.api_key_id IN (SELECT id FROM api_keys WHERE user_id = :userId)
         ORDER BY le.timestamp_request DESC NULLS LAST

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/PaginatedRequestProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/PaginatedRequestProjection.java
@@ -20,4 +20,6 @@ public interface PaginatedRequestProjection {
     Integer getQueueDepthAtEnqueue();
     String getErrorMessage();
     String getTeamName();
+    String getUsername();
+    String getEnvironment();
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
@@ -149,6 +149,8 @@ public class RequestLogService {
                 m.put("queue_depth_at_enqueue", p.getQueueDepthAtEnqueue());
                 m.put("error_message", p.getErrorMessage());
                 m.put("team_name", p.getTeamName());
+                m.put("username", p.getUsername());
+                m.put("environment", p.getEnvironment());
                 return m;
             })
             .toList();

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogControllerTest.java
@@ -130,6 +130,13 @@ class RequestLogControllerTest {
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.total").value(2))
            .andExpect(jsonPath("$.requests.length()").value(2))
-           .andExpect(jsonPath("$.requests[0].request_id").value("req-bbb-222"));
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-bbb-222"))
+           // application-key-style request: environment set, no user
+           .andExpect(jsonPath("$.requests[0].username").isEmpty())
+           .andExpect(jsonPath("$.requests[0].environment").value("production"))
+           // developer-key request: username set, no environment
+           .andExpect(jsonPath("$.requests[1].request_id").value("req-aaa-111"))
+           .andExpect(jsonPath("$.requests[1].username").value("testuser"))
+           .andExpect(jsonPath("$.requests[1].environment").isEmpty());
     }
 }

--- a/logos/logos-webservice/src/test/resources/sql/seed-operations.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-operations.sql
@@ -1,13 +1,15 @@
 INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
                        timestamp_request, timestamp_forwarding, timestamp_response,
-                       was_cold_start, queue_depth_at_enqueue)
+                       was_cold_start, queue_depth_at_enqueue, user_id, environment)
 VALUES
+  -- developer-key request: carries the requesting user, no environment
   (9001, 'req-aaa-111', 3001, 5001, 6001, 'success',
    NOW() - INTERVAL '10 minutes', NOW() - INTERVAL '9 minutes', NOW() - INTERVAL '8 minutes',
-   false, 1),
+   false, 1, 1001, NULL),
+  -- application-key-style request: carries the environment, no user
   (9002, 'req-bbb-222', 3001, 5001, 6001, 'success',
    NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes', NOW() - INTERVAL '3 minutes',
-   true, 0);
+   true, 0, NULL, 'production');
 
 INSERT INTO ollama_provider_snapshots
   (id, provider_id, snapshot_ts, poll_success,


### PR DESCRIPTION
## Problem

The **Recent requests** section on the statistics page attributes each request only to a **team**. When several people (or an app deployment) share a team, you can't tell who — or which environment — actually made a request.

## Change

Each request card now additionally shows **who** made the request:

- **Developer key** → the requesting user's **username** (`pi-user` icon),
- **Application key** → the key's **application environment** (`pi-tag` icon), shown when no username is available.

### Backend (`logos-webservice`)
- `findPaginatedRequests` / `findPaginatedRequestsByUser`: `LEFT JOIN users` on the denormalized `log_entry.user_id` and select `log_entry.environment` (both are stamped on the log entry at request time from the resolved api key).
- `PaginatedRequestProjection` + `RequestLogService`: expose `username` and `environment` in the `/logosdb/paginated_requests` response.

### Frontend (`logos-ui`)
- `PaginatedRequestItem` gains `username` / `environment`.
- The request card renders the requester next to the team badge; live WebSocket rows carry no requester info, so `mergeWithLive` preserves the paginated values on overlay (same treatment as `team_name`).

## Validation

- Full `logos-webservice` suite: **195 tests, 0 failures** (testcontainers). `RequestLogControllerTest` extended: seed now contains one developer-key request (user, no environment) and one application-key-style request (environment, no user), asserted through the endpoint.
- `logos-ui`: `npm run build` succeeds (only pre-existing budget warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent requests now show the requester’s username when available.
  * Requests without a username display their environment instead.
  * Request details now retain requester and environment information across paginated and live results.

* **Bug Fixes**
  * Improved consistency of requester information in request lists and merged results.

* **Tests**
  * Expanded coverage for usernames and environments in paginated request results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->