### PR TITLE
`Logos`: Updated read me to better start logos and logos-ui locally

### DIFF
--- a/logos/README.md
+++ b/logos/README.md
@@ -113,19 +113,7 @@ To deploy Logos locally:
    git clone https://github.com/ls1intum/edutelligence/
    ```
 
-2. Insert initial Provider Configuration
-
-   In docker-compose.dev.yaml, adjust the environment section of the logos-orchestrator
-   container to specify the initial LLM provider that Logos should connect to after startup.
-
-   Example Configuration:
-      ```
-       environment:
-         PROVIDER_NAME: azure
-         BASE_URL: https://ase-se01.openai.azure.com/openai/deployments/
-      ```
-
-3. Build and Run Logos
+2. Build and Run Logos Docker Container
 
    From the `logos/` directory:
 
@@ -133,11 +121,18 @@ To deploy Logos locally:
    docker compose -f docker-compose.dev.yaml up --build
    ```
 
-4. Log In
+    From the `logos/logos-ui/` directory:
+
+   ```bash
+   cd logos-ui/
+   ng serve
+   ```
+
+3. Log In
 
    Once running, open the UI at:
    ```
-   http://localhost:18081/
+   http://localhost:4200/
    ```
    and click **Sign in**. You'll be redirected to the local Keycloak instance
    (seeded from `keycloak/tum-realm.json`) to log in. A handful of dev accounts
@@ -171,7 +166,7 @@ To deploy Logos locally:
    To add more dev accounts, edit `keycloak/tum-realm.json` and restart the
    `keycloak` container.
 
-5. Explore the API
+4. Explore the API
 
    A full overview of available endpoints can be found at: https://logos.aet.cit.tum.de/docs
 

--- a/logos/docker-compose.dev.yaml
+++ b/logos/docker-compose.dev.yaml
@@ -297,27 +297,6 @@ services:
     networks:
       - internal
 
-  logos-ui:
-    build:
-      context: ./logos-ui
-    container_name: logos-ui
-    restart: unless-stopped
-    expose:
-      - "80"
-    labels:
-      - "traefik.enable=true"
-
-      # === UI routing (HTTP, no TLS) ===
-      - "traefik.http.routers.internal-ui.rule=Host(`${LOGOS_DOMAIN:-localhost}`) && PathPrefix(`/`)"
-      - "traefik.http.routers.internal-ui.entrypoints=web8080"
-      - "traefik.http.routers.internal-ui.service=internal-ui-svc"
-      - "traefik.http.routers.internal-ui.priority=0"
-
-      # Shared service definition
-      - "traefik.http.services.internal-ui-svc.loadbalancer.server.port=80"
-    networks:
-      - internal
-
 volumes:
   data_volume:
   postgres_data:

--- a/logos/logos-ui/angular.json
+++ b/logos/logos-ui/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {


### PR DESCRIPTION
directory logos/README.md → scroll to "## Running the Service (Development)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development instructions to start the service and UI separately.
  * Changed the development UI address to `http://localhost:4200/`.
  * Renumbered the API exploration step.

* **Chores**
  * Disabled Angular CLI analytics for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->