### PR TITLE
`Logos`: Update vLLM to v0.26.0

### DIFF
--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -65,7 +65,7 @@
 
 ARG BASE_IMAGE=python:3.12-slim
 ARG INSTALL_VLLM=0
-ARG VLLM_PIP_SPEC="vllm==v0.25.1"
+ARG VLLM_PIP_SPEC="vllm==v0.26.0"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.


### PR DESCRIPTION
## Motivation

Keep the workernode's inference stack current: bump the default vLLM pin to [v0.26.0](https://github.com/vllm-project/vllm/releases/tag/v0.26.0).

## Description

Updates the `VLLM_PIP_SPEC` build arg default in `logos/logos-workernode/Dockerfile` to `vllm==v0.26.0`. Torch and FlashInfer are resolved from vLLM's own dependency pins at build time, so no other changes are needed.

---
*This PR was created automatically by the `Logos - Update vLLM` workflow.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled vLLM runtime to version 0.26.0 for applicable worker node builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->