### PR TITLE
`Iris`: Retry rate-limited Weaviate visibility updates

### DIFF
--- a/iris/src/iris/pipeline/lecture_visibility_update_pipeline.py
+++ b/iris/src/iris/pipeline/lecture_visibility_update_pipeline.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -15,6 +16,7 @@ from iris.vector_database.lecture_unit_page_chunk_schema import (
 )
 from iris.vector_database.lecture_unit_schema import LectureUnitSchema
 from iris.vector_database.lecture_unit_segment_schema import LectureUnitSegmentSchema
+from iris.vector_database.write_retry import WeaviateWriteRetry
 
 
 @dataclass(frozen=True)
@@ -32,14 +34,19 @@ class LectureVisibilityUpdatePipeline:
         page_chunk_collection: Collection,
         lecture_unit_collection: Collection,
         lecture_unit_segment_collection: Collection,
+        write_retry_factory: Callable[
+            [], WeaviateWriteRetry
+        ] = WeaviateWriteRetry.for_request,
     ):
         self.page_chunk_collection = page_chunk_collection
         self.lecture_unit_collection = lecture_unit_collection
         self.lecture_unit_segment_collection = lecture_unit_segment_collection
+        self.write_retry_factory = write_retry_factory
 
     def __call__(
         self, dto: LectureUnitVisibilityUpdateDTO
     ) -> LectureVisibilityUpdateResult:
+        write_retry = self.write_retry_factory()
         with batch_update_lock:
             units = self._find_units(dto)
             if not units:
@@ -54,6 +61,7 @@ class LectureVisibilityUpdatePipeline:
                     ),
                     LectureUnitSchema.SLIDE_VISIBILITY.value: snapshot,
                 },
+                write_retry,
             )
             page_count = 0
             segment_count = 0
@@ -63,15 +71,19 @@ class LectureVisibilityUpdatePipeline:
                     LectureUnitPageChunkSchema,
                     dto,
                     slide,
+                    write_retry,
                 )
                 segment_count += self._update_slide_visibility(
                     self.lecture_unit_segment_collection,
                     LectureUnitSegmentSchema,
                     dto,
                     slide,
+                    write_retry,
                 )
             self._update_units(
-                units, {LectureUnitSchema.RELEASE_DATE.value: dto.release_date}
+                units,
+                {LectureUnitSchema.RELEASE_DATE.value: dto.release_date},
+                write_retry,
             )
         return LectureVisibilityUpdateResult(len(units), page_count, segment_count)
 
@@ -109,9 +121,15 @@ class LectureVisibilityUpdatePipeline:
             limit=100,
         ).objects
 
-    def _update_units(self, units, properties: dict) -> None:
+    def _update_units(
+        self,
+        units,
+        properties: dict,
+        write_retry: WeaviateWriteRetry,
+    ) -> None:
         for obj in units:
-            self.lecture_unit_collection.data.update(
+            write_retry.update(
+                self.lecture_unit_collection,
                 uuid=str(obj.uuid),
                 properties=properties,
             )
@@ -122,13 +140,15 @@ class LectureVisibilityUpdatePipeline:
         schema: type[LectureUnitPageChunkSchema] | type[LectureUnitSegmentSchema],
         dto: LectureUnitVisibilityUpdateDTO,
         slide: SlideVisibilityDTO,
+        write_retry: WeaviateWriteRetry,
     ) -> int:
         objects = collection.query.fetch_objects(
             filters=LectureVisibilityUpdatePipeline._slide_filter(schema, dto, slide),
             limit=10_000,
         ).objects
         for obj in objects:
-            collection.data.update(
+            write_retry.update(
+                collection,
                 uuid=str(obj.uuid),
                 properties={schema.HIDDEN_UNTIL.value: slide.hidden_until},
             )

--- a/iris/src/iris/tracing/langfuse_tracer.py
+++ b/iris/src/iris/tracing/langfuse_tracer.py
@@ -380,16 +380,17 @@ def observe(
             if not langfuse_mod or not _is_enabled():
                 return func(*args, **kwargs)
 
-            # Delegate to LangFuse's observe decorator
+            # Only fall back when tracing setup fails. Business exceptions from the
+            # observed call must propagate without executing the function twice.
             try:
                 langfuse_observe = langfuse_mod.observe
                 observed_func = langfuse_observe(name=name, as_type=as_type)(func)
-                return observed_func(*args, **kwargs)
             except Exception as e:
                 logger.debug(
                     "LangFuse observe failed, executing without tracing: %s", e
                 )
                 return func(*args, **kwargs)
+            return observed_func(*args, **kwargs)
 
         return wrapper  # type: ignore
 

--- a/iris/src/iris/vector_database/write_retry.py
+++ b/iris/src/iris/vector_database/write_retry.py
@@ -1,8 +1,7 @@
 import random
-import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from typing import NoReturn
 
 from weaviate.collections import Collection
 from weaviate.exceptions import UnexpectedStatusCodeError
@@ -11,10 +10,10 @@ from iris.common.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-REQUEST_TIMEOUT_SECONDS = 8.0
+MAX_RETRY_WAIT_SECONDS = 8.0
 MAX_WRITE_ATTEMPTS = 6
-INITIAL_RETRY_DELAY_SECONDS = 0.05
-MAX_RETRY_DELAY_SECONDS = 1.0
+INITIAL_RETRY_DELAY_SECONDS = 0.25
+MAX_RETRY_DELAY_SECONDS = 4.0
 
 
 class WeaviateRateLimitExhausted(RuntimeError):
@@ -23,7 +22,7 @@ class WeaviateRateLimitExhausted(RuntimeError):
     def __init__(
         self,
         attempts: int,
-        last_error: UnexpectedStatusCodeError | None = None,
+        last_error: UnexpectedStatusCodeError,
     ):
         super().__init__(
             f"Weaviate remained rate-limited after {attempts} write attempt(s)"
@@ -32,62 +31,34 @@ class WeaviateRateLimitExhausted(RuntimeError):
         self.last_error = last_error
 
 
-@dataclass
-class WeaviateRateLimitGate:
-    """Share a short Weaviate cooldown between request threads in this process."""
-
-    _cooldown_until: float = 0.0
-    _lock: threading.Lock = field(default_factory=threading.Lock)
-
-    def remaining_delay(self, now: float) -> float:
-        with self._lock:
-            return max(0.0, self._cooldown_until - now)
-
-    def extend(self, until: float) -> None:
-        with self._lock:
-            self._cooldown_until = max(self._cooldown_until, until)
-
-
-_shared_rate_limit_gate = WeaviateRateLimitGate()
-
-
 class WeaviateWriteRetry:
-    """Retry idempotent Weaviate updates within one shared request deadline."""
+    """Retry idempotent Weaviate updates within one shared wait budget."""
 
     def __init__(
         self,
         *,
-        deadline: float,
-        clock: Callable[[], float] = time.monotonic,
+        retry_wait_budget: float = MAX_RETRY_WAIT_SECONDS,
         sleep: Callable[[float], None] = time.sleep,
         jitter: Callable[[float, float], float] = random.uniform,
-        gate: WeaviateRateLimitGate = _shared_rate_limit_gate,
     ):
-        self.deadline = deadline
-        self.clock = clock
+        self.remaining_retry_wait = retry_wait_budget
         self.sleep = sleep
         self.jitter = jitter
-        self.gate = gate
 
     @classmethod
     def for_request(cls) -> "WeaviateWriteRetry":
-        """Create a retry context with one deadline for the complete request."""
-        return cls(deadline=time.monotonic() + REQUEST_TIMEOUT_SECONDS)
+        """Create one retry context for the complete visibility request."""
+        return cls()
 
     def update(self, collection: Collection, *, uuid: str, properties: dict) -> None:
         """Update one object, waiting briefly when Weaviate returns HTTP 429."""
-        last_error: UnexpectedStatusCodeError | None = None
-
         for attempt in range(1, MAX_WRITE_ATTEMPTS + 1):
-            self._wait_for_shared_cooldown(last_error, attempt - 1)
             try:
                 collection.data.update(uuid=uuid, properties=properties)
                 return
             except UnexpectedStatusCodeError as error:
                 if error.status_code != 429:
                     raise
-                last_error = error
-
                 if attempt == MAX_WRITE_ATTEMPTS:
                     self._raise_exhausted(attempt, error)
 
@@ -95,39 +66,28 @@ class WeaviateWriteRetry:
                     MAX_RETRY_DELAY_SECONDS,
                     INITIAL_RETRY_DELAY_SECONDS * (2 ** (attempt - 1)),
                 )
-                retry_delay = self.jitter(0.0, retry_limit)
-                self.gate.extend(self.clock() + retry_delay)
+                retry_delay = self.jitter(retry_limit / 2, retry_limit)
+                retry_delay = min(retry_limit, max(retry_limit / 2, retry_delay))
+                if retry_delay > self.remaining_retry_wait:
+                    self._raise_exhausted(attempt, error)
+
+                self.remaining_retry_wait -= retry_delay
                 logger.warning(
                     "Weaviate rate-limited an object update; retrying | "
-                    "attempt=%s max_attempts=%s retry_in_ms=%s",
+                    "attempt=%s max_attempts=%s retry_in_ms=%s "
+                    "remaining_wait_ms=%s",
                     attempt,
                     MAX_WRITE_ATTEMPTS,
                     round(retry_delay * 1000),
+                    round(self.remaining_retry_wait * 1000),
                 )
+                self.sleep(retry_delay)
 
         raise AssertionError("Weaviate retry loop exited unexpectedly")
-
-    def _wait_for_shared_cooldown(
-        self,
-        last_error: UnexpectedStatusCodeError | None,
-        attempts: int,
-    ) -> None:
-        now = self.clock()
-        if last_error is not None and now >= self.deadline:
-            self._raise_exhausted(attempts, last_error)
-        delay = self.gate.remaining_delay(now)
-        if delay <= 0:
-            return
-        if now + delay >= self.deadline:
-            self._raise_exhausted(attempts, last_error)
-        self.sleep(delay)
 
     @staticmethod
     def _raise_exhausted(
         attempts: int,
-        last_error: UnexpectedStatusCodeError | None,
-    ) -> None:
-        exhausted = WeaviateRateLimitExhausted(attempts, last_error)
-        if last_error is None:
-            raise exhausted
-        raise exhausted from last_error
+        last_error: UnexpectedStatusCodeError,
+    ) -> NoReturn:
+        raise WeaviateRateLimitExhausted(attempts, last_error) from last_error

--- a/iris/src/iris/vector_database/write_retry.py
+++ b/iris/src/iris/vector_database/write_retry.py
@@ -1,0 +1,133 @@
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from weaviate.collections import Collection
+from weaviate.exceptions import UnexpectedStatusCodeError
+
+from iris.common.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 8.0
+MAX_WRITE_ATTEMPTS = 6
+INITIAL_RETRY_DELAY_SECONDS = 0.05
+MAX_RETRY_DELAY_SECONDS = 1.0
+
+
+class WeaviateRateLimitExhausted(RuntimeError):
+    """Raised when a Weaviate write stays rate-limited past its retry budget."""
+
+    def __init__(
+        self,
+        attempts: int,
+        last_error: UnexpectedStatusCodeError | None = None,
+    ):
+        super().__init__(
+            f"Weaviate remained rate-limited after {attempts} write attempt(s)"
+        )
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+@dataclass
+class WeaviateRateLimitGate:
+    """Share a short Weaviate cooldown between request threads in this process."""
+
+    _cooldown_until: float = 0.0
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def remaining_delay(self, now: float) -> float:
+        with self._lock:
+            return max(0.0, self._cooldown_until - now)
+
+    def extend(self, until: float) -> None:
+        with self._lock:
+            self._cooldown_until = max(self._cooldown_until, until)
+
+
+_shared_rate_limit_gate = WeaviateRateLimitGate()
+
+
+class WeaviateWriteRetry:
+    """Retry idempotent Weaviate updates within one shared request deadline."""
+
+    def __init__(
+        self,
+        *,
+        deadline: float,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        jitter: Callable[[float, float], float] = random.uniform,
+        gate: WeaviateRateLimitGate = _shared_rate_limit_gate,
+    ):
+        self.deadline = deadline
+        self.clock = clock
+        self.sleep = sleep
+        self.jitter = jitter
+        self.gate = gate
+
+    @classmethod
+    def for_request(cls) -> "WeaviateWriteRetry":
+        """Create a retry context with one deadline for the complete request."""
+        return cls(deadline=time.monotonic() + REQUEST_TIMEOUT_SECONDS)
+
+    def update(self, collection: Collection, *, uuid: str, properties: dict) -> None:
+        """Update one object, waiting briefly when Weaviate returns HTTP 429."""
+        last_error: UnexpectedStatusCodeError | None = None
+
+        for attempt in range(1, MAX_WRITE_ATTEMPTS + 1):
+            self._wait_for_shared_cooldown(last_error, attempt - 1)
+            try:
+                collection.data.update(uuid=uuid, properties=properties)
+                return
+            except UnexpectedStatusCodeError as error:
+                if error.status_code != 429:
+                    raise
+                last_error = error
+
+                if attempt == MAX_WRITE_ATTEMPTS:
+                    self._raise_exhausted(attempt, error)
+
+                retry_limit = min(
+                    MAX_RETRY_DELAY_SECONDS,
+                    INITIAL_RETRY_DELAY_SECONDS * (2 ** (attempt - 1)),
+                )
+                retry_delay = self.jitter(0.0, retry_limit)
+                self.gate.extend(self.clock() + retry_delay)
+                logger.warning(
+                    "Weaviate rate-limited an object update; retrying | "
+                    "attempt=%s max_attempts=%s retry_in_ms=%s",
+                    attempt,
+                    MAX_WRITE_ATTEMPTS,
+                    round(retry_delay * 1000),
+                )
+
+        raise AssertionError("Weaviate retry loop exited unexpectedly")
+
+    def _wait_for_shared_cooldown(
+        self,
+        last_error: UnexpectedStatusCodeError | None,
+        attempts: int,
+    ) -> None:
+        now = self.clock()
+        if last_error is not None and now >= self.deadline:
+            self._raise_exhausted(attempts, last_error)
+        delay = self.gate.remaining_delay(now)
+        if delay <= 0:
+            return
+        if now + delay >= self.deadline:
+            self._raise_exhausted(attempts, last_error)
+        self.sleep(delay)
+
+    @staticmethod
+    def _raise_exhausted(
+        attempts: int,
+        last_error: UnexpectedStatusCodeError | None,
+    ) -> None:
+        exhausted = WeaviateRateLimitExhausted(attempts, last_error)
+        if last_error is None:
+            raise exhausted
+        raise exhausted from last_error

--- a/iris/src/iris/web/routers/webhooks.py
+++ b/iris/src/iris/web/routers/webhooks.py
@@ -31,6 +31,7 @@ from iris.vector_database.lecture_unit_schema import init_lecture_unit_schema
 from iris.vector_database.lecture_unit_segment_schema import (
     init_lecture_unit_segment_schema,
 )
+from iris.vector_database.write_retry import WeaviateRateLimitExhausted
 from iris.web.utils import validate_pipeline_variant
 
 from ...domain.ingestion.deletion_pipeline_execution_dto import (
@@ -228,23 +229,40 @@ def lecture_metadata_webhook(dto: LectureUnitMetadataUpdateDTO):
     responses={
         status.HTTP_404_NOT_FOUND: {
             "description": "Lecture unit has not been ingested",
-        }
+        },
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "description": "Weaviate remained rate-limited past the request budget",
+        },
     },
     dependencies=[Depends(TokenValidator())],
 )
 @observe(name="POST /webhooks/lectures/visibility")
 def lecture_visibility_webhook(dto: LectureUnitVisibilityUpdateDTO):
     """Update release and slide visibility without reprocessing content."""
-    with lecture_update_lock(
-        dto.base_url, dto.course_id, dto.lecture_id, dto.lecture_unit_id
-    ):
-        db = VectorDatabase()
-        client = db.get_client()
-        result = LectureVisibilityUpdatePipeline(
-            init_lecture_unit_page_chunk_schema(client),
-            init_lecture_unit_schema(client),
-            init_lecture_unit_segment_schema(client),
-        )(dto)
+    try:
+        with lecture_update_lock(
+            dto.base_url, dto.course_id, dto.lecture_id, dto.lecture_unit_id
+        ):
+            db = VectorDatabase()
+            client = db.get_client()
+            result = LectureVisibilityUpdatePipeline(
+                init_lecture_unit_page_chunk_schema(client),
+                init_lecture_unit_schema(client),
+                init_lecture_unit_segment_schema(client),
+            )(dto)
+    except WeaviateRateLimitExhausted as error:
+        logger.error(
+            "Weaviate remained rate-limited during a lecture visibility update | "
+            "lecture_unit_id=%s attempts=%s",
+            dto.lecture_unit_id,
+            error.attempts,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "errorMessage": "Weaviate is temporarily rate-limited; retry later"
+            },
+        ) from error
     if result.lecture_units_updated == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/iris/tests/test_langfuse_tracer.py
+++ b/iris/tests/test_langfuse_tracer.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from iris.tracing.langfuse_tracer import observe
+
+
+def test_observe_does_not_execute_business_function_twice_after_error():
+    business_function = Mock(side_effect=RuntimeError("business error"))
+    langfuse = SimpleNamespace(
+        observe=lambda **_kwargs: lambda function: function,
+    )
+
+    with (
+        patch(
+            "iris.tracing.langfuse_tracer._get_langfuse_module",
+            return_value=langfuse,
+        ),
+        patch("iris.tracing.langfuse_tracer._is_enabled", return_value=True),
+    ):
+        observed = observe()(business_function)
+
+        with pytest.raises(RuntimeError, match="business error"):
+            observed()
+
+    business_function.assert_called_once_with()
+
+
+def test_observe_falls_back_once_when_tracing_setup_fails():
+    business_function = Mock(return_value="result")
+    langfuse = SimpleNamespace(observe=Mock(side_effect=RuntimeError("setup error")))
+
+    with (
+        patch(
+            "iris.tracing.langfuse_tracer._get_langfuse_module",
+            return_value=langfuse,
+        ),
+        patch("iris.tracing.langfuse_tracer._is_enabled", return_value=True),
+    ):
+        observed = observe()(business_function)
+
+        assert observed() == "result"
+
+    business_function.assert_called_once_with()

--- a/iris/tests/test_lecture_visibility_update_pipeline.py
+++ b/iris/tests/test_lecture_visibility_update_pipeline.py
@@ -7,12 +7,13 @@ from threading import Event, Thread
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 from weaviate.classes.config import Property
 from weaviate.collections.classes.config import DataType
-from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateInvalidInputError
 
 from iris.domain.ingestion.lecture_visibility_update_dto import (
     LectureUnitVisibilityUpdateDTO,
@@ -39,6 +40,11 @@ from iris.vector_database.lecture_unit_segment_schema import (
     LectureUnitSegmentSchema,
     init_lecture_unit_segment_schema,
 )
+from iris.vector_database.write_retry import (
+    WeaviateRateLimitExhausted,
+    WeaviateRateLimitGate,
+    WeaviateWriteRetry,
+)
 from iris.web.routers.webhooks import lecture_visibility_webhook
 
 
@@ -58,6 +64,14 @@ def visibility_dto() -> LectureUnitVisibilityUpdateDTO:
             ],
         }
     )
+
+
+def rate_limit_error() -> UnexpectedStatusCodeError:
+    response = httpx.Response(
+        429,
+        request=httpx.Request("PATCH", "https://weaviate.example/v1/objects/id"),
+    )
+    return UnexpectedStatusCodeError("Object was not updated", response)
 
 
 def test_visibility_update_dto_accepts_artemis_aliases():
@@ -90,6 +104,9 @@ def test_visibility_webhook_route_documents_missing_ingestion():
     route = next(route for route in router.routes if route.path.endswith("/visibility"))
 
     assert route.responses[404]["description"] == "Lecture unit has not been ingested"
+    assert route.responses[503]["description"] == (
+        "Weaviate remained rate-limited past the request budget"
+    )
 
 
 def test_visibility_schema_fields_are_defined():
@@ -276,6 +293,82 @@ def test_visibility_pipeline_keeps_unit_denied_when_slide_update_fails():
     with pytest.raises(RuntimeError, match="Weaviate write failed"):
         LectureVisibilityUpdatePipeline(
             page_collection, unit_collection, segment_collection
+        )(visibility_dto())
+
+    assert unit_collection.data.update.call_count == 1
+    assert unit_collection.data.update.call_args.kwargs["properties"][
+        LectureUnitSchema.RELEASE_DATE.value
+    ] == datetime.max.replace(tzinfo=timezone.utc)
+
+
+def test_visibility_pipeline_retries_rate_limited_final_parent_update():
+    unit_collection = Mock()
+    unit_collection.query.fetch_objects.return_value.objects = [
+        SimpleNamespace(uuid="unit-uuid")
+    ]
+    unit_collection.data.update.side_effect = [None, rate_limit_error(), None]
+    page_collection = Mock()
+    page_collection.query.fetch_objects.return_value.objects = []
+    segment_collection = Mock()
+    segment_collection.query.fetch_objects.return_value.objects = []
+    now = [0.0]
+    sleeps = []
+
+    def sleep(delay):
+        sleeps.append(delay)
+        now[0] += delay
+
+    writer = WeaviateWriteRetry(
+        deadline=8.0,
+        clock=lambda: now[0],
+        sleep=sleep,
+        jitter=lambda _lower, upper: upper,
+        gate=WeaviateRateLimitGate(),
+    )
+
+    result = LectureVisibilityUpdatePipeline(
+        page_collection,
+        unit_collection,
+        segment_collection,
+        write_retry_factory=lambda: writer,
+    )(visibility_dto())
+
+    assert result.lecture_units_updated == 1
+    assert unit_collection.data.update.call_count == 3
+    assert sleeps == pytest.approx([0.05])
+    assert unit_collection.data.update.call_args.kwargs["properties"] == {
+        LectureUnitSchema.RELEASE_DATE.value: datetime(
+            2026, 7, 4, 12, 0, tzinfo=timezone.utc
+        )
+    }
+
+
+def test_visibility_pipeline_keeps_parent_barrier_after_rate_limit_exhaustion():
+    unit_collection = Mock()
+    unit_collection.query.fetch_objects.return_value.objects = [
+        SimpleNamespace(uuid="unit-uuid")
+    ]
+    page_collection = Mock()
+    page_collection.query.fetch_objects.return_value.objects = [
+        SimpleNamespace(uuid="page-uuid")
+    ]
+    page_collection.data.update.side_effect = rate_limit_error()
+    segment_collection = Mock()
+    now = [0.0]
+    writer = WeaviateWriteRetry(
+        deadline=0.04,
+        clock=lambda: now[0],
+        sleep=lambda delay: now.__setitem__(0, now[0] + delay),
+        jitter=lambda _lower, upper: upper,
+        gate=WeaviateRateLimitGate(),
+    )
+
+    with pytest.raises(WeaviateRateLimitExhausted):
+        LectureVisibilityUpdatePipeline(
+            page_collection,
+            unit_collection,
+            segment_collection,
+            write_retry_factory=lambda: writer,
         )(visibility_dto())
 
     assert unit_collection.data.update.call_count == 1
@@ -630,6 +723,27 @@ def test_visibility_endpoint_returns_not_found_when_ingestion_has_not_created_un
 
     assert exc_info.value.status_code == 404
     database.assert_called_once_with()
+
+
+def test_visibility_endpoint_returns_service_unavailable_after_rate_limit_budget():
+    with (
+        patch("iris.web.routers.webhooks.VectorDatabase"),
+        patch("iris.web.routers.webhooks.init_lecture_unit_page_chunk_schema"),
+        patch("iris.web.routers.webhooks.init_lecture_unit_schema"),
+        patch("iris.web.routers.webhooks.init_lecture_unit_segment_schema"),
+        patch("iris.web.routers.webhooks.LectureVisibilityUpdatePipeline") as pipeline,
+    ):
+        pipeline.return_value.side_effect = WeaviateRateLimitExhausted(
+            1, rate_limit_error()
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            lecture_visibility_webhook(visibility_dto())
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == {
+        "errorMessage": "Weaviate is temporarily rate-limited; retry later"
+    }
 
 
 def test_visibility_webhook_route_matches_artemis_contract():

--- a/iris/tests/test_lecture_visibility_update_pipeline.py
+++ b/iris/tests/test_lecture_visibility_update_pipeline.py
@@ -42,7 +42,6 @@ from iris.vector_database.lecture_unit_segment_schema import (
 )
 from iris.vector_database.write_retry import (
     WeaviateRateLimitExhausted,
-    WeaviateRateLimitGate,
     WeaviateWriteRetry,
 )
 from iris.web.routers.webhooks import lecture_visibility_webhook
@@ -319,11 +318,8 @@ def test_visibility_pipeline_retries_rate_limited_final_parent_update():
         now[0] += delay
 
     writer = WeaviateWriteRetry(
-        deadline=8.0,
-        clock=lambda: now[0],
         sleep=sleep,
         jitter=lambda _lower, upper: upper,
-        gate=WeaviateRateLimitGate(),
     )
 
     result = LectureVisibilityUpdatePipeline(
@@ -335,12 +331,43 @@ def test_visibility_pipeline_retries_rate_limited_final_parent_update():
 
     assert result.lecture_units_updated == 1
     assert unit_collection.data.update.call_count == 3
-    assert sleeps == pytest.approx([0.05])
+    assert sleeps == pytest.approx([0.25])
     assert unit_collection.data.update.call_args.kwargs["properties"] == {
         LectureUnitSchema.RELEASE_DATE.value: datetime(
             2026, 7, 4, 12, 0, tzinfo=timezone.utc
         )
     }
+
+
+def test_visibility_pipeline_retries_rate_limited_parent_barrier():
+    unit_collection = Mock()
+    unit_collection.query.fetch_objects.return_value.objects = [
+        SimpleNamespace(uuid="unit-uuid")
+    ]
+    unit_collection.data.update.side_effect = [rate_limit_error(), None, None]
+    page_collection = Mock()
+    page_collection.query.fetch_objects.return_value.objects = []
+    segment_collection = Mock()
+    segment_collection.query.fetch_objects.return_value.objects = []
+    sleeps = []
+    writer = WeaviateWriteRetry(
+        sleep=sleeps.append,
+        jitter=lambda _lower, upper: upper,
+    )
+
+    result = LectureVisibilityUpdatePipeline(
+        page_collection,
+        unit_collection,
+        segment_collection,
+        write_retry_factory=lambda: writer,
+    )(visibility_dto())
+
+    assert result.lecture_units_updated == 1
+    assert unit_collection.data.update.call_count == 3
+    assert sleeps == pytest.approx([0.25])
+    assert unit_collection.data.update.call_args_list[1].kwargs["properties"][
+        LectureUnitSchema.RELEASE_DATE.value
+    ] == datetime.max.replace(tzinfo=timezone.utc)
 
 
 def test_visibility_pipeline_keeps_parent_barrier_after_rate_limit_exhaustion():
@@ -356,11 +383,9 @@ def test_visibility_pipeline_keeps_parent_barrier_after_rate_limit_exhaustion():
     segment_collection = Mock()
     now = [0.0]
     writer = WeaviateWriteRetry(
-        deadline=0.04,
-        clock=lambda: now[0],
+        retry_wait_budget=0.1,
         sleep=lambda delay: now.__setitem__(0, now[0] + delay),
         jitter=lambda _lower, upper: upper,
-        gate=WeaviateRateLimitGate(),
     )
 
     with pytest.raises(WeaviateRateLimitExhausted):

--- a/iris/tests/test_weaviate_write_retry.py
+++ b/iris/tests/test_weaviate_write_retry.py
@@ -1,0 +1,145 @@
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from weaviate.exceptions import UnexpectedStatusCodeError
+
+from iris.vector_database.write_retry import (
+    MAX_WRITE_ATTEMPTS,
+    WeaviateRateLimitExhausted,
+    WeaviateRateLimitGate,
+    WeaviateWriteRetry,
+)
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
+        self.now += delay
+
+
+def unexpected_status(status_code: int) -> UnexpectedStatusCodeError:
+    response = httpx.Response(
+        status_code,
+        request=httpx.Request("PATCH", "https://weaviate.example/v1/objects/id"),
+    )
+    return UnexpectedStatusCodeError("Object was not updated", response)
+
+
+def retry_context(
+    clock: FakeClock,
+    *,
+    deadline: float = 8.0,
+    gate: WeaviateRateLimitGate | None = None,
+) -> WeaviateWriteRetry:
+    return WeaviateWriteRetry(
+        deadline=deadline,
+        clock=clock,
+        sleep=clock.sleep,
+        jitter=lambda _lower, upper: upper,
+        gate=gate or WeaviateRateLimitGate(),
+    )
+
+
+def test_update_retries_http_429_with_exponential_backoff():
+    clock = FakeClock()
+    collection = Mock()
+    collection.data.update.side_effect = [
+        unexpected_status(429),
+        unexpected_status(429),
+        None,
+    ]
+
+    retry_context(clock).update(collection, uuid="object-id", properties={"x": 1})
+
+    assert collection.data.update.call_count == 3
+    assert clock.sleeps == pytest.approx([0.05, 0.1])
+
+
+def test_update_does_not_retry_non_rate_limit_errors():
+    clock = FakeClock()
+    collection = Mock()
+    error = unexpected_status(500)
+    collection.data.update.side_effect = error
+
+    with pytest.raises(UnexpectedStatusCodeError) as exc_info:
+        retry_context(clock).update(collection, uuid="object-id", properties={"x": 1})
+
+    assert exc_info.value is error
+    collection.data.update.assert_called_once()
+    assert not clock.sleeps
+
+
+def test_update_stops_before_sleeping_past_request_deadline():
+    clock = FakeClock()
+    collection = Mock()
+    error = unexpected_status(429)
+    collection.data.update.side_effect = error
+
+    with pytest.raises(WeaviateRateLimitExhausted) as exc_info:
+        retry_context(clock, deadline=0.04).update(
+            collection, uuid="object-id", properties={"x": 1}
+        )
+
+    assert exc_info.value.attempts == 1
+    assert exc_info.value.last_error is error
+    collection.data.update.assert_called_once()
+    assert not clock.sleeps
+
+
+def test_update_caps_attempts_even_when_jitter_is_zero():
+    clock = FakeClock()
+    collection = Mock()
+    error = unexpected_status(429)
+    collection.data.update.side_effect = error
+    writer = WeaviateWriteRetry(
+        deadline=8.0,
+        clock=clock,
+        sleep=clock.sleep,
+        jitter=lambda _lower, _upper: 0.0,
+        gate=WeaviateRateLimitGate(),
+    )
+
+    with pytest.raises(WeaviateRateLimitExhausted) as exc_info:
+        writer.update(collection, uuid="object-id", properties={"x": 1})
+
+    assert exc_info.value.attempts == MAX_WRITE_ATTEMPTS
+    assert collection.data.update.call_count == MAX_WRITE_ATTEMPTS
+    assert not clock.sleeps
+
+
+def test_request_deadline_is_shared_across_multiple_updates():
+    clock = FakeClock()
+    collection = Mock()
+    collection.data.update.side_effect = [None, unexpected_status(429)]
+    writer = retry_context(clock, deadline=8.0)
+
+    writer.update(collection, uuid="first", properties={"x": 1})
+    clock.now = 7.98
+
+    with pytest.raises(WeaviateRateLimitExhausted):
+        writer.update(collection, uuid="second", properties={"x": 2})
+
+    assert collection.data.update.call_count == 2
+    assert not clock.sleeps
+
+
+def test_shared_gate_delays_another_writer_before_its_first_attempt():
+    clock = FakeClock()
+    gate = WeaviateRateLimitGate()
+    gate.extend(0.2)
+    collection = Mock()
+
+    retry_context(clock, gate=gate).update(
+        collection, uuid="object-id", properties={"x": 1}
+    )
+
+    assert clock.sleeps == pytest.approx([0.2])
+    collection.data.update.assert_called_once()

--- a/iris/tests/test_weaviate_write_retry.py
+++ b/iris/tests/test_weaviate_write_retry.py
@@ -5,9 +5,9 @@ import pytest
 from weaviate.exceptions import UnexpectedStatusCodeError
 
 from iris.vector_database.write_retry import (
+    MAX_RETRY_WAIT_SECONDS,
     MAX_WRITE_ATTEMPTS,
     WeaviateRateLimitExhausted,
-    WeaviateRateLimitGate,
     WeaviateWriteRetry,
 )
 
@@ -36,15 +36,12 @@ def unexpected_status(status_code: int) -> UnexpectedStatusCodeError:
 def retry_context(
     clock: FakeClock,
     *,
-    deadline: float = 8.0,
-    gate: WeaviateRateLimitGate | None = None,
+    retry_wait_budget: float = MAX_RETRY_WAIT_SECONDS,
 ) -> WeaviateWriteRetry:
     return WeaviateWriteRetry(
-        deadline=deadline,
-        clock=clock,
+        retry_wait_budget=retry_wait_budget,
         sleep=clock.sleep,
         jitter=lambda _lower, upper: upper,
-        gate=gate or WeaviateRateLimitGate(),
     )
 
 
@@ -60,7 +57,7 @@ def test_update_retries_http_429_with_exponential_backoff():
     retry_context(clock).update(collection, uuid="object-id", properties={"x": 1})
 
     assert collection.data.update.call_count == 3
-    assert clock.sleeps == pytest.approx([0.05, 0.1])
+    assert clock.sleeps == pytest.approx([0.25, 0.5])
 
 
 def test_update_does_not_retry_non_rate_limit_errors():
@@ -77,14 +74,14 @@ def test_update_does_not_retry_non_rate_limit_errors():
     assert not clock.sleeps
 
 
-def test_update_stops_before_sleeping_past_request_deadline():
+def test_update_stops_before_exceeding_retry_wait_budget():
     clock = FakeClock()
     collection = Mock()
     error = unexpected_status(429)
     collection.data.update.side_effect = error
 
     with pytest.raises(WeaviateRateLimitExhausted) as exc_info:
-        retry_context(clock, deadline=0.04).update(
+        retry_context(clock, retry_wait_budget=0.1).update(
             collection, uuid="object-id", properties={"x": 1}
         )
 
@@ -100,11 +97,8 @@ def test_update_caps_attempts_even_when_jitter_is_zero():
     error = unexpected_status(429)
     collection.data.update.side_effect = error
     writer = WeaviateWriteRetry(
-        deadline=8.0,
-        clock=clock,
         sleep=clock.sleep,
         jitter=lambda _lower, _upper: 0.0,
-        gate=WeaviateRateLimitGate(),
     )
 
     with pytest.raises(WeaviateRateLimitExhausted) as exc_info:
@@ -112,34 +106,51 @@ def test_update_caps_attempts_even_when_jitter_is_zero():
 
     assert exc_info.value.attempts == MAX_WRITE_ATTEMPTS
     assert collection.data.update.call_count == MAX_WRITE_ATTEMPTS
-    assert not clock.sleeps
+    assert clock.sleeps == pytest.approx([0.125, 0.25, 0.5, 1.0, 2.0])
 
 
-def test_request_deadline_is_shared_across_multiple_updates():
+def test_default_budget_allows_every_backoff_step():
     clock = FakeClock()
     collection = Mock()
-    collection.data.update.side_effect = [None, unexpected_status(429)]
-    writer = retry_context(clock, deadline=8.0)
+    collection.data.update.side_effect = unexpected_status(429)
+    writer = retry_context(clock)
+
+    with pytest.raises(WeaviateRateLimitExhausted):
+        writer.update(collection, uuid="object-id", properties={"x": 1})
+
+    assert collection.data.update.call_count == MAX_WRITE_ATTEMPTS
+    assert clock.sleeps == pytest.approx([0.25, 0.5, 1.0, 2.0, 4.0])
+    assert writer.remaining_retry_wait == pytest.approx(0.25)
+
+
+def test_retry_wait_budget_is_shared_across_multiple_updates():
+    clock = FakeClock()
+    collection = Mock()
+    collection.data.update.side_effect = [
+        unexpected_status(429),
+        None,
+        unexpected_status(429),
+    ]
+    writer = retry_context(clock, retry_wait_budget=0.3)
 
     writer.update(collection, uuid="first", properties={"x": 1})
-    clock.now = 7.98
 
     with pytest.raises(WeaviateRateLimitExhausted):
         writer.update(collection, uuid="second", properties={"x": 2})
 
-    assert collection.data.update.call_count == 2
-    assert not clock.sleeps
+    assert collection.data.update.call_count == 3
+    assert clock.sleeps == pytest.approx([0.25])
 
 
-def test_shared_gate_delays_another_writer_before_its_first_attempt():
+def test_successful_work_does_not_consume_retry_wait_budget():
     clock = FakeClock()
-    gate = WeaviateRateLimitGate()
-    gate.extend(0.2)
     collection = Mock()
+    collection.data.update.side_effect = [None, unexpected_status(429), None]
+    writer = retry_context(clock, retry_wait_budget=0.25)
 
-    retry_context(clock, gate=gate).update(
-        collection, uuid="object-id", properties={"x": 1}
-    )
+    writer.update(collection, uuid="first", properties={"x": 1})
+    clock.now = 60.0
+    writer.update(collection, uuid="second", properties={"x": 2})
 
-    assert clock.sleeps == pytest.approx([0.2])
-    collection.data.update.assert_called_once()
+    assert collection.data.update.call_count == 3
+    assert clock.sleeps == pytest.approx([0.25])


### PR DESCRIPTION
## Summary

This PR makes lecture visibility updates resilient to transient Weaviate HTTP 429 responses without adding persistence or scheduling infrastructure.

## What changed

- retry idempotent Weaviate object updates only when the response status is 429
- use capped exponential equal-jitter backoff with at most six attempts
- share one eight-second retry wait budget across the complete visibility update request
- count only actual 429 backoff against that budget, not successful work or lock contention
- always attempt a Weaviate write before declaring the retry budget exhausted
- preserve the parent visibility barrier if a child update cannot be completed
- return HTTP 503 when the retry budget is exhausted
- leave non-429 Weaviate errors unchanged
- prevent tracing failures from executing a failing business operation a second time

## Scope

The change is limited to Iris. It adds no database state, background queue, scheduler, or Artemis change.

## Validation

- `poetry run pytest -q --tb=short`: 396 passed
- focused retry, visibility, and tracing tests: 38 passed
- pre-commit hooks passed
- Black, isort, Pylint, and targeted mypy checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary database rate limits with automatic retries.
  * Lecture visibility updates now return a clear 503 response when retry attempts are exhausted.
  * Prevented business operations from running twice when tracing setup or execution fails.

* **Tests**
  * Added coverage for retry behavior, rate-limit responses, and tracing failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->