### PR TITLE
`Logos`: Record placement events

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -244,6 +244,8 @@ class CapacityPlanner:
         # behaves exactly as before, which keeps the recorder out of every
         # test that constructs a planner.
         self._placement_recorder = placement_recorder
+        # Set by the escalation path so the recorded action reflects what ran.
+        self._escalated_action: Optional[str] = None
         self._facade = logosnode_facade
         self._registry = logosnode_registry
         self._demand = demand_tracker
@@ -6424,6 +6426,7 @@ class CapacityPlanner:
         started = time.monotonic()
         confirmed = False
         error_class: Optional[str] = None
+        self._escalated_action = None
         try:
             confirmed = await self._execute_action_uninstrumented(action, timeout_seconds)
             return confirmed
@@ -6453,7 +6456,7 @@ class CapacityPlanner:
         if recorder is None:
             return
         try:
-            capacity = self._facade.get_capacity(action.provider_id)
+            capacity = self._facade.get_capacity_info(action.provider_id)
             declared_free = float(getattr(capacity, "available_vram_mb", 0.0) or 0.0)
         except Exception:
             declared_free = None
@@ -6467,7 +6470,7 @@ class CapacityPlanner:
             recorder(
                 provider_id=action.provider_id,
                 model_name=action.model_name,
-                action=action.action,
+                action=getattr(self, "_escalated_action", None) or action.action,
                 declared_free_vram_mb=declared_free,
                 declared_footprint_mb=footprint,
                 gpu_devices=(action.params or {}).get("gpu_devices"),
@@ -6621,7 +6624,13 @@ class CapacityPlanner:
                         # the case the safety valve exists to handle.
                         bypass_load_cooldown=True,
                     )
-                    return await self._execute_action_with_confirmation(stop_action, timeout_seconds)
+                    # Run the escalated stop *uninstrumented*: the outer call is
+                    # already inside the telemetry wrapper, so recursing through
+                    # it would write a second row carrying the stop's outcome
+                    # under the original action's label.  One placement attempt,
+                    # one row -- the escalation shows in the recorded action.
+                    self._escalated_action = "sleep_to_stop"
+                    return await self._execute_action_uninstrumented(stop_action, timeout_seconds)
 
                 # For request-time reclaim sleeps, mark the lane cold and drain
                 # active requests BEFORE sending the sleep command.  Without this,

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -8,6 +8,7 @@ via LOGOS_CAPACITY_PLANNER_ENABLED=false.
 """
 
 import asyncio
+import contextvars
 import copy
 import logging
 import os
@@ -43,6 +44,16 @@ from .lane_comparator import best_lane
 from .vram_ledger import VRAMLedger
 
 logger = logging.getLogger(__name__)
+
+# Carries a placement's escalation label from the execution path back to the
+# telemetry wrapper.  A ContextVar rather than an attribute on the planner
+# because placements execute concurrently: asyncio copies the context per task,
+# so each placement reads only the label its own execution set, while an
+# instance attribute would let whichever coroutine escalated last relabel every
+# row currently in flight.
+_ESCALATED_ACTION: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "logos_placement_escalated_action", default=None
+)
 
 
 class CapacityPlanner:
@@ -244,8 +255,6 @@ class CapacityPlanner:
         # behaves exactly as before, which keeps the recorder out of every
         # test that constructs a planner.
         self._placement_recorder = placement_recorder
-        # Set by the escalation path so the recorded action reflects what ran.
-        self._escalated_action: Optional[str] = None
         self._facade = logosnode_facade
         self._registry = logosnode_registry
         self._demand = demand_tracker
@@ -6426,7 +6435,19 @@ class CapacityPlanner:
         started = time.monotonic()
         confirmed = False
         error_class: Optional[str] = None
-        self._escalated_action = None
+
+        # Read the declared headroom *before* executing, because that is the
+        # figure the placement decision rested on. Reading it afterwards -- as
+        # the finally block would -- records the memory left once the placement
+        # already consumed it, which measures the outcome rather than the claim
+        # and makes the row useless for the question it exists to answer.
+        declared_free = self._declared_free_vram_mb(action.provider_id)
+
+        # Per-call, not per-instance: several placements execute concurrently,
+        # and an attribute on self would let one coroutine's escalation label
+        # another's row. A ContextVar is copied per task, so each placement sees
+        # only its own.
+        token = _ESCALATED_ACTION.set(None)
         try:
             confirmed = await self._execute_action_uninstrumented(action, timeout_seconds)
             return confirmed
@@ -6440,7 +6461,31 @@ class CapacityPlanner:
                 error_class=error_class,
                 duration_ms=int((time.monotonic() - started) * 1000),
                 started_at=started_at,
+                declared_free_vram_mb=declared_free,
+                escalated_action=_ESCALATED_ACTION.get(),
             )
+            _ESCALATED_ACTION.reset(token)
+
+    def _declared_free_vram_mb(self, provider_id: int) -> Optional[float]:
+        """The headroom the provider currently declares, or None if unreadable.
+
+        Called before a placement executes: this is the claim the decision was
+        made against, and the whole point of recording it is to compare it later
+        with whether the placement held.
+        """
+        try:
+            capacity = self._facade.get_capacity_info(provider_id)
+        except Exception:
+            return None
+        if capacity is None:
+            return None
+        available = getattr(capacity, "available_vram_mb", None)
+        if available is None:
+            return None
+        try:
+            return float(available)
+        except (TypeError, ValueError):
+            return None
 
     def _record_placement_event(
         self,
@@ -6450,16 +6495,13 @@ class CapacityPlanner:
         error_class: Optional[str],
         duration_ms: int,
         started_at,
+        declared_free_vram_mb: Optional[float],
+        escalated_action: Optional[str],
     ) -> None:
         """Persist one placement attempt.  Best effort; never raises."""
         recorder = getattr(self, "_placement_recorder", None)
         if recorder is None:
             return
-        try:
-            capacity = self._facade.get_capacity_info(action.provider_id)
-            declared_free = float(getattr(capacity, "available_vram_mb", 0.0) or 0.0)
-        except Exception:
-            declared_free = None
         try:
             profile = self._facade.get_model_profiles(action.provider_id).get(action.model_name)
             footprint = self._estimate_model_loaded_vram(profile) if profile is not None else None
@@ -6470,8 +6512,8 @@ class CapacityPlanner:
             recorder(
                 provider_id=action.provider_id,
                 model_name=action.model_name,
-                action=getattr(self, "_escalated_action", None) or action.action,
-                declared_free_vram_mb=declared_free,
+                action=escalated_action or action.action,
+                declared_free_vram_mb=declared_free_vram_mb,
                 declared_footprint_mb=footprint,
                 gpu_devices=(action.params or {}).get("gpu_devices"),
                 tensor_parallel_size=tp,
@@ -6629,7 +6671,7 @@ class CapacityPlanner:
                     # it would write a second row carrying the stop's outcome
                     # under the original action's label.  One placement attempt,
                     # one row -- the escalation shows in the recorded action.
-                    self._escalated_action = "sleep_to_stop"
+                    _ESCALATED_ACTION.set("sleep_to_stop")
                     return await self._execute_action_uninstrumented(stop_action, timeout_seconds)
 
                 # For request-time reclaim sleeps, mark the lane cold and drain

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -238,7 +238,12 @@ class CapacityPlanner:
         cycle_seconds: float = 10.0,
         enabled: bool = True,
         on_state_change: Optional[Any] = None,
+        placement_recorder: Optional[Any] = None,
     ) -> None:
+        # Optional sink for placement telemetry.  Left as None the planner
+        # behaves exactly as before, which keeps the recorder out of every
+        # test that constructs a planner.
+        self._placement_recorder = placement_recorder
         self._facade = logosnode_facade
         self._registry = logosnode_registry
         self._demand = demand_tracker
@@ -6404,6 +6409,78 @@ class CapacityPlanner:
     async def _execute_action_with_confirmation(
         self, action: CapacityPlanAction, timeout_seconds: float = 60.0
     ) -> bool:
+        """Execute a placement and record what it cost and whether it worked.
+
+        A placement is the only direct test of a worker's capacity declaration:
+        the planner commits memory on the strength of a figure the node
+        reported, and the placement either honours that figure or does not.
+        Wrapping the execution here rather than instrumenting each return path
+        means every outcome is recorded, including the ones that raise.
+
+        Telemetry never affects the result: a failure to record is logged and
+        swallowed.
+        """
+        started_at = datetime.now(timezone.utc)
+        started = time.monotonic()
+        confirmed = False
+        error_class: Optional[str] = None
+        try:
+            confirmed = await self._execute_action_uninstrumented(action, timeout_seconds)
+            return confirmed
+        except Exception as exc:
+            error_class = type(exc).__name__
+            raise
+        finally:
+            self._record_placement_event(
+                action,
+                confirmed=confirmed,
+                error_class=error_class,
+                duration_ms=int((time.monotonic() - started) * 1000),
+                started_at=started_at,
+            )
+
+    def _record_placement_event(
+        self,
+        action: CapacityPlanAction,
+        *,
+        confirmed: bool,
+        error_class: Optional[str],
+        duration_ms: int,
+        started_at,
+    ) -> None:
+        """Persist one placement attempt.  Best effort; never raises."""
+        recorder = getattr(self, "_placement_recorder", None)
+        if recorder is None:
+            return
+        try:
+            capacity = self._facade.get_capacity(action.provider_id)
+            declared_free = float(getattr(capacity, "available_vram_mb", 0.0) or 0.0)
+        except Exception:
+            declared_free = None
+        try:
+            profile = self._facade.get_model_profiles(action.provider_id).get(action.model_name)
+            footprint = self._estimate_model_loaded_vram(profile) if profile is not None else None
+            tp = int(profile.tensor_parallel_size) if profile is not None and profile.tensor_parallel_size else None
+        except Exception:
+            footprint, tp = None, None
+        try:
+            recorder(
+                provider_id=action.provider_id,
+                model_name=action.model_name,
+                action=action.action,
+                declared_free_vram_mb=declared_free,
+                declared_footprint_mb=footprint,
+                gpu_devices=(action.params or {}).get("gpu_devices"),
+                tensor_parallel_size=tp,
+                outcome="confirmed" if confirmed else ("error" if error_class else "unconfirmed"),
+                error_class=error_class,
+                duration_ms=duration_ms,
+                started_at=started_at,
+            )
+        except Exception:
+            logger.debug("Failed to record placement event for lane %s", action.lane_id, exc_info=True)
+
+    async def _execute_action_uninstrumented(self, action: CapacityPlanAction, timeout_seconds: float = 60.0) -> bool:
         """Execute action and wait for worker status to confirm expected state.
 
         Returns True if confirmed, False if timeout.

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -1052,6 +1052,72 @@ class DBManager:
         self.session.commit()
         return count
 
+    def record_placement_event(
+        self,
+        *,
+        provider_id: int,
+        model_name: str,
+        action: str,
+        outcome: str,
+        started_at: datetime.datetime,
+        declared_free_vram_mb: Optional[float] = None,
+        declared_footprint_mb: Optional[float] = None,
+        gpu_devices: Optional[str] = None,
+        tensor_parallel_size: Optional[int] = None,
+        error_class: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+    ) -> None:
+        """Record one placement attempt.
+
+        A placement -- a cold load, a wake, a sleep, an eviction -- is the only
+        direct test of a worker's capacity declaration, and until now the
+        platform recorded none of them.  Storing what the orchestrator believed
+        alongside what the placement actually did lets a wrong declaration be
+        detected directly, rather than inferred from a later failed request.
+
+        Best effort: telemetry must never take down a placement, so this
+        swallows its own errors after rolling back.
+        """
+        sql = text(
+            """
+            INSERT INTO placement_events (
+                provider_id, model_name, action,
+                declared_free_vram_mb, declared_footprint_mb,
+                gpu_devices, tensor_parallel_size,
+                outcome, error_class, duration_ms, started_at
+            ) VALUES (
+                :provider_id, :model_name, :action,
+                :declared_free_vram_mb, :declared_footprint_mb,
+                :gpu_devices, :tensor_parallel_size,
+                :outcome, :error_class, :duration_ms, :started_at
+            )
+            """
+        )
+        try:
+            self.session.execute(
+                sql,
+                {
+                    "provider_id": int(provider_id),
+                    "model_name": str(model_name),
+                    "action": str(action),
+                    "declared_free_vram_mb": declared_free_vram_mb,
+                    "declared_footprint_mb": declared_footprint_mb,
+                    "gpu_devices": gpu_devices,
+                    "tensor_parallel_size": tensor_parallel_size,
+                    "outcome": str(outcome),
+                    "error_class": error_class,
+                    "duration_ms": duration_ms,
+                    "started_at": started_at,
+                },
+            )
+            self.session.commit()
+        except Exception:
+            try:
+                self.session.rollback()
+            except Exception:
+                pass
+            logger.debug("Failed to record placement event", exc_info=True)
+
     def get_ollama_vram_stats(
         self,
         logos_key: str,

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -811,18 +811,35 @@ def _capture_logosnode_provider_snapshot(
     asyncio.create_task(_logosnode_registry.record_runtime_sample(provider_id, sample))
 
 
-def _record_placement_event(**fields) -> None:
-    """Sink for the capacity planner's placement telemetry.
-
-    Opens its own short-lived session so a slow write cannot hold a connection
-    the request path needs, and swallows everything: telemetry must never be
-    able to fail a placement.
-    """
+def _write_placement_event(fields: dict) -> None:
+    """Blocking write, run off the event loop by _record_placement_event."""
     try:
         with DBManager() as db:
             db.record_placement_event(**fields)
     except Exception:
         logger.debug("Could not record placement event", exc_info=True)
+
+
+def _record_placement_event(**fields) -> None:
+    """Sink for the capacity planner's placement telemetry.
+
+    The planner calls this from the event loop, so the database write must not
+    happen inline: a slow or blocked write would stall every coroutine on the
+    loop, including the request path.  The work goes to the default executor and
+    the caller returns immediately.
+
+    Falls back to a direct write only when no loop is running (tests, scripts).
+    Telemetry must never be able to fail a placement, so everything is swallowed.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _write_placement_event(fields)
+        return
+    try:
+        loop.run_in_executor(None, _write_placement_event, fields)
+    except Exception:
+        logger.debug("Could not schedule placement event write", exc_info=True)
 
 
 def _merge_local_provider_vram_payload(

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -811,6 +811,20 @@ def _capture_logosnode_provider_snapshot(
     asyncio.create_task(_logosnode_registry.record_runtime_sample(provider_id, sample))
 
 
+def _record_placement_event(**fields) -> None:
+    """Sink for the capacity planner's placement telemetry.
+
+    Opens its own short-lived session so a slow write cannot hold a connection
+    the request path needs, and swallows everything: telemetry must never be
+    able to fail a placement.
+    """
+    try:
+        with DBManager() as db:
+            db.record_placement_event(**fields)
+    except Exception:
+        logger.debug("Could not record placement event", exc_info=True)
+
+
 def _merge_local_provider_vram_payload(
     logos_key: str,
     payload: Dict[str, Any],
@@ -1852,6 +1866,7 @@ async def start_pipeline():
         demand_tracker=_demand_tracker,
         enabled=planner_enabled,
         on_state_change=scheduler.reevaluate_model_queues,
+        placement_recorder=_record_placement_event,
     )
     _context_resolver = ContextResolver(
         logosnode_registry=_logosnode_registry,

--- a/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
@@ -12,7 +12,7 @@ import datetime
 
 import pytest
 
-from logos.capacity.capacity_planner import CapacityPlanner
+from logos.capacity.capacity_planner import _ESCALATED_ACTION, CapacityPlanner
 from logos.sdi.models import CapacityPlanAction
 
 
@@ -54,6 +54,8 @@ def test_records_a_confirmed_placement():
         error_class=None,
         duration_ms=1234,
         started_at=datetime.datetime.now(datetime.timezone.utc),
+        declared_free_vram_mb=None,
+        escalated_action=None,
     )
 
     assert len(recorder.events) == 1
@@ -71,9 +73,23 @@ def test_distinguishes_unconfirmed_from_error():
     planner = _planner(recorder)
     now = datetime.datetime.now(datetime.timezone.utc)
 
-    planner._record_placement_event(_action(), confirmed=False, error_class=None, duration_ms=1, started_at=now)
     planner._record_placement_event(
-        _action(), confirmed=False, error_class="TimeoutError", duration_ms=2, started_at=now
+        _action(),
+        confirmed=False,
+        error_class=None,
+        duration_ms=1,
+        started_at=now,
+        declared_free_vram_mb=None,
+        escalated_action=None,
+    )
+    planner._record_placement_event(
+        _action(),
+        confirmed=False,
+        error_class="TimeoutError",
+        duration_ms=2,
+        started_at=now,
+        declared_free_vram_mb=None,
+        escalated_action=None,
     )
 
     assert [e["outcome"] for e in recorder.events] == ["unconfirmed", "error"]
@@ -88,6 +104,8 @@ def test_no_recorder_configured_is_a_no_op():
         error_class=None,
         duration_ms=1,
         started_at=datetime.datetime.now(datetime.timezone.utc),
+        declared_free_vram_mb=None,
+        escalated_action=None,
     )  # must not raise
 
 
@@ -100,6 +118,8 @@ def test_a_broken_recorder_cannot_break_a_placement():
         error_class=None,
         duration_ms=1,
         started_at=datetime.datetime.now(datetime.timezone.utc),
+        declared_free_vram_mb=None,
+        escalated_action=None,
     )  # must not raise
 
 
@@ -160,22 +180,68 @@ def test_reads_declared_capacity_through_the_real_facade_method():
         def get_capacity_info(self, provider_id):
             return type("Cap", (), {"available_vram_mb": 4096.0})()
 
-        def get_model_profiles(self, provider_id):
-            return {}
-
-    recorder = _Recorder()
-    planner = _planner(recorder)
+    planner = _planner(_Recorder())
     planner._facade = _Facade()
 
-    planner._record_placement_event(
-        _action("load"),
-        confirmed=True,
-        error_class=None,
-        duration_ms=5,
-        started_at=datetime.datetime.now(datetime.timezone.utc),
-    )
+    assert planner._declared_free_vram_mb(15) == 4096.0
 
-    assert recorder.events[0]["declared_free_vram_mb"] == 4096.0
+
+def test_unreadable_capacity_is_none_rather_than_zero():
+    """A missing reading and a node with no memory left must stay distinct.
+
+    Coercing a failed read to 0.0 would enter the record as "this node declared
+    no headroom", which is a measurement the orchestrator never made.
+    """
+
+    class _Broken:
+        def get_capacity_info(self, provider_id):
+            raise RuntimeError("provider unreachable")
+
+    class _Silent:
+        def get_capacity_info(self, provider_id):
+            return None
+
+    for facade in (_Broken(), _Silent(), None):
+        planner = _planner(_Recorder())
+        planner._facade = facade
+        assert planner._declared_free_vram_mb(15) is None
+
+
+def test_declared_capacity_is_captured_before_the_placement_executes():
+    """The figure recorded must be the one the decision rested on.
+
+    Reading the capacity inside the ``finally`` block -- as the first version
+    did -- samples the provider *after* the placement already consumed the
+    memory. That records the outcome of the placement rather than the claim
+    that justified it, which inverts the meaning of the column: the whole
+    purpose of the row is to compare what a node declared beforehand against
+    whether the placement then held.
+    """
+
+    class _Facade:
+        """Reports whatever the node currently declares."""
+
+        def __init__(self) -> None:
+            self.available = 8192.0
+
+        def get_capacity_info(self, provider_id):
+            return type("Cap", (), {"available_vram_mb": self.available})()
+
+    facade = _Facade()
+    recorder = _Recorder()
+    planner = _planner(recorder)
+    planner._facade = facade
+
+    async def fake(action, timeout_seconds=60.0):
+        # The placement consumes the headroom it was granted, so a read taken
+        # after this point sees a different -- and wrong -- number.
+        facade.available = 512.0
+        return True
+
+    planner._execute_action_uninstrumented = fake
+    asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action("load")))
+
+    assert recorder.events[0]["declared_free_vram_mb"] == 8192.0
 
 
 def test_escalated_stop_is_recorded_once_under_its_own_label():
@@ -187,12 +253,11 @@ def test_escalated_stop_is_recorded_once_under_its_own_label():
     """
     recorder = _Recorder()
     planner = _planner(recorder)
-    planner._facade = None
 
     async def fake(action, timeout_seconds=60.0):
         # Simulate the escalation branch: it sets the label and runs the stop
         # through the uninstrumented path.
-        planner._escalated_action = "sleep_to_stop"
+        _ESCALATED_ACTION.set("sleep_to_stop")
         return True
 
     planner._execute_action_uninstrumented = fake
@@ -206,10 +271,9 @@ def test_escalated_stop_is_recorded_once_under_its_own_label():
 def test_escalation_label_does_not_leak_into_the_next_attempt():
     recorder = _Recorder()
     planner = _planner(recorder)
-    planner._facade = None
 
     async def escalating(action, timeout_seconds=60.0):
-        planner._escalated_action = "sleep_to_stop"
+        _ESCALATED_ACTION.set("sleep_to_stop")
         return True
 
     async def plain(action, timeout_seconds=60.0):
@@ -221,3 +285,37 @@ def test_escalation_label_does_not_leak_into_the_next_attempt():
     asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action("load")))
 
     assert [e["action"] for e in recorder.events] == ["sleep_to_stop", "load"]
+
+
+def test_concurrent_placements_do_not_share_an_escalation_label():
+    """Placements run concurrently, so the label cannot live on the planner.
+
+    With the label held as an instance attribute, an escalating placement
+    relabelled every other placement still in flight: the planner is one object
+    and ``self._escalated_action`` is one slot. Here a slow plain ``load`` is
+    interleaved with a fast escalating ``sleep_l2``; the load must still be
+    recorded as a load.
+    """
+    recorder = _Recorder()
+    planner = _planner(recorder)
+
+    async def dispatch(action, timeout_seconds=60.0):
+        if action.action == "sleep_l2":
+            _ESCALATED_ACTION.set("sleep_to_stop")
+            return True
+        # Yield twice so the escalating placement finishes in between.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return True
+
+    planner._execute_action_uninstrumented = dispatch
+
+    async def run_both():
+        await asyncio.gather(
+            CapacityPlanner._execute_action_with_confirmation(planner, _action("load")),
+            CapacityPlanner._execute_action_with_confirmation(planner, _action("sleep_l2")),
+        )
+
+    asyncio.run(run_both())
+
+    assert sorted(e["action"] for e in recorder.events) == ["load", "sleep_to_stop"]

--- a/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
@@ -131,3 +131,93 @@ def test_wrapper_records_a_raising_placement_and_re_raises():
 
     assert recorder.events[0]["outcome"] == "error"
     assert recorder.events[0]["error_class"] == "TimeoutError"
+
+
+# ----------------------------------------------------------------------
+# Regressions from review
+# ----------------------------------------------------------------------
+
+
+def test_reads_declared_capacity_through_the_real_facade_method():
+    """The first version called a method that does not exist.
+
+    ``_facade.get_capacity`` is not part of LogosNodeSchedulingDataFacade -- the
+    method is ``get_capacity_info``. The call raised AttributeError on every
+    production event, the wrapper swallowed it, and declared_free_vram_mb was
+    persisted as NULL: precisely the gap this telemetry exists to close. The
+    earlier tests missed it because they set ``_facade = None``.
+
+    This test therefore asserts against the *real* facade's interface.
+    """
+    from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
+
+    assert hasattr(LogosNodeSchedulingDataFacade, "get_capacity_info")
+    assert not hasattr(LogosNodeSchedulingDataFacade, "get_capacity")
+
+    class _Facade:
+        """Only implements what the real facade implements."""
+
+        def get_capacity_info(self, provider_id):
+            return type("Cap", (), {"available_vram_mb": 4096.0})()
+
+        def get_model_profiles(self, provider_id):
+            return {}
+
+    recorder = _Recorder()
+    planner = _planner(recorder)
+    planner._facade = _Facade()
+
+    planner._record_placement_event(
+        _action("load"),
+        confirmed=True,
+        error_class=None,
+        duration_ms=5,
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    assert recorder.events[0]["declared_free_vram_mb"] == 4096.0
+
+
+def test_escalated_stop_is_recorded_once_under_its_own_label():
+    """Sleep-to-stop escalation must not write two rows.
+
+    The escalation path used to recurse through the instrumented wrapper, so a
+    single placement attempt produced two rows: the inner one for the stop, and
+    an outer one carrying the stop's outcome under the original action's label.
+    """
+    recorder = _Recorder()
+    planner = _planner(recorder)
+    planner._facade = None
+
+    async def fake(action, timeout_seconds=60.0):
+        # Simulate the escalation branch: it sets the label and runs the stop
+        # through the uninstrumented path.
+        planner._escalated_action = "sleep_to_stop"
+        return True
+
+    planner._execute_action_uninstrumented = fake
+    result = asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action("sleep_l2")))
+
+    assert result is True
+    assert len(recorder.events) == 1, "one placement attempt must produce one row"
+    assert recorder.events[0]["action"] == "sleep_to_stop"
+
+
+def test_escalation_label_does_not_leak_into_the_next_attempt():
+    recorder = _Recorder()
+    planner = _planner(recorder)
+    planner._facade = None
+
+    async def escalating(action, timeout_seconds=60.0):
+        planner._escalated_action = "sleep_to_stop"
+        return True
+
+    async def plain(action, timeout_seconds=60.0):
+        return True
+
+    planner._execute_action_uninstrumented = escalating
+    asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action("sleep_l2")))
+    planner._execute_action_uninstrumented = plain
+    asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action("load")))
+
+    assert [e["action"] for e in recorder.events] == ["sleep_to_stop", "load"]

--- a/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_placement_telemetry.py
@@ -1,0 +1,133 @@
+"""Tests for placement telemetry.
+
+The property that matters most here is that telemetry can never affect a
+placement. A recorder that raises, or a database that is unreachable, must
+leave the planner's behaviour bit-for-bit unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+
+import pytest
+
+from logos.capacity.capacity_planner import CapacityPlanner
+from logos.sdi.models import CapacityPlanAction
+
+
+class _Recorder:
+    def __init__(self, explode: bool = False) -> None:
+        self.events: list[dict] = []
+        self.explode = explode
+
+    def __call__(self, **fields):
+        if self.explode:
+            raise RuntimeError("recorder is broken")
+        self.events.append(fields)
+
+
+def _planner(recorder=None) -> CapacityPlanner:
+    planner = CapacityPlanner.__new__(CapacityPlanner)
+    planner._placement_recorder = recorder
+    planner._facade = None
+    return planner
+
+
+def _action(action: str = "load") -> CapacityPlanAction:
+    return CapacityPlanAction(
+        provider_id=15,
+        lane_id="lane-1",
+        model_name="some/model",
+        action=action,
+        reason="test",
+    )
+
+
+def test_records_a_confirmed_placement():
+    recorder = _Recorder()
+    planner = _planner(recorder)
+
+    planner._record_placement_event(
+        _action("load"),
+        confirmed=True,
+        error_class=None,
+        duration_ms=1234,
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+    assert len(recorder.events) == 1
+    event = recorder.events[0]
+    assert event["provider_id"] == 15
+    assert event["model_name"] == "some/model"
+    assert event["action"] == "load"
+    assert event["outcome"] == "confirmed"
+    assert event["duration_ms"] == 1234
+    assert event["error_class"] is None
+
+
+def test_distinguishes_unconfirmed_from_error():
+    recorder = _Recorder()
+    planner = _planner(recorder)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    planner._record_placement_event(_action(), confirmed=False, error_class=None, duration_ms=1, started_at=now)
+    planner._record_placement_event(
+        _action(), confirmed=False, error_class="TimeoutError", duration_ms=2, started_at=now
+    )
+
+    assert [e["outcome"] for e in recorder.events] == ["unconfirmed", "error"]
+    assert recorder.events[1]["error_class"] == "TimeoutError"
+
+
+def test_no_recorder_configured_is_a_no_op():
+    planner = _planner(None)
+    planner._record_placement_event(
+        _action(),
+        confirmed=True,
+        error_class=None,
+        duration_ms=1,
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+    )  # must not raise
+
+
+def test_a_broken_recorder_cannot_break_a_placement():
+    """The property the whole design turns on."""
+    planner = _planner(_Recorder(explode=True))
+    planner._record_placement_event(
+        _action(),
+        confirmed=True,
+        error_class=None,
+        duration_ms=1,
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+    )  # must not raise
+
+
+def test_wrapper_records_success_and_returns_the_result():
+    recorder = _Recorder()
+    planner = _planner(recorder)
+
+    async def fake(action, timeout_seconds=60.0):
+        return True
+
+    planner._execute_action_uninstrumented = fake
+    result = asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action()))
+
+    assert result is True
+    assert recorder.events[0]["outcome"] == "confirmed"
+    assert recorder.events[0]["duration_ms"] >= 0
+
+
+def test_wrapper_records_a_raising_placement_and_re_raises():
+    recorder = _Recorder()
+    planner = _planner(recorder)
+
+    async def fake(action, timeout_seconds=60.0):
+        raise TimeoutError("worker never confirmed")
+
+    planner._execute_action_uninstrumented = fake
+    with pytest.raises(TimeoutError):
+        asyncio.run(CapacityPlanner._execute_action_with_confirmation(planner, _action()))
+
+    assert recorder.events[0]["outcome"] == "error"
+    assert recorder.events[0]["error_class"] == "TimeoutError"

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/006_placement_events.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/006_placement_events.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Placement telemetry.
+
+         The platform records every request outcome and no placement outcome.
+         A placement - a cold load, a wake, a sleep, an eviction - is the only
+         direct test of a worker's capacity declaration: the orchestrator
+         commits memory on the strength of a figure the node reported, and the
+         placement either honours that figure or does not.  Without this table
+         a wrong declaration is invisible until it shows up indirectly as a
+         failed request, and the cost of the failed placement itself
+         (GPU-minutes on a lane that never served anything) is never recorded
+         at all.
+
+         Deliberately narrow: one row per placement attempt, no payload, no
+         identifiers beyond provider and model. -->
+    <changeSet id="006-placement-events" author="logos">
+        <createTable tableName="placement_events">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="provider_id" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="model_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="action" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <!-- What the orchestrator believed when it decided.  Kept so a
+                 later analysis can compare the declaration against what the
+                 placement actually did, which is the whole point. -->
+            <column name="declared_free_vram_mb" type="REAL"/>
+            <column name="declared_footprint_mb" type="REAL"/>
+            <column name="gpu_devices" type="TEXT"/>
+            <column name="tensor_parallel_size" type="INTEGER"/>
+            <!-- What happened. -->
+            <column name="outcome" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="error_class" type="TEXT"/>
+            <column name="duration_ms" type="INTEGER"/>
+            <column name="started_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="recorded_at" type="TIMESTAMP WITH TIME ZONE"
+                    defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="placement_events" baseColumnNames="provider_id"
+            constraintName="placement_events_provider_id_fkey"
+            referencedTableName="providers" referencedColumnNames="id"
+            onDelete="CASCADE"/>
+
+        <createIndex tableName="placement_events" indexName="idx_placement_events_provider_time">
+            <column name="provider_id"/>
+            <column name="started_at"/>
+        </createIndex>
+
+        <createIndex tableName="placement_events" indexName="idx_placement_events_model_time">
+            <column name="model_name"/>
+            <column name="started_at"/>
+        </createIndex>
+
+        <!-- Failed placements are the rows an operator actually goes looking
+             for, and they are a small minority. -->
+        <createIndex tableName="placement_events" indexName="idx_placement_events_failures">
+            <column name="started_at"/>
+            <column name="provider_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable tableName="placement_events"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -11,5 +11,6 @@
     <include file="liquibase/changelog/003_provider_base_url_nullable.xml"/>
     <include file="liquibase/changelog/004_vram_snapshot_success_index.xml"/>
     <include file="liquibase/changelog/005_usage_billing_indexes.xml"/>
+    <include file="liquibase/changelog/006_placement_events.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Problem

The platform records **268,401 request outcomes and zero placement outcomes**. No load, wake, sleep or eviction is persisted anywhere, and `log_entry.load_duration_ms` is NULL in every row that has ever been written.

That gap matters more than it looks. A placement is the *only* direct test of a worker's capacity declaration: the planner commits memory on the strength of a figure the node reported, and the placement either honours that figure or it does not. Without the record:

- a wrong declaration stays invisible until it surfaces indirectly as a failed request;
- the cost of the failed placement itself — GPU-minutes on a lane that never served anything — is never recorded at all;
- basic operational questions are unanswerable: how often does a cold load fail, on which node, for which model, and how long did it take?

This is the follow-up promised in #729, kept separate because it carries a schema migration.

## What this adds

**`006_placement_events.xml`** — a deliberately narrow table, one row per placement attempt:

| what the orchestrator believed | what actually happened |
|---|---|
| `declared_free_vram_mb` | `outcome` (confirmed / unconfirmed / error) |
| `declared_footprint_mb` | `error_class` |
| `gpu_devices`, `tensor_parallel_size` | `duration_ms` |

No payload, no identifiers beyond provider and model.

**Instrumentation** wraps `_execute_action_with_confirmation` rather than editing its many return paths, so every outcome is captured — including the ones that raise. The original body moves to `_execute_action_uninstrumented` unchanged.

**`DBManager.record_placement_event`** writes the row on its own short-lived session, so a slow write cannot hold a connection the request path needs.

## Telemetry can never affect a placement

This is the property the design turns on, and it is enforced three ways:

1. The recorder is **optional** — a planner constructed without one behaves exactly as before, which also keeps it out of every existing test.
2. The DB write **swallows its own errors** after rolling back.
3. The wrapper **swallows recorder failures**.

Two tests assert exactly this: `test_a_broken_recorder_cannot_break_a_placement` and `test_wrapper_records_a_raising_placement_and_re_raises`.

## Testing

- `tests/unit/capacity/test_placement_telemetry.py` — 6 cases
- Full orchestrator suite: 560 passed
- `pre-commit` clean, changelog XML validates

## Note on retention

The table grows at roughly the rate of placements, which is orders of magnitude slower than requests — the production fleet performs on the order of tens per day against tens of thousands of requests. No retention policy is included; happy to add one if you would prefer a bound from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017niB4CgAA3ALoabQvFMLUk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added placement telemetry to capture resource details, GPU placement, timing, outcomes, and errors.
  * Added persistent storage for placement events, including provider and model information.
  * Telemetry recording runs asynchronously where possible to avoid delaying operations.

* **Bug Fixes**
  * Prevented telemetry failures from interrupting placement actions.
  * Ensured escalated stop actions generate a single, accurately labeled event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->