### PR TITLE
`Logos`: Fix calibration recording a KV-starved context for every KV size

### DIFF
--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -66,6 +66,7 @@ _CALIBRATION_PORT = 11499
 _KV_CACHE_MIN_STEP_MB = 1024.0  # sweep step and safety margin
 _KV_CACHE_VRAM_CAP_RATIO = 0.8  # fraction of total GPU VRAM used as KV search ceiling
 _FINAL_MEASUREMENT_RETRIES = 3  # retries for the final VRAM measurement startup
+_LOG_DIAGNOSTIC_TAIL_LINES = 80  # lines of probe log echoed into worker logs on failure
 _FAILED_COMMANDS_FILE = "calibration_failed_commands.txt"
 _SUCCEEDED_COMMANDS_FILE = "calibration_succeeded_commands.txt"
 _UNSUPPORTED_MODELS_FILE = "calibration_unsupported_models.txt"
@@ -995,15 +996,29 @@ def _log_size(log_path: Path) -> int:
         return 0
 
 
-def _read_log_since(log_path: Path, offset: int, max_lines: int = 80) -> str:
-    """Read the last *max_lines* of the log written AFTER *offset* bytes.
+def _tail_lines(text: str, max_lines: int) -> str:
+    """Last *max_lines* lines of *text* — for display only, never for parsing."""
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:] if len(lines) > max_lines else lines)
+
+
+def _read_log_since(log_path: Path, offset: int, max_lines: int | None = None) -> str:
+    """Read the log written AFTER *offset* bytes — the whole probe segment.
 
     Reading the tail of the whole file (as this used to do) spans probe
-    boundaries, because all probes of a run append to one file. A successful
-    start emits hundreds of warmup lines, pushing that probe's own
-    "Maximum concurrency for N tokens per request" line out of an 80-line
-    window while stale lines from an EARLIER probe stay in it. Slicing from the
-    pre-spawn offset makes every extraction refer to the probe being parsed.
+    boundaries, because all probes of a run append to one file. Slicing from
+    the pre-spawn offset makes every extraction refer to the probe being parsed.
+
+    Returns the segment COMPLETE by default. A line cap must not be applied to
+    parser input: vLLM prints its init summary — including "Maximum concurrency
+    for N tokens per request", the only authoritative record of the context a
+    probe served — BEFORE the CUDA-graph warmup, which then emits hundreds of
+    lines. In the deimama Qwen3.8-27B log that line sits 137-241 lines from the
+    end of its segment, so an 80-line tail dropped it from 6 of 7 probes and
+    left every curve point without its concurrency annotation.
+
+    Pass *max_lines* only for human-facing diagnostics, where the newest lines
+    carry the failure and unbounded output would flood the logs.
     """
     try:
         with log_path.open("rb") as f:
@@ -1011,7 +1026,10 @@ def _read_log_since(log_path: Path, offset: int, max_lines: int = 80) -> str:
             chunk = f.read()
     except OSError:
         return ""
-    lines = chunk.decode("utf-8", errors="replace").splitlines()
+    text = chunk.decode("utf-8", errors="replace")
+    if max_lines is None:
+        return text
+    lines = text.splitlines()
     tail = lines[-max_lines:] if len(lines) > max_lines else lines
     return "\n".join(tail)
 
@@ -1636,17 +1654,18 @@ def calibrate_model(
                 stop_vllm(proc)
                 time.sleep(_VRAM_SETTLE_S)
                 return None
-            log_tail = _read_log_since(log_path, _spawn_log_offset)
+            # Parse the COMPLETE probe segment; echo only its tail to the logs.
+            probe_log = _read_log_since(log_path, _spawn_log_offset)
             logger.warning(
                 "        FAIL kv_cache=%s: %s",
                 kv_str,
                 exc,
             )
-            if log_tail:
+            if probe_log:
                 logger.warning(
                     "  -- vLLM log tail --\n%s%s%s\n  -- end vLLM log tail --",
                     _C_DIM,
-                    log_tail,
+                    _tail_lines(probe_log, _LOG_DIAGNOSTIC_TAIL_LINES),
                     _C_RESET,
                 )
             stop_vllm(proc)
@@ -1661,7 +1680,7 @@ def calibrate_model(
             # reads the partial result, surfaces ``node_unhealthy_reason``
             # into the runtime status, and the master orchestrator skips
             # this worker until the node recovers.
-            node_pattern = _classify_node_transient_error(log_tail)
+            node_pattern = _classify_node_transient_error(probe_log)
             if node_pattern is not None:
                 if not _node_unhealthy_box:
                     _node_unhealthy_box.append(node_pattern)
@@ -1686,7 +1705,7 @@ def calibrate_model(
             # with --max-model-len injected. The new fingerprint differs
             # (carries --max-model-len) so the blacklist check sees it as a
             # fresh attempt.
-            suggested_max_len = _extract_vllm_max_model_len_suggestion(log_tail)
+            suggested_max_len = _extract_vllm_max_model_len_suggestion(probe_log)
             if suggested_max_len is not None:
                 # This rejection is the one place where vLLM states the model's
                 # OWN limits ("max seq len (262144), 8.16 GiB KV cache is
@@ -1696,10 +1715,10 @@ def calibrate_model(
                 # caller keeps the sweep's cap and KV->context rate anchored to
                 # the model instead of to our own shrink.
                 if plan_overrides is not None:
-                    _obs_seq_len = _extract_vllm_max_seq_len(log_tail, allow_config_fallback=False)
+                    _obs_seq_len = _extract_vllm_max_seq_len(probe_log, allow_config_fallback=False)
                     if _obs_seq_len:
                         plan_overrides["_observed_model_max_seq_len"] = _obs_seq_len
-                    _obs_kv_gib = _extract_vllm_kv_gib_needed_for_full(log_tail)
+                    _obs_kv_gib = _extract_vllm_kv_gib_needed_for_full(probe_log)
                     if _obs_kv_gib:
                         plan_overrides["_observed_kv_gib_for_full"] = _obs_kv_gib
                 attempts_used = int(planned.get("_max_model_len_retry_count") or 0)
@@ -1736,7 +1755,7 @@ def calibrate_model(
             # blacklisting the command. The resolved value is captured from the
             # successful probe and persisted so the lane spawner can reuse it —
             # otherwise the lane reverts to 1024 and crashes identically at runtime.
-            suggested_max_seqs = _extract_vllm_max_num_seqs_suggestion(log_tail)
+            suggested_max_seqs = _extract_vllm_max_num_seqs_suggestion(probe_log)
             if suggested_max_seqs is not None:
                 ns_attempts_used = int(planned.get("_max_num_seqs_retry_count") or 0)
                 current_seqs = planned.get("max_num_seqs")
@@ -1781,7 +1800,7 @@ def calibrate_model(
             # line. Persist into the model-level unsupported list and
             # latch ``_unsupported_box`` so the search loops bail without
             # spawning vLLM again.
-            fatal_pattern = _classify_fatal_load_error(log_tail)
+            fatal_pattern = _classify_fatal_load_error(probe_log)
             if fatal_pattern is not None and not _unsupported_box:
                 _record_unsupported_model(
                     unsupported_path,
@@ -1851,14 +1870,14 @@ def calibrate_model(
                 )
                 return None
             _probes[kv_mb] = "ok"
-            # Read only what THIS probe wrote. Reading the whole file's tail
-            # mixes in the previous probe's lines and drops this one's own
-            # init summary behind the warmup output.
-            log_tail = _read_log_since(log_path, _last_probe_log_offset[0])
-            _conc = _extract_vllm_max_concurrency(log_tail)
+            # Read the COMPLETE segment THIS probe wrote. Reading the whole
+            # file's tail mixes in the previous probe's lines, and any line cap
+            # drops this probe's init summary behind its warmup output.
+            probe_log = _read_log_since(log_path, _last_probe_log_offset[0])
+            _conc = _extract_vllm_max_concurrency(probe_log)
             if _conc is not None:
                 anchors_parallelity[kv_mb] = _conc
-            suggested_mml = _extract_vllm_max_model_len_suggestion(log_tail)
+            suggested_mml = _extract_vllm_max_model_len_suggestion(probe_log)
             # Model-level truths seen while this probe was still being rejected
             # (captured in _try_start, where they are guaranteed to be in view).
             _injected_max_len = bool(probe_overrides.get("_max_model_len_retry_count") or 0)
@@ -1872,15 +1891,17 @@ def calibrate_model(
                 # Only consult the config dump when we did NOT inject a
                 # --max-model-len for this probe; otherwise it echoes our own
                 # shrunken value back as if it were the model's default.
-                model_default_max_len = _extract_vllm_max_seq_len(log_tail, allow_config_fallback=not _injected_max_len)
+                model_default_max_len = _extract_vllm_max_seq_len(
+                    probe_log, allow_config_fallback=not _injected_max_len
+                )
             if kv_needed_for_full_mb is None:
-                _gib = _extract_vllm_kv_gib_needed_for_full(log_tail)
+                _gib = _extract_vllm_kv_gib_needed_for_full(probe_log)
                 if _gib:
                     kv_needed_for_full_mb = _gib * 1024.0
             # What the engine ACTUALLY loaded wins over everything inferred: a
             # probe that started without an injected --max-model-len serves the
             # model default, which may be far above the floor probe's ceiling.
-            resolved_mml = int(_extract_vllm_served_context(log_tail) or 0)
+            resolved_mml = int(_extract_vllm_served_context(probe_log) or 0)
             if resolved_mml <= 0:
                 resolved_mml = int(probe_overrides.get("_resolved_max_model_len") or 0)
             if resolved_mml <= 0:

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -592,16 +592,25 @@ def _extract_vllm_max_model_len_suggestion(log_tail: str) -> int | None:
     return value if value > 0 else None
 
 
-def _extract_vllm_max_seq_len(log_tail: str) -> int | None:
+def _extract_vllm_max_seq_len(log_tail: str, *, allow_config_fallback: bool = True) -> int | None:
     """Return the model's default max seq len mentioned by vLLM, if present.
 
     This appears in KV-too-small startup failures and lets calibration record
     the plateau ``max_model_len`` once the default fits again.
+
+    ``allow_config_fallback=False`` restricts the search to the authoritative
+    "max seq len (N)" phrasing of vLLM's KV-too-small ValueError and skips the
+    ``max_model_len=N`` config-dump fallback. Callers MUST pass False whenever
+    calibration itself injected ``--max-model-len`` for the probe being parsed:
+    the config dump then echoes OUR OWN injected value, so treating it as the
+    model default silently pins the whole sweep to the floor probe's shrunken
+    context (deipapa/deimama 2026-08-18: Qwen3.8-27B recorded a flat 27440
+    curve although probes at 10-20G served the model's full 262144).
     """
     if not log_tail:
         return None
     m = _VLLM_MAX_SEQ_LEN_RE.search(log_tail)
-    if not m:
+    if not m and allow_config_fallback:
         m = _VLLM_MAX_MODEL_LEN_CONFIG_RE.search(log_tail)
     if not m:
         return None
@@ -649,7 +658,7 @@ def _extract_vllm_max_num_seqs_suggestion(log_tail: str) -> int | None:
 # This is total_kv_cache_tokens / max_model_len — i.e. how many simultaneous
 # full-context requests the KV pool can serve. We read it back (rather than
 # pinning --max-num-seqs) to record the "parallelity factor" of each KV point.
-_VLLM_MAX_CONCURRENCY_RE = re.compile(r"Maximum concurrency for [\d,]+ tokens per request:\s*([\d.]+)x")
+_VLLM_MAX_CONCURRENCY_RE = re.compile(r"Maximum concurrency for ([\d,]+) tokens per request:\s*([\d.]+)x")
 
 
 def _extract_vllm_max_concurrency(log_tail: str) -> float | None:
@@ -664,8 +673,33 @@ def _extract_vllm_max_concurrency(log_tail: str) -> float | None:
     if not matches:
         return None
     try:
-        value = float(matches[-1])
-    except (TypeError, ValueError):
+        value = float(matches[-1][1])
+    except (TypeError, ValueError, IndexError):
+        return None
+    return value if value > 0 else None
+
+
+def _extract_vllm_served_context(log_tail: str) -> int | None:
+    """Return the context length vLLM actually loaded, from the same line.
+
+    "Maximum concurrency for 262,144 tokens per request: 2.21x" names the
+    engine's resolved ``max_model_len``, printed on every successful init. It
+    is the ONLY authoritative answer to "what did this probe really serve" —
+    a probe that starts without an injected ``--max-model-len`` carries no
+    suggestion and no fresh config echo, so without this the sweep has to fall
+    back to a cached model-default and can attribute the floor probe's
+    shrunken context to every larger KV size (see ``_extract_vllm_max_seq_len``).
+
+    Uses the LAST occurrence so retries within one probe report the final load.
+    """
+    if not log_tail:
+        return None
+    matches = _VLLM_MAX_CONCURRENCY_RE.findall(log_tail)
+    if not matches:
+        return None
+    try:
+        value = int(matches[-1][0].replace(",", ""))
+    except (TypeError, ValueError, IndexError):
         return None
     return value if value > 0 else None
 
@@ -948,14 +982,38 @@ def _kill_stale_vllm_workers() -> None:
         time.sleep(_VRAM_SETTLE_S)  # let GPU memory release
 
 
-def _read_log_tail(log_path: Path, max_lines: int = 80) -> str:
-    """Read the last *max_lines* of a vLLM log file, or '' on failure."""
+def _log_size(log_path: Path) -> int:
+    """Current size of the vLLM log in bytes, or 0 when it does not exist yet.
+
+    Probes within one calibration run APPEND to a shared log file, so a byte
+    offset taken just before a spawn is what separates "this probe's output"
+    from every earlier probe's.
+    """
     try:
-        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-        tail = lines[-max_lines:] if len(lines) > max_lines else lines
-        return "\n".join(tail)
-    except Exception:
+        return log_path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _read_log_since(log_path: Path, offset: int, max_lines: int = 80) -> str:
+    """Read the last *max_lines* of the log written AFTER *offset* bytes.
+
+    Reading the tail of the whole file (as this used to do) spans probe
+    boundaries, because all probes of a run append to one file. A successful
+    start emits hundreds of warmup lines, pushing that probe's own
+    "Maximum concurrency for N tokens per request" line out of an 80-line
+    window while stale lines from an EARLIER probe stay in it. Slicing from the
+    pre-spawn offset makes every extraction refer to the probe being parsed.
+    """
+    try:
+        with log_path.open("rb") as f:
+            f.seek(max(offset, 0))
+            chunk = f.read()
+    except OSError:
         return ""
+    lines = chunk.decode("utf-8", errors="replace").splitlines()
+    tail = lines[-max_lines:] if len(lines) > max_lines else lines
+    return "\n".join(tail)
 
 
 def stop_vllm(proc: subprocess.Popen[str]) -> None:
@@ -1414,6 +1472,11 @@ def calibrate_model(
     # blacklist-skip write inside _try_start raises NameError.
     _probes: dict[float, str] = {}
 
+    # Byte offset in the shared vLLM log where the most recent spawn began.
+    # Single-element box so _try_start can publish it and _probe_kv can read
+    # the SAME probe's output back (see _read_log_since).
+    _last_probe_log_offset: list[int] = [0]
+
     # Single-element box (mutable across closure scope without `nonlocal`)
     # that latches the FatalLoadErrorPattern detected for this model, if
     # any. Once set, subsequent _try_start calls short-circuit so the
@@ -1519,6 +1582,10 @@ def calibrate_model(
                 else:
                     logger.info("  [RAM cache] %s → loading from disk (tmpfs full)", model)
             _ram_cached = True
+        # Remember where this probe's output starts so every later extraction
+        # parses THIS probe rather than the tail of the shared append log.
+        _spawn_log_offset = _log_size(log_path)
+        _last_probe_log_offset[0] = _spawn_log_offset
         proc, cmd = spawn_vllm(
             planned,
             vllm_binary,
@@ -1569,7 +1636,7 @@ def calibrate_model(
                 stop_vllm(proc)
                 time.sleep(_VRAM_SETTLE_S)
                 return None
-            log_tail = _read_log_tail(log_path)
+            log_tail = _read_log_since(log_path, _spawn_log_offset)
             logger.warning(
                 "        FAIL kv_cache=%s: %s",
                 kv_str,
@@ -1621,6 +1688,20 @@ def calibrate_model(
             # fresh attempt.
             suggested_max_len = _extract_vllm_max_model_len_suggestion(log_tail)
             if suggested_max_len is not None:
+                # This rejection is the one place where vLLM states the model's
+                # OWN limits ("max seq len (262144), 8.16 GiB KV cache is
+                # needed"). Capture them here — after the retry succeeds the
+                # numbers are gone from the log, and the only max_model_len
+                # left to read is the one we injected. Publishing them to the
+                # caller keeps the sweep's cap and KV->context rate anchored to
+                # the model instead of to our own shrink.
+                if plan_overrides is not None:
+                    _obs_seq_len = _extract_vllm_max_seq_len(log_tail, allow_config_fallback=False)
+                    if _obs_seq_len:
+                        plan_overrides["_observed_model_max_seq_len"] = _obs_seq_len
+                    _obs_kv_gib = _extract_vllm_kv_gib_needed_for_full(log_tail)
+                    if _obs_kv_gib:
+                        plan_overrides["_observed_kv_gib_for_full"] = _obs_kv_gib
                 attempts_used = int(planned.get("_max_model_len_retry_count") or 0)
                 current_max = planned.get("max_model_len")
                 current_max_int = int(current_max) if current_max else None
@@ -1770,22 +1851,46 @@ def calibrate_model(
                 )
                 return None
             _probes[kv_mb] = "ok"
-            log_tail = _read_log_tail(log_path)
+            # Read only what THIS probe wrote. Reading the whole file's tail
+            # mixes in the previous probe's lines and drops this one's own
+            # init summary behind the warmup output.
+            log_tail = _read_log_since(log_path, _last_probe_log_offset[0])
             _conc = _extract_vllm_max_concurrency(log_tail)
             if _conc is not None:
                 anchors_parallelity[kv_mb] = _conc
             suggested_mml = _extract_vllm_max_model_len_suggestion(log_tail)
+            # Model-level truths seen while this probe was still being rejected
+            # (captured in _try_start, where they are guaranteed to be in view).
+            _injected_max_len = bool(probe_overrides.get("_max_model_len_retry_count") or 0)
+            _obs_seq_len = int(probe_overrides.get("_observed_model_max_seq_len") or 0)
+            if model_default_max_len is None and _obs_seq_len > 0:
+                model_default_max_len = _obs_seq_len
+            _obs_kv_gib = probe_overrides.get("_observed_kv_gib_for_full")
+            if kv_needed_for_full_mb is None and _obs_kv_gib:
+                kv_needed_for_full_mb = float(_obs_kv_gib) * 1024.0
             if model_default_max_len is None:
-                model_default_max_len = _extract_vllm_max_seq_len(log_tail)
+                # Only consult the config dump when we did NOT inject a
+                # --max-model-len for this probe; otherwise it echoes our own
+                # shrunken value back as if it were the model's default.
+                model_default_max_len = _extract_vllm_max_seq_len(log_tail, allow_config_fallback=not _injected_max_len)
             if kv_needed_for_full_mb is None:
                 _gib = _extract_vllm_kv_gib_needed_for_full(log_tail)
                 if _gib:
                     kv_needed_for_full_mb = _gib * 1024.0
-            resolved_mml = int(probe_overrides.get("_resolved_max_model_len") or 0)
+            # What the engine ACTUALLY loaded wins over everything inferred: a
+            # probe that started without an injected --max-model-len serves the
+            # model default, which may be far above the floor probe's ceiling.
+            resolved_mml = int(_extract_vllm_served_context(log_tail) or 0)
+            if resolved_mml <= 0:
+                resolved_mml = int(probe_overrides.get("_resolved_max_model_len") or 0)
             if resolved_mml <= 0:
                 resolved_mml = int(suggested_mml or model_default_max_len or 0)
             if resolved_mml <= 0:
                 resolved_mml = int(plan.get("max_model_len") or 0)
+            # A probe that served MORE than the running assumption proves the
+            # assumption was a floor artefact, not the model's limit.
+            if model_default_max_len is not None and resolved_mml > model_default_max_len:
+                model_default_max_len = resolved_mml
             resolved_seqs = int(probe_overrides.get("_resolved_max_num_seqs") or 0)
             if resolved_seqs > 0:
                 resolved_max_num_seqs = (
@@ -1913,21 +2018,34 @@ def calibrate_model(
         # mml seen, capped at the model max) across [first-full-context-KV,
         # kv_max], and discard any 0/garbage entries.
         _clean = [(k, m) for k, m in kv_max_model_len_pairs if m and m > 0]
+        # Only a point that reached the model's full context is a plateau. If
+        # the best measured context is still BELOW the model default, the curve
+        # is on its rising edge and holding that value across the upper KV range
+        # would advertise a KV-starved context as the hardware ceiling — exactly
+        # the flat curve that pinned Qwen3.8-27B to 27440 (2026-08-18).
+        _may_plateau = not model_default_max_len or max((m for _, m in _clean), default=0) >= int(model_default_max_len)
         if _clean:
-            _plateau = max(m for _, m in _clean)
-            if model_default_max_len:
-                _plateau = min(_plateau, int(model_default_max_len))
             _by_kv: dict[float, int] = {}
             for k, m in _clean:
                 rk = round(k, 1)
                 _by_kv[rk] = max(_by_kv.get(rk, 0), int(m))
-            _first_full_kv = min((k for k, m in _clean if m >= _plateau), default=None)
-            if _first_full_kv is not None:
-                _s = _first_full_kv
-                while _s <= kv_max:
-                    rk = round(_s, 1)
-                    _by_kv[rk] = max(_by_kv.get(rk, 0), _plateau)
-                    _s += _KV_CACHE_MIN_STEP_MB
+            if _may_plateau:
+                _plateau = max(m for _, m in _clean)
+                if model_default_max_len:
+                    _plateau = min(_plateau, int(model_default_max_len))
+                _first_full_kv = min((k for k, m in _clean if m >= _plateau), default=None)
+                if _first_full_kv is not None:
+                    _s = _first_full_kv
+                    while _s <= kv_max:
+                        rk = round(_s, 1)
+                        _by_kv[rk] = max(_by_kv.get(rk, 0), _plateau)
+                        _s += _KV_CACHE_MIN_STEP_MB
+            else:
+                logger.info(
+                    "  Curve tops out at %d < model default %d — rising edge, no plateau backfill.",
+                    max(m for _, m in _clean),
+                    int(model_default_max_len or 0),
+                )
             kv_max_model_len_pairs = sorted(_by_kv.items())
 
         kv_cache_sent_mb = best_kv

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2047,13 +2047,29 @@ _QWEN38_FLOOR_OK = (
 )
 
 
+# vLLM prints its init summary BEFORE capturing CUDA graphs, then emits
+# hundreds of warmup lines. Measured on the deimama log: the concurrency line
+# sits 137-241 lines from the end of its probe segment. Any tail window applied
+# to parser input therefore loses it.
+_QWEN38_WARMUP_LINE_COUNT = 200
+
+
+def _qwen38_warmup_noise(lines: int = _QWEN38_WARMUP_LINE_COUNT) -> str:
+    """Post-init CUDA-graph warmup chatter, as it follows every real start."""
+    return "".join(
+        f"(EngineCore pid=112949) INFO 08-18 08:13:3{i % 10} [backends.py:634] "
+        f"Capturing CUDA graphs (decode, PIECEWISE): batch {i}\n"
+        for i in range(lines)
+    )
+
+
 def _qwen38_full_context_ok(kv_mb: float, conc: float) -> str:
     """A probe that starts unshrunken and serves the model's full context."""
     return (
         f"(EngineCore pid=112949) INFO 08-18 08:13:33 [kv_cache_utils.py:2236] Maximum concurrency "
         f"for 262,144 tokens per request: {conc:.2f}x\n"
         f"(EngineCore pid=112949) INFO 08-18 08:13:33 [core.py:100] init engine, max_model_len=262144\n"
-    )
+    ) + _qwen38_warmup_noise()
 
 
 def test_kv_starved_floor_probe_does_not_flatten_curve(tmp_path: Path):
@@ -2083,7 +2099,9 @@ def test_kv_starved_floor_probe_does_not_flatten_curve(tmp_path: Path):
         kv_calls.append((kv_mb, pinned))
         if kv_mb <= 1024.0:
             # Floor: reject unshrunken, succeed once --max-model-len is pinned.
-            log_path.open("a", encoding="utf-8").write(_QWEN38_FLOOR_OK if pinned else _QWEN38_FLOOR_REJECT)
+            log_path.open("a", encoding="utf-8").write(
+                (_QWEN38_FLOOR_OK + _qwen38_warmup_noise()) if pinned else _QWEN38_FLOOR_REJECT
+            )
         else:
             log_path.open("a", encoding="utf-8").write(_qwen38_full_context_ok(kv_mb, conc_by_kv.get(kv_mb, 1.50)))
         mock_proc = MagicMock()
@@ -2132,3 +2150,16 @@ def test_kv_starved_floor_probe_does_not_flatten_curve(tmp_path: Path):
     assert all(mml == 262144 for mml in big.values()), f"large-KV points not at full context: {big}"
     # The curve must RISE — a flat curve is what made the planner pick min_kv.
     assert pairs[1024] < max(pairs.values())
+
+    # Concurrency must survive the warmup chatter that follows vLLM's init
+    # summary, otherwise the planner cannot tell 10G/1.22x from 17G/>2x and
+    # settles for the cheapest full-context point.
+    triples = result.kv_max_model_len_parallelity_pairs or []
+    par_by_kv = {round(kv): par for kv, _, par in triples}
+    assert par_by_kv.get(1024) == pytest.approx(1.00), par_by_kv
+    for kv_mb, expected in conc_by_kv.items():
+        if round(kv_mb) in par_by_kv:
+            assert par_by_kv[round(kv_mb)] == pytest.approx(
+                expected
+            ), f"kv={kv_mb} lost its concurrency annotation: {par_by_kv}"
+    assert any(p is not None and p > 2.0 for p in par_by_kv.values()), par_by_kv

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -898,8 +898,8 @@ def test_explicit_kv_auto_retries_with_max_model_len_from_vllm_suggestion():
             None,  # auto-retry with --max-model-len succeeds
         ],
     )
-    patches["read_log_tail"] = patch(
-        "logos_worker_node.calibration._read_log_tail",
+    patches["read_log_since"] = patch(
+        "logos_worker_node.calibration._read_log_since",
         return_value=suggestion_tail,
     )
 
@@ -921,8 +921,8 @@ def test_explicit_kv_does_not_loop_when_suggestion_does_not_shrink():
     patches = _patch_calibration_infra(
         wait_ready_side_effect=[RuntimeError("vLLM exited (code=1)")],
     )
-    patches["read_log_tail"] = patch(
-        "logos_worker_node.calibration._read_log_tail",
+    patches["read_log_since"] = patch(
+        "logos_worker_node.calibration._read_log_since",
         return_value=suggestion_tail,
     )
 
@@ -956,8 +956,8 @@ def test_kv_probe_auto_retries_with_max_num_seqs_for_mamba_model():
             None,  # auto-retry with --max-num-seqs succeeds
         ],
     )
-    patches["read_log_tail"] = patch(
-        "logos_worker_node.calibration._read_log_tail",
+    patches["read_log_since"] = patch(
+        "logos_worker_node.calibration._read_log_since",
         return_value=suggestion_tail,
     )
 
@@ -977,8 +977,8 @@ def test_max_num_seqs_retry_does_not_loop_when_suggestion_does_not_shrink():
     patches = _patch_calibration_infra(
         wait_ready_side_effect=[RuntimeError("vLLM exited (code=1)")],
     )
-    patches["read_log_tail"] = patch(
-        "logos_worker_node.calibration._read_log_tail",
+    patches["read_log_since"] = patch(
+        "logos_worker_node.calibration._read_log_since",
         return_value=suggestion_tail,
     )
 
@@ -1737,6 +1737,26 @@ def test_node_transient_classifier_registry_has_expected_codes():
     assert {"filesystem-eio", "filesystem-readonly"} <= codes
 
 
+def _spawn_writing_log(log_path: Path, text: str):
+    """Patch spawn_vllm so it APPENDS *text* to the probe log, like the real one.
+
+    Calibration reads a probe's log slice starting at the byte offset taken
+    just before the spawn, so simulated vLLM output has to be written by the
+    spawn itself — text present beforehand belongs to an earlier probe.
+    """
+
+    def _side_effect(plan, vllm_binary, host, port, path, kv_cache_memory_bytes, **kwargs):
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(text)
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        return (mock_proc, ["vllm", "serve"])
+
+    return patch("logos_worker_node.calibration.spawn_vllm", side_effect=_side_effect)
+
+
 def test_try_start_with_node_eio_writes_no_blacklist_artifacts(tmp_path: Path):
     """The critical guarantee: when a probe fails because the node's storage
     is broken (EIO), calibrate_model must NOT pollute either the per-command
@@ -1746,16 +1766,18 @@ def test_try_start_with_node_eio_writes_no_blacklist_artifacts(tmp_path: Path):
     """
     log_dir = tmp_path / "calibration_logs"
     log_dir.mkdir()
-    # Pre-seed the per-model log file with an EIO tail.
     log_path = log_dir / "Qwen__SomeModel.log"
-    log_path.write_text(
-        "(APIServer pid=611559) OSError: [Errno 5] Input/output error: "
-        "'/usr/share/ollama/.ollama/models/.hf_cache/hub/models--Qwen--SomeModel'\n",
-        encoding="utf-8",
-    )
 
     patches = _patch_calibration_infra(
         wait_ready_side_effect=RuntimeError("vLLM exited (code=1)"),
+    )
+    # Emit the EIO tail from inside the spawn, like the real spawn_vllm does.
+    # Text written BEFORE the spawn belongs to an earlier probe and is
+    # deliberately out of view (see _read_log_since).
+    patches["spawn"] = _spawn_writing_log(
+        log_path,
+        "(APIServer pid=611559) OSError: [Errno 5] Input/output error: "
+        "'/usr/share/ollama/.ollama/models/.hf_cache/hub/models--Qwen--SomeModel'\n",
     )
     # Make sure _record_failed_command and _record_unsupported_model are real
     # (not pre-patched out) so we can detect any accidental writes.
@@ -1803,18 +1825,17 @@ def test_try_start_failure_with_fatal_tail_records_unsupported_and_aborts_search
     """
     log_dir = tmp_path / "calibration_logs"
     log_dir.mkdir()
-    # Pre-seed the per-model log file with a fatal-pattern tail so the
-    # classifier matches when _try_start reads the log after the simulated
-    # spawn failure.
     log_path = log_dir / "Qwen__Bogus.log"
-    log_path.write_text(
-        "(APIServer pid=572249)   Value error, " "Invalid repository ID or local directory specified: 'Qwen/Bogus'.\n",
-        encoding="utf-8",
-    )
 
     # Patch the kv search to fail on every probe (RuntimeError = vLLM exited).
     patches = _patch_calibration_infra(
         wait_ready_side_effect=RuntimeError("vLLM exited (code=1)"),
+    )
+    # The fatal tail must come from the probe's own output, so write it during
+    # the spawn rather than pre-seeding the shared log file.
+    patches["spawn"] = _spawn_writing_log(
+        log_path,
+        "(APIServer pid=572249)   Value error, " "Invalid repository ID or local directory specified: 'Qwen/Bogus'.\n",
     )
 
     plan = _make_plan(model="Qwen/Bogus")
@@ -2000,3 +2021,114 @@ def test_build_vllm_cmd_enables_prefix_caching_to_match_serving():
     plan_off = {**plan, "enable_prefix_caching": False}
     cmd_off = _build_vllm_cmd(plan_off, "vllm", "127.0.0.1", 11499, "1G")
     assert "--enable-prefix-caching" not in cmd_off
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Regression: KV-starved floor probe must not flatten the whole curve
+# (Qwen/Qwen3.8-27B on deipapa/deimama, 2026-08-18)
+# ═══════════════════════════════════════════════════════════════════════
+
+# Verbatim vLLM output from the deimama calibration of Qwen/Qwen3.8-27B.
+# The floor probe is rejected and names the model's real limits; the retry
+# with the suggested --max-model-len then starts at that shrunken context.
+_QWEN38_FLOOR_REJECT = (
+    "(EngineCore pid=105718) ERROR 08-18 08:05:08 [core.py:1349] ValueError: To serve at least one "
+    "request with the model's max seq len (262144), (8.16 GiB KV cache is needed, which is larger "
+    "than the available KV cache memory (1.0 GiB). Based on the available memory, the estimated "
+    "maximum model length is 27440. Try increasing `gpu_memory_utilization` (which also controls "
+    "CPU memory on the CPU backend) or decreasing `max_model_len` when initializing the engine.\n"
+)
+_QWEN38_FLOOR_OK = (
+    "(EngineCore pid=107776) INFO 08-18 08:08:22 [kv_cache_utils.py:2236] Maximum concurrency for "
+    "27,440 tokens per request: 1.00x\n"
+    # The config echo of OUR injected --max-model-len. Mistaking this for the
+    # model default is what pinned the whole sweep to 27440.
+    "(EngineCore pid=107776) INFO 08-18 08:08:22 [core.py:100] init engine, max_model_len=27440\n"
+)
+
+
+def _qwen38_full_context_ok(kv_mb: float, conc: float) -> str:
+    """A probe that starts unshrunken and serves the model's full context."""
+    return (
+        f"(EngineCore pid=112949) INFO 08-18 08:13:33 [kv_cache_utils.py:2236] Maximum concurrency "
+        f"for 262,144 tokens per request: {conc:.2f}x\n"
+        f"(EngineCore pid=112949) INFO 08-18 08:13:33 [core.py:100] init engine, max_model_len=262144\n"
+    )
+
+
+def test_kv_starved_floor_probe_does_not_flatten_curve(tmp_path: Path):
+    """A floor probe that had to shrink --max-model-len must not cap the curve.
+
+    Real failure (Qwen3.8-27B, deipapa/deimama 2026-08-18): at kv=1G vLLM
+    refused the model's 262144 default and suggested 27440, so calibration
+    injected --max-model-len=27440 and the probe started. Every LARGER KV probe
+    then started unshrunken and vLLM reported "Maximum concurrency for 262,144
+    tokens per request", yet the persisted curve read a flat 27440 from 1G to
+    18G. The planner therefore spawned the lane at min_kv=1024 — cheapest KV
+    for what looked like the same context — and served 27440 tokens at 1.00x
+    concurrency instead of 262144 at >2x.
+    """
+    log_dir = tmp_path / "calibration_logs"
+    log_dir.mkdir()
+    log_path = log_dir / "Qwen__Qwen3.8-27B.log"
+
+    # (kv_mb, had_pinned_max_model_len) per spawn, newest last.
+    kv_calls: list[tuple[float, bool]] = []
+    # Concurrency rises with KV, exactly as measured on deimama.
+    conc_by_kv = {10240.0: 1.22, 15360.0: 1.84, 17408.0: 2.08, 18432.0: 2.21, 19456.0: 2.33, 20480.0: 2.45}
+
+    def spawn_side_effect(plan, vllm_binary, host, port, path, kv_cache_memory_bytes, **kwargs):
+        kv_mb = _parse_kv_to_mb(kv_cache_memory_bytes)
+        pinned = bool(plan.get("max_model_len"))
+        kv_calls.append((kv_mb, pinned))
+        if kv_mb <= 1024.0:
+            # Floor: reject unshrunken, succeed once --max-model-len is pinned.
+            log_path.open("a", encoding="utf-8").write(_QWEN38_FLOOR_OK if pinned else _QWEN38_FLOOR_REJECT)
+        else:
+            log_path.open("a", encoding="utf-8").write(_qwen38_full_context_ok(kv_mb, conc_by_kv.get(kv_mb, 1.50)))
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        return (mock_proc, ["vllm", "serve"])
+
+    def ready(*args, **kwargs):
+        kv_mb, pinned = kv_calls[-1]
+        # The floor only starts once --max-model-len is pinned; >20G is OOM.
+        if kv_mb <= 1024.0 and not pinned:
+            raise RuntimeError("vLLM exited before becoming ready (code=1)")
+        if kv_mb > 20480.0:
+            raise RuntimeError("OOM")
+        return None
+
+    patches = _patch_search_infra(wait_ready_side_effect=ready, gpu_vram_total_mb=49140.0)
+    patches["spawn"] = patch("logos_worker_node.calibration.spawn_vllm", side_effect=spawn_side_effect)
+    patches["ready"] = patch("logos_worker_node.calibration.wait_ready", side_effect=ready)
+
+    for p in patches.values():
+        p.__enter__()
+    try:
+        result = calibrate_model(
+            _make_search_plan(model="Qwen/Qwen3.8-27B", tensor_parallel_size=2),
+            vllm_binary="vllm",
+            port=11499,
+            log_dir=log_dir,
+            sleep_level=1,
+            ready_timeout_s=60.0,
+        )
+    finally:
+        for p in patches.values():
+            p.__exit__(None, None, None)
+
+    assert result.success, result.error
+    pairs = dict((round(kv), mml) for kv, mml in (result.kv_max_model_len_pairs or []))
+    assert pairs, "sweep recorded no curve"
+
+    # The floor stays honest about its own limit ...
+    assert pairs[1024] == 27440
+    # ... and every probe that served the full context is recorded as such.
+    assert result.max_model_len == 262144, f"curve capped at {result.max_model_len}"
+    big = {kv: mml for kv, mml in pairs.items() if kv >= 10240}
+    assert big, "no large-KV points recorded"
+    assert all(mml == 262144 for mml in big.values()), f"large-KV points not at full context: {big}"
+    # The curve must RISE — a flat curve is what made the planner pick min_kv.
+    assert pairs[1024] < max(pairs.values())


### PR DESCRIPTION
## Auftrag

Prüfen, ob `Qwen/Qwen3.8-27B` auf den Logos-Worker-Nodes mit größerem Kontextfenster und besserem Durchsatz betrieben werden kann.

**Ergebnis: ja — und zwar ohne Hardware-Änderung.** Das Modell kann auf dem vorhandenen TP=2-Setup **262.144 Tokens** bei >2x Concurrency liefern. Ausgeliefert wurden 27.440 bei 1.00x. Ursache ist ein Bug im Kalibrierungspfad, kein VRAM-Limit.

## Befund

Das Modell (`Qwen3_5ForConditionalGeneration`, 64 Layer, davon nur 16 mit full attention) hat `max_position_embeddings = 262144`. Die Kalibrierung auf deimama hat das auch **tatsächlich gemessen** — hier die echten vLLM-Zeilen aus `Qwen__Qwen3.8-27B.log`:

| KV | Kontext | Concurrency |
|---|---|---|
| 1G | 27.440 | 1.00x |
| 10G | **262.144** | 1.22x |
| 15G | **262.144** | 1.84x |
| 17G | **262.144** | 2.08x |
| 18G | **262.144** | 2.21x |
| 20G | **262.144** | 2.45x |

Persistiert wurde stattdessen eine **flache Kurve mit 27.440 über 1G–18G**, alle `parallelity: null`. Weil die Kurve flach ist, wählt der Planner konsequenterweise `min_kv = 1024` — das billigste KV für scheinbar identischen Kontext. Ergebnis: 27.440 Tokens bei 1.00x.

## Ursachenkette

1. Der Floor-Probe (1G) kann keinen Request beim Modell-Default halten. vLLM lehnt ab und nennt dabei die *echten* Modellwerte: `max seq len (262144), 8.16 GiB KV cache is needed, ... estimated maximum model length is 27440`.
2. Die Kalibrierung injiziert korrekt `--max-model-len=27440` und der Probe startet.
3. **Der Config-Dump des erfolgreichen Starts echot unseren eigenen injizierten Wert** (`max_model_len=27440`). `_extract_vllm_max_seq_len` akzeptierte ihn über den Fallback-Regex als *Modell-Default*. Damit werden `cap` und `plateau_at_floor` aus unserem eigenen Shrink berechnet.
4. Größere Probes starten **unshrunken** und vLLM meldet den echten Kontext in `Maximum concurrency for 262,144 tokens per request` — aber diese Zahl wurde nirgends gelesen. Die Probes fielen auf den gecachten (falschen) Default zurück.
5. Die aus vLLMs eigenem Report abgeleitete KV→Kontext-Rate wurde anschließend **verworfen**, weil sie diesen falschen Ankern um >10% widersprach.
6. Der Plateau-Backfill hielt den KV-ausgehungerten Wert über den gesamten oberen KV-Bereich → perfekt flache Kurve.

Zusätzlich: alle `parallelity`-Werte kamen als `None` zurück, weil `_read_log_tail` die letzten 80 Zeilen der **gemeinsamen Append-Datei** liest. Nach einem erfolgreichen Start mit CUDA-Graph-Capture ist die eigene `Maximum concurrency`-Zeile längst aus dem Fenster geschoben, während Zeilen des *vorherigen* Probes noch darin stehen.

## Änderungen

- **Probe-isolierte Log-Lesung** (`_read_log_since`): Jeder Probe wird ab dem Byte-Offset gelesen, der unmittelbar vor seinem Spawn genommen wurde. Behebt gleichzeitig die fehlenden `parallelity`-Annotationen. `_read_log_tail` entfällt (keine Nutzung mehr).
- **Modellwerte an der Quelle erfassen**: `max seq len` und `GiB KV needed` werden aus der Ablehnung gelesen, die die Injection auslöst — dort nennt vLLM sie garantiert.
- **Autoritative Kontextquelle** (`_extract_vllm_served_context`): Was die Engine wirklich geladen hat, gewinnt über alles Abgeleitete.
- **Kein kontaminierter Fallback**: Der `max_model_len`-Config-Dump wird nur konsultiert, wenn für diesen Probe *kein* `--max-model-len` injiziert wurde.
- **Plateau-Guard**: Backfill nur, wenn ein Punkt den Modell-Default erreicht hat. Sonst ist die Kurve auf der steigenden Flanke und darf nicht flachgehalten werden.

## Test

`test_kv_starved_floor_probe_does_not_flatten_curve` speist die **verbatim vLLM-Ausgaben** aus dem deimama-Lauf ein (Floor-Ablehnung, Floor-Erfolg mit Config-Echo, Full-Context-Starts mit gemessenen Concurrency-Werten).

Verifiziert gegen den ungefixten Code — dort schlägt er mit genau dem Prod-Bild fehl:

```
assert result.max_model_len == 262144, f"curve capped at {result.max_model_len}"
E   AssertionError: curve capped at 27440
    pairs: (18432.0, 27440, None), (19456.0, 27440, None), (20480.0, 27440, 2.45)
```

Suite: **413 passed, 2 skipped**. `black --line-length 120` und `flake8` clean (das verbleibende F824 `nonlocal best_kv` ist vorbestehend und unangetastet).

## Keine Prod-Änderungen

DB, Lanes und Node-Konfiguration sind unangetastet — wie abgesprochen. Zum Wirksamwerden ist eine **Neukalibrierung** von `Qwen/Qwen3.8-27B` nötig; die alten Profilwerte bleiben bis dahin flach.

## Zwei Punkte aus dem Handover, die sich anders auflösen

- **`kv_budget_mb = 1024` ist kein Persistenz-Bug.** Der Planner liest die Envelope aus dem Worker-Runtime-Snapshot, nicht aus `model_profiles`; das Feld spiegelt den zur Laufzeit tatsächlich gewählten Wert. Bei flacher Kurve ist `min_kv` sogar die richtige Wahl — der Fehler lag in der Kurve. Ein manuelles Hochsetzen auf 18432 hätte den Kontext **nicht** vergrößert.
- **`max_context_length = NULL` ist kein Bug.** Das Feld ist laut `model_profiles.py` ausdrücklich *"manual override only"*; der Orchestrator liest primär `calibration_max_model_len`. Dieses war mit 27440 falsch belegt — aus derselben Wurzel, die hier behoben wird.

## Nebenbefunde (nicht Teil dieses PRs)

- **deimama kann das Modell fahren.** Der erfolgreiche TP=2-Lauf (08:05–08:22) wurde vom späteren TP=1-Lauf (08:51) überschrieben, der zwangsläufig an den Gewichten scheitert: 2× RTX 6000 Ada mit 48 GB, das Modell braucht ~95,5 GB. Warum dort TP=1 geplant wurde, ist offen — das ist der Hebel für die zweite Lane und die Queue-Staus.
- Die HTTP-500-Fehler der Lane sind damit nicht erklärt und brauchen eine eigene Untersuchung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoWwvULLgf5vi3NmgMk8t1