### PR TITLE
`Logos`: Hide provider names from app developers

### DIFF
--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
@@ -162,7 +162,9 @@
                               @if (group.hasLocal) { <span>Local</span> }
                             </span>
                           </div>
-                          <span class="model-providers">{{ group.providers.join(' · ') }}</span>
+                          @if (showProviderNames() && group.providers.length > 0) {
+                            <span class="model-providers">{{ group.providers.join(' · ') }}</span>
+                          }
                         </div>
                       }
                     </div>

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
@@ -1,10 +1,18 @@
-import { Component, OnInit, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  inject,
+  signal,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalFormComponent } from '../../shared/components/modal/modal-form/modal-form';
 import { ErrorMessageComponent } from '../../shared/components/error-message/error-message';
 import { IconTileComponent } from '../../shared/components/icon-tile/icon-tile';
 import { MyKeysService } from '../../core/services/my-keys.service';
 import { TeamManagementService } from '../../core/services/team-management.service';
+import { AuthService } from '../../core/auth/services/auth.service';
 import { MyKey, ModelAccess } from '../../shared/models/my-key.model';
 import { MyTeam } from '../../shared/models/team.model';
 import { isInteractiveClick } from '../../shared/utils/interactive-click';
@@ -32,6 +40,11 @@ interface ModelGroup {
 export class MyWorkspace implements OnInit {
   private keysService = inject(MyKeysService);
   private teamService = inject(TeamManagementService);
+  private authService = inject(AuthService);
+
+  readonly showProviderNames = computed(
+    () => this.authService.role() === 'logos_admin' || this.authService.role() === 'app_admin',
+  );
 
   workspaces = signal<TeamWorkspace[]>([]);
   loading = signal(true);
@@ -163,7 +176,9 @@ export class MyWorkspace implements OnInit {
         hasCloud: false,
         hasLocal: false,
       };
-      if (!group.providers.includes(m.provider_name)) group.providers.push(m.provider_name);
+      if (m.provider_name && !group.providers.includes(m.provider_name)) {
+        group.providers.push(m.provider_name);
+      }
       if (m.provider_type === 'cloud') group.hasCloud = true;
       else group.hasLocal = true;
       groups.set(m.model_name, group);

--- a/logos/logos-ui/src/app/shared/models/my-key.model.ts
+++ b/logos/logos-ui/src/app/shared/models/my-key.model.ts
@@ -29,7 +29,7 @@ export interface MyKey {
 
 export interface ModelAccess {
   model_name: string;
-  provider_name: string;
+  provider_name?: string;
   provider_type: string;
   /** Served context window in tokens; null when no worker reports one. */
   context_window: number | null;

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/controller/MeKeysController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/controller/MeKeysController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import de.tum.cit.aet.logos.logoswebservice.auth.AuthContext;
 import de.tum.cit.aet.logos.logoswebservice.identity.dto.ModelAccessDTO;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKey;
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.Role;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
 import de.tum.cit.aet.logos.logoswebservice.identity.service.MeKeysService;
 
@@ -80,7 +81,10 @@ public class MeKeysController {
         if (!auth.userId().equals(key.getUserId())) {
             return ResponseEntity.status(403).body(Map.of("detail", "You do not own this API key."));
         }
-        Optional<List<ModelAccessDTO>> result = meKeysService.getAccessibleModels(keyId, auth.userId());
+        boolean includeProviderNames = Role.LOGOS_ADMIN.matches(auth.role())
+            || Role.APP_ADMIN.matches(auth.role());
+        Optional<List<ModelAccessDTO>> result = meKeysService.getAccessibleModels(
+            keyId, auth.userId(), includeProviderNames);
         return result
             .<ResponseEntity<?>>map(ResponseEntity::ok)
             .orElseGet(() -> ResponseEntity.status(404).body(Map.of("detail", "API key not found or not owned.")));

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/dto/ModelAccessDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/dto/ModelAccessDTO.java
@@ -1,7 +1,10 @@
 package de.tum.cit.aet.logos.logoswebservice.identity.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public record ModelAccessDTO(
     String model_name,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     String provider_name,
     String provider_type,
     // Served context window in tokens, from the orchestrator's live worker

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
@@ -57,7 +57,8 @@ public class MeKeysService {
         return Optional.of(Map.of("result", "Log level updated to " + level));
     }
 
-    public Optional<List<ModelAccessDTO>> getAccessibleModels(int keyId, int userId) {
+    public Optional<List<ModelAccessDTO>> getAccessibleModels(
+            int keyId, int userId, boolean includeProviderNames) {
         Optional<ApiKey> keyOpt = apiKeyRepository.findById(keyId);
         if (keyOpt.isEmpty()) {
             return Optional.empty();
@@ -75,7 +76,10 @@ public class MeKeysService {
         Map<String, Integer> windows = modelWindowClient.getContextWindows();
         return Optional.of(rows.stream()
             .map(r -> new ModelAccessDTO(
-                r.getModelName(), r.getProviderName(), r.getProviderType(), windows.get(r.getModelName())))
+                r.getModelName(),
+                includeProviderNames ? r.getProviderName() : null,
+                r.getProviderType(),
+                windows.get(r.getModelName())))
             .toList());
     }
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
 
 import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
@@ -115,11 +116,20 @@ class MeKeysControllerTest {
     }
 
     @Test
-    void getModels_returnsTeamModelList() throws Exception {
+    void getModels_hidesProviderNamesFromAppDevelopers() throws Exception {
         mvc.perform(get("/me/keys/3101/models").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.length()").value(1))
            .andExpect(jsonPath("$[0].model_name").value("test-model"))
+           .andExpect(jsonPath("$[0].provider_name").doesNotExist());
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(statements = "UPDATE users SET role = 'app_admin' WHERE id = 1101")
+    void getModels_includesProviderNamesForAppAdmins() throws Exception {
+        mvc.perform(get("/me/keys/3101/models").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
+           .andExpect(status().isOk())
            .andExpect(jsonPath("$[0].provider_name").value("test-provider"));
     }
 


### PR DESCRIPTION
## Summary
- omit provider names from accessible-model responses for app developers
- hide provider labels in My Workspace while retaining them for app and Logos admins
- cover developer redaction and admin visibility with integration tests

## Motivation and Context
Closes #732

Provider names are infrastructure details that app developers should not be able to view. The response now fails closed and only exposes these names to recognized admin roles, while the frontend independently enforces the same display rule.

## Description
The My Keys endpoint passes the authenticated user role into model response mapping. `provider_name` is omitted for app developers and remains available to `app_admin` and `logos_admin` users. The Angular model treats the field as optional, groups models without requiring it, and renders provider labels only for admin roles.

## Steps for Testing
1. Run `mvn clean test` in `logos/logos-webservice` (205 tests pass).
2. Run `npm run build` in `logos/logos-ui`.
3. Sign in as an app developer, expand a key in My Workspace, and confirm model names/types appear without provider names.
4. Sign in as an app admin or Logos admin and confirm provider names remain visible.

## Database Changes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider names in model lists are now shown only to application and platform administrators.
  * Other users can still access models without seeing provider details.
* **Bug Fixes**
  * Models without provider names are handled correctly and no longer create empty provider entries.
  * Responses now omit unavailable context-window values for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->