### PR TITLE
`Logos`: Add a Claude Code setup page

### DIFF
--- a/logos/logos-ui/src/app/app.routes.ts
+++ b/logos/logos-ui/src/app/app.routes.ts
@@ -27,6 +27,7 @@ export const routes: Routes = [
       { path: 'teams/:id',       title: 'Team · Logos',            data: { roles: ['logos_admin', 'app_admin'] },   canActivate: [roleGuard], loadComponent: () => import('./features/team-detail/team-detail').then(m => m.TeamDetail) },
       { path: 'my-workspace',    title: 'My Workspace · Logos',    canActivate: [hasKeysGuard], loadComponent: () => import('./features/my-workspace/my-workspace').then(m => m.MyWorkspace) },
       { path: 'open-code',       title: 'OpenCode · Logos',        canActivate: [hasKeysGuard], loadComponent: () => import('./features/open-code/open-code').then(m => m.OpenCode) },
+      { path: 'claude-code',     title: 'Claude Code · Logos',     canActivate: [hasKeysGuard], loadComponent: () => import('./features/claude-code/claude-code').then(m => m.ClaudeCode) },
       { path: 'no-access',       title: 'No Access · Logos',       loadComponent: () => import('./features/no-access/no-access').then(m => m.NoAccess) },
       { path: '**', redirectTo: 'my-workspace' },
     ],

--- a/logos/logos-ui/src/app/features/claude-code/claude-code.html
+++ b/logos/logos-ui/src/app/features/claude-code/claude-code.html
@@ -1,0 +1,242 @@
+<div class="claude-code">
+  <h1 class="page-title">Claude Code</h1>
+  <p class="page-subtitle">Connect Claude Code to Logos in four steps.</p>
+
+  <!-- ── 1 - INSTALL CLAUDE CODE ───────────────────────────────────────── -->
+  <div class="config-section">
+    <p class="step-label">1. INSTALL CLAUDE CODE</p>
+    <div class="os-tabs" role="tablist">
+      <button class="os-tab" role="tab"
+        [class.os-tab--active]="installTab() === 'mac'"
+        (click)="installTab.set('mac')">macOS</button>
+      <button class="os-tab" role="tab"
+        [class.os-tab--active]="installTab() === 'linux'"
+        (click)="installTab.set('linux')">Linux</button>
+      <button class="os-tab" role="tab"
+        [class.os-tab--active]="installTab() === 'windows'"
+        (click)="installTab.set('windows')">Windows</button>
+    </div>
+
+    @if (installTab() === 'mac') {
+      <div class="terminal-block">
+        <span class="terminal-prefix" aria-hidden="true">$</span>
+        <code class="terminal-cmd">{{ installCommands.mac }}</code>
+        <button class="btn-copy-cmd" [class.btn-copy-cmd--done]="copiedCmd() === installCommands.mac"
+          (click)="copyCmd(installCommands.mac)" aria-label="Copy command">
+          <i [class]="copiedCmd() === installCommands.mac ? 'pi pi-check' : 'pi pi-copy'" aria-hidden="true"></i>
+        </button>
+      </div>
+      <p class="tab-note">
+        Homebrew installs do not auto-update. Prefer the self-updating native installer?
+        Use <code class="inline-code">{{ installCommands.nativeUnix }}</code> instead.
+      </p>
+    }
+    @if (installTab() === 'linux') {
+      <div class="terminal-block">
+        <span class="terminal-prefix" aria-hidden="true">$</span>
+        <code class="terminal-cmd">{{ installCommands.nativeUnix }}</code>
+        <button class="btn-copy-cmd" [class.btn-copy-cmd--done]="copiedCmd() === installCommands.nativeUnix"
+          (click)="copyCmd(installCommands.nativeUnix)" aria-label="Copy command">
+          <i [class]="copiedCmd() === installCommands.nativeUnix ? 'pi pi-check' : 'pi pi-copy'" aria-hidden="true"></i>
+        </button>
+      </div>
+      <p class="tab-note">
+        Works on WSL too. Debian, Fedora, RHEL and Alpine can also install via
+        <code class="inline-code">apt</code>, <code class="inline-code">dnf</code> or
+        <code class="inline-code">apk</code>; see
+        <a class="ext-link" href="https://code.claude.com/docs/en/setup" target="_blank" rel="noopener">the setup guide</a>.
+      </p>
+    }
+    @if (installTab() === 'windows') {
+      <div class="terminal-block">
+        <span class="terminal-prefix" aria-hidden="true">&gt;</span>
+        <code class="terminal-cmd">{{ installCommands.windows }}</code>
+        <button class="btn-copy-cmd" [class.btn-copy-cmd--done]="copiedCmd() === installCommands.windows"
+          (click)="copyCmd(installCommands.windows)" aria-label="Copy command">
+          <i [class]="copiedCmd() === installCommands.windows ? 'pi pi-check' : 'pi pi-copy'" aria-hidden="true"></i>
+        </button>
+      </div>
+      <p class="tab-note">
+        Run in PowerShell, not CMD. WinGet works as well
+        (<code class="inline-code">{{ installCommands.winget }}</code>), but does not auto-update.
+      </p>
+    }
+  </div>
+
+  <!-- ── 2 - SELECT API KEY ────────────────────────────────────────────── -->
+  <div class="config-section">
+    <p class="step-label">2. SELECT API KEY</p>
+
+    @if (keysLoading()) {
+      <div class="model-loading">
+        <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
+        <span>Loading your keys…</span>
+      </div>
+    } @else if (keysError()) {
+      <p class="model-error">Failed to load your API keys. Please refresh.</p>
+    } @else if (keys().length === 0) {
+      <p class="model-empty">No API keys found for your account.</p>
+    } @else {
+      <app-select
+        [options]="keyOptions()"
+        [value]="selectedKey() ? String(selectedKey()!.id) : ''"
+        ariaLabel="Select API key"
+        (valueChange)="selectKeyById($event ?? '')"
+      />
+    }
+  </div>
+
+  <!-- ── 3 - MODEL ─────────────────────────────────────────────────────── -->
+  <div class="config-section">
+    <p class="step-label">3. MODEL</p>
+    <p class="section-note" style="margin-bottom: 12px;">
+      Claude Code has one active model at a time, so every alias — <code class="inline-code">opus</code>,
+      <code class="inline-code">sonnet</code>, <code class="inline-code">haiku</code> — is pointed at
+      the model you pick here. Switching alias with <code class="inline-code">/model</code> then never
+      leaves Logos.
+    </p>
+
+    @if (keysLoading() || modelsLoading()) {
+      <div class="model-loading">
+        <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
+        <span>Loading models…</span>
+      </div>
+    } @else if (modelsError()) {
+      <p class="model-error">Failed to load models for this key.</p>
+    } @else if (models().length === 0) {
+      <p class="model-empty">No models are accessible for this key.</p>
+    } @else {
+      <app-select
+        [options]="modelOptions()"
+        [value]="selected()?.model_name ?? ''"
+        ariaLabel="Select model"
+        (valueChange)="selectModel($event ?? '')"
+      />
+
+      @if (selected()) {
+        <p class="context-note">
+          Serves <strong>{{ contextTokens() | number }}</strong> tokens of context,
+          <strong>{{ outputTokens() | number }}</strong> of them reserved for output.
+          @if (!selected()!.context_window) {
+            This model reports no window, so this is a conservative fallback.
+          }
+          Claude Code otherwise assumes 200,000 tokens for models it does not know and lets
+          requests overflow before it compacts, so the config below states the real number.
+        </p>
+      }
+
+      @if (windowUnenforced()) {
+        <div class="privacy-callout" role="note">
+          <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
+          <p>
+            <strong>Claude Code will ignore the context window below for this model.</strong>
+            It applies only to model IDs that Claude Code cannot resolve to a Claude model —
+            names starting with <code class="inline-code">claude-</code> or containing
+            <code class="inline-code">[1m]</code> need
+            <code class="inline-code">DISABLE_COMPACT</code> or
+            <code class="inline-code">CLAUDE_CODE_DISABLE_1M_CONTEXT</code> as well. Pick another
+            model, or set those yourself.
+          </p>
+        </div>
+      }
+    }
+  </div>
+
+  <!-- ── 4 - CONNECT ───────────────────────────────────────────────────── -->
+  <div class="config-section">
+    <p class="step-label">4. CONNECT</p>
+
+    <div class="privacy-callout" role="note">
+      <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
+      <p>
+        <strong>This replaces your claude.ai login for every Claude Code session on this
+        machine</strong>, not just this project: prompts go to Logos, and your subscription
+        is not used. Run <code class="inline-code">/status</code> to see which credential is
+        active, or remove the <code class="inline-code">env</code> block to switch back.
+      </p>
+    </div>
+
+    <p class="substep-label">a. Write the Logos settings</p>
+
+    <div class="os-tabs" role="tablist">
+      <button class="os-tab" role="tab"
+        [class.os-tab--active]="connectMethod() === 'download'"
+        (click)="connectMethod.set('download')">Download settings</button>
+      <button class="os-tab" role="tab"
+        [class.os-tab--active]="connectMethod() === 'terminal'"
+        (click)="connectMethod.set('terminal')">Terminal</button>
+    </div>
+
+    @if (connectMethod() === 'download') {
+      <p class="apply-hint">
+        Only if you have no <code class="inline-code">settings.json</code> yet: save it as
+        <code class="inline-code">~/.claude/settings.json</code>
+        (Windows: <code class="inline-code">%USERPROFILE%\.claude\settings.json</code>).
+        It has to be that user-level file — an <code class="inline-code">env</code> block in a
+        project's <code class="inline-code">.claude/settings.json</code> is only read after the
+        first-run setup, so Claude Code would still ask you to log in.
+      </p>
+      <div class="code-header">
+        <span class="file-tab">~/.claude/settings.json</span>
+        <button class="btn-copy-config" (click)="downloadSettings()">
+          <i class="pi pi-download" aria-hidden="true"></i> Download Settings
+        </button>
+      </div>
+      <div class="code-block" role="region" aria-label="Generated settings.json">
+        <div class="line-numbers" aria-hidden="true">
+          @for (line of settingsLines(); track $index) {
+            <span>{{ $index + 1 }}</span>
+          }
+        </div>
+        <pre class="code-content">{{ settingsJson() }}</pre>
+      </div>
+    } @else {
+      <p class="apply-hint">
+        Run in your terminal; adds only the Logos keys, an existing settings file is kept:
+      </p>
+      <div class="os-tabs" role="tablist">
+        <button class="os-tab" role="tab"
+          [class.os-tab--active]="installTab() === 'mac'"
+          (click)="installTab.set('mac')">macOS</button>
+        <button class="os-tab" role="tab"
+          [class.os-tab--active]="installTab() === 'linux'"
+          (click)="installTab.set('linux')">Linux</button>
+        <button class="os-tab" role="tab"
+          [class.os-tab--active]="installTab() === 'windows'"
+          (click)="installTab.set('windows')">Windows</button>
+      </div>
+      <div class="terminal-block">
+        <span class="terminal-prefix" aria-hidden="true">{{ installTab() === 'windows' ? '&gt;' : '$' }}</span>
+        <code class="terminal-cmd">{{ mergeCommand() }}</code>
+        <button class="btn-copy-cmd" [class.btn-copy-cmd--done]="copiedCmd() === mergeCommand()"
+          (click)="copyCmd(mergeCommand())" aria-label="Copy command">
+          <i [class]="copiedCmd() === mergeCommand() ? 'pi pi-check' : 'pi pi-copy'" aria-hidden="true"></i>
+        </button>
+      </div>
+      @if (installTab() === 'windows') {
+        <p class="tab-note">Run in PowerShell; uses only built-in cmdlets.</p>
+      } @else if (installTab() === 'mac') {
+        <p class="tab-note">
+          Uses <code class="inline-code">python3</code>, included in the Xcode Command Line
+          Tools (already present if you installed via Homebrew).
+        </p>
+      } @else {
+        <p class="tab-note">Uses the system <code class="inline-code">python3</code>.</p>
+      }
+    }
+
+    <p class="substep-label">b. Restart Claude Code</p>
+    <p class="apply-hint">
+      Environment variables are read at startup, so exit any running session first. If one was
+      already logged in to claude.ai, run <code class="inline-code">/logout</code> so only the
+      Logos credential remains.
+    </p>
+
+    <p class="substep-label">c. Verify</p>
+    <p class="apply-hint">
+      Run <code class="inline-code">claude</code> and type <code class="inline-code">/status</code>:
+      it shows the base URL and the credential source. It should name this Logos instance, not
+      api.anthropic.com.
+    </p>
+  </div>
+</div>

--- a/logos/logos-ui/src/app/features/claude-code/claude-code.scss
+++ b/logos/logos-ui/src/app/features/claude-code/claude-code.scss
@@ -1,0 +1,316 @@
+@use 'styles/glass' as *;
+
+.claude-code {
+  padding: 36px 32px 48px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.claude-code .page-subtitle {
+  margin-bottom: 24px;
+}
+
+// ── Section cards ─────────────────────────────────────────────────────────
+.config-section {
+  @include glass-surface;
+  margin-top: 16px;
+  padding: 20px 24px 24px;
+}
+
+.step-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-widest);
+  text-transform: uppercase;
+  color: rgb(var(--color-typography-700));
+  margin-bottom: 14px;
+}
+
+// ── OS tabs ───────────────────────────────────────────────────────────────
+.os-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.os-tab {
+  padding: 5px 14px;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-border));
+  background: transparent;
+  color: rgb(var(--color-typography-700));
+  font-size: var(--font-size-md);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+  &:hover {
+    background: rgb(var(--color-primary-400)  / var(--opacity-faint));
+    color: rgb(var(--color-text-accent));
+  }
+
+  &--active {
+    background: rgb(var(--nav-active-fill) / var(--nav-active-fill-opacity));
+    border-color: rgb(var(--nav-active-stroke) / var(--nav-active-stroke-opacity));
+    color: rgb(var(--color-text-accent));
+    font-weight: var(--font-weight-semibold);
+  }
+}
+
+// ── Terminal blocks ───────────────────────────────────────────────────────
+.terminal-block {
+  display: flex;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgb(var(--color-background-200));
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-border));
+  font-family: monospace;
+  margin-bottom: 10px;
+}
+
+.terminal-prefix {
+  color: rgb(var(--color-accent-green));
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-md);
+  margin-right: 10px;
+  user-select: none;
+}
+
+.terminal-cmd {
+  flex: 1 1 auto;
+  font-size: var(--font-size-md);
+  color: rgb(var(--color-typography-100));
+  word-break: break-all;
+}
+
+.btn-copy-cmd {
+  flex-shrink: 0;
+  margin-left: 12px;
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  color: rgb(var(--color-typography-700));
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+
+  i { font-size: var(--font-size-base); }
+
+  &:hover {
+    color: rgb(var(--color-text-accent));
+    background: rgb(var(--color-primary-400)  / var(--opacity-soft));
+  }
+
+  &--done { color: rgb(var(--color-accent-green)); }
+}
+
+.tab-note {
+  font-size: var(--font-size-sm);
+  color: rgb(var(--color-typography-700));
+  margin-top: 2px;
+}
+
+
+.section-note {
+  font-size: var(--font-size-sm);
+  color: rgb(var(--color-typography-700));
+  line-height: var(--line-height-normal);
+}
+
+// ── Config code block ─────────────────────────────────────────────────────
+.code-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+
+  .step-label { margin-bottom: 0; flex: 1 1 auto; }
+}
+
+.file-tab {
+  font-size: var(--font-size-sm);
+  font-family: monospace;
+  color: rgb(var(--color-typography-300));
+  padding: 2px 10px;
+  border-radius: 8px;
+  background: rgb(var(--color-primary-500) / var(--opacity-soft));
+}
+
+.btn-copy-config {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  border-radius: 8px;
+  border: 1px solid rgb(var(--color-outline-200));
+  background: transparent;
+  color: rgb(var(--color-typography-300));
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+  &:hover {
+    background: rgb(var(--color-primary-400)  / var(--opacity-soft));
+    color: rgb(var(--color-text-accent));
+    border-color: rgb(var(--color-primary-400)  / var(--opacity-border));
+  }
+
+  &--done {
+    color: rgb(var(--color-accent-green));
+    border-color: rgb(var(--color-accent-green)  / var(--opacity-border));
+  }
+}
+
+.code-block {
+  display: flex;
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-border));
+  border-radius: 8px;
+  margin-bottom: 14px;
+  background: rgb(var(--color-background-50));
+  overflow: hidden;
+}
+
+.line-numbers {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 0 16px 16px;
+  min-width: 36px;
+  text-align: right;
+  user-select: none;
+
+  span {
+    font-size: var(--font-size-md);
+    font-family: monospace;
+    color: rgb(var(--color-typography-300));
+    line-height: var(--line-height-loose);
+  }
+}
+
+.code-content {
+  flex: 1 1 auto;
+  padding: 16px 24px 20px 16px;
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-family: monospace;
+  color: rgb(var(--color-typography-100));
+  line-height: var(--line-height-loose);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+// ── Apply config ──────────────────────────────────────────────────────────
+.apply-hint {
+  font-size: var(--font-size-base);
+  color: rgb(var(--color-typography-300));
+  margin-bottom: 12px;
+}
+
+.install-hint {
+  font-size: var(--font-size-base);
+  color: rgb(var(--color-typography-300));
+  margin-bottom: 8px;
+}
+
+.ext-link {
+  color: rgb(var(--color-text-accent));
+  text-decoration: none;
+
+  &:hover { text-decoration: underline; }
+}
+
+// ── Privacy callout ───────────────────────────────────────────────────────
+.privacy-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: rgb(var(--color-warning) / var(--opacity-faint));
+  border: 1px solid rgb(var(--color-warning) / var(--opacity-border));
+
+  i {
+    flex-shrink: 0;
+    margin-top: 2px;
+    font-size: var(--font-size-base);
+    color: rgb(var(--color-warning));
+  }
+
+  p {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    color: rgb(var(--color-typography-300));
+    line-height: var(--line-height-normal);
+
+    strong { color: rgb(var(--color-typography-100)); }
+  }
+}
+
+// ── Connect sub-steps ─────────────────────────────────────────────────────
+.substep-label {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: rgb(var(--color-typography-100));
+  margin: 18px 0 8px;
+
+  &:first-of-type { margin-top: 4px; }
+}
+
+
+// ── Model select ─────────────────────────────────────────────────────────
+.model-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-md);
+  color: rgb(var(--color-typography-500));
+}
+
+.model-error { font-size: var(--font-size-md); color: rgb(var(--color-error)); }
+.model-empty { font-size: var(--font-size-md); color: rgb(var(--color-typography-500)); }
+
+// ── Shared inline code ────────────────────────────────────────────────────
+.inline-code {
+  font-family: monospace;
+  font-size: var(--font-size-md);
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgb(var(--color-primary-500) / var(--opacity-soft));
+  color: rgb(var(--color-primary-600));
+}
+
+// ── Mobile ────────────────────────────────────────────────────────────────
+@media (max-width: 768px) {
+  .claude-code {
+    padding: 24px 16px 32px;
+  }
+
+  .config-section {
+    padding: 16px 16px 20px;
+  }
+
+  .code-header {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+
+  .os-tabs {
+    flex-wrap: wrap;
+  }
+
+  .terminal-block {
+    align-items: flex-start;
+  }
+}
+
+// ── Served context window ─────────────────────────────────────────────────
+.context-note {
+  font-size: var(--font-size-sm);
+  color: rgb(var(--color-typography-700));
+  line-height: var(--line-height-normal);
+  margin-top: 12px;
+
+  strong { color: rgb(var(--color-typography-100)); }
+}

--- a/logos/logos-ui/src/app/features/claude-code/claude-code.ts
+++ b/logos/logos-ui/src/app/features/claude-code/claude-code.ts
@@ -1,0 +1,248 @@
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  OnInit,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MyKeysService } from '../../core/services/my-keys.service';
+import { MyKey, ModelAccess } from '../../shared/models/my-key.model';
+import { SelectComponent, AppSelectOption } from '../../shared/components/select/select';
+
+@Component({
+  selector: 'app-claude-code',
+  standalone: true,
+  imports: [CommonModule, SelectComponent],
+  templateUrl: './claude-code.html',
+  changeDetection: ChangeDetectionStrategy.Eager,
+  styleUrl: './claude-code.scss',
+})
+export class ClaudeCode implements OnInit {
+  private myKeysService = inject(MyKeysService);
+
+  readonly String = String;
+
+  // ── Key list ──────────────────────────────────────────────────────────────
+  keys = signal<MyKey[]>([]);
+  keysLoading = signal(true);
+  keysError = signal(false);
+  selectedKey = signal<MyKey | null>(null);
+
+  // ── Models for selected key ───────────────────────────────────────────────
+  models = signal<ModelAccess[]>([]);
+  modelsLoading = signal(false);
+  modelsError = signal(false);
+  selected = signal<ModelAccess | null>(null);
+
+  // ── UI state ──────────────────────────────────────────────────────────────
+  installTab = signal<'mac' | 'linux' | 'windows'>('mac');
+  connectMethod = signal<'download' | 'terminal'>('download');
+  copiedCmd = signal<string | null>(null);
+
+  // Claude Code talks the Anthropic Messages API and appends /v1/messages to
+  // ANTHROPIC_BASE_URL itself, so unlike the OpenCode page this URL must NOT
+  // carry a /v1 suffix. The :9443 admin entrypoint this page may be served on
+  // in prod never routes /v1, so that port is stripped; in dev the UI and /v1
+  // share one port and the origin is left untouched.
+  baseUrl = computed(() => window.location.origin.replace(/:9443$/, ''));
+
+  // Claude Code assumes a 200k window for models it doesn't know, so requests
+  // overflow upstream long before it decides to compact. The window a model
+  // really serves is reported by the orchestrator; models without one get a
+  // conservative fallback (32768 local, 128000 cloud) matching the OpenCode page.
+  // Input and output share this one budget upstream — vLLM counts both against
+  // --max-model-len — so the output cap is reserved out of the window rather
+  // than added on top, and capped at 32768 so long sessions keep room to think.
+  contextTokens = computed(() => {
+    const m = this.selected();
+    if (!m) return 0;
+    if (m.context_window && m.context_window > 0) return m.context_window;
+    return m.provider_type !== 'cloud' ? 32768 : 128000;
+  });
+
+  outputTokens = computed(() => Math.min(32768, Math.floor(this.contextTokens() / 4)));
+
+  // CLAUDE_CODE_MAX_CONTEXT_TOKENS only applies directly to a model id that
+  // Claude Code cannot resolve to a Claude model. An id starting with "claude-"
+  // needs DISABLE_COMPACT as well, and one containing "[1m]" needs
+  // CLAUDE_CODE_DISABLE_1M_CONTEXT — neither is something this page should set
+  // silently, so it warns instead. No Logos model is named that way today; this
+  // guards against one being registered later.
+  windowUnenforced = computed(() => {
+    const name = (this.selected()?.model_name ?? '').toLowerCase();
+    return name.startsWith('claude-') || name.includes('[1m]');
+  });
+
+  maskedKey = computed(() => {
+    const k = this.selectedKey()?.key_value ?? '';
+    return k.length > 14 ? k.slice(0, 14) + ' ···' : k;
+  });
+
+  private buildSettings(): Record<string, unknown> {
+    const key = this.selectedKey()?.key_value ?? '';
+    const model = this.selected()?.model_name ?? '';
+
+    return {
+      env: {
+        ANTHROPIC_BASE_URL: this.baseUrl(),
+        // Sends the key as "Authorization: Bearer", which is what the Logos
+        // orchestrator reads. ANTHROPIC_API_KEY would use x-api-key instead, so
+        // it is blanked to stop a globally exported value from winning.
+        ANTHROPIC_AUTH_TOKEN: key,
+        ANTHROPIC_API_KEY: '',
+        // Every model slot points at the same Logos model: the primary one plus
+        // the aliases behind /model, so switching alias never leaves Logos.
+        ANTHROPIC_MODEL: model,
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: model,
+        ANTHROPIC_DEFAULT_SONNET_MODEL: model,
+        ANTHROPIC_DEFAULT_OPUS_MODEL: model,
+        ANTHROPIC_DEFAULT_FABLE_MODEL: model,
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(this.contextTokens()),
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.outputTokens()),
+        // Keeps telemetry and model discovery off api.anthropic.com, so the only
+        // traffic leaving the machine goes to Logos.
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      },
+      permissions: {
+        // WebSearch is a server-side Anthropic tool: Claude Code sends it as
+        // {"type":"web_search_20250305"} with no input_schema, which the worker
+        // nodes reject with HTTP 400, and Claude Code then retries in a loop.
+        // Denying it keeps the tool out of the request entirely.
+        deny: ['WebSearch'],
+      },
+    };
+  }
+
+  settingsJson = computed(() => JSON.stringify(this.buildSettings(), null, 2));
+
+  settingsLines = computed(() => this.settingsJson().split('\n'));
+
+  readonly keyOptions = computed<AppSelectOption[]>(() =>
+    this.keys().map((k) => ({ value: String(k.id), label: k.name })),
+  );
+
+  readonly modelOptions = computed<AppSelectOption[]>(() =>
+    this.models().map((m) => ({ value: m.model_name, label: m.model_name })),
+  );
+
+  readonly installCommands = {
+    mac: 'brew install --cask claude-code',
+    nativeUnix: 'curl -fsSL https://claude.ai/install.sh | bash',
+    windows: 'irm https://claude.ai/install.ps1 | iex',
+    winget: 'winget install Anthropic.ClaudeCode',
+  } as const;
+
+  // Merges only the Logos parts into an existing settings file: the env keys are
+  // set/updated, WebSearch is added to permissions.deny if missing, everything
+  // else in the file stays untouched. Creates file and directory if missing.
+  // Uses tools the OS already has (python3 / PowerShell) so Node.js is not required.
+  readonly mergeCommand = computed(() =>
+    this.installTab() === 'windows' ? this.windowsMergeCommand() : this.posixMergeCommand(),
+  );
+
+  private posixMergeCommand(): string {
+    // The JSON is passed as argv inside shell single quotes, so a literal ' in
+    // the data (model names are admin-defined) must become '\''.
+    const json = JSON.stringify(this.buildSettings()).replace(/'/g, "'\\''");
+    return (
+      "python3 -c 'import json,os,sys;" +
+      'p=os.path.expanduser("~/.claude/settings.json");' +
+      'add=json.loads(sys.argv[1]);' +
+      'cfg=json.load(open(p)) if os.path.exists(p) else {};' +
+      'cfg.setdefault("env",{}).update(add["env"]);' +
+      'd=cfg.setdefault("permissions",{}).setdefault("deny",[]);' +
+      '"WebSearch" in d or d.append("WebSearch");' +
+      'os.makedirs(os.path.dirname(p),exist_ok=True);' +
+      'json.dump(cfg,open(p,"w"),indent=2);' +
+      'print("Logos settings written to "+p)\' ' +
+      "'" + json + "'"
+    );
+  }
+
+  private windowsMergeCommand(): string {
+    // In a PowerShell single-quoted string a literal ' is escaped by doubling.
+    const json = JSON.stringify(this.buildSettings()).replace(/'/g, "''");
+    return (
+      "$p=Join-Path $env:USERPROFILE '.claude\\settings.json'; " +
+      "$add='" + json + "' | ConvertFrom-Json; " +
+      '$cfg=if(Test-Path $p){Get-Content $p -Raw | ConvertFrom-Json}else{[pscustomobject]@{}}; ' +
+      'if(!$cfg.env){$cfg | Add-Member env ([pscustomobject]@{}) -Force}; ' +
+      'foreach($k in $add.env.PSObject.Properties.Name){$cfg.env | Add-Member $k $add.env.$k -Force}; ' +
+      'if(!$cfg.permissions){$cfg | Add-Member permissions ([pscustomobject]@{}) -Force}; ' +
+      'if(!$cfg.permissions.deny){$cfg.permissions | Add-Member deny @() -Force}; ' +
+      "if($cfg.permissions.deny -notcontains 'WebSearch'){$cfg.permissions.deny=@($cfg.permissions.deny)+'WebSearch'}; " +
+      'New-Item -Force -ItemType Directory (Split-Path $p) | Out-Null; ' +
+      '$cfg | ConvertTo-Json -Depth 12 | Set-Content $p; ' +
+      'Write-Host "Logos settings written to $p"'
+    );
+  }
+
+  async ngOnInit(): Promise<void> {
+    try {
+      const keys = await this.myKeysService.getMyKeys();
+      this.keys.set(keys);
+      this.keysLoading.set(false);
+      // pickKey's own modelsLoading covers the (slower, orchestrator-dependent)
+      // model fetch — keysLoading shouldn't stay true waiting on that too.
+      if (keys.length > 0) await this.pickKey(keys[0]);
+    } catch {
+      this.keysError.set(true);
+      this.keysLoading.set(false);
+    }
+  }
+
+  selectKeyById(id: string) {
+    const key = this.keys().find((k) => k.id === Number(id)) ?? null;
+    if (key) this.pickKey(key);
+  }
+
+  private async pickKey(key: MyKey): Promise<void> {
+    this.selectedKey.set(key);
+    this.models.set([]);
+    this.selected.set(null);
+    this.modelsLoading.set(true);
+    this.modelsError.set(false);
+    try {
+      const models = await this.myKeysService.getKeyModels(key.id);
+      // On duplicate names keep the local entry: the served window falls back to
+      // provider_type-based limits, and the local window is the safe lower bound.
+      const byName = new Map<string, ModelAccess>();
+      for (const m of models) {
+        const prev = byName.get(m.model_name);
+        if (!prev || (prev.provider_type === 'cloud' && m.provider_type !== 'cloud')) {
+          byName.set(m.model_name, m);
+        }
+      }
+      const unique = [...byName.values()];
+      this.models.set(unique);
+      if (unique.length > 0) this.selected.set(unique[0]);
+    } catch {
+      this.modelsError.set(true);
+    } finally {
+      this.modelsLoading.set(false);
+    }
+  }
+
+  selectModel(name: string) {
+    this.selected.set(this.models().find((m) => m.model_name === name) ?? null);
+  }
+
+  downloadSettings() {
+    const blob = new Blob([this.settingsJson()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'settings.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  copyCmd(text: string) {
+    navigator.clipboard.writeText(text).then(() => {
+      this.copiedCmd.set(text);
+      setTimeout(() => this.copiedCmd.set(null), 2000);
+    });
+  }
+}

--- a/logos/logos-ui/src/app/shared/constants/nav-items.ts
+++ b/logos/logos-ui/src/app/shared/constants/nav-items.ts
@@ -18,6 +18,7 @@ export const MENU_ITEMS: MenuItem[] = [
   // Personal (all roles)
   { label: 'My Workspace', path: '/my-workspace',  piIcon: 'objects-column', group: 'personal',   roles: ALL_ROLES },
   { label: 'OpenCode',   path: '/open-code',       piIcon: 'code',           group: 'personal',   roles: ALL_ROLES },
+  { label: 'Claude Code', path: '/claude-code',   piIcon: 'sparkles',       group: 'personal',   roles: ALL_ROLES },
 ];
 
 export const HOME_ROUTE: Record<UserRole, string> = {


### PR DESCRIPTION
Adds a **Claude Code** page next to the existing OpenCode one — same main menu, same `personal` group, same four-step shape (install → key → model → connect), with a download and a terminal merge command that keeps an existing settings file.

Claude Code speaks the Anthropic Messages API, which Logos serves natively at `POST /v1/messages`, so no proxy is involved.

### Why a page rather than a wiki snippet

The configuration is easy to get subtly wrong, and every one of these fails in a way that doesn't obviously point at the cause. The page knows the answers because it already has the key and the model list:

| | What the page does | What goes wrong otherwise |
|---|---|---|
| `ANTHROPIC_BASE_URL` | no `/v1` suffix | Claude Code appends the path itself → 404s |
| credential | `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY` blanked | `ANTHROPIC_API_KEY` sends `x-api-key`, the orchestrator reads `Authorization: Bearer` → 401 |
| model slots | all of them point at the picked model | switching alias with `/model` silently leaves Logos |
| `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | the window the workers actually report | Claude Code assumes 200k for unknown models and lets requests overflow upstream before it compacts |
| output cap | reserved *out of* that window | input and output share one budget upstream (vLLM counts both against `--max-model-len`) |
| WebSearch | denied | Claude Code sends `{"type":"web_search_20250305"}` with no `input_schema`, the worker nodes reject it with 400, and Claude Code retries in a loop |

The context window is the one that has cost the most time so far — hence taking it from `context_window` on the model rather than letting the user guess, with a conservative fallback (32768 local / 128000 cloud, matching the OpenCode page) when no worker reports one.

The page also warns when the picked model id would make `CLAUDE_CODE_MAX_CONTEXT_TOKENS` inert: it applies directly only to ids Claude Code cannot resolve to a Claude model, so an id starting with `claude-` or containing `[1m]` needs `DISABLE_COMPACT` / `CLAUDE_CODE_DISABLE_1M_CONTEXT` too. No Logos model is named that way today; this guards against one being registered later.

Settings go to the user-level `~/.claude/settings.json` on purpose — an `env` block in a project's `.claude/settings.json` is only read after first-run setup, so Claude Code would still ask the user to log in.

### Verification

`npx tsc --noEmit` and `npm run build` both clean; the new lazy chunk builds and adds no budget warning. Not yet rendered against a live orchestrator — the dev proxy points at a local backend, so the key/model dropdowns need one to populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft5fzaK1DdrwURrJwBggeV