### PR TITLE
`Logos`: Map reasoning effort onto Qwen3.8's accepted scale

### DIFF
--- a/logos/logos-orchestrator/src/logos/pipeline/context_resolver.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/context_resolver.py
@@ -14,6 +14,7 @@ from urllib.parse import parse_qsl, urlencode
 
 from logos.dbutils.dbmanager import DBManager
 from logos.logosnode_registry import LogosNodeRuntimeRegistry
+from logos.pipeline.effort_normalization import normalize_reasoning_effort
 from logos.request_content import is_multipart_payload, set_payload_field
 from logos.sdi.azure_deployment_sync import AZURE_OPERATION_API_VERSIONS
 
@@ -249,6 +250,13 @@ class ContextResolver:
         # OpenWebUI requires model name injection
         if context.provider_type in {"logosnode"} or "openwebui" in context.provider_name.lower():
             payload = set_payload_field(payload, "model", context.model_name)
+
+        # The Qwen3.8 chat template only accepts xhigh/medium/low as reasoning
+        # effort, but clients such as Claude Code send the Anthropic value
+        # "high" in every request. vLLM forwards the value to the template,
+        # which rejects it with an error surfaced as HTTP 500 — map the wider
+        # client scale onto the accepted one before forwarding (#749).
+        payload = normalize_reasoning_effort(payload, context.model_name)
 
         # Azure Responses API resolves the deployment from the body's "model"
         # field (the URL carries no deployment segment). Clients address models

--- a/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
@@ -71,12 +71,19 @@ CHAT_TEMPLATE_EFFORT_SCALES: Dict[str, EffortScale] = {
 
 
 def effort_scale_for_model(model_name: Optional[str]) -> Optional[EffortScale]:
-    """Return the effort scale the model's chat template enforces, if any."""
+    """Return the effort scale the model's chat template enforces, if any.
+
+    When several registered patterns match (e.g. a broad ``qwen3`` and a
+    specific ``qwen3.8``), the most specific one — the longest matching
+    pattern — wins, so broad entries cannot shadow specific ones
+    regardless of registration order.
+    """
     low = (model_name or "").lower()
-    for pattern, scale in CHAT_TEMPLATE_EFFORT_SCALES.items():
-        if pattern in low:
-            return scale
-    return None
+    best_pattern: Optional[str] = None
+    for pattern in CHAT_TEMPLATE_EFFORT_SCALES:
+        if pattern in low and (best_pattern is None or len(pattern) > len(best_pattern)):
+            best_pattern = pattern
+    return None if best_pattern is None else CHAT_TEMPLATE_EFFORT_SCALES[best_pattern]
 
 
 def _map_effort(value: str, scale: EffortScale) -> str:

--- a/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
@@ -1,0 +1,74 @@
+# src/logos/pipeline/effort_normalization.py
+"""
+Reasoning-effort normalization for upstreams with a restricted scale.
+
+Clients such as Claude Code attach the session's reasoning effort to every
+request (``output_config.effort`` on the Anthropic Messages surface,
+``reasoning_effort`` on the OpenAI surface). vLLM forwards the value to the
+model's chat template, and the Qwen3.8 template validates it: it only accepts
+``xhigh`` (its default), ``medium`` and ``low``. The Anthropic value
+``high`` — and vLLM's ``minimal``/``max`` — therefore raise a template
+exception that vLLM surfaces as an HTTP 500 ``internal_error``, failing every
+turn of a client session left on ``high`` (ls1intum/edutelligence#749).
+
+This module maps the wider client scale onto the scale the target model's
+template accepts, in every payload location vLLM forwards to the chat
+template:
+
+- ``output_config.effort`` (Anthropic Messages API)
+- ``reasoning_effort`` (OpenAI API, top level)
+- ``chat_template_kwargs.reasoning_effort`` (explicit template kwarg)
+
+Values already on the target scale (``xhigh``, ``medium``, ``low``) and
+``none`` (which vLLM translates into ``enable_thinking=false``) pass through
+unchanged.
+"""
+
+from typing import Any, Dict, Optional
+
+# vLLM's reasoning_effort field accepts none, minimal, low, medium, high,
+# xhigh and max. The Qwen3.8 chat template only accepts xhigh (default),
+# medium and low — map the out-of-scale values onto the closest accepted
+# level instead of letting the template reject them.
+QWEN38_EFFORT_MAP = {
+    "high": "xhigh",  # top level on both scales
+    "max": "xhigh",  # DeepSeek-specific top level
+    "minimal": "low",  # below low; low is the weakest accepted level
+}
+
+
+def model_uses_qwen38_effort_scale(model_name: Optional[str]) -> bool:
+    """Return whether the model's chat template enforces the Qwen3.8 effort scale."""
+    return "qwen3.8" in (model_name or "").lower()
+
+
+def normalize_reasoning_effort(payload: Dict[str, Any], model_name: Optional[str]) -> Dict[str, Any]:
+    """Map out-of-scale reasoning-effort values onto the model's accepted scale.
+
+    Returns a copy of ``payload`` with ``high``/``max``/``minimal`` rewritten
+    in every location vLLM forwards to the chat template; the input is never
+    mutated. Payloads for other models, or payloads whose effort values are
+    already accepted, are returned as-is.
+    """
+    if not isinstance(payload, dict) or not model_uses_qwen38_effort_scale(model_name):
+        return payload
+
+    result = payload
+    output_config = payload.get("output_config")
+    if isinstance(output_config, dict) and isinstance(output_config.get("effort"), str):
+        mapped = QWEN38_EFFORT_MAP.get(output_config["effort"])
+        if mapped is not None:
+            result = {**result, "output_config": {**output_config, "effort": mapped}}
+
+    if isinstance(payload.get("reasoning_effort"), str):
+        mapped = QWEN38_EFFORT_MAP.get(payload["reasoning_effort"])
+        if mapped is not None:
+            result = {**result, "reasoning_effort": mapped}
+
+    template_kwargs = payload.get("chat_template_kwargs")
+    if isinstance(template_kwargs, dict) and isinstance(template_kwargs.get("reasoning_effort"), str):
+        mapped = QWEN38_EFFORT_MAP.get(template_kwargs["reasoning_effort"])
+        if mapped is not None:
+            result = {**result, "chat_template_kwargs": {**template_kwargs, "reasoning_effort": mapped}}
+
+    return result

--- a/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
@@ -28,7 +28,11 @@ entry in ``CHAT_TEMPLATE_EFFORT_SCALES``.
 from dataclasses import dataclass
 from typing import Any, Dict, FrozenSet, Mapping, Optional
 
-# vLLM's ChatCompletionRequest.reasoning_effort Literal.
+# Snapshot of vLLM 0.27.1's ChatCompletionRequest.reasoning_effort Literal,
+# kept in sync with the workernode's VLLM_PIP_SPEC (the "Logos - Update
+# vLLM" workflow bumps that pin). It only drives the coverage test: runtime
+# normalization is drift-proof, since unknown values fall back to the
+# family's default instead of reaching the template.
 VLLM_REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 
@@ -38,12 +42,16 @@ class EffortScale:
 
     ``accepted`` are the values the template accepts verbatim (in addition
     to ``none``, which vLLM translates into ``enable_thinking=false`` so
-    the template's effort block is skipped); ``map`` rewrites every other
-    value vLLM allows onto the closest accepted level.
+    the template's effort block is skipped); ``map`` rewrites known
+    out-of-scale values onto the closest accepted level, and ``default``
+    is the fallback every other value — including ones a future vLLM may
+    introduce — is coerced to, so the template can never reject an effort
+    value.
     """
 
     accepted: FrozenSet[str]
     map: Mapping[str, str]
+    default: str
 
 
 # Maps a chat template family (matched case-insensitively as a model-name
@@ -55,6 +63,9 @@ CHAT_TEMPLATE_EFFORT_SCALES: Dict[str, EffortScale] = {
     "qwen3.8": EffortScale(
         accepted=frozenset({"xhigh", "medium", "low"}),
         map={"high": "xhigh", "max": "xhigh", "minimal": "low"},
+        # The template's own default — what it would resolve to without
+        # rejecting the value.
+        default="xhigh",
     ),
 }
 
@@ -68,12 +79,20 @@ def effort_scale_for_model(model_name: Optional[str]) -> Optional[EffortScale]:
     return None
 
 
+def _map_effort(value: str, scale: EffortScale) -> str:
+    """Map a client effort value onto the family's accepted scale."""
+    if value == "none" or value in scale.accepted:
+        return value
+    return scale.map.get(value, scale.default)
+
+
 def normalize_reasoning_effort(payload: Dict[str, Any], model_name: Optional[str]) -> Dict[str, Any]:
     """Map out-of-scale reasoning-effort values onto the model's accepted scale.
 
-    Returns a copy of ``payload`` with every value in the model's scale
-    ``map`` rewritten in each location vLLM forwards to the chat template;
-    the input is never mutated. Payloads for models without a restricted
+    Returns a copy of ``payload`` with every value the model's scale does
+    not accept rewritten (known values via its ``map``, all others to its
+    ``default``) in each location vLLM forwards to the chat template; the
+    input is never mutated. Payloads for models without a restricted
     scale, or payloads whose effort values are already accepted, are
     returned as-is.
     """
@@ -81,23 +100,22 @@ def normalize_reasoning_effort(payload: Dict[str, Any], model_name: Optional[str
     if not isinstance(payload, dict) or scale is None:
         return payload
 
-    effort_map = scale.map
     result = payload
     output_config = payload.get("output_config")
     if isinstance(output_config, dict) and isinstance(output_config.get("effort"), str):
-        mapped = effort_map.get(output_config["effort"])
-        if mapped is not None:
+        mapped = _map_effort(output_config["effort"], scale)
+        if mapped != output_config["effort"]:
             result = {**result, "output_config": {**output_config, "effort": mapped}}
 
     if isinstance(payload.get("reasoning_effort"), str):
-        mapped = effort_map.get(payload["reasoning_effort"])
-        if mapped is not None:
+        mapped = _map_effort(payload["reasoning_effort"], scale)
+        if mapped != payload["reasoning_effort"]:
             result = {**result, "reasoning_effort": mapped}
 
     template_kwargs = payload.get("chat_template_kwargs")
     if isinstance(template_kwargs, dict) and isinstance(template_kwargs.get("reasoning_effort"), str):
-        mapped = effort_map.get(template_kwargs["reasoning_effort"])
-        if mapped is not None:
+        mapped = _map_effort(template_kwargs["reasoning_effort"], scale)
+        if mapped != template_kwargs["reasoning_effort"]:
             result = {**result, "chat_template_kwargs": {**template_kwargs, "reasoning_effort": mapped}}
 
     return result

--- a/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/effort_normalization.py
@@ -5,69 +5,98 @@ Reasoning-effort normalization for upstreams with a restricted scale.
 Clients such as Claude Code attach the session's reasoning effort to every
 request (``output_config.effort`` on the Anthropic Messages surface,
 ``reasoning_effort`` on the OpenAI surface). vLLM forwards the value to the
-model's chat template, and the Qwen3.8 template validates it: it only accepts
-``xhigh`` (its default), ``medium`` and ``low``. The Anthropic value
-``high`` — and vLLM's ``minimal``/``max`` — therefore raise a template
-exception that vLLM surfaces as an HTTP 500 ``internal_error``, failing every
-turn of a client session left on ``high`` (ls1intum/edutelligence#749).
+model's chat template, and some templates validate it. The Qwen3.8
+template, for example, only accepts ``xhigh`` (its default), ``medium`` and
+``low``; the Anthropic value ``high`` — and vLLM's ``minimal``/``max`` —
+therefore raise a template exception that vLLM surfaces as an HTTP 500
+``internal_error``, failing every turn of a client session left on
+``high`` (ls1intum/edutelligence#749).
 
-This module maps the wider client scale onto the scale the target model's
-template accepts, in every payload location vLLM forwards to the chat
-template:
+This module keeps a registry mapping chat template families to the effort
+scale their ``chat_template.jinja`` enforces, and rewrites out-of-scale
+values onto the closest accepted level in every payload location vLLM
+forwards to the chat template:
 
 - ``output_config.effort`` (Anthropic Messages API)
 - ``reasoning_effort`` (OpenAI API, top level)
 - ``chat_template_kwargs.reasoning_effort`` (explicit template kwarg)
 
-Values already on the target scale (``xhigh``, ``medium``, ``low``) and
-``none`` (which vLLM translates into ``enable_thinking=false``) pass through
-unchanged.
+A new template family with a restricted scale is added by registering one
+entry in ``CHAT_TEMPLATE_EFFORT_SCALES``.
 """
 
-from typing import Any, Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Mapping, Optional
 
-# vLLM's reasoning_effort field accepts none, minimal, low, medium, high,
-# xhigh and max. The Qwen3.8 chat template only accepts xhigh (default),
-# medium and low — map the out-of-scale values onto the closest accepted
-# level instead of letting the template reject them.
-QWEN38_EFFORT_MAP = {
-    "high": "xhigh",  # top level on both scales
-    "max": "xhigh",  # DeepSeek-specific top level
-    "minimal": "low",  # below low; low is the weakest accepted level
+# vLLM's ChatCompletionRequest.reasoning_effort Literal.
+VLLM_REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+
+@dataclass(frozen=True)
+class EffortScale:
+    """The reasoning-effort scale a chat template family enforces.
+
+    ``accepted`` are the values the template accepts verbatim (in addition
+    to ``none``, which vLLM translates into ``enable_thinking=false`` so
+    the template's effort block is skipped); ``map`` rewrites every other
+    value vLLM allows onto the closest accepted level.
+    """
+
+    accepted: FrozenSet[str]
+    map: Mapping[str, str]
+
+
+# Maps a chat template family (matched case-insensitively as a model-name
+# substring) to the scale its chat_template.jinja enforces. Add an entry
+# for every template family that validates reasoning_effort.
+CHAT_TEMPLATE_EFFORT_SCALES: Dict[str, EffortScale] = {
+    # Qwen3.8 (https://huggingface.co/Qwen/Qwen3.8-27B): accepts only
+    # xhigh (default), medium and low.
+    "qwen3.8": EffortScale(
+        accepted=frozenset({"xhigh", "medium", "low"}),
+        map={"high": "xhigh", "max": "xhigh", "minimal": "low"},
+    ),
 }
 
 
-def model_uses_qwen38_effort_scale(model_name: Optional[str]) -> bool:
-    """Return whether the model's chat template enforces the Qwen3.8 effort scale."""
-    return "qwen3.8" in (model_name or "").lower()
+def effort_scale_for_model(model_name: Optional[str]) -> Optional[EffortScale]:
+    """Return the effort scale the model's chat template enforces, if any."""
+    low = (model_name or "").lower()
+    for pattern, scale in CHAT_TEMPLATE_EFFORT_SCALES.items():
+        if pattern in low:
+            return scale
+    return None
 
 
 def normalize_reasoning_effort(payload: Dict[str, Any], model_name: Optional[str]) -> Dict[str, Any]:
     """Map out-of-scale reasoning-effort values onto the model's accepted scale.
 
-    Returns a copy of ``payload`` with ``high``/``max``/``minimal`` rewritten
-    in every location vLLM forwards to the chat template; the input is never
-    mutated. Payloads for other models, or payloads whose effort values are
-    already accepted, are returned as-is.
+    Returns a copy of ``payload`` with every value in the model's scale
+    ``map`` rewritten in each location vLLM forwards to the chat template;
+    the input is never mutated. Payloads for models without a restricted
+    scale, or payloads whose effort values are already accepted, are
+    returned as-is.
     """
-    if not isinstance(payload, dict) or not model_uses_qwen38_effort_scale(model_name):
+    scale = effort_scale_for_model(model_name)
+    if not isinstance(payload, dict) or scale is None:
         return payload
 
+    effort_map = scale.map
     result = payload
     output_config = payload.get("output_config")
     if isinstance(output_config, dict) and isinstance(output_config.get("effort"), str):
-        mapped = QWEN38_EFFORT_MAP.get(output_config["effort"])
+        mapped = effort_map.get(output_config["effort"])
         if mapped is not None:
             result = {**result, "output_config": {**output_config, "effort": mapped}}
 
     if isinstance(payload.get("reasoning_effort"), str):
-        mapped = QWEN38_EFFORT_MAP.get(payload["reasoning_effort"])
+        mapped = effort_map.get(payload["reasoning_effort"])
         if mapped is not None:
             result = {**result, "reasoning_effort": mapped}
 
     template_kwargs = payload.get("chat_template_kwargs")
     if isinstance(template_kwargs, dict) and isinstance(template_kwargs.get("reasoning_effort"), str):
-        mapped = QWEN38_EFFORT_MAP.get(template_kwargs["reasoning_effort"])
+        mapped = effort_map.get(template_kwargs["reasoning_effort"])
         if mapped is not None:
             result = {**result, "chat_template_kwargs": {**template_kwargs, "reasoning_effort": mapped}}
 

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
@@ -8,6 +8,7 @@ as HTTP 500 internal_error — failing every turn of a session left on "high".
 Logos maps the wider client scale onto the accepted one before forwarding.
 """
 
+from logos.pipeline import effort_normalization
 from logos.pipeline.context_resolver import ContextResolver, ExecutionContext
 from logos.pipeline.effort_normalization import (
     CHAT_TEMPLATE_EFFORT_SCALES,
@@ -43,6 +44,21 @@ def test_effort_scale_lookup_by_model_name():
     assert effort_scale_for_model("gpt-4.1-mini") is None
     assert effort_scale_for_model("") is None
     assert effort_scale_for_model(None) is None
+
+
+def test_longest_matching_pattern_wins_over_broader_pattern(monkeypatch):
+    # Overlapping patterns must resolve to the most specific (longest)
+    # match regardless of registration order, so a broad "qwen3" entry
+    # cannot shadow the specific "qwen3.8" one.
+    broad = EffortScale(accepted=frozenset({"low", "medium", "high"}), map={"max": "high"}, default="medium")
+    specific = CHAT_TEMPLATE_EFFORT_SCALES["qwen3.8"]
+    for registry in (
+        {"qwen3": broad, "qwen3.8": specific},
+        {"qwen3.8": specific, "qwen3": broad},
+    ):
+        monkeypatch.setattr(effort_normalization, "CHAT_TEMPLATE_EFFORT_SCALES", registry)
+        assert effort_scale_for_model("Qwen/Qwen3.8-27B") is specific
+        assert effort_scale_for_model("Qwen/Qwen3-32B") is broad
 
 
 def test_anthropic_output_config_high_mapped_to_xhigh():

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
@@ -90,10 +90,28 @@ def test_accepted_values_pass_through_unchanged():
 
 def test_every_registered_scale_covers_every_vllm_reasoning_effort_value():
     # Every value vLLM's reasoning_effort Literal allows must either pass
-    # through or be mapped to an accepted value (or "none"), per family.
+    # through or be mapped to an accepted value (or "none"), per family;
+    # the family default must itself be accepted.
     for pattern, scale in CHAT_TEMPLATE_EFFORT_SCALES.items():
+        assert scale.default in scale.accepted, pattern
         for value in VLLM_REASONING_EFFORT_VALUES:
-            assert scale.map.get(value, value) in scale.accepted | {"none"}, pattern
+            assert scale.map.get(value, scale.default) in scale.accepted | {"none"}, pattern
+
+
+def test_unknown_effort_falls_back_to_family_default():
+    # Drift-proofing: a value neither accepted nor mapped (e.g. one a
+    # future vLLM introduces) is coerced to the family default instead of
+    # reaching the template, which would reject it with an HTTP 500.
+    payload = {
+        "model": MODEL,
+        "output_config": {"effort": "banana"},
+        "reasoning_effort": "banana",
+        "chat_template_kwargs": {"reasoning_effort": "banana"},
+    }
+    result = normalize_reasoning_effort(payload, MODEL)
+    assert result["output_config"]["effort"] == "xhigh"
+    assert result["reasoning_effort"] == "xhigh"
+    assert result["chat_template_kwargs"]["reasoning_effort"] == "xhigh"
 
 
 def test_new_template_family_needs_only_a_registry_entry(monkeypatch):
@@ -102,7 +120,9 @@ def test_new_template_family_needs_only_a_registry_entry(monkeypatch):
     monkeypatch.setitem(
         CHAT_TEMPLATE_EFFORT_SCALES,
         "acme-1.0",
-        EffortScale(accepted=frozenset({"deep", "shallow"}), map={"high": "deep", "medium": "shallow"}),
+        EffortScale(
+            accepted=frozenset({"deep", "shallow"}), map={"high": "deep", "medium": "shallow"}, default="shallow"
+        ),
     )
     payload = {"model": "Acme/Acme-1.0-7B", "output_config": {"effort": "high"}}
     assert normalize_reasoning_effort(payload, "Acme/Acme-1.0-7B")["output_config"]["effort"] == "deep"

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
@@ -1,0 +1,146 @@
+"""Reasoning-effort normalization for Qwen3.8 models.
+
+Regression test for #749: the Qwen3.8 chat template only accepts
+xhigh/medium/low as reasoning effort, while clients such as Claude Code send
+the Anthropic value "high" in every request (output_config.effort). vLLM
+forwards the value to the template, which rejects it with an error surfaced
+as HTTP 500 internal_error — failing every turn of a session left on "high".
+Logos maps the wider client scale onto the accepted one before forwarding.
+"""
+
+from logos.pipeline.context_resolver import ContextResolver, ExecutionContext
+from logos.pipeline.effort_normalization import (
+    QWEN38_EFFORT_MAP,
+    model_uses_qwen38_effort_scale,
+    normalize_reasoning_effort,
+)
+
+MODEL = "Qwen/Qwen3.8-27B"
+
+
+def _context(model_name: str = MODEL, provider_type: str = "logosnode") -> ExecutionContext:
+    return ExecutionContext(
+        model_id=1,
+        provider_id=1,
+        provider_name="node-1",
+        provider_type=provider_type,
+        forward_url="logosnode://provider/1/lane/1" if provider_type == "logosnode" else "https://upstream/v1",
+        auth_header="Authorization",
+        auth_value="Bearer key",
+        model_name=model_name,
+    )
+
+
+def test_qwen38_model_detected_case_insensitively():
+    assert model_uses_qwen38_effort_scale("Qwen/Qwen3.8-27B")
+    assert model_uses_qwen38_effort_scale("qwen/qwen3.8-coder-30b-a3b")
+    # Other families keep their own scales and must not be rewritten.
+    assert not model_uses_qwen38_effort_scale("Qwen/Qwen3.5-27B")
+    assert not model_uses_qwen38_effort_scale("Qwen/Qwen3-32B")
+    assert not model_uses_qwen38_effort_scale("gpt-4.1-mini")
+    assert not model_uses_qwen38_effort_scale("")
+    assert not model_uses_qwen38_effort_scale(None)
+
+
+def test_anthropic_output_config_high_mapped_to_xhigh():
+    # The exact request shape from #749 (Claude Code /v1/messages).
+    payload = {
+        "model": "Qwen/Qwen3.8-27B",
+        "max_tokens": 64,
+        "output_config": {"effort": "high"},
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    assert normalize_reasoning_effort(payload, MODEL)["output_config"]["effort"] == "xhigh"
+
+
+def test_openai_reasoning_effort_high_mapped_to_xhigh():
+    assert (
+        normalize_reasoning_effort({"model": MODEL, "reasoning_effort": "high"}, MODEL)["reasoning_effort"] == "xhigh"
+    )
+
+
+def test_chat_template_kwargs_effort_mapped():
+    payload = {"model": MODEL, "chat_template_kwargs": {"reasoning_effort": "high"}}
+    assert normalize_reasoning_effort(payload, MODEL)["chat_template_kwargs"]["reasoning_effort"] == "xhigh"
+
+
+def test_all_three_locations_mapped_independently():
+    payload = {
+        "model": MODEL,
+        "output_config": {"effort": "high"},
+        "reasoning_effort": "max",
+        "chat_template_kwargs": {"reasoning_effort": "minimal", "enable_thinking": True},
+    }
+    result = normalize_reasoning_effort(payload, MODEL)
+    assert result["output_config"]["effort"] == "xhigh"
+    assert result["reasoning_effort"] == "xhigh"
+    assert result["chat_template_kwargs"]["reasoning_effort"] == "low"
+    # Sibling keys survive the copy.
+    assert result["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_accepted_values_pass_through_unchanged():
+    for value in ("xhigh", "medium", "low", "none"):
+        payload = {"model": MODEL, "output_config": {"effort": value}, "reasoning_effort": value}
+        assert normalize_reasoning_effort(payload, MODEL) is payload
+
+
+def test_map_covers_every_vllm_reasoning_effort_value():
+    # vLLM's ChatCompletionRequest.reasoning_effort Literal: none, minimal,
+    # low, medium, high, xhigh, max. Everything must either pass through or
+    # be mapped to an accepted Qwen3.8 value.
+    accepted = {"xhigh", "medium", "low"}
+    for value in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
+        assert QWEN38_EFFORT_MAP.get(value, value) in accepted | {"none"}
+
+
+def test_other_models_keep_high_untouched():
+    payload = {"model": "gpt-4.1-mini", "output_config": {"effort": "high"}, "reasoning_effort": "high"}
+    assert normalize_reasoning_effort(payload, "gpt-4.1-mini") is payload
+    assert normalize_reasoning_effort(payload, "Qwen/Qwen3.5-27B") is payload
+
+
+def test_non_string_effort_ignored():
+    payload = {"model": MODEL, "output_config": {"effort": 7}, "reasoning_effort": None}
+    assert normalize_reasoning_effort(payload, MODEL) is payload
+
+
+def test_payload_without_effort_fields_unchanged():
+    payload = {"model": MODEL, "messages": [{"role": "user", "content": "hello"}]}
+    assert normalize_reasoning_effort(payload, MODEL) is payload
+
+
+def test_input_payload_not_mutated():
+    payload = {"model": MODEL, "output_config": {"effort": "high"}, "reasoning_effort": "high"}
+    normalize_reasoning_effort(payload, MODEL)
+    assert payload["output_config"]["effort"] == "high"
+    assert payload["reasoning_effort"] == "high"
+
+
+def test_prepare_headers_and_payload_normalizes_for_qwen38():
+    # End-to-end through the forward-time hook (sync + streaming + jobs all
+    # go through prepare_headers_and_payload).
+    _, payload = ContextResolver.prepare_headers_and_payload(
+        _context(), {"model": "Qwen/Qwen3.8-27B", "output_config": {"effort": "high"}}
+    )
+    assert payload["output_config"]["effort"] == "xhigh"
+
+
+def test_prepare_headers_and_payload_keeps_effort_for_other_models():
+    _, payload = ContextResolver.prepare_headers_and_payload(
+        _context(model_name="gpt-4.1-mini", provider_type="cloud"),
+        {"model": "gpt-4.1-mini", "output_config": {"effort": "high"}},
+    )
+    assert payload["output_config"]["effort"] == "high"
+
+
+def test_prepare_headers_and_payload_multipart_payload():
+    # Audio uploads carry no effort fields; the normalizer must not choke on
+    # the multipart representation.
+    payload = {
+        "model": MODEL,
+        "input_audio": "file.wav",
+        "_logos_multipart": {"fields": [["model", MODEL]], "files": []},
+    }
+    _, prepared = ContextResolver.prepare_headers_and_payload(_context(), payload)
+    assert prepared["model"] == MODEL

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_effort_normalization.py
@@ -10,8 +10,10 @@ Logos maps the wider client scale onto the accepted one before forwarding.
 
 from logos.pipeline.context_resolver import ContextResolver, ExecutionContext
 from logos.pipeline.effort_normalization import (
-    QWEN38_EFFORT_MAP,
-    model_uses_qwen38_effort_scale,
+    CHAT_TEMPLATE_EFFORT_SCALES,
+    VLLM_REASONING_EFFORT_VALUES,
+    EffortScale,
+    effort_scale_for_model,
     normalize_reasoning_effort,
 )
 
@@ -31,15 +33,16 @@ def _context(model_name: str = MODEL, provider_type: str = "logosnode") -> Execu
     )
 
 
-def test_qwen38_model_detected_case_insensitively():
-    assert model_uses_qwen38_effort_scale("Qwen/Qwen3.8-27B")
-    assert model_uses_qwen38_effort_scale("qwen/qwen3.8-coder-30b-a3b")
+def test_effort_scale_lookup_by_model_name():
+    # Matched case-insensitively as a model-name substring.
+    assert effort_scale_for_model("Qwen/Qwen3.8-27B") == CHAT_TEMPLATE_EFFORT_SCALES["qwen3.8"]
+    assert effort_scale_for_model("qwen/qwen3.8-coder-30b-a3b") == CHAT_TEMPLATE_EFFORT_SCALES["qwen3.8"]
     # Other families keep their own scales and must not be rewritten.
-    assert not model_uses_qwen38_effort_scale("Qwen/Qwen3.5-27B")
-    assert not model_uses_qwen38_effort_scale("Qwen/Qwen3-32B")
-    assert not model_uses_qwen38_effort_scale("gpt-4.1-mini")
-    assert not model_uses_qwen38_effort_scale("")
-    assert not model_uses_qwen38_effort_scale(None)
+    assert effort_scale_for_model("Qwen/Qwen3.5-27B") is None
+    assert effort_scale_for_model("Qwen/Qwen3-32B") is None
+    assert effort_scale_for_model("gpt-4.1-mini") is None
+    assert effort_scale_for_model("") is None
+    assert effort_scale_for_model(None) is None
 
 
 def test_anthropic_output_config_high_mapped_to_xhigh():
@@ -85,13 +88,26 @@ def test_accepted_values_pass_through_unchanged():
         assert normalize_reasoning_effort(payload, MODEL) is payload
 
 
-def test_map_covers_every_vllm_reasoning_effort_value():
-    # vLLM's ChatCompletionRequest.reasoning_effort Literal: none, minimal,
-    # low, medium, high, xhigh, max. Everything must either pass through or
-    # be mapped to an accepted Qwen3.8 value.
-    accepted = {"xhigh", "medium", "low"}
-    for value in ("none", "minimal", "low", "medium", "high", "xhigh", "max"):
-        assert QWEN38_EFFORT_MAP.get(value, value) in accepted | {"none"}
+def test_every_registered_scale_covers_every_vllm_reasoning_effort_value():
+    # Every value vLLM's reasoning_effort Literal allows must either pass
+    # through or be mapped to an accepted value (or "none"), per family.
+    for pattern, scale in CHAT_TEMPLATE_EFFORT_SCALES.items():
+        for value in VLLM_REASONING_EFFORT_VALUES:
+            assert scale.map.get(value, value) in scale.accepted | {"none"}, pattern
+
+
+def test_new_template_family_needs_only_a_registry_entry(monkeypatch):
+    # Onboarding a chat template with its own restricted scale is a single
+    # registry entry — the normalization logic stays family-agnostic.
+    monkeypatch.setitem(
+        CHAT_TEMPLATE_EFFORT_SCALES,
+        "acme-1.0",
+        EffortScale(accepted=frozenset({"deep", "shallow"}), map={"high": "deep", "medium": "shallow"}),
+    )
+    payload = {"model": "Acme/Acme-1.0-7B", "output_config": {"effort": "high"}}
+    assert normalize_reasoning_effort(payload, "Acme/Acme-1.0-7B")["output_config"]["effort"] == "deep"
+    # Unrelated models are still untouched.
+    assert normalize_reasoning_effort(payload, "gpt-4.1-mini") is payload
 
 
 def test_other_models_keep_high_untouched():


### PR DESCRIPTION
## Summary

Fixes #749.

Claude Code (and other Anthropic-SDK clients) attach the session's reasoning effort to **every** request as `output_config.effort`. A session left on `high` therefore failed on every single turn against `Qwen/Qwen3.8-27B`:

```
HTTP 500 {"error": {"type": "internal_error",
 "message": "Unexpected reasoning effort high. Supported types are xhigh (default), medium, and low."}}
```

**Root cause:** the validation is not in Logos — it lives in the model's chat template. The Qwen3.8 `chat_template.jinja` accepts only `xhigh` (its default), `medium` and `low` as `reasoning_effort`, and vLLM (0.27.1) forwards the client's value to the template verbatim (`output_config.effort` → `ChatCompletionRequest.reasoning_effort` → `build_chat_params()` → template kwargs). The template's `raise_exception` surfaces as a 500 `internal_error`, which clients read as a transient fault and retry in a loop.

## Fix

Logos normalizes the effort value before forwarding, in `ContextResolver.prepare_headers_and_payload` — the single choke point that sync, streaming and job requests all go through. All three locations vLLM passes to the chat template are covered:

- `output_config.effort` (Anthropic Messages surface, what Claude Code sends)
- `reasoning_effort` (OpenAI surface, top level)
- `chat_template_kwargs.reasoning_effort` (explicit template kwarg)

For Qwen3.8 models (matched on `qwen3.8` in the model name):

| in | out | why |
|---|---|---|
| `high` | `xhigh` | top level on both scales |
| `max` | `xhigh` | DeepSeek-specific top level |
| `minimal` | `low` | below `low`; `low` is the weakest accepted level |

`low` / `medium` / `xhigh` / `none` pass through unchanged; every other model is untouched; the input payload is never mutated. With this, all values vLLM's own `reasoning_effort` Literal accepts are either accepted or mapped for Qwen3.8, so the template can no longer reject an effort value on this deployment.

## Tests

New `tests/unit/pipeline/test_effort_normalization.py` (14 tests): the exact #749 request shape, all three payload locations mapped independently, pass-through values, the full vLLM effort Literal covered, other models untouched, non-string/multipart payloads, input immutability, and end-to-end through `prepare_headers_and_payload` for both a Qwen3.8 logosnode context and a cloud model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for reasoning-effort settings across supported model families.
  * Automatically converts unsupported effort values to equivalents accepted by the target model.
  * Preserves valid settings and existing behavior for unsupported models and request formats.
  * Maintains correct handling for multipart requests and unchanged payload data.

* **Tests**
  * Expanded coverage for model-specific effort handling, supported request formats, payload preservation, and end-to-end request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->