### PR TITLE
`Logos`: Show prefix cache and MTP hit rates, fix Prometheus request-metric labels

### DIFF
--- a/logos/logos-orchestrator/src/logos/logosnode_registry.py
+++ b/logos/logos-orchestrator/src/logos/logosnode_registry.py
@@ -149,6 +149,7 @@ def _lane_log_snapshot(lane: dict[str, Any]) -> dict[str, Any]:
     if cache_pressure is None:
         cache_pressure = backend_metrics.get("gpu_cache_usage_perc")
     prefix_hit = lane_metric_float(backend_metrics.get("prefix_cache_hit_rate"))
+    mtp_accept = lane_metric_float(backend_metrics.get("mtp_acceptance_rate"))
     ttft_p95 = _lane_ttft_p95_seconds(backend_metrics)
 
     return {
@@ -162,6 +163,7 @@ def _lane_log_snapshot(lane: dict[str, Any]) -> dict[str, Any]:
         "requests_running": (round(requests_running, 1) if requests_running is not None else None),
         "gpu_cache_usage_percent": (round(float(cache_pressure), 1) if cache_pressure is not None else None),
         "prefix_cache_hit_rate": (round(prefix_hit, 3) if prefix_hit is not None else None),
+        "mtp_acceptance_rate": (round(mtp_accept, 3) if mtp_accept is not None else None),
         "ttft_p95_seconds": round(ttft_p95, 3) if ttft_p95 is not None else None,
         "gpu_devices": _lane_gpu_devices(lane),
     }
@@ -181,12 +183,14 @@ def _render_lane_summary(snapshot: dict[str, Any], *, indent: str = "    ") -> l
     ttft_text = _format_optional_float(snapshot.get("ttft_p95_seconds"), "s")
     prefix_hit_raw = snapshot.get("prefix_cache_hit_rate")
     prefix_text = _format_optional_float(round(prefix_hit_raw * 100, 1) if prefix_hit_raw is not None else None, "%")
+    mtp_raw = snapshot.get("mtp_acceptance_rate")
+    mtp_text = _format_optional_float(round(mtp_raw * 100, 1) if mtp_raw is not None else None, "%")
 
     lines = wrap_plain(f"model: {snapshot['model']}", indent=indent)
     lines.append(f"{indent}state={state_text} mem={snapshot['effective_vram_mb']:.0f}MB gpus={snapshot['gpu_devices']}")
     lines.append(
         f"{indent}waiting={queue_text} running={running_text} "
-        f"kv_cache={cache_text} ttft_p95={ttft_text} prefix_hit={prefix_text}"
+        f"kv_cache={cache_text} ttft_p95={ttft_text} prefix_hit={prefix_text} mtp_accept={mtp_text}"
     )
     return lines
 

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -496,8 +496,8 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
                 "_gpu_cache_usage_percent_count": 0,
                 "_prefix_cache_hit_rate_sum": 0.0,
                 "_prefix_cache_hit_rate_count": 0,
-                "_mtp_acceptance_rate_sum": 0.0,
-                "_mtp_acceptance_rate_count": 0,
+                "_mtp_draft_tokens_total": 0.0,
+                "_mtp_accepted_tokens_total": 0.0,
             },
         )
 
@@ -601,10 +601,16 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
             entry["_prefix_cache_hit_rate_sum"] += prefix_cache_hit_rate
             entry["_prefix_cache_hit_rate_count"] += 1
 
-        mtp_acceptance_rate = _safe_float(backend_metrics.get("mtp_acceptance_rate"))
-        if mtp_acceptance_rate is not None:
-            entry["_mtp_acceptance_rate_sum"] += mtp_acceptance_rate
-            entry["_mtp_acceptance_rate_count"] += 1
+        # Token-weighted MTP aggregation: sum the cumulative draft/accepted
+        # token counters per model (an unweighted mean of per-lane rates would
+        # misstate the model rate when lanes have different draft volumes).
+        mtp_draft_tokens_total = _safe_float(backend_metrics.get("mtp_draft_tokens_total"))
+        if mtp_draft_tokens_total is not None:
+            entry["_mtp_draft_tokens_total"] += mtp_draft_tokens_total
+
+        mtp_accepted_tokens_total = _safe_float(backend_metrics.get("mtp_accepted_tokens_total"))
+        if mtp_accepted_tokens_total is not None:
+            entry["_mtp_accepted_tokens_total"] += mtp_accepted_tokens_total
 
         _merge_histogram_buckets(entry["ttft_histogram"], ttft_histogram)
 
@@ -619,10 +625,10 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
         if prefix_count > 0:
             entry["prefix_cache_hit_rate_avg"] = prefix_sum / prefix_count
 
-        mtp_count = int(entry.pop("_mtp_acceptance_rate_count", 0) or 0)
-        mtp_sum = float(entry.pop("_mtp_acceptance_rate_sum", 0.0) or 0.0)
-        if mtp_count > 0:
-            entry["mtp_acceptance_rate_avg"] = mtp_sum / mtp_count
+        mtp_draft = float(entry.pop("_mtp_draft_tokens_total", 0.0) or 0.0)
+        mtp_accepted = float(entry.pop("_mtp_accepted_tokens_total", 0.0) or 0.0)
+        if mtp_draft > 0:
+            entry["mtp_acceptance_rate_avg"] = mtp_accepted / mtp_draft
 
         entry["ttft_p95_seconds"] = _histogram_quantile_seconds(entry.get("ttft_histogram"))
 

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -491,10 +491,13 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
                 "gpu_cache_usage_percent_avg": None,
                 "gpu_cache_usage_percent_max": None,
                 "prefix_cache_hit_rate_avg": None,
+                "mtp_acceptance_rate_avg": None,
                 "_gpu_cache_usage_percent_sum": 0.0,
                 "_gpu_cache_usage_percent_count": 0,
                 "_prefix_cache_hit_rate_sum": 0.0,
                 "_prefix_cache_hit_rate_count": 0,
+                "_mtp_acceptance_rate_sum": 0.0,
+                "_mtp_acceptance_rate_count": 0,
             },
         )
 
@@ -528,6 +531,7 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
             "requests_running": _safe_float(backend_metrics.get("requests_running")),
             "gpu_cache_usage_percent": _safe_float(backend_metrics.get("gpu_cache_usage_percent")),
             "prefix_cache_hit_rate": _safe_float(backend_metrics.get("prefix_cache_hit_rate")),
+            "mtp_acceptance_rate": _safe_float(backend_metrics.get("mtp_acceptance_rate")),
             "prompt_tokens_total": _safe_float(backend_metrics.get("prompt_tokens_total")),
             "generation_tokens_total": _safe_float(backend_metrics.get("generation_tokens_total")),
             "ttft_histogram": ttft_histogram,
@@ -597,6 +601,11 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
             entry["_prefix_cache_hit_rate_sum"] += prefix_cache_hit_rate
             entry["_prefix_cache_hit_rate_count"] += 1
 
+        mtp_acceptance_rate = _safe_float(backend_metrics.get("mtp_acceptance_rate"))
+        if mtp_acceptance_rate is not None:
+            entry["_mtp_acceptance_rate_sum"] += mtp_acceptance_rate
+            entry["_mtp_acceptance_rate_count"] += 1
+
         _merge_histogram_buckets(entry["ttft_histogram"], ttft_histogram)
 
     for entry in model_signals.values():
@@ -609,6 +618,11 @@ def _build_logosnode_scheduler_signals(runtime: Dict[str, Any]) -> Dict[str, Any
         prefix_sum = float(entry.pop("_prefix_cache_hit_rate_sum", 0.0) or 0.0)
         if prefix_count > 0:
             entry["prefix_cache_hit_rate_avg"] = prefix_sum / prefix_count
+
+        mtp_count = int(entry.pop("_mtp_acceptance_rate_count", 0) or 0)
+        mtp_sum = float(entry.pop("_mtp_acceptance_rate_sum", 0.0) or 0.0)
+        if mtp_count > 0:
+            entry["mtp_acceptance_rate_avg"] = mtp_sum / mtp_count
 
         entry["ttft_p95_seconds"] = _histogram_quantile_seconds(entry.get("ttft_histogram"))
 
@@ -2262,6 +2276,24 @@ async def refresh_pipeline_runtime_state(*, rebuild_model_classifier: bool = Fal
     )
 
 
+def _cached_prompt_tokens(usage: Dict[str, Any]) -> Optional[int]:
+    """Cached-prompt tokens as reported by the provider, or None when absent.
+
+    Handles both shapes that reach the completion log: the flattened dict
+    from ``extract_token_usage`` (``prompt_cached_tokens``) and the raw
+    streaming usage (``prompt_tokens_details.cached_tokens``).
+    """
+    cached = usage.get("prompt_cached_tokens")
+    if isinstance(cached, int) and not isinstance(cached, bool):
+        return cached
+    details = usage.get("prompt_tokens_details")
+    if isinstance(details, dict):
+        cached = details.get("cached_tokens")
+        if isinstance(cached, int) and not isinstance(cached, bool):
+            return cached
+    return None
+
+
 def _log_request_completion(
     model_id: int,
     request_id: Optional[str],
@@ -2274,6 +2306,7 @@ def _log_request_completion(
     duration_ms = (time.perf_counter() - start_time) * 1000.0
     prompt_tokens = usage.get("prompt_tokens", 0) or 0
     completion_tokens = usage.get("completion_tokens", 0) or 0
+    cached_tokens = _cached_prompt_tokens(usage)
     generation_s = duration_ms / 1000.0
     tps = (completion_tokens / generation_s) if generation_s > 0 and completion_tokens > 0 else 0.0
 
@@ -2302,6 +2335,10 @@ def _log_request_completion(
         )
         if tps > 0:
             parts.append(f"tps={tps:.1f}")
+    # Prefix-cache hit share of this request's prompt; only shown when the
+    # provider reports cached tokens (vLLM, Azure, OpenAI prompt caching).
+    if prompt_tokens > 0 and cached_tokens is not None:
+        parts.append(f"prefix_hit={cached_tokens / prompt_tokens:.0%}")
     logger.info(" ".join(parts))
 
 

--- a/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
@@ -35,7 +35,7 @@ REQUESTS_IN_FLIGHT = Gauge(
 COLD_STARTS_TOTAL = Counter(
     "logos_cold_starts_total",
     "Number of requests served by a cold (freshly loaded) model",
-    ["model"],
+    ["model", "provider"],
     registry=registry,
 )
 

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -16,11 +16,27 @@ from typing import Any, Callable, Dict, Optional
 from logos.dbutils.dbmanager import DBManager
 from logos.dbutils.dbmodules import ResultStatus
 from logos.monitoring import prometheus_metrics as prom
+from logos.terminal_logging import model_name_cache, provider_name_cache
 
 logger = logging.getLogger(__name__)
 
-# Track in-flight request start times for duration histograms
-_request_start_times: Dict[str, float] = {}
+# Track in-flight requests: request_id → (start_time, model, provider).
+# start_time feeds the duration histogram; model/provider are the label
+# values for REQUEST_DURATION_SECONDS / COLD_STARTS_TOTAL (see #738) —
+# "unknown" is only the pre-selection fallback.
+_request_states: Dict[str, tuple[float, str, str]] = {}
+
+
+def _resolve_label_names(model_id: Optional[int], provider_id: Optional[int]) -> tuple[str, str]:
+    """Resolve the model/provider label values for completion metrics.
+
+    Uses the in-memory name caches (DB-backed, at most one lookup per id).
+    None ids — requests that failed before a model/provider was selected —
+    keep the "unknown" fallback so no observation is dropped.
+    """
+    model = model_name_cache.get(model_id) if model_id is not None else "unknown"
+    provider = provider_name_cache.get(provider_id) if provider_id is not None else "unknown"
+    return model, provider
 
 
 class MonitoringRecorder:
@@ -44,7 +60,8 @@ class MonitoringRecorder:
         prom.REQUESTS_IN_FLIGHT.inc()
         if queue_depth is not None:
             prom.QUEUE_DEPTH.set(queue_depth)
-        _request_start_times[request_id] = time.monotonic()
+        model, provider = _resolve_label_names(model_id, provider_id)
+        _request_states[request_id] = (time.monotonic(), model, provider)
 
         payload = {
             "model_id": model_id,
@@ -78,6 +95,13 @@ class MonitoringRecorder:
         prom.REQUESTS_TOTAL.labels(status="scheduled").inc()
         prom.SCHEDULING_DECISIONS_TOTAL.labels(result="scheduled").inc()
 
+        # Overwrite the enqueue-time labels with the actually selected
+        # model/provider; keep the original start time for duration.
+        model, provider = _resolve_label_names(model_id, provider_id)
+        previous = _request_states.get(request_id)
+        start = previous[0] if previous is not None else time.monotonic()
+        _request_states[request_id] = (start, model, provider)
+
         payload = {
             "model_id": model_id,
             "provider_id": provider_id,
@@ -109,17 +133,22 @@ class MonitoringRecorder:
         prom.REQUESTS_TOTAL.labels(status=status_value).inc()
         prom.REQUESTS_IN_FLIGHT.dec()
 
-        start = _request_start_times.pop(request_id, None)
+        state = _request_states.pop(request_id, None)
+        if state is not None:
+            start, model, provider = state
+        else:
+            start, model, provider = None, "unknown", "unknown"
+
         if start is not None:
             duration = time.monotonic() - start
             prom.REQUEST_DURATION_SECONDS.labels(
-                model="unknown",
-                provider="unknown",
+                model=model,
+                provider=provider,
                 status=status_value,
             ).observe(duration)
 
         if cold_start:
-            prom.COLD_STARTS_TOTAL.labels(model="unknown").inc()
+            prom.COLD_STARTS_TOTAL.labels(model=model).inc()
 
         payload = {
             "request_complete_ts": datetime.datetime.now(datetime.timezone.utc),

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -148,7 +148,10 @@ class MonitoringRecorder:
             ).observe(duration)
 
         if cold_start:
-            prom.COLD_STARTS_TOTAL.labels(model=model).inc()
+            prom.COLD_STARTS_TOTAL.labels(
+                model=model,
+                provider=provider,
+            ).inc()
 
         payload = {
             "request_complete_ts": datetime.datetime.now(datetime.timezone.utc),

--- a/logos/logos-orchestrator/src/logos/terminal_logging.py
+++ b/logos/logos-orchestrator/src/logos/terminal_logging.py
@@ -216,8 +216,45 @@ class ModelNameCache:
             self._cache[model_id] = name
 
 
-#: Global singleton — import and use directly in other modules.
+class ProviderNameCache:
+    """Thread-safe in-memory provider-id → name resolver backed by the DB.
+
+    Mirror of :class:`ModelNameCache` for providers — used to label
+    Prometheus series (e.g. request duration / cold starts) with the
+    provider that actually served a request. Never hits the DB more than
+    once per provider_id; falls back to str(provider_id) on any error.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[int, str] = {}
+
+    def get(self, provider_id: int) -> str:
+        """Return the provider name for *provider_id*, resolving via DB on first call."""
+        if provider_id in self._cache:
+            return self._cache[provider_id]
+        name = self._resolve(provider_id)
+        self._cache[provider_id] = name
+        return name
+
+    def _resolve(self, provider_id: int) -> str:
+        try:
+            from logos.dbutils.dbmanager import DBManager  # noqa: PLC0415
+
+            with DBManager() as db:
+                info = db.get_provider(provider_id)
+            return (info or {}).get("name") or str(provider_id)
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-except
+            return str(provider_id)
+
+    def prime(self, provider_id: int, name: str) -> None:
+        """Pre-populate the cache without a DB round-trip."""
+        if name:
+            self._cache[provider_id] = name
+
+
+#: Global singletons — import and use directly in other modules.
 model_name_cache = ModelNameCache()
+provider_name_cache = ProviderNameCache()
 
 
 def terminal_width(default: int = 120, max_width: int = 140) -> int:

--- a/logos/logos-orchestrator/src/logos/terminal_logging.py
+++ b/logos/logos-orchestrator/src/logos/terminal_logging.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import textwrap
+import threading
 from datetime import datetime, timezone
 from typing import Any
 
@@ -227,14 +228,23 @@ class ProviderNameCache:
 
     def __init__(self) -> None:
         self._cache: dict[int, str] = {}
+        self._lock = threading.Lock()
 
     def get(self, provider_id: int) -> str:
-        """Return the provider name for *provider_id*, resolving via DB on first call."""
+        """Return the provider name for *provider_id*, resolving via DB on first call.
+
+        Cache misses are serialized by ``_lock`` with a double-check, so
+        concurrent first requests for one provider_id trigger a single DB
+        lookup (the documented one-lookup guarantee).
+        """
         if provider_id in self._cache:
             return self._cache[provider_id]
-        name = self._resolve(provider_id)
-        self._cache[provider_id] = name
-        return name
+        with self._lock:
+            if provider_id in self._cache:
+                return self._cache[provider_id]
+            name = self._resolve(provider_id)
+            self._cache[provider_id] = name
+            return name
 
     def _resolve(self, provider_id: int) -> str:
         try:
@@ -249,7 +259,8 @@ class ProviderNameCache:
     def prime(self, provider_id: int, name: str) -> None:
         """Pre-populate the cache without a DB round-trip."""
         if name:
-            self._cache[provider_id] = name
+            with self._lock:
+                self._cache[provider_id] = name
 
 
 #: Global singletons — import and use directly in other modules.

--- a/logos/logos-orchestrator/tests/unit/main/test_logosnode_registry_display.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_logosnode_registry_display.py
@@ -46,11 +46,14 @@ def test_snapshot_with_backend_metrics_uses_scrape_values() -> None:
             "requests_running": 1.0,
             "gpu_cache_usage_percent": 42.5,
             "prefix_cache_hit_rate": 0.511,
+            "mtp_acceptance_rate": 0.611,
         },
     )
     snap = _lane_log_snapshot(lane)
     assert snap["queue_waiting"] == 2.0
     assert snap["requests_running"] == 1.0
+    assert snap["prefix_cache_hit_rate"] == 0.511
+    assert snap["mtp_acceptance_rate"] == 0.611
 
 
 def test_snapshot_without_backend_metrics_returns_none_for_waiting_and_running() -> None:
@@ -114,6 +117,23 @@ def test_render_summary_does_not_expose_active_counter() -> None:
     assert "active=" not in rendered
 
 
+def test_render_summary_shows_prefix_hit_and_mtp_acceptance() -> None:
+    snap = _snap(
+        backend_metrics={"prefix_cache_hit_rate": 0.511, "mtp_acceptance_rate": 0.61},
+    )
+    rendered = "\n".join(_render_lane_summary(snap))
+    assert "prefix_hit=51.1%" in rendered
+    assert "mtp_accept=61.0%" in rendered
+
+
+def test_render_summary_missing_hit_rates_show_dashes() -> None:
+    """Lanes without the metrics (ollama, idle vLLM) render -- placeholders."""
+    snap = _snap(backend_metrics={})
+    rendered = "\n".join(_render_lane_summary(snap))
+    assert "prefix_hit=--" in rendered
+    assert "mtp_accept=--" in rendered
+
+
 # ---------------------------------------------------------------------------
 # _render_lane_diff
 # ---------------------------------------------------------------------------
@@ -131,6 +151,7 @@ def _make_snap(**overrides) -> dict:
         "requests_running": None,
         "gpu_cache_usage_percent": None,
         "prefix_cache_hit_rate": None,
+        "mtp_acceptance_rate": None,
         "ttft_p95_seconds": None,
         "gpu_devices": "0",
     }

--- a/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -7,6 +9,7 @@ import pytest
 import logos as main
 from logos import ExecutionResult
 from logos.errors import UpstreamStreamError
+from logos.terminal_logging import strip_ansi
 
 
 def _make_dummy_db(cost_micro_cents=None):
@@ -1160,3 +1163,68 @@ async def test_proxy_sync_response_logs_status_and_skips_ttft_on_error(monkeypat
             "error_message": "proxy failed",
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# _log_request_completion — prefix-cache hit rate field (issue 748)
+# ---------------------------------------------------------------------------
+
+
+def _completion_log_line(monkeypatch, caplog, usage, status="success"):
+    """Run _log_request_completion and return the emitted INFO line (ANSI-stripped)."""
+    monkeypatch.setattr(main, "model_name_cache", {"get": lambda model_id: "test-model"})
+    with caplog.at_level(logging.INFO, logger="LogosLogger"):
+        main._log_request_completion(
+            model_id=1,
+            request_id="req-1",
+            start_time=time.perf_counter() - 1.0,
+            usage=usage,
+            status=status,
+            is_streaming=False,
+        )
+    lines = [record.getMessage() for record in caplog.records if "done " in record.getMessage()]
+    return strip_ansi(lines[-1]) if lines else ""
+
+
+def test_log_request_completion_includes_prefix_hit_rate(monkeypatch, caplog):
+    """Flattened usage (prompt_cached_tokens) → prefix_hit=NN% on the log line."""
+    line = _completion_log_line(
+        monkeypatch,
+        caplog,
+        {"prompt_tokens": 1000, "completion_tokens": 100, "prompt_cached_tokens": 420},
+    )
+    assert "prefix_hit=42%" in line
+
+
+def test_log_request_completion_includes_prefix_hit_rate_from_nested_details(monkeypatch, caplog):
+    """Raw streaming usage (prompt_tokens_details.cached_tokens) is also reported."""
+    line = _completion_log_line(
+        monkeypatch,
+        caplog,
+        {
+            "prompt_tokens": 1000,
+            "completion_tokens": 100,
+            "prompt_tokens_details": {"cached_tokens": 750},
+        },
+    )
+    assert "prefix_hit=75%" in line
+
+
+def test_log_request_completion_includes_zero_prefix_hit(monkeypatch, caplog):
+    """An explicit cached_tokens=0 is a real 0% hit, not 'not reported'."""
+    line = _completion_log_line(
+        monkeypatch,
+        caplog,
+        {"prompt_tokens": 1000, "completion_tokens": 100, "prompt_cached_tokens": 0},
+    )
+    assert "prefix_hit=0%" in line
+
+
+def test_log_request_completion_omits_prefix_hit_when_unreported(monkeypatch, caplog):
+    """Providers that do not report cached tokens add no prefix_hit field."""
+    line = _completion_log_line(
+        monkeypatch,
+        caplog,
+        {"prompt_tokens": 1000, "completion_tokens": 100},
+    )
+    assert "prefix_hit" not in line

--- a/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
@@ -137,6 +137,7 @@ async def test_get_ollama_vram_stats_returns_live_worker_inventory(monkeypatch):
                                     "requests_running": 2,
                                     "gpu_cache_usage_percent": 66.0,
                                     "prefix_cache_hit_rate": 0.42,
+                                    "mtp_acceptance_rate": 0.61,
                                     "prompt_tokens_total": 1200,
                                     "generation_tokens_total": 3400,
                                     "ttft_histogram": {"0.5": 8, "1.0": 10},
@@ -189,7 +190,11 @@ async def test_get_ollama_vram_stats_returns_live_worker_inventory(monkeypatch):
     assert scheduler_signals["models"]["Qwen/Qwen3-8B"]["queue_waiting_current"] == 3.0
     assert scheduler_signals["models"]["Qwen/Qwen3-8B"]["requests_running_current"] == 2.0
     assert scheduler_signals["models"]["Qwen/Qwen3-8B"]["ttft_p95_seconds"] == pytest.approx(0.875)
+    assert scheduler_signals["models"]["Qwen/Qwen3-8B"]["prefix_cache_hit_rate_avg"] == pytest.approx(0.42)
+    assert scheduler_signals["models"]["Qwen/Qwen3-8B"]["mtp_acceptance_rate_avg"] == pytest.approx(0.61)
     assert scheduler_signals["lanes"]["qwen-a"]["gpu_cache_usage_percent"] == 66.0
+    assert scheduler_signals["lanes"]["qwen-a"]["prefix_cache_hit_rate"] == 0.42
+    assert scheduler_signals["lanes"]["qwen-a"]["mtp_acceptance_rate"] == 0.61
 
     offline_provider = payload["providers"][1]
     assert offline_provider["connected"] is False

--- a/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py
@@ -138,6 +138,8 @@ async def test_get_ollama_vram_stats_returns_live_worker_inventory(monkeypatch):
                                     "gpu_cache_usage_percent": 66.0,
                                     "prefix_cache_hit_rate": 0.42,
                                     "mtp_acceptance_rate": 0.61,
+                                    "mtp_draft_tokens_total": 1000,
+                                    "mtp_accepted_tokens_total": 610,
                                     "prompt_tokens_total": 1200,
                                     "generation_tokens_total": 3400,
                                     "ttft_histogram": {"0.5": 8, "1.0": 10},
@@ -474,3 +476,73 @@ async def test_get_ollama_vram_stats_merges_persisted_rows_and_recent_buffer(
     provider = payload["providers"][0]
     assert [sample["snapshot_id"] for sample in provider["data"]] == [101, 102]
     assert payload["last_snapshot_id"] == 102
+
+
+def test_scheduler_signals_mtp_acceptance_is_token_weighted_across_lanes() -> None:
+    """Per-model MTP rate sums the draft/accepted counters, it is NOT the
+    unweighted mean of per-lane rates (regression for the CodeRabbit review)."""
+
+    def _lane(lane_id: str, draft: float, accepted: float) -> dict:
+        return {
+            "lane_id": lane_id,
+            "model": "mtp-model",
+            "vllm": True,
+            "runtime_state": "running",
+            "active_requests": 0,
+            "effective_vram_mb": 8000.0,
+            "backend_metrics": {
+                "engine": "vllm",
+                "mtp_acceptance_rate": (accepted / draft) if draft > 0 else None,
+                "mtp_draft_tokens_total": draft,
+                "mtp_accepted_tokens_total": accepted,
+            },
+        }
+
+    # Lane A: perfect acceptance but a single draft token.
+    # Lane B: zero acceptance over 10,000 draft tokens.
+    runtime = {
+        "timestamp": "2026-03-16T18:00:00Z",
+        "transport": {"connected": True},
+        "devices": {},
+        "capacity": {},
+        "lanes": [
+            _lane("lane-a", draft=1, accepted=1),
+            _lane("lane-b", draft=10_000, accepted=0),
+        ],
+    }
+
+    signals = main._build_logosnode_scheduler_signals(runtime)
+    model = signals["models"]["mtp-model"]
+
+    # Token-weighted: 1 accepted / 10,001 draft. The unweighted lane-rate
+    # mean would be 0.5 — exactly the misstatement this regression guards.
+    assert model["mtp_acceptance_rate_avg"] == pytest.approx(1 / 10_001)
+
+    # The per-lane signal still carries each lane's own rate.
+    assert signals["lanes"]["lane-a"]["mtp_acceptance_rate"] == pytest.approx(1.0)
+    assert signals["lanes"]["lane-b"]["mtp_acceptance_rate"] == pytest.approx(0.0)
+
+
+def test_scheduler_signals_mtp_acceptance_none_without_spec_decode() -> None:
+    """Lanes without speculative decoding leave the per-model rate unset."""
+    runtime = {
+        "timestamp": "2026-03-16T18:00:00Z",
+        "transport": {"connected": True},
+        "devices": {},
+        "capacity": {},
+        "lanes": [
+            {
+                "lane_id": "lane-a",
+                "model": "plain-model",
+                "vllm": True,
+                "runtime_state": "loaded",
+                "active_requests": 0,
+                "effective_vram_mb": 8000.0,
+                "backend_metrics": {"engine": "vllm", "prefix_cache_hit_rate": 0.3},
+            }
+        ],
+    }
+
+    signals = main._build_logosnode_scheduler_signals(runtime)
+    assert signals["models"]["plain-model"]["mtp_acceptance_rate_avg"] is None
+    assert signals["models"]["plain-model"]["prefix_cache_hit_rate_avg"] == pytest.approx(0.3)

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
@@ -1,9 +1,10 @@
+from types import SimpleNamespace
+
 from logos import MonitoringRecorder
+from logos.monitoring import recorder as recorder_module
 
 
-def test_recorder_updates_log_entry_metrics_by_request_id():
-    calls = []
-
+def _dummy_db_factory(calls):
     class DummyDB:
         def __enter__(self):
             return self
@@ -14,7 +15,75 @@ def test_recorder_updates_log_entry_metrics_by_request_id():
         def update_request_log_metrics(self, **kwargs):
             calls.append(kwargs)
 
-    recorder = MonitoringRecorder(db_factory=lambda: DummyDB())
+    return lambda: DummyDB()
+
+
+def _make_recorder(monkeypatch, model_names, provider_names):
+    """Recorder with stubbed name caches (no DB lookups in unit tests)."""
+    calls = []
+    monkeypatch.setattr(
+        recorder_module,
+        "model_name_cache",
+        SimpleNamespace(get=lambda model_id: model_names.get(model_id, str(model_id))),
+    )
+    monkeypatch.setattr(
+        recorder_module,
+        "provider_name_cache",
+        SimpleNamespace(get=lambda provider_id: provider_names.get(provider_id, str(provider_id))),
+    )
+    return MonitoringRecorder(db_factory=_dummy_db_factory(calls)), calls
+
+
+def _make_recording_metric(name):
+    class _RecordingMetric:
+        def __init__(self):
+            self.name = name
+            self.label_calls = []
+            self.observations = []
+            self.inc_calls = 0
+
+        def labels(self, **kwargs):
+            self.label_calls.append(kwargs)
+            return self
+
+        def observe(self, value):
+            self.observations.append(value)
+
+        def inc(self):
+            self.inc_calls += 1
+
+        def dec(self):
+            pass
+
+        def set(self, value):
+            pass
+
+    return _RecordingMetric()
+
+
+def _patch_prom(monkeypatch):
+    """Replace the recorder's prom module with label-recording fakes.
+
+    Some test modules install a stubbed ``prometheus_client`` into
+    sys.modules at import time, so asserting on the real registry would
+    depend on test ordering — recording the .labels() calls is
+    deterministic in both worlds.
+    """
+    fake = SimpleNamespace(
+        REQUESTS_TOTAL=_make_recording_metric("logos_requests_total"),
+        REQUESTS_IN_FLIGHT=_make_recording_metric("logos_requests_in_flight"),
+        SCHEDULING_DECISIONS_TOTAL=_make_recording_metric("logos_scheduling_decisions_total"),
+        REQUEST_DURATION_SECONDS=_make_recording_metric("logos_request_duration_seconds"),
+        COLD_STARTS_TOTAL=_make_recording_metric("logos_cold_starts_total"),
+        QUEUE_DEPTH=_make_recording_metric("logos_queue_depth"),
+    )
+    monkeypatch.setattr(recorder_module, "prom", fake)
+    return fake
+
+
+def test_recorder_updates_log_entry_metrics_by_request_id(monkeypatch):
+    recorder, calls = _make_recorder(monkeypatch, {27: "test-model"}, {12: "test-provider"})
+    _patch_prom(monkeypatch)
 
     recorder.record_enqueue(
         request_id="req-1",
@@ -49,3 +118,119 @@ def test_recorder_updates_log_entry_metrics_by_request_id():
 
     assert calls[2]["result_status"] == "success"
     assert calls[2]["cold_start"] is False
+
+
+# ---------------------------------------------------------------------------
+# Prometheus label plumbing (issue 738)
+# ---------------------------------------------------------------------------
+
+
+def test_record_complete_labels_duration_with_model_and_provider(monkeypatch):
+    recorder, _ = _make_recorder(monkeypatch, {27: "Qwen/Qwen3-8B"}, {12: "local-node"})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_enqueue(
+        request_id="req-738-duration",
+        model_id=27,
+        provider_id=12,
+        initial_priority="normal",
+        queue_depth=0,
+    )
+    recorder.record_scheduled(
+        request_id="req-738-duration",
+        model_id=27,
+        provider_id=12,
+        priority_when_scheduled="normal",
+        queue_depth_at_schedule=0,
+    )
+    recorder.record_complete(request_id="req-738-duration", result_status="success")
+
+    duration = fake.REQUEST_DURATION_SECONDS
+    assert duration.label_calls == [{"model": "Qwen/Qwen3-8B", "provider": "local-node", "status": "success"}]
+    assert len(duration.observations) == 1
+
+
+def test_record_scheduled_overwrites_enqueue_labels(monkeypatch):
+    """The actually selected model/provider wins over the enqueue-time guess."""
+    recorder, _ = _make_recorder(monkeypatch, {27: "model-a", 28: "model-b"}, {12: "provider-a", 13: "provider-b"})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_enqueue(
+        request_id="req-738-override",
+        model_id=27,
+        provider_id=12,
+        initial_priority="normal",
+        queue_depth=0,
+    )
+    # Scheduling picked a different model/provider than the top candidate.
+    recorder.record_scheduled(
+        request_id="req-738-override",
+        model_id=28,
+        provider_id=13,
+        priority_when_scheduled="high",
+        queue_depth_at_schedule=0,
+    )
+    recorder.record_complete(request_id="req-738-override", result_status="success")
+
+    duration = fake.REQUEST_DURATION_SECONDS
+    assert duration.label_calls == [{"model": "model-b", "provider": "provider-b", "status": "success"}]
+    # The enqueue-time guess must not produce its own observation.
+    assert {"model": "model-a", "provider": "provider-a", "status": "success"} not in duration.label_calls
+
+
+def test_unresolved_request_falls_back_to_unknown_labels(monkeypatch):
+    """Requests that fail before a model/provider is selected keep 'unknown'."""
+    recorder, _ = _make_recorder(monkeypatch, {}, {})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_enqueue(
+        request_id="req-738-unresolved",
+        model_id=None,
+        provider_id=None,
+        initial_priority="normal",
+        queue_depth=0,
+    )
+    recorder.record_complete(
+        request_id="req-738-unresolved",
+        result_status="error",
+        error_message="no capacity",
+    )
+
+    duration = fake.REQUEST_DURATION_SECONDS
+    assert duration.label_calls == [{"model": "unknown", "provider": "unknown", "status": "error"}]
+    assert len(duration.observations) == 1
+
+
+def test_cold_starts_total_labeled_with_model(monkeypatch):
+    recorder, _ = _make_recorder(monkeypatch, {27: "cold-model"}, {12: "local-node"})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_enqueue(
+        request_id="req-738-cold",
+        model_id=27,
+        provider_id=12,
+        initial_priority="normal",
+        queue_depth=0,
+    )
+    recorder.record_scheduled(
+        request_id="req-738-cold",
+        model_id=27,
+        provider_id=12,
+        priority_when_scheduled="normal",
+        queue_depth_at_schedule=0,
+    )
+    recorder.record_complete(request_id="req-738-cold", result_status="success", cold_start=True)
+
+    assert fake.COLD_STARTS_TOTAL.label_calls == [{"model": "cold-model"}]
+    assert fake.COLD_STARTS_TOTAL.inc_calls == 1
+
+
+def test_complete_without_enqueue_records_no_duration(monkeypatch):
+    """A completion without any recorded start time observes nothing (old behaviour)."""
+    recorder, _ = _make_recorder(monkeypatch, {}, {})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_complete(request_id="req-738-ghost", result_status="error")
+
+    assert fake.REQUEST_DURATION_SECONDS.label_calls == []
+    assert fake.REQUEST_DURATION_SECONDS.observations == []

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
@@ -221,7 +221,7 @@ def test_cold_starts_total_labeled_with_model(monkeypatch):
     )
     recorder.record_complete(request_id="req-738-cold", result_status="success", cold_start=True)
 
-    assert fake.COLD_STARTS_TOTAL.label_calls == [{"model": "cold-model"}]
+    assert fake.COLD_STARTS_TOTAL.label_calls == [{"model": "cold-model", "provider": "local-node"}]
     assert fake.COLD_STARTS_TOTAL.inc_calls == 1
 
 

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
@@ -53,6 +53,12 @@
                   @if (row.ttftLabel != null) {
                     <span class="stat-label">TTFT p95 <span class="stat-value" [style.color]="row.ttftColor">{{ row.ttftLabel }}</span></span>
                   }
+                  @if (row.lane.prefix_cache_hit_rate != null) {
+                    <span class="stat-label">Prefix hit <span class="stat-value neutral">{{ (row.lane.prefix_cache_hit_rate * 100).toFixed(1) }}%</span></span>
+                  }
+                  @if (row.lane.mtp_acceptance_rate != null) {
+                    <span class="stat-label">MTP accept <span class="stat-value neutral">{{ (row.lane.mtp_acceptance_rate * 100).toFixed(1) }}%</span></span>
+                  }
                   @if (row.lane.queue_waiting != null) {
                     <span class="stat-label">Queue <span class="stat-value neutral">{{ row.lane.queue_waiting }}</span></span>
                   }

--- a/logos/logos-ui/src/app/features/statistics/statistics.models.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.models.ts
@@ -112,6 +112,8 @@ export type LaneSignalData = {
   ttft_p95_seconds: number | null;
   queue_waiting: number | null;
   requests_running: number | null;
+  prefix_cache_hit_rate: number | null;
+  mtp_acceptance_rate: number | null;
 };
 
 // PaginatedRequestItem from logos-ui-old/components/statistics/types.ts

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -847,6 +847,7 @@ class VllmProcessHandle:
             "requests_running": None,
             "gpu_cache_usage_percent": None,
             "prefix_cache_hit_rate": None,
+            "mtp_acceptance_rate": None,
             "prompt_tokens_total": None,
             "generation_tokens_total": None,
             "ttft_histogram": {},
@@ -860,6 +861,8 @@ class VllmProcessHandle:
                 return metrics
             _prefix_queries: float = 0.0
             _prefix_hits: float = 0.0
+            _spec_draft_tokens: float = 0.0
+            _spec_accepted_tokens: float = 0.0
             for raw_line in resp.text.splitlines():
                 line = raw_line.strip()
                 if not line or line.startswith("#"):
@@ -900,6 +903,18 @@ class VllmProcessHandle:
                     or metric_name.endswith(":prefix_cache_hits")
                 ):
                     _prefix_hits += value
+                elif metric_name.endswith("spec_decode_num_draft_tokens") or metric_name.endswith(
+                    "spec_decode_num_draft_tokens_total"
+                ):
+                    # vLLM speculative decoding (e.g. MTP draft heads):
+                    # cumulative tokens proposed by the draft model.
+                    _spec_draft_tokens += value
+                elif metric_name.endswith("spec_decode_num_accepted_tokens") or metric_name.endswith(
+                    "spec_decode_num_accepted_tokens_total"
+                ):
+                    # Cumulative draft tokens accepted by the target model.
+                    # Only present when --speculative-config is active.
+                    _spec_accepted_tokens += value
                 elif metric_name.endswith("prompt_tokens_total"):
                     metrics["prompt_tokens_total"] = value
                 elif metric_name.endswith("generation_tokens_total"):
@@ -918,6 +933,10 @@ class VllmProcessHandle:
             # gauge was not present.
             if metrics["prefix_cache_hit_rate"] is None and _prefix_queries > 0:
                 metrics["prefix_cache_hit_rate"] = _prefix_hits / _prefix_queries
+            # Speculative decoding acceptance rate (MTP): accepted / draft
+            # tokens since process start. None unless spec decode is enabled.
+            if _spec_draft_tokens > 0:
+                metrics["mtp_acceptance_rate"] = _spec_accepted_tokens / _spec_draft_tokens
         except httpx.HTTPError:
             return metrics
         return metrics

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -848,6 +848,8 @@ class VllmProcessHandle:
             "gpu_cache_usage_percent": None,
             "prefix_cache_hit_rate": None,
             "mtp_acceptance_rate": None,
+            "mtp_draft_tokens_total": None,
+            "mtp_accepted_tokens_total": None,
             "prompt_tokens_total": None,
             "generation_tokens_total": None,
             "ttft_histogram": {},
@@ -861,8 +863,8 @@ class VllmProcessHandle:
                 return metrics
             _prefix_queries: float = 0.0
             _prefix_hits: float = 0.0
-            _spec_draft_tokens: float = 0.0
-            _spec_accepted_tokens: float = 0.0
+            _spec_draft_tokens_total: float = 0.0
+            _spec_accepted_tokens_total: float = 0.0
             for raw_line in resp.text.splitlines():
                 line = raw_line.strip()
                 if not line or line.startswith("#"):
@@ -908,13 +910,13 @@ class VllmProcessHandle:
                 ):
                     # vLLM speculative decoding (e.g. MTP draft heads):
                     # cumulative tokens proposed by the draft model.
-                    _spec_draft_tokens += value
+                    _spec_draft_tokens_total += value
                 elif metric_name.endswith("spec_decode_num_accepted_tokens") or metric_name.endswith(
                     "spec_decode_num_accepted_tokens_total"
                 ):
                     # Cumulative draft tokens accepted by the target model.
                     # Only present when --speculative-config is active.
-                    _spec_accepted_tokens += value
+                    _spec_accepted_tokens_total += value
                 elif metric_name.endswith("prompt_tokens_total"):
                     metrics["prompt_tokens_total"] = value
                 elif metric_name.endswith("generation_tokens_total"):
@@ -933,10 +935,16 @@ class VllmProcessHandle:
             # gauge was not present.
             if metrics["prefix_cache_hit_rate"] is None and _prefix_queries > 0:
                 metrics["prefix_cache_hit_rate"] = _prefix_hits / _prefix_queries
-            # Speculative decoding acceptance rate (MTP): accepted / draft
-            # tokens since process start. None unless spec decode is enabled.
-            if _spec_draft_tokens > 0:
-                metrics["mtp_acceptance_rate"] = _spec_accepted_tokens / _spec_draft_tokens
+            # Speculative decoding (MTP) — only reported when spec decode is
+            # enabled (vLLM exposes no spec_decode_* counters otherwise).
+            if _spec_draft_tokens_total > 0 or _spec_accepted_tokens_total > 0:
+                # Acceptance rate: accepted / draft tokens since process start.
+                if _spec_draft_tokens_total > 0:
+                    metrics["mtp_acceptance_rate"] = _spec_accepted_tokens_total / _spec_draft_tokens_total
+                # Expose the underlying cumulative counters (for per-model
+                # token-weighted aggregation in the orchestrator).
+                metrics["mtp_draft_tokens_total"] = _spec_draft_tokens_total
+                metrics["mtp_accepted_tokens_total"] = _spec_accepted_tokens_total
         except httpx.HTTPError:
             return metrics
         return metrics

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1067,6 +1067,81 @@ vllm:gpu_prefix_cache_hits{model_name="m"} 10
     assert metrics["prefix_cache_hit_rate"] == pytest.approx(0.75)
 
 
+@pytest.mark.asyncio
+async def test_get_backend_metrics_parses_spec_decode_counters() -> None:
+    """MTP/speculative decoding: acceptance rate from draft/accepted counters."""
+
+    class DummyResponse:
+        status_code = 200
+        text = """
+vllm:num_requests_running{model_name="m"} 1
+vllm:kv_cache_usage_perc{model_name="m"} 0.5
+vllm:spec_decode_num_drafts_total{model_name="m"} 300
+vllm:spec_decode_num_draft_tokens_total{model_name="m"} 1000
+vllm:spec_decode_num_accepted_tokens_total{model_name="m"} 620
+"""
+
+    class DummyClient:
+        async def get(self, _url: str, timeout: float = 5.0):  # noqa: ARG002
+            return DummyResponse()
+
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._http = DummyClient()  # type: ignore[assignment]
+
+    metrics = await handle.get_backend_metrics()
+    assert metrics["mtp_acceptance_rate"] == pytest.approx(0.62)
+    # No prefix-cache counters in this scrape.
+    assert metrics["prefix_cache_hit_rate"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_backend_metrics_spec_decode_counter_unsuffixed_names() -> None:
+    """Accept the counter names without the _total suffix variant."""
+
+    class DummyResponse:
+        status_code = 200
+        text = """
+vllm:num_requests_running{model_name="m"} 1
+vllm:spec_decode_num_draft_tokens{model_name="m"} 200
+vllm:spec_decode_num_accepted_tokens{model_name="m"} 90
+"""
+
+    class DummyClient:
+        async def get(self, _url: str, timeout: float = 5.0):  # noqa: ARG002
+            return DummyResponse()
+
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._http = DummyClient()  # type: ignore[assignment]
+
+    metrics = await handle.get_backend_metrics()
+    assert metrics["mtp_acceptance_rate"] == pytest.approx(0.45)
+
+
+@pytest.mark.asyncio
+async def test_get_backend_metrics_without_spec_decode_counters_reports_none() -> None:
+    """Lanes without --speculative-config expose no spec_decode_* counters."""
+
+    class DummyResponse:
+        status_code = 200
+        text = """
+vllm:num_requests_running{model_name="m"} 1
+vllm:kv_cache_usage_perc{model_name="m"} 0.5
+vllm:gpu_prefix_cache_queries{model_name="m"} 100
+vllm:gpu_prefix_cache_hits{model_name="m"} 10
+"""
+
+    class DummyClient:
+        async def get(self, _url: str, timeout: float = 5.0):  # noqa: ARG002
+            return DummyResponse()
+
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._http = DummyClient()  # type: ignore[assignment]
+
+    metrics = await handle.get_backend_metrics()
+    assert metrics["mtp_acceptance_rate"] is None
+    assert metrics["prefix_cache_hit_rate"] == pytest.approx(0.1)
+
+
 def test_build_env_injects_nccl_safety_for_tp_greater_than_1(monkeypatch) -> None:
     handle = VllmProcessHandle(
         "lane-test",

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1090,6 +1090,9 @@ vllm:spec_decode_num_accepted_tokens_total{model_name="m"} 620
 
     metrics = await handle.get_backend_metrics()
     assert metrics["mtp_acceptance_rate"] == pytest.approx(0.62)
+    # Cumulative counters are exposed for token-weighted aggregation upstream.
+    assert metrics["mtp_draft_tokens_total"] == pytest.approx(1000)
+    assert metrics["mtp_accepted_tokens_total"] == pytest.approx(620)
     # No prefix-cache counters in this scrape.
     assert metrics["prefix_cache_hit_rate"] is None
 
@@ -1115,6 +1118,8 @@ vllm:spec_decode_num_accepted_tokens{model_name="m"} 90
 
     metrics = await handle.get_backend_metrics()
     assert metrics["mtp_acceptance_rate"] == pytest.approx(0.45)
+    assert metrics["mtp_draft_tokens_total"] == pytest.approx(200)
+    assert metrics["mtp_accepted_tokens_total"] == pytest.approx(90)
 
 
 @pytest.mark.asyncio
@@ -1139,6 +1144,8 @@ vllm:gpu_prefix_cache_hits{model_name="m"} 10
 
     metrics = await handle.get_backend_metrics()
     assert metrics["mtp_acceptance_rate"] is None
+    assert metrics["mtp_draft_tokens_total"] is None
+    assert metrics["mtp_accepted_tokens_total"] is None
     assert metrics["prefix_cache_hit_rate"] == pytest.approx(0.1)
 
 


### PR DESCRIPTION
## Closes

- Closes #748 — show prefix caching and MTP hit rates (logs + statistics page)
- Closes #738 — Prometheus `logos_request_duration_seconds` / `logos_cold_starts_total` hardcoded to `model="unknown"` / `provider="unknown"`
- #740 (speculative-config in the calibration plan) is already satisfied by the merged PR #747; it is included in this PR scope because its follow-up (surfacing the MTP metrics) lands here.

## Summary

Two observability gaps, one pipeline:

1. **Hit rates were measured but never shown.** The vLLM worker already scraped `prefix_cache_hit_rate` per lane and the orchestrator already aggregated it per model into the live statistics payload — but neither the logs nor the statistics UI rendered it. MTP (speculative decoding) acceptance rates were not scraped at all.
2. **Prometheus request metrics had dead labels.** `REQUEST_DURATION_SECONDS` and `COLD_STARTS_TOTAL` declared `model`/`provider` labels but the recorder never populated them, so every observation collapsed into `unknown` and the Grafana model/provider breakdowns were unusable.

## Changes

**MTP / prefix-cache hit rates (issue 748)**
- `logos/logos-workernode/logos_worker_node/vllm_process.py`: `get_backend_metrics()` now scrapes vLLM's `spec_decode_num_{draft,accepted}_tokens_total` counters (both suffixed and unsuffixed name variants, same pattern as the prefix-cache counters) and derives `mtp_acceptance_rate` = accepted/draft tokens since process start. `None` when speculative decoding is not enabled.
- `logos/logos-orchestrator/src/logos/main.py`:
  - `_build_logosnode_scheduler_signals()` carries the new per-lane `mtp_acceptance_rate` and adds the per-model `mtp_acceptance_rate_avg` next to `prefix_cache_hit_rate_avg`.
  - `_log_request_completion()` adds `prefix_hit=NN%` (cached/prompt tokens) to the per-request completion log line. Handles both the flattened usage (`prompt_cached_tokens`, from `extract_token_usage`) and the raw streaming usage (`prompt_tokens_details.cached_tokens`). Only shown when the provider reports cached tokens.
- `logos/logos-orchestrator/src/logos/logosnode_registry.py`: lane status log lines now include `mtp_accept=NN%` next to the existing `prefix_hit=NN%`.
- `logos/logos-ui`: `LaneSignalData` declares `prefix_cache_hit_rate` / `mtp_acceptance_rate`; the Lane Health panel on the statistics page renders "Prefix hit NN.N%" and "MTP accept NN.N%" per vLLM lane (lanes are grouped per provider, i.e. per model/provider pair).

**Prometheus labels (issue 738)** — Option A from the issue (thread state through the recorder, no call-site signature changes):
- `logos/logos-orchestrator/src/logos/monitoring/recorder.py`: the per-request state is now `(start_time, model, provider)` instead of a bare start time. `record_enqueue` writes it (top candidate), `record_scheduled` overwrites model/provider with the actually selected ones (keeping the original start time), `record_complete` labels `REQUEST_DURATION_SECONDS` and `COLD_STARTS_TOTAL` with them. `"unknown"` remains only the pre-selection fallback, so no observation is dropped.
- `logos/logos-orchestrator/src/logos/terminal_logging.py`: new `ProviderNameCache` singleton (mirror of `ModelNameCache`, DB-backed, one lookup per id, `str(id)` fallback) so label values are names, consistent with `logos_demand_score{model=...}`.

No schema changes, no Java/webservice changes (the stats websocket passes the orchestrator payload through as `Map<String,Object>`), no CI/test-runner changes.

## Testing

- New unit tests:
  - `logos/logos-workernode/tests/test_vllm_process.py`: spec-decode counter parsing (with/without `_total` suffix), no-MTP lane stays `None`.
  - `logos/logos-orchestrator/tests/unit/main/test_statistics_endpoints.py`: live inventory fixture now carries `mtp_acceptance_rate`; asserts per-lane and per-model averages flow into `get_ollama_vram_stats`.
  - `logos/logos-orchestrator/tests/unit/main/test_logosnode_registry_display.py`: snapshot + rendered lane summary for `mtp_accept` (including `--` placeholders).
  - `logos/logos-orchestrator/tests/unit/main/test_request_logging.py`: `prefix_hit` field for flattened usage, nested streaming usage, explicit 0%, and omission when unreported.
  - `logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py`: duration/cold-start labels carry the resolved model/provider, scheduled-overrides-enqueue, `unknown` fallback, and no-observation-without-start. Uses a recording fake for the prom module so it is deterministic regardless of the `prometheus_client` stub installed by the capacity test modules.
- Full suites green locally:
  - orchestrator: `pytest tests/unit` → 609 passed, 1 xfailed (pre-existing)
  - workernode (CI scope): `pytest -q --timeout=30 --ignore=tests/test_model_cache.py --ignore=tests/test_calibration.py --ignore=tests/test_lane_manager.py` → 278 passed, 2 skipped
  - UI: `npm run build` (static export) succeeds
- Grafana dropdown verification (dev/test) is tracked as the remaining manual step for #738 — it needs a deployed instance with real traffic.

## Follow-ups

- The lane-summary diff renderer (`_render_lane_diff`) intentionally does not track the new metric fields, consistent with the existing `prefix_cache_hit_rate` exclusion (metrics must not spam "Lane Change" blocks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lane-level MTP acceptance rate and prefix-cache hit-rate metrics.
  * Displayed these metrics as percentages in lane health statistics.
  * Added speculative-decoding acceptance metrics to backend monitoring.
  * Completion logs now include prefix-cache hit percentages when available.

* **Bug Fixes**
  * Improved request monitoring with accurate model/provider labels, durations, and cold-start tracking.
  * Added fallback labels when model or provider details cannot be resolved.

* **Tests**
  * Expanded coverage for metric aggregation, display formatting, logging, and monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->