### PR TITLE
`Logos`: Fix Claude Code context overflow on the AI tools page

### DIFF
--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.html
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.html
@@ -214,7 +214,12 @@
             This model reports no window, so this is a conservative fallback.
           }
           Claude Code otherwise assumes 200,000 tokens for models it does not know and lets
-          requests overflow before it compacts, so the config below states the real number.
+          requests overflow before it compacts, and its compact threshold does not account
+          for the output reservation. So the config below states the real number minus both
+          the output reservation and a
+          <strong>{{ contextHeadroom() | number }}</strong>-token headroom: the CLI's token
+          estimate also runs slightly under what the worker counts, and the margin keeps its
+          auto-compact ahead of the hard limit.
         </p>
 
         @if (windowUnenforced()) {

--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.ts
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.ts
@@ -177,6 +177,24 @@ export class AiTools implements OnInit {
 
   outputTokens = computed(() => Math.min(32768, Math.floor(this.contextTokens() / 4)));
 
+  // The settings below state the window minus the output reservation minus this
+  // headroom. Both deductions are needed: Claude Code's auto-compact threshold is
+  // computed against CLAUDE_CODE_MAX_CONTEXT_TOKENS WITHOUT reserving
+  // CLAUDE_CODE_MAX_OUTPUT_TOKENS of it (measured: a session 400'd at exactly
+  // window - max_output + 1 input tokens while the CLI was told a full window), so
+  // the output has to come out of the number we hand it. The headroom additionally
+  // covers the CLI's token estimate, which runs slightly under what the vLLM
+  // worker's Qwen tokenizer counts. It scales with the window (~3%) and is clamped:
+  // small windows cannot afford a fixed 8k cut, large ones do not need more.
+  contextHeadroom = computed(() => {
+    const w = this.contextTokens();
+    return w > 0 ? Math.min(8192, Math.max(512, Math.floor(w * 0.03))) : 0;
+  });
+
+  contextTokensCapped = computed(
+    () => this.contextTokens() - this.outputTokens() - this.contextHeadroom(),
+  );
+
   windowUnenforced = computed(() => {
     const name = (this.selected()?.model_name ?? '').toLowerCase();
     return name.startsWith('claude-') || name.includes('[1m]');
@@ -198,7 +216,7 @@ export class AiTools implements OnInit {
         ANTHROPIC_DEFAULT_SONNET_MODEL: model,
         ANTHROPIC_DEFAULT_OPUS_MODEL: model,
         ANTHROPIC_DEFAULT_FABLE_MODEL: model,
-        CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(this.contextTokens()),
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(this.contextTokensCapped()),
         CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(this.outputTokens()),
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
       },


### PR DESCRIPTION
## What & why

The Claude Code tab on the AI tools page generated `settings.json` with the
model's **full** context window:

```
CLAUDE_CODE_MAX_CONTEXT_TOKENS: 262144   (full window)
CLAUDE_CODE_MAX_OUTPUT_TOKENS: 32768
```

Two effects combine to overflow the model in long sessions:

1. Claude Code's auto-compact threshold is computed against
   `CLAUDE_CODE_MAX_CONTEXT_TOKENS` **without reserving the output budget** —
   with the full window it keeps sending requests as the input approaches
   `window − max_output`.
2. Its internal token estimate runs slightly **under** what the vLLM worker's
   Qwen tokenizer counts, so the request slips one token or more past the true
   input cap.

The result is a 400 in long sessions, measured at exactly the boundary
(`262144 − 32768 = 229376`, request landed at 229377) — auto-compact never
fired, because the CLI was told a window ~24k above the overflow point:

```
API Error: 400 This model's maximum context length is 262144 tokens. However, you
requested 32768 output tokens and your prompt contains at least 229377 input tokens,
for a total of at least 262145 tokens.
```

## Change

`ai-tools.ts`: the generated config now uses

```
CLAUDE_CODE_MAX_CONTEXT_TOKENS = window − output − headroom
```

where `headroom` scales with the window (~3%, clamped to 512…8192) — small
windows don't lose a fixed 8k, large ones stay covered. The output reservation
is subtracted explicitly because the CLI's compact threshold does not.

`ai-tools.html`: the context note explains both deductions.

| window | output | headroom | Claude Code sees | overflow point | margin |
|---|---|---|---|---|---|
| 262144 (Qwen3.8-27B) | 32768 | 7864 | 221512 | 229376 | 7864 |
| 131072 (gpt-oss-120b) | 32768 | 3932 | 94372 | 98304 | 3932 |
| 128000 (cloud fallback) | 32000 | 3840 | 92160 | 96000 | 3840 |
| 32768 (local fallback) | 8192 | 983 | 23593 | 24576 | 983 |

## Verification

- `npm ci && ng build` (logos-ui) passes.
- Headroom arithmetic checked for the windows above.
- Mirrors the same fix applied to the standalone `claude-logos.sh` launcher
  (262144 → 221184 = 262144 − 32768 − 8192), verified against a real session
  that 400'd at 229377 input tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
