### PR TITLE
`Logos`: Fix stale key after rotation and dark-mode key box in key modal

### DIFF
--- a/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.scss
+++ b/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.scss
@@ -30,14 +30,12 @@
 }
 
 .key-value-row {
+  @include glass-surface;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 12px 14px;
-  border-radius: 8px;
-  border: 1px solid rgb(var(--color-outline-200));
-  background: rgb(var(--glass-fill)  / var(--opacity-muted));
   margin-bottom: 14px;
   margin-top: 4px;
 }
@@ -104,10 +102,8 @@
 }
 
 .rotate-confirm-box {
-  border: 1px solid rgb(var(--color-outline-200));
-  border-radius: 8px;
+  @include glass-surface;
   padding: 12px 14px;
-  background: rgb(var(--glass-fill) / var(--opacity-muted));
   margin-bottom: 14px;
 }
 
@@ -323,9 +319,7 @@
 }
 
 .perm-list {
-  border-radius: 8px;
-  border: 1px solid rgb(var(--color-outline-200));
-  background: rgb(var(--glass-fill)  / var(--opacity-muted));
+  @include glass-surface;
   max-height: 220px;
   overflow-y: auto;
 }

--- a/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.spec.ts
@@ -1,3 +1,4 @@
+import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TeamManagementService } from '../../../core/services/team-management.service';
@@ -11,6 +12,7 @@ describe('ApiKeyModalComponent', () => {
     updateApiKey: ReturnType<typeof vi.fn>;
     setApiKeyProviderPermissions: ReturnType<typeof vi.fn>;
     setApiKeyModelPermissions: ReturnType<typeof vi.fn>;
+    rotateApiKey: ReturnType<typeof vi.fn>;
   };
 
   const key: TeamApiKey = {
@@ -29,6 +31,7 @@ describe('ApiKeyModalComponent', () => {
       updateApiKey: vi.fn().mockResolvedValue(undefined),
       setApiKeyProviderPermissions: vi.fn().mockResolvedValue(undefined),
       setApiKeyModelPermissions: vi.fn().mockResolvedValue(undefined),
+      rotateApiKey: vi.fn().mockResolvedValue({ result: 'ok', api_key: 'lg-rotated-123' }),
     };
 
     await TestBed.configureTestingModule({
@@ -62,5 +65,50 @@ describe('ApiKeyModalComponent', () => {
 
     expect(teamService.setApiKeyProviderPermissions).toHaveBeenCalledWith(42, [10]);
     expect(teamService.setApiKeyModelPermissions).toHaveBeenCalledWith(42, [20]);
+  });
+
+  describe('rotation', () => {
+    it('updates the shared key object after a successful rotation', async () => {
+      key.key_value = 'lg-old-key-42';
+
+      await component.confirmRotate();
+
+      expect(teamService.rotateApiKey).toHaveBeenCalledWith(42);
+      expect(key.key_value).toBe('lg-rotated-123');
+      expect(component.effectiveKeyValue()).toBe('lg-rotated-123');
+      expect(component.rotateConfirm()).toBe(false);
+      expect(component.rotateError()).toBe('');
+    });
+
+    it('shows the rotated key when the modal is closed and reopened', async () => {
+      key.key_value = 'lg-old-key-42';
+
+      await component.confirmRotate();
+
+      // Reopening the modal re-runs initForm via ngOnChanges, resetting the
+      // transient form state; the displayed value must come from the (now
+      // rotated) key object, not a stale pre-rotation value (issue #733).
+      component.ngOnChanges({
+        visible: new SimpleChange(false, true, false),
+        key: new SimpleChange(null, key, false),
+      });
+
+      expect(component.effectiveKeyValue()).toBe('lg-rotated-123');
+      expect(component.maskedKey()).toContain('lg-rotated-123');
+    });
+
+    it('keeps the old key and reports an error when rotation fails', async () => {
+      teamService.rotateApiKey.mockRejectedValue(new Error('boom'));
+      key.key_value = 'lg-old-key-42';
+      component.requestRotate();
+
+      await component.confirmRotate();
+
+      expect(key.key_value).toBe('lg-old-key-42');
+      expect(component.effectiveKeyValue()).toBe('lg-old-key-42');
+      expect(component.rotateError()).toBe('Failed to rotate key, please try again.');
+      // The confirm box stays open so the user can retry or cancel.
+      expect(component.rotateConfirm()).toBe(true);
+    });
   });
 });

--- a/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.ts
+++ b/logos/logos-ui/src/app/features/team-detail/api-key-modal/api-key-modal.ts
@@ -104,11 +104,8 @@ export class ApiKeyModalComponent implements OnChanges {
   rotateLoading = signal(false);
   rotateError = signal('');
 
-  /** Live key value updated after a successful rotation. */
-  private liveKeyValue = signal<string | null>(null);
-
   effectiveKeyValue(): string | null {
-    return this.liveKeyValue() ?? this.key?.key_value ?? null;
+    return this.key?.key_value ?? null;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -131,7 +128,6 @@ export class ApiKeyModalComponent implements OnChanges {
     this.fCustom.set(!!key.use_custom_permissions);
     this.saveError.set('');
     this.copied.set(false);
-    this.liveKeyValue.set(null);
     this.rotateConfirm.set(false);
     this.rotateError.set('');
   }
@@ -236,7 +232,12 @@ export class ApiKeyModalComponent implements OnChanges {
     this.rotateError.set('');
     try {
       const res = await this.svc.rotateApiKey(key.id);
-      this.liveKeyValue.set(res.api_key);
+      // Update the shared key object in place so a reopened modal shows the
+      // rotated value instead of the pre-rotation one from the parent's
+      // cached list. The object is the same reference held by the team-detail
+      // apiKeys signal and the tab that opened this modal (no refetch happens
+      // in between), so both keep displaying the new key.
+      key.key_value = res.api_key;
       this.rotateConfirm.set(false);
     } catch {
       this.rotateError.set('Failed to rotate key, please try again.');

--- a/logos/logos-ui/src/app/features/user-management/user-management.scss
+++ b/logos/logos-ui/src/app/features/user-management/user-management.scss
@@ -184,10 +184,8 @@
 }
 
 .api-key-box {
+  @include glass-surface;
   padding: 10px 12px;
-  border-radius: 8px;
-  background: rgb(var(--glass-fill) / var(--opacity-muted));
-  border: 1px solid rgb(var(--color-outline-200));
   font-family: monospace;
   font-size: var(--font-size-sm);
   color: rgb(var(--color-typography-0));


### PR DESCRIPTION
Fixes the remaining part of #733 (stale key after rotation) and fixes #754 (unreadable key box in dark mode).

## #733 — Stale key when reopening the key modal after rotation

After rotating a key in the "Developer Key Settings" / "Service Key Settings" modal and closing it, reopening the modal showed the pre-rotation key (a page refresh was needed to see the new one).

Root cause: the modal stored the rotated value in a private `liveKeyValue` signal that `initForm()` resets on every open, while the `TeamApiKey` object in the team-detail `apiKeys` list — which the modal falls back to — was never updated.

Fix: update the shared `TeamApiKey.key_value` in place on a successful rotation. The object is the same reference held by the team-detail `apiKeys` signal and the tab that opened the modal, so a reopened modal (and its copy/masked display) immediately shows the rotated key. The now-redundant `liveKeyValue` signal is removed.

## #754 — Unreadable secret-key box in dark mode

The secret-key box in the key modal (screenshot in the issue) used `rgb(var(--glass-fill) / var(--opacity-muted))`. In dark mode `--glass-fill` is still white and `--opacity-muted` is `0.68`, producing a light box with light text.

Fix: use the themed `glass-surface` mixin (`--color-surface-0`, identical to the stat boxes below it in the same modal) for `.key-value-row`, plus the two siblings with the same broken pattern — `.rotate-confirm-box` and `.perm-list`. The same raw pattern in user-management's `.api-key-box` is fixed as well.

## Tests

Added rotation tests to `api-key-modal.spec.ts`:
- successful rotation updates the shared key object and the displayed value
- a closed + reopened modal shows the rotated key (regression test for the reported flow)
- a failed rotation keeps the old key, reports the error, and keeps the confirm box open

Verified locally: `ng test` (5/5 passing) and `ng build` (production build succeeds; the component's style-budget *warning* pre-exists on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - API-key rotation now updates the displayed key immediately and remains current when the modal is reopened.
  - Failed rotations preserve the existing key, show an error message, and keep the confirmation prompt open for retry or cancellation.

- **Style**
  - Updated API-key panels, confirmation areas, and permission lists to use consistent glass-surface styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->