### PR TITLE
`Logos`: Delete Harbor artifacts by digest, protect tagged indexes

### DIFF
--- a/.github/workflows/logos_cleanup-pr-builds.yml
+++ b/.github/workflows/logos_cleanup-pr-builds.yml
@@ -2,19 +2,23 @@
 #
 # Deletes the PR's build images from Harbor when the PR is merged (or closed).
 #
-# What it deletes:
-#   1. The artifact tagged `pr-<number>` (the manifest list the build's
-#      `finalize` step created). Only ever touched for THIS PR.
+# What it deletes, per repository:
+#   1. The artifact tagged `pr-<number>`. If that tag is the artifact's ONLY tag
+#      the whole artifact goes; if it carries other tags too (an identical
+#      rebuild on main shares the digest with `latest`) only the tag is removed,
+#      so deleting a PR build can never take a live tag down with it.
 #   2. Untagged "by-digest" artifacts older than 24 h. Every build pushes its
-#      image by digest (untagged) and only tags it later, so an orphaned
-#      by-digest artifact is left behind. The 24 h age margin guarantees we
-#      never delete an artifact that is still mid-build (builds finish in
-#      minutes, not hours) — the thing the old cleanup accidentally did. The
-#      sweep also skips any artifact a still-tagged index references, so an
-#      open PR's build is never deleted.
+#      image by digest (untagged) and only tags it later, so orphaned by-digest
+#      artifacts pile up. Two guards keep this safe:
+#        - the 24 h age margin — an in-flight build's artifact is minutes old,
+#          never hours, so a running build is never hit;
+#        - the reference guard — child manifests belonging to a still-tagged
+#          index are skipped. Sweeping those is what breaks a live tag such as
+#          `latest`, whose index children are themselves untagged artifacts.
 #
-# Auth: the Harbor account from vars.LOGOS_HARBOR_USER / secrets.LOGOS_HARBOR_PASSWORD
-# (HTTP basic auth), the same credentials the build workflow pushes with.
+# Auth: vars.LOGOS_HARBOR_USER / secrets.LOGOS_HARBOR_PASSWORD (HTTP basic auth),
+# the same robot the build workflow pushes with. Needs only Artifact: List +
+# Artifact: Delete (plus Tag: Delete for the shared-digest case).
 # The Harbor retention policy remains the backstop for everything else.
 
 name: Logos - Cleanup PR builds from Harbor
@@ -49,85 +53,106 @@ jobs:
           API_BASE="https://${HARBOR_REGISTRY%/}/api/v2.0"
           AUTH="${HARBOR_USER}:${HARBOR_PASSWORD}"
 
-          # Harbor stores push_time as an RFC3339 string (UTC); ISO-8601 UTC
-          # strings sort chronologically, so we compare the cutoff as a string.
+          # Harbor reports push_time as an RFC3339 string, and ISO-8601 UTC
+          # strings sort chronologically, so the cutoff is compared as a string.
           CUTOFF_ISO="$(date -u -d "@$(( $(date -u +%s) - UNTAGGED_AGE_MARGIN_SECONDS ))" +%Y-%m-%dT%H:%M:%SZ)"
 
-          # Repositories inside the project (image refs are ${HARBOR_REGISTRY}/${PROJECT}/<name>).
+          # Repositories inside the project (images are ${HARBOR_REGISTRY}/${PROJECT}/<name>).
+          # The API path is project-relative, so these carry no "logos/" prefix.
           REPOS=("logos" "logos-webservice" "logos-ui" "logos-db" "logos-workernode-vllm")
 
-          # Fail loud on bad credentials — a 401 must not masquerade as "nothing to clean".
-          curl -fsS -u "${AUTH}" "${API_BASE}/projects?name=${PROJECT}" > /dev/null
-          echo "Authenticated to ${HARBOR_REGISTRY} as ${HARBOR_USER}"
-
-          # GET artifacts (q=<query>, page=<n>). Prints the JSON body; empty on
-          # 404 (repository not created yet); aborts the run on any other HTTP
-          # error. page_size is capped at 100 by the API, so callers paginate.
-          get_artifacts() {
-            local q="$1" page="$2" body code
-            body="$(curl -sS -u "${AUTH}" -w '%{http_code}' \
-              "${BASE}?q=${q}&page=${page}&page_size=100")"
+          # GET <url>: prints the body on 200, nothing on 404 (repository not
+          # created yet), and aborts the run on anything else — a 401/403 must
+          # never masquerade as "nothing to clean up".
+          api_get() {
+            local url="$1" body code
+            body="$(curl -sS -u "${AUTH}" -w '%{http_code}' "${url}")"
             code="${body: -3}"
             case "${code}" in
               200) printf '%s' "${body%???}" ;;
               404) : ;;
-              *)   echo "ERROR: HTTP ${code} on GET ${BASE}?q=${q}&page=${page}" >&2; return 1 ;;
+              *)   echo "ERROR: HTTP ${code} on GET ${url}" >&2; return 1 ;;
             esac
           }
 
-          # DELETE an artifact id. Never fatal: a 404 (already gone) or 409
-          # (still referenced) is reported and skipped.
-          delete_artifact() {
-            local id="$1"
-            if curl -fsS -u "${AUTH}" -X DELETE "${BASE}/${id}"; then
-              echo "Deleted ${repo} artifact ${id}"
-            else
-              echo "WARN: could not delete ${repo} artifact ${id}; skipping"
-            fi
+          # DELETE <url> <label>: never fatal, so one stuck artifact cannot leave
+          # the rest of the cleanup undone.
+          api_delete() {
+            local url="$1" label="$2" code
+            code="$(curl -sS -u "${AUTH}" -o /dev/null -w '%{http_code}' -X DELETE "${url}")"
+            case "${code}" in
+              200|202|204) echo "Deleted ${label}" ;;
+              404)         echo "Already gone: ${label}" ;;
+              *)           echo "WARN: HTTP ${code} deleting ${label}; skipping" >&2 ;;
+            esac
           }
 
+          # Probe the credentials through a listing, the one permission this job
+          # cannot work without anyway.
+          probe_code="$(curl -sS -o /dev/null -w '%{http_code}' -u "${AUTH}" \
+            "${API_BASE}/projects/${PROJECT}/repositories/${REPOS[0]}/artifacts?page=1&page_size=1")"
+          case "${probe_code}" in
+            200|404) echo "Authenticated to ${HARBOR_REGISTRY} as ${HARBOR_USER}" ;;
+            *)       echo "ERROR: credential probe returned HTTP ${probe_code}" >&2; exit 1 ;;
+          esac
+
           for repo in "${REPOS[@]}"; do
+            echo "::group::${repo}"
             BASE="${API_BASE}/projects/${PROJECT}/repositories/${repo}/artifacts"
 
-            # 1) Drop the artifact(s) carrying this PR's tag (exact tag match).
-            get_artifacts "tags=${TAG}" 1 | jq -r '.[].id // empty' |
-              while IFS= read -r id; do
-                if [ -z "${id}" ]; then continue; fi
-                delete_artifact "${id}"
-                :
-              done
-
-            # 2) Child artifact ids referenced by a still-tagged index (open PRs)
-            #    must survive the untagged sweep. Best-effort: empty if the API
-            #    omits `references` in list responses.
-            tagged="$(get_artifacts 'tags=*' 1)"
-            PROTECTED="$(printf '%s' "${tagged}" | jq -r '.[].references[]?.child_id' 2> /dev/null || true)"
-
-            # 3) Sweep untagged by-digest artifacts older than the margin.
+            # Snapshot the repository as one JSON object per line. page_size is
+            # capped at 100 by the API, so this paginates. Taking a snapshot up
+            # front means the tag deletions below cannot race the sweep.
+            snapshot="$(mktemp)"
             page=1
             while :; do
-              resp="$(get_artifacts 'tags=nil' "${page}")"
+              resp="$(api_get "${BASE}?page=${page}&page_size=100")"
               [ -z "${resp}" ] && break
-              count="$(printf '%s' "${resp}" | jq 'length')"
-              [ "${count}" -eq 0 ] && break
-              printf '%s' "${resp}" | jq -r --arg cutoff "${CUTOFF_ISO}" \
-                '.[] | select(.push_time < $cutoff) | .id' |
-                while IFS= read -r id; do
-                  if [ -z "${id}" ]; then continue; fi
-                  # Keep anything a live tagged index still references.
-                  if [ -n "${PROTECTED}" ] && printf '%s\n' "${PROTECTED}" | grep -qxF "${id}"; then
-                    echo "Keep ${repo} artifact ${id} (referenced by a tagged index)"
-                    :
-                  else
-                    delete_artifact "${id}"
-                  fi
-                  :
-                done
-              [ "${count}" -lt 100 ] && break
+              n="$(printf '%s' "${resp}" | jq 'length')"
+              [ "${n}" -eq 0 ] && break
+              printf '%s' "${resp}" | jq -c '.[]' >> "${snapshot}"
+              [ "${n}" -lt 100 ] && break
               page=$(( page + 1 ))
-              [ "${page}" -gt 200 ] && { echo "WARN: ${repo}: >20000 untagged artifacts, stopping sweep" >&2; break; }
-              :
+              if [ "${page}" -gt 100 ]; then
+                echo "WARN: ${repo}: more than 10000 artifacts, stopping pagination" >&2
+                break
+              fi
             done
+
+            # Child manifests of a tagged index. These are untagged artifacts in
+            # their own right, so without this guard the sweep below would delete
+            # the layers behind a live tag like `latest`.
+            protected="$(jq -r 'select(((.tags // []) | length) > 0)
+              | .references[]?.child_digest // empty' "${snapshot}" | sort -u)"
+
+            # 1) This PR's tag. Drop the artifact only when `pr-N` is its sole
+            #    tag, otherwise remove just the tag and keep the artifact.
+            while IFS="$(printf '\t')" read -r digest tagcount; do
+              [ -z "${digest}" ] && continue
+              if [ "${tagcount:-0}" -le 1 ]; then
+                api_delete "${BASE}/${digest}" "${repo}@${digest} (tagged ${TAG})"
+              else
+                api_delete "${BASE}/${digest}/tags/${TAG}" \
+                  "tag ${repo}:${TAG} (artifact kept, carries ${tagcount} tags)"
+              fi
+            done < <(jq -r --arg t "${TAG}" \
+              'select((.tags // []) | map(.name) | index($t))
+               | [.digest, ((.tags // []) | length)] | @tsv' "${snapshot}")
+
+            # 2) Untagged by-digest leftovers older than the safety margin.
+            while IFS= read -r digest; do
+              [ -z "${digest}" ] && continue
+              if [ -n "${protected}" ] && printf '%s\n' "${protected}" | grep -qxF "${digest}"; then
+                echo "Keep ${repo}@${digest} (child of a tagged index)"
+                continue
+              fi
+              api_delete "${BASE}/${digest}" "${repo}@${digest} (untagged, pushed before ${CUTOFF_ISO})"
+            done < <(jq -r --arg c "${CUTOFF_ISO}" \
+              'select(((.tags // []) | length) == 0 and .push_time != null and .push_time < $c)
+               | .digest' "${snapshot}")
+
+            rm -f "${snapshot}"
+            echo "::endgroup::"
           done
 
           echo "Cleanup done for PR tag ${TAG}"


### PR DESCRIPTION
### Problem

The cleanup job added in #757 authenticates and lists correctly, but every delete fails:

```
Authenticated to harbor.aet.cit.tum.de as robot$github-logos
curl: (22) The requested URL returned error: 404
WARN: could not delete logos artifact 22561; skipping
```

`DELETE /projects/{p}/repositories/{r}/artifacts/{reference}` takes **a digest or a tag** — the
job was passing the numeric artifact `id` from the listing, so Harbor looked for an artifact
whose digest is literally `22561` and returned 404. Nothing was ever cleaned up.

This is not a permissions problem: `Artifact: List` + `Artifact: Delete` on the robot are enough.

### Fixes

Testing the delete path turned up three more problems, two of which could destroy a live tag:

1. **Delete by digest**, not by id. This is the 404.
2. **Never take a live tag down with a PR build.** An artifact can carry several tags — an
   identical rebuild on main shares its digest with `latest` — and deleting it by digest removes
   all of them. The job now drops the artifact only when `pr-<n>` is its sole tag, and otherwise
   deletes just the tag.
3. **Never sweep the children of a tagged index.** The child manifests behind an index are
   untagged artifacts in their own right, so the untagged sweep would happily delete the layers
   backing `latest`. They are now skipped via `references[].child_digest`. This is the most
   likely cause of previously vanishing `latest` images.
4. **`q=tags=*` is not a supported query pattern** — the API supports exact, fuzzy, range and
   list matches only — so the previous guard silently matched nothing. Each repository is now
   snapshotted once (paginated, `page_size` is capped at 100) and filtered locally, which also
   removes the race between the tag deletion and the sweep.

The 24 h age margin for untagged artifacts is unchanged: an in-flight build's artifact is minutes
old, so a running build is never hit.

### Verification

Run against a mocked Harbor API seeded with a real `pr-759` artifact payload plus edge cases:

| Artifact | Expected | Result |
|---|---|---|
| `pr-759` index, sole tag | deleted by digest | ✅ |
| digest tagged `pr-759` **and** `latest` | tag removed, artifact kept | ✅ |
| old untagged child of `latest` | kept | ✅ |
| old untagged orphan | deleted | ✅ |
| untagged, pushed 5 min ago (in-flight) | kept | ✅ |
| `latest` index | untouched | ✅ |

Pagination checked separately: 105 artifacts across two pages, all deleted, no duplicates.
`shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)