### PR TITLE
`Logos`: Fix calibration leaving workers without lanes, and profile loss

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -551,7 +551,20 @@ class CapacityPlanner:
         itself is the expected path. Say it out loud once it stops being
         plausible, then repeat on a cooldown so the outage is visible for as
         long as it lasts.
+
+        A worker with no live session is excluded too, but that is reported
+        everywhere already — the cycle panel prints it offline and the
+        connected count is short. Warning about it would fire forever for any
+        node that is simply switched off, and the point of this line is to
+        surface the case nothing else names: a *connected* worker that no lane
+        can be placed on. Its clock is reset so a reconnect starts fresh
+        rather than inheriting the downtime.
         """
+        registry = self._registry
+        if registry is not None and not registry.is_provider_online(provider_id):
+            self._clear_unplannable(provider_id)
+            logger.debug("Skipping worker=%s: offline this cycle", provider_id)
+            return
         now = time.time()
         first_seen = self._unplannable_since.setdefault(provider_id, now)
         worker = self._facade.get_provider_name(provider_id) or provider_id
@@ -562,11 +575,10 @@ class CapacityPlanner:
         if now - self._unplannable_warned_at.get(provider_id, 0.0) < _UNPLANNABLE_WARN_EVERY_SECONDS:
             return
         self._unplannable_warned_at[provider_id] = now
-        registry = self._registry
         logger.warning(
-            "worker=%s excluded from lane placement for %.0f min "
-            "(calibrating=%s, first_status_received=%s) — no lane can be "
-            "placed on it while this holds",
+            "worker=%s is connected but has been excluded from lane placement "
+            "for %.0f min (calibrating=%s, first_status_received=%s) — no lane "
+            "can be placed on it while this holds",
             worker,
             stuck_for / 60.0,
             registry.is_calibrating(provider_id) if registry else "n/a",
@@ -2756,6 +2768,24 @@ class CapacityPlanner:
         # provider always claiming the model.
         if awake_lanes:
             return (0.0, free_vram)
+
+        # A cold load this worker just failed cannot serve the model, so it
+        # must not win the ranking either. The execution pass drops a load in
+        # cooldown (see the pre-pass in _validate_vram_budget), but the ranker runs
+        # first: leaving the failed worker as winner makes every other worker
+        # skip the model with "best-first ranker picked worker=X", and then X's
+        # own action is thrown away — nothing is placed anywhere until the
+        # cooldown expires. Observed in production on 2026-08-21, where a
+        # worker whose vLLM died during startup kept winning the ranking for
+        # the next two minutes while the other worker that could have served
+        # the model sat idle.
+        #
+        # Only the cold-load path is gated: a sleeping lane is a wake, which
+        # has its own cooldown and is already filtered above.
+        if not sleeping_lanes and self._lane_is_in_load_failure_cooldown(
+            provider_id, self._planner_lane_id(model_name)
+        ):
+            return None
 
         profile = profiles.get(model_name)
 

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -1091,16 +1091,26 @@ class CapacityPlanner:
         Returns ``(ok, effective_available_mb, required_mb)``. *ok* is True
         when ``effective_available_mb >= required_mb``.
 
-        ``required_mb`` = ``HOST_RAM_SAFETY_MARGIN_MB + transient_estimate``,
-        where ``transient_estimate`` is:
+        ``required_mb`` = ``HOST_RAM_SAFETY_MARGIN_MB`` + the larger of two
+        costs, because host RAM has to cover both and they overlap:
 
-          1. The calibrated ``sleep_l{level}_transient_host_ram_mb`` from
-             the profile when present.
-          2. For sleep_l2 only: a rough estimate from ``disk_size_bytes``
-             (the weight-transfer dominates l2 transient cost) when the
-             calibrated value is missing.
-          3. ``HOST_RAM_SLEEP_HEADROOM_MB`` as a final flat fallback for
-             pre-calibration profiles.
+          * the *transient* peak while the sleep runs, from the calibrated
+            ``sleep_l{level}_transient_host_ram_mb``; for sleep_l2 a rough
+            estimate from ``disk_size_bytes`` when that is missing (the
+            weight transfer dominates l2), and a flat
+            ``HOST_RAM_SLEEP_HEADROOM_MB`` for pre-calibration profiles.
+          * the *residency* the lane keeps for as long as it stays asleep,
+            from ``host_ram_residual_mb``. sleep_l1 relocates the weights to
+            the host instead of dropping them, so the sleep does not hand
+            that memory back when it finishes — it holds it until the lane
+            wakes or is stopped.
+
+        Only the transient used to be counted, which asks "can this sleep
+        complete" and never "what does it leave behind". A worker could pass
+        the check for every lane in turn and still end up with its RAM spoken
+        for, because each sleep quietly kept what the check had treated as
+        borrowed. Failing here escalates the action to a stop, which is the
+        honest trade when the host cannot afford a resident sleeper.
 
         Fails open if the worker has no host-RAM telemetry.
         """
@@ -1126,7 +1136,11 @@ class CapacityPlanner:
         if transient_mb is None:
             transient_mb = self.HOST_RAM_SLEEP_HEADROOM_MB
 
-        required = self.HOST_RAM_SAFETY_MARGIN_MB + transient_mb
+        residency_mb = 0.0
+        if profile is not None and profile.host_ram_residual_mb:
+            residency_mb = max(float(profile.host_ram_residual_mb), 0.0)
+
+        required = self.HOST_RAM_SAFETY_MARGIN_MB + max(transient_mb, residency_mb)
         return effective_available >= required, effective_available, required
 
     async def _stop_sleeping_lanes_for_headroom(

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -44,6 +44,13 @@ from .vram_ledger import VRAMLedger
 
 logger = logging.getLogger(__name__)
 
+# How long a worker may stay excluded from lane placement before the planner
+# says so. A calibration session over a handful of models runs well past ten
+# minutes, so this sits above any plausible session; anything longer means the
+# worker is holding lanes it will never get back.
+_UNPLANNABLE_WARN_AFTER_SECONDS = 45 * 60.0
+_UNPLANNABLE_WARN_EVERY_SECONDS = 15 * 60.0
+
 
 class CapacityPlanner:
     """
@@ -380,6 +387,12 @@ class CapacityPlanner:
         # subset). Suppresses new load actions on the lane until expiry.
         self._lane_load_failure_until: dict[tuple[int, str], float] = {}
 
+        # Workers the cycle is currently skipping, and when the skipping began.
+        # Backs the stuck-worker warning in _note_unplannable: a worker no
+        # lane can be placed on is otherwise invisible in the logs.
+        self._unplannable_since: dict[int, float] = {}
+        self._unplannable_warned_at: dict[int, float] = {}
+
         # Phase 4b: Atomic VRAM reservation ledger — prevents double-booking
         # when concurrent load/wake/sleep/stop operations overlap.
         self._vram_ledger = VRAMLedger()
@@ -528,6 +541,42 @@ class CapacityPlanner:
             return False
         return not self._registry.is_calibrating(provider_id)
 
+    def _note_unplannable(self, provider_id: int) -> None:
+        """Log a worker that has been skipped long enough to be a fault.
+
+        Being unplannable is normal and short-lived — the seconds before a
+        first status, the minutes of a calibration session. *Staying*
+        unplannable is not: the worker's lanes were stopped and nothing is
+        putting them back, which no other log line reports because the skip
+        itself is the expected path. Say it out loud once it stops being
+        plausible, then repeat on a cooldown so the outage is visible for as
+        long as it lasts.
+        """
+        now = time.time()
+        first_seen = self._unplannable_since.setdefault(provider_id, now)
+        worker = self._facade.get_provider_name(provider_id) or provider_id
+        stuck_for = now - first_seen
+        if stuck_for < _UNPLANNABLE_WARN_AFTER_SECONDS:
+            logger.debug("Skipping worker=%s: not plannable this cycle", worker)
+            return
+        if now - self._unplannable_warned_at.get(provider_id, 0.0) < _UNPLANNABLE_WARN_EVERY_SECONDS:
+            return
+        self._unplannable_warned_at[provider_id] = now
+        registry = self._registry
+        logger.warning(
+            "worker=%s excluded from lane placement for %.0f min "
+            "(calibrating=%s, first_status_received=%s) — no lane can be "
+            "placed on it while this holds",
+            worker,
+            stuck_for / 60.0,
+            registry.is_calibrating(provider_id) if registry else "n/a",
+            registry.has_received_first_status(provider_id) if registry else "n/a",
+        )
+
+    def _clear_unplannable(self, provider_id: int) -> None:
+        self._unplannable_since.pop(provider_id, None)
+        self._unplannable_warned_at.pop(provider_id, None)
+
     async def _run_cycle(self) -> None:
         """Execute one planner cycle."""
         cycle_start = time.time()
@@ -614,11 +663,9 @@ class CapacityPlanner:
             # we don't know what lanes are already loaded and acting on
             # stale/empty state can destroy existing lanes.
             if not self._is_plannable(provider_id):
-                logger.debug(
-                    "Skipping worker=%s: not plannable this cycle",
-                    self._facade.get_provider_name(provider_id) or provider_id,
-                )
+                self._note_unplannable(provider_id)
                 continue
+            self._clear_unplannable(provider_id)
 
             try:
                 lanes = self._facade.get_all_provider_lane_signals(provider_id)

--- a/logos/logos-orchestrator/src/logos/logosnode_registry.py
+++ b/logos/logos-orchestrator/src/logos/logosnode_registry.py
@@ -262,6 +262,15 @@ CALIBRATION_SESSION_STARTED_EVENT = "calibration_session_started"
 START_CALIBRATION_SESSION_ACTION = "start_calibration_session"
 TERMINAL_CALIBRATION_SESSION_EVENTS = frozenset({"calibration_session_finished", "calibration_session_cancelled"})
 
+# How long the optimistic mark set when start_calibration_session is dispatched
+# survives a worker status that reports no session. The worker activates the
+# session inside its RPC handler, before it answers, so every snapshot built
+# after the reply already reports it — this window only has to cover a status
+# message that was already in flight when the command went out. It is bounded
+# because an unbounded wait is the failure being fixed: a start that never
+# materialises must not latch the provider out of lane placement forever.
+CALIBRATION_START_GRACE = timedelta(seconds=60)
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -297,12 +306,16 @@ class ProviderSession:
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     desired_lanes: dict[str, dict[str, Any]] = field(default_factory=dict)
     max_lanes: int = 0  # 0 = unlimited (reported by worker in hello)
-    # True between the worker's calibration_session_started event and its
-    # terminal event, and seeded from the worker's hello so a reconnect
-    # mid-session is correct before the first status arrives. A calibrating
+    # True while the worker is running a calibration session, seeded from its
+    # hello and then reconciled against every status it sends. A calibrating
     # worker has freed all VRAM for its probes, so its idle lanes and free
     # VRAM are reserved rather than available.
     calibrating: bool = False
+    # Set when start_calibration_session is dispatched: until it passes, a
+    # status reporting no session is treated as a snapshot that predates the
+    # command rather than as proof the session ended. See
+    # CALIBRATION_START_GRACE.
+    optimistic_calibration_until: datetime | None = None
 
     def is_stale(self, stale_after_seconds: int) -> bool:
         return (_utc_now() - self.last_heartbeat) > timedelta(seconds=stale_after_seconds)
@@ -602,7 +615,12 @@ class LogosNodeRuntimeRegistry:
         # session starts non-calibrating and the event replay that would mark
         # it only arrives after the first status. None = worker predates the
         # field; leave the replay as the only source in that case.
+        #
+        # A hello is a fresh connection, so it also retires any pending
+        # optimistic mark: whatever command was in flight against the previous
+        # connection cannot be answered on this one.
         if calibrating is not None:
+            session.optimistic_calibration_until = None
             self._set_calibrating(session, bool(calibrating), "hello")
         if capabilities_models is not None:
             new_caps = {m for m in capabilities_models if isinstance(m, str) and m.strip()}
@@ -618,6 +636,7 @@ class LogosNodeRuntimeRegistry:
         runtime: dict[str, Any],
         capabilities_models: list[str] | None = None,
         configured_models: list[str] | None = None,
+        calibrating: bool | None = None,
     ) -> None:
         session = await self._get_session(provider_id)
         if session is None:
@@ -629,6 +648,10 @@ class LogosNodeRuntimeRegistry:
         session.last_heartbeat = _utc_now()
         if was_first:
             self.sync_desired_lanes_from_runtime(provider_id)
+        # None = worker predates the field; the lifecycle events stay the only
+        # source in that case.
+        if calibrating is not None:
+            self._reconcile_calibrating_from_status(session, bool(calibrating))
 
         # Detect node-health transitions and log loudly on the master side
         # so operators see the condition in the logos-orchestrator container
@@ -788,9 +811,44 @@ class LogosNodeRuntimeRegistry:
         """
         event_name = str(event.get("event", "")).strip()
         if event_name == CALIBRATION_SESSION_STARTED_EVENT:
+            session.optimistic_calibration_until = None
             self._set_calibrating(session, True, event_name)
         elif event_name in TERMINAL_CALIBRATION_SESSION_EVENTS:
+            session.optimistic_calibration_until = None
             self._set_calibrating(session, False, event_name)
+
+    def _reconcile_calibrating_from_status(self, session: ProviderSession, calibrating: bool) -> None:
+        """Settle ``session.calibrating`` from the worker's own status snapshot.
+
+        The lifecycle events are one-shot signals, which makes the flag they
+        drive a latch: a terminal event that never lands as a live event — the
+        post-connect replay filter drops it, the connection it belonged to is
+        gone — leaves the provider excluded from lane placement with nothing
+        left to release it, and the only recovery is restarting the worker.
+
+        Every status carries the worker's current session state, so this
+        converges within one status interval no matter which event was lost.
+        The events stay useful: they act within the same second, while the
+        status is the periodic ground truth behind them.
+        """
+        if calibrating:
+            session.optimistic_calibration_until = None
+            self._set_calibrating(session, True, "worker status")
+            return
+
+        deadline = session.optimistic_calibration_until
+        if deadline is not None:
+            if _utc_now() < deadline:
+                # A start we just dispatched; this snapshot may predate it.
+                return
+            session.optimistic_calibration_until = None
+            logger.warning(
+                "provider=%s reported no calibration session %ds after "
+                "start_calibration_session was dispatched — releasing it for lane placement",
+                session.worker_id or str(session.provider_id),
+                int(CALIBRATION_START_GRACE.total_seconds()),
+            )
+        self._set_calibrating(session, False, "worker status")
 
     def _set_calibrating(self, session: ProviderSession, calibrating: bool, source: str) -> None:
         """Set ``session.calibrating``, logging only actual transitions."""
@@ -932,14 +990,20 @@ class LogosNodeRuntimeRegistry:
         # own events remain the authority for the rest of the session.
         calibration_start = action == START_CALIBRATION_SESSION_ACTION
         was_calibrating = session.calibrating
+        prior_optimistic_until = session.optimistic_calibration_until
         if calibration_start:
             self._set_calibrating(session, True, "start_calibration_session dispatched")
+            # A status built before this command is still in flight and would
+            # report no session; hold it off until the worker has had time to
+            # report the one we just asked for.
+            session.optimistic_calibration_until = _utc_now() + CALIBRATION_START_GRACE
 
         def _undo_optimistic_calibration_mark() -> None:
             # Restore rather than clear: the worker refuses a start while a
             # session is already running, and clearing would then release a
             # live session for lane placement.
             if calibration_start:
+                session.optimistic_calibration_until = prior_optimistic_until
                 self._set_calibrating(session, was_calibrating, "start_calibration_session refused")
 
         try:
@@ -967,8 +1031,8 @@ class LogosNodeRuntimeRegistry:
             )
             # Deliberately not undone here: a timeout leaves it unknown whether
             # the session started, and releasing a running one is the failure
-            # this guard exists to prevent. The worker's terminal event, or its
-            # hello on the next connect, settles the flag either way.
+            # this guard exists to prevent. The worker's own status settles it
+            # once the optimistic window passes — no event or reconnect needed.
             raise LogosNodeOfflineError("Command timeout waiting for worker response") from exc
 
         if not bool(result.get("success", False)):

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -4159,6 +4159,9 @@ async def logosnode_session(websocket: WebSocket, token: str):
                     configured_models=(
                         payload.get("configured_models") if isinstance(payload.get("configured_models"), list) else None
                     ),
+                    calibrating=(
+                        bool(payload.get("calibrating")) if isinstance(payload.get("calibrating"), bool) else None
+                    ),
                 )
                 _capture_logosnode_provider_snapshot(ticket.provider_id, runtime)
             elif msg_type == "event":

--- a/logos/logos-orchestrator/src/logos/sdi/models.py
+++ b/logos/logos-orchestrator/src/logos/sdi/models.py
@@ -357,6 +357,15 @@ class ModelProfile:
     # weight-transfer size and is more predictive.
     sleep_l1_transient_host_ram_mb: Optional[float] = None
     sleep_l2_transient_host_ram_mb: Optional[float] = None
+    # Host RAM the lane keeps for the whole time it sleeps, as opposed to the
+    # peak during the call above. sleep_l1 relocates the weights to the host
+    # rather than dropping them, so a sleeping lane holds roughly its weight
+    # footprint until it wakes. The worker has measured this all along — from
+    # calibration and from lane telemetry — but never sent it, so the planner
+    # priced sleeping as free on the host axis and kept choosing it while the
+    # same RAM was also lent to the model cache. None from a worker that
+    # predates the field, or for a model that has never slept here.
+    host_ram_residual_mb: Optional[float] = None
     # Worker reports True when this model cannot sleep here (worker-wide
     # disable_sleep_mode kill switch or per-model enable_sleep_mode=false
     # override). The calibration orchestrator treats this as
@@ -423,6 +432,7 @@ class ModelProfile:
             "residency_source": self.residency_source,
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
+            "host_ram_residual_mb": self.host_ram_residual_mb,
             "sleep_mode_disabled": self.sleep_mode_disabled,
             "calibration_unsupported": self.calibration_unsupported,
             "calibration_unsupported_reason": self.calibration_unsupported_reason,

--- a/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
@@ -651,6 +651,7 @@ class LogosNodeDataProvider:
                 residency_source=data.get("residency_source"),
                 sleep_l1_transient_host_ram_mb=data.get("sleep_l1_transient_host_ram_mb"),
                 sleep_l2_transient_host_ram_mb=data.get("sleep_l2_transient_host_ram_mb"),
+                host_ram_residual_mb=data.get("host_ram_residual_mb"),
                 sleep_mode_disabled=data.get("sleep_mode_disabled"),
                 calibration_unsupported=data.get("calibration_unsupported"),
                 calibration_unsupported_reason=data.get("calibration_unsupported_reason"),

--- a/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
@@ -24,6 +24,7 @@ marked xfail with a TODO.
 from __future__ import annotations
 
 import sys
+import time
 from dataclasses import dataclass, field
 from types import ModuleType, SimpleNamespace
 from typing import Any, Dict, List
@@ -196,6 +197,7 @@ def _planner(providers: List[_MockProvider]) -> CapacityPlanner:
     planner._registry = registry
     planner._demand = demand
     planner._lane_wake_failure_until = {}
+    planner._lane_load_failure_until = {}
     planner._cross_provider_best_first = True
     planner._replica_first_eviction = True
     planner._replicate_on_free_vram = False  # opt-in; tests turn it on
@@ -427,6 +429,73 @@ class TestEstimateDemandActionCost:
         )
         assert result is None
 
+    def test_a_cold_load_in_failure_cooldown_is_infeasible(self):
+        """A load this worker just failed cannot serve the model, so it cannot
+        be a ranking candidate either — see the deadlock test below."""
+        provider = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0)},
+            available_vram_mb=80_000.0,
+        )
+        planner = _planner([provider])
+        planner._lane_load_failure_until[(1, planner._planner_lane_id("X"))] = time.time() + 120.0
+
+        result = planner._estimate_demand_action_cost(
+            1,
+            "X",
+            provider.lanes,
+            provider.profiles,
+            planner._facade.get_capacity_info(1),
+        )
+        assert result is None
+
+    def test_an_expired_cooldown_makes_the_worker_a_candidate_again(self):
+        """The cooldown is a pause, not a ban."""
+        provider = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0)},
+            available_vram_mb=80_000.0,
+        )
+        planner = _planner([provider])
+        planner._lane_load_failure_until[(1, planner._planner_lane_id("X"))] = time.time() - 1.0
+
+        result = planner._estimate_demand_action_cost(
+            1,
+            "X",
+            provider.lanes,
+            provider.profiles,
+            planner._facade.get_capacity_info(1),
+        )
+        assert result is not None
+
+    def test_a_sleeping_lane_is_unaffected_by_the_load_cooldown(self):
+        """Waking a lane that is already resident is not the load that failed,
+        and has its own cooldown."""
+        provider = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[_lane(lane_id="planner-X", model_name="X", runtime_state="loaded", sleep_state="sleeping")],
+            profiles={"X": _profile(loaded_vram_mb=20_000.0, sleeping_residual_mb=1_000.0)},
+            available_vram_mb=80_000.0,
+        )
+        planner = _planner([provider])
+        planner._lane_load_failure_until[(1, "planner-X")] = time.time() + 120.0
+
+        result = planner._estimate_demand_action_cost(
+            1,
+            "X",
+            provider.lanes,
+            provider.profiles,
+            planner._facade.get_capacity_info(1),
+        )
+        assert result is not None
+        cost, _ = result
+        assert cost == pytest.approx(CapacityPlanner.TARGET_ACTION_COST_S["wake"])
+
 
 # ---------------------------------------------------------------------------
 # Cross-provider ranker tests
@@ -460,6 +529,72 @@ class TestRankProvidersForDemandedModels:
             [("X", 1.5)],
         )
         assert winners == {"X": a.provider_id}
+
+    def test_a_worker_whose_load_just_failed_does_not_win(self):
+        """Production, 2026-08-21: A's vLLM died during startup, so its lane
+        went into the load-failure cooldown. The ranker did not look at that
+        and kept naming A the winner, which made B skip the model with
+        "best-first ranker picked worker=A" — and A's own action was then
+        dropped by the cooldown check in _validate_vram_budget. Neither worker
+        loaded anything for the next two minutes, while a request sat queued.
+        """
+        a = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=90_000,  # would otherwise win the free-VRAM tiebreak
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+        b = _MockProvider(
+            provider_id=2,
+            name="B",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=80_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+        planner = _planner([a, b])
+        planner._lane_load_failure_until[(a.provider_id, planner._planner_lane_id("X"))] = time.time() + 120.0
+
+        winners = planner._rank_providers_for_demanded_models(
+            [a.provider_id, b.provider_id],
+            [("X", 1.5)],
+        )
+        assert winners == {"X": b.provider_id}
+
+    def test_all_workers_in_cooldown_leaves_the_model_unranked(self):
+        """With no viable worker the ranker must name none, so nothing is
+        skipped for "another worker was picked" — the per-worker paths then
+        make their own decision instead of deferring to a winner that cannot
+        act. _compute_demand_actions defaults a missing entry to the worker
+        being evaluated for exactly this reason."""
+        a = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=90_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+        b = _MockProvider(
+            provider_id=2,
+            name="B",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=80_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+        planner = _planner([a, b])
+        lane_id = planner._planner_lane_id("X")
+        planner._lane_load_failure_until[(a.provider_id, lane_id)] = time.time() + 120.0
+        planner._lane_load_failure_until[(b.provider_id, lane_id)] = time.time() + 120.0
+
+        winners = planner._rank_providers_for_demanded_models(
+            [a.provider_id, b.provider_id],
+            [("X", 1.5)],
+        )
+        assert "X" not in winners
 
     def test_sleeping_provider_beats_cold_provider(self):
         """Scenario 4: A has X sleeping (with eviction), B is cold (no eviction).

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_lane_guard.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_lane_guard.py
@@ -586,11 +586,20 @@ def _unplannable_planner(registry):
     return planner
 
 
+def _connected_but_excluded_registry():
+    return MagicMock(
+        **{
+            "is_calibrating.return_value": True,
+            "has_received_first_status.return_value": True,
+            "is_provider_online.return_value": True,
+        }
+    )
+
+
 def test_a_briefly_unplannable_worker_is_not_warned_about(caplog):
     """Skipping is the expected path for the seconds before a first status and
     the minutes of a session — it must not be noise."""
-    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
-    planner = _unplannable_planner(registry)
+    planner = _unplannable_planner(_connected_but_excluded_registry())
 
     with caplog.at_level(logging.WARNING):
         planner._note_unplannable(1)
@@ -601,8 +610,7 @@ def test_a_briefly_unplannable_worker_is_not_warned_about(caplog):
 def test_a_worker_stuck_unplannable_is_reported(caplog):
     """Nothing else logs this state: the skip is silent by design, so an
     excluded worker held no lanes for hours without a single line about it."""
-    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
-    planner = _unplannable_planner(registry)
+    planner = _unplannable_planner(_connected_but_excluded_registry())
     planner._note_unplannable(1)
     planner._unplannable_since[1] = time.time() - (_UNPLANNABLE_WARN_AFTER_SECONDS + 60)
 
@@ -618,10 +626,49 @@ def test_a_worker_stuck_unplannable_is_reported(caplog):
     assert caplog.records == []
 
 
+def test_an_offline_worker_is_never_warned_about(caplog):
+    """An offline worker is unplannable too, and every other surface already
+    says so — the cycle panel prints it offline, the connected count is short.
+    Warning here would fire every 15 minutes forever for any node that is
+    simply switched off, drowning the case this line exists for."""
+    registry = MagicMock(
+        **{
+            "is_calibrating.return_value": False,
+            "has_received_first_status.return_value": False,
+            "is_provider_online.return_value": False,
+        }
+    )
+    planner = _unplannable_planner(registry)
+    planner._unplannable_since[1] = time.time() - (_UNPLANNABLE_WARN_AFTER_SECONDS * 10)
+
+    with caplog.at_level(logging.WARNING):
+        planner._note_unplannable(1)
+
+    assert caplog.records == []
+
+
+def test_an_offline_worker_restarts_the_clock_on_reconnect(caplog):
+    """Downtime is not exclusion. A worker that comes back must be given the
+    full grace period again, not warned about the moment it reconnects."""
+    registry = _connected_but_excluded_registry()
+    planner = _unplannable_planner(registry)
+
+    planner._note_unplannable(1)
+    planner._unplannable_since[1] = time.time() - (_UNPLANNABLE_WARN_AFTER_SECONDS + 60)
+
+    registry.is_provider_online.return_value = False
+    planner._note_unplannable(1)
+    assert planner._unplannable_since == {}
+
+    registry.is_provider_online.return_value = True
+    with caplog.at_level(logging.WARNING):
+        planner._note_unplannable(1)
+    assert caplog.records == []
+
+
 def test_a_recovered_worker_forgets_its_stuck_history():
     """The next outage has to be timed from when it began, not from the last."""
-    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
-    planner = _unplannable_planner(registry)
+    planner = _unplannable_planner(_connected_but_excluded_registry())
 
     planner._note_unplannable(1)
     planner._clear_unplannable(1)

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_lane_guard.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_lane_guard.py
@@ -14,13 +14,16 @@ never set that slot, so it does not see every session.
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
 
-from logos.capacity.capacity_planner import CapacityPlanner
-from logos.logosnode_registry import LogosNodeCommandError, LogosNodeRuntimeRegistry, ProviderSession
+from logos.capacity.capacity_planner import _UNPLANNABLE_WARN_AFTER_SECONDS, CapacityPlanner
+from logos.logosnode_registry import LogosNodeCommandError, LogosNodeRuntimeRegistry, ProviderSession, _utc_now
 
 # ---------------------------------------------------------------------------
 # Registry: calibrating flag driven by worker events
@@ -422,3 +425,206 @@ def test_a_replayed_event_is_still_recorded_in_the_session_history():
     asyncio.run(registry.append_event(1, _event("calibration_session_finished"), replay=True))
 
     assert [e["event"] for e in session.latest_events] == ["calibration_session_finished"]
+
+
+# ---------------------------------------------------------------------------
+# Registry: the worker's status is the periodic ground truth
+#
+# The lifecycle events are one-shot, which makes the flag they drive a latch.
+# A terminal event that never lands as a live event leaves the worker excluded
+# from lane placement with nothing left to release it — observed in production
+# as three workers holding no lanes for over seven hours after a nightly
+# calibration run, cleared only by restarting the container. Every status
+# carries the worker's own view of whether a session is running, so the flag
+# converges within one status interval regardless of which event was lost.
+# ---------------------------------------------------------------------------
+
+
+def _status(registry, provider_id: int = 1, *, calibrating: bool | None = None) -> None:
+    asyncio.run(registry.update_runtime(provider_id, {"lanes": []}, calibrating=calibrating))
+
+
+def test_a_status_releases_a_flag_that_no_event_ever_cleared():
+    """The production failure, end to end: the session's start is seen, its end
+    is not, and the next status is what gets the worker planning again."""
+    registry, session = _registry_with_session()
+    session.first_status_received = True
+    planner = _planner_with_registry(registry)
+
+    asyncio.run(registry.append_event(1, _event("calibration_session_started")))
+    assert planner._is_plannable(1) is False
+
+    # The terminal event arrives as replay — dropped, as it must be — so the
+    # flag is still set with nothing else left to clear it.
+    asyncio.run(registry.append_event(1, _event("calibration_session_finished"), replay=True))
+    assert planner._is_plannable(1) is False
+
+    _status(registry, calibrating=False)
+    assert planner._is_plannable(1) is True
+
+
+def test_a_status_reporting_a_session_keeps_the_worker_excluded():
+    """The reconciliation is symmetric: a status can also be what first tells
+    the server a session is running."""
+    registry, session = _registry_with_session()
+    session.first_status_received = True
+    planner = _planner_with_registry(registry)
+
+    _status(registry, calibrating=True)
+    assert planner._is_plannable(1) is False
+
+    _status(registry, calibrating=False)
+    assert planner._is_plannable(1) is True
+
+
+def test_a_status_without_the_field_leaves_the_flag_untouched():
+    """Worker predating the field → the events stay the only source."""
+    registry, session = _registry_with_session()
+    session.calibrating = True
+
+    _status(registry, calibrating=None)
+    assert registry.is_calibrating(1) is True
+
+
+def test_a_status_predating_a_dispatched_start_cannot_release_it():
+    """A status built before start_calibration_session went out is still in
+    flight when the mark is set. Acting on it would undo the mark and reopen
+    exactly the window the dispatch-time marking exists to close."""
+    registry, _session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    assert registry.is_calibrating(1) is True
+
+    _status(registry, calibrating=False)
+    assert registry.is_calibrating(1) is True, "an in-flight status must not clear a fresh mark"
+
+
+def test_a_start_that_never_materialises_is_released_after_the_grace():
+    """The window is bounded on purpose. A start the worker never acted on —
+    a timed-out command, a session that died before it began — must not latch
+    the worker out of lane placement indefinitely."""
+    registry, session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    session.optimistic_calibration_until = _utc_now() - timedelta(seconds=1)
+
+    _status(registry, calibrating=False)
+    assert registry.is_calibrating(1) is False
+
+
+def test_a_confirming_status_retires_the_optimistic_window():
+    """Once the worker has reported the session, later statuses are trusted
+    immediately — the window is only there to bridge the dispatch."""
+    registry, session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    _status(registry, calibrating=True)
+    assert session.optimistic_calibration_until is None
+
+    _status(registry, calibrating=False)
+    assert registry.is_calibrating(1) is False
+
+
+def test_a_started_event_retires_the_optimistic_window():
+    """Same for the event path, which normally lands before the first status."""
+    registry, session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    asyncio.run(registry.append_event(1, _event("calibration_session_started")))
+    assert session.optimistic_calibration_until is None
+
+    _status(registry, calibrating=False)
+    assert registry.is_calibrating(1) is False
+
+
+def test_a_terminal_event_retires_the_optimistic_window():
+    """A session that starts and ends inside the window must leave nothing
+    behind that would make the next status be ignored."""
+    registry, session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    asyncio.run(registry.append_event(1, _event("calibration_session_finished")))
+
+    assert session.optimistic_calibration_until is None
+    assert registry.is_calibrating(1) is False
+
+
+def test_a_reconnect_retires_the_optimistic_window():
+    """A hello is a new connection: no command dispatched against the previous
+    one can still be answered on it, and hello reports the truth anyway."""
+    registry, session, _ = _registry_answering_start()
+
+    asyncio.run(registry.send_command(1, "start_calibration_session", params={"sleep_level": 1}))
+    asyncio.run(registry.on_hello(provider_id=1, worker_id="worker-a", calibrating=False))
+
+    assert session.optimistic_calibration_until is None
+    assert registry.is_calibrating(1) is False
+
+
+def test_a_refused_start_restores_the_previous_window():
+    """Undoing the mark has to undo the window with it, or the status that
+    would have corrected the state is ignored for a minute."""
+    registry, session, _ = _registry_answering_start(reply={"ok": False, "error": "node is in a degraded state"})
+
+    with pytest.raises(LogosNodeCommandError):
+        asyncio.run(registry.send_command(1, "start_calibration_session"))
+
+    assert session.optimistic_calibration_until is None
+    assert registry.is_calibrating(1) is False
+
+
+# ---------------------------------------------------------------------------
+# Planner: a worker nothing can be placed on says so
+# ---------------------------------------------------------------------------
+
+
+def _unplannable_planner(registry):
+    planner = _planner_with_registry(registry)
+    planner._unplannable_since = {}
+    planner._unplannable_warned_at = {}
+    planner._facade = MagicMock(**{"get_provider_name.return_value": "deimama"})
+    return planner
+
+
+def test_a_briefly_unplannable_worker_is_not_warned_about(caplog):
+    """Skipping is the expected path for the seconds before a first status and
+    the minutes of a session — it must not be noise."""
+    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
+    planner = _unplannable_planner(registry)
+
+    with caplog.at_level(logging.WARNING):
+        planner._note_unplannable(1)
+
+    assert caplog.records == []
+
+
+def test_a_worker_stuck_unplannable_is_reported(caplog):
+    """Nothing else logs this state: the skip is silent by design, so an
+    excluded worker held no lanes for hours without a single line about it."""
+    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
+    planner = _unplannable_planner(registry)
+    planner._note_unplannable(1)
+    planner._unplannable_since[1] = time.time() - (_UNPLANNABLE_WARN_AFTER_SECONDS + 60)
+
+    with caplog.at_level(logging.WARNING):
+        planner._note_unplannable(1)
+    assert "deimama" in caplog.text
+    assert "excluded from lane placement" in caplog.text
+
+    # Repeats on a cooldown rather than once per cycle.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        planner._note_unplannable(1)
+    assert caplog.records == []
+
+
+def test_a_recovered_worker_forgets_its_stuck_history():
+    """The next outage has to be timed from when it began, not from the last."""
+    registry = MagicMock(**{"is_calibrating.return_value": True, "has_received_first_status.return_value": True})
+    planner = _unplannable_planner(registry)
+
+    planner._note_unplannable(1)
+    planner._clear_unplannable(1)
+
+    assert planner._unplannable_since == {}
+    assert planner._unplannable_warned_at == {}

--- a/logos/logos-orchestrator/tests/unit/capacity/test_host_ram_planner.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_host_ram_planner.py
@@ -9,7 +9,7 @@ It is a pure gate — it does not stop existing lanes.
 from __future__ import annotations
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 # Prometheus stub (matches test_planner_concurrency.py).
@@ -155,3 +155,73 @@ def test_lane_host_ram_from_snapshot_returns_measured_value():
     assert p._lane_host_ram_from_snapshot(1, "planner-foo") == 12_345.0
     assert p._lane_host_ram_from_snapshot(1, "planner-bar") == 6_789.0
     assert p._lane_host_ram_from_snapshot(1, "planner-missing") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Sleeping costs host RAM for as long as it lasts
+#
+# sleep_l1 relocates a lane's weights to host RAM rather than dropping them,
+# so the memory is spoken for until the lane wakes or is stopped. Only the
+# transient peak *during* the call was ever checked, which answers "can this
+# sleep complete" and nothing about what it leaves behind — so a worker could
+# pass the check for lane after lane and still end up with its RAM gone.
+# ---------------------------------------------------------------------------
+
+
+def _profile(**kwargs) -> SimpleNamespace:
+    base = {
+        "sleep_l1_transient_host_ram_mb": None,
+        "sleep_l2_transient_host_ram_mb": None,
+        "host_ram_residual_mb": None,
+        "disk_size_bytes": None,
+    }
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def test_sleep_precheck_counts_what_the_sleep_leaves_behind():
+    """A cheap transfer with an expensive resting footprint: 2 GB moves, 40 GB
+    stays. Judging it on the transient alone waves it through and the host is
+    40 GB poorer with nothing recording it."""
+    p = _bare_planner(_snapshot_with_host_memory(30_000.0))
+
+    ok, _eff, required = p._check_host_ram_headroom_for_sleep(
+        1, 1, _profile(sleep_l1_transient_host_ram_mb=2_000.0, host_ram_residual_mb=40_000.0)
+    )
+
+    assert ok is False
+    assert required >= 40_000.0
+
+
+def test_sleep_precheck_still_denies_on_the_transient_alone():
+    """The original guard: the peak during the call has to fit too, whatever
+    the lane settles at afterwards."""
+    p = _bare_planner(_snapshot_with_host_memory(10_000.0))
+
+    ok, _eff, required = p._check_host_ram_headroom_for_sleep(
+        1, 2, _profile(sleep_l2_transient_host_ram_mb=60_000.0, host_ram_residual_mb=1_000.0)
+    )
+
+    assert ok is False
+    assert required >= 60_000.0
+
+
+def test_sleep_precheck_passes_when_the_host_can_afford_a_resident_sleeper():
+    p = _bare_planner(_snapshot_with_host_memory(200_000.0))
+
+    ok, _eff, _required = p._check_host_ram_headroom_for_sleep(
+        1, 1, _profile(sleep_l1_transient_host_ram_mb=2_000.0, host_ram_residual_mb=40_000.0)
+    )
+
+    assert ok is True
+
+
+def test_sleep_precheck_without_a_residency_measurement_is_unchanged():
+    """Workers that predate the field, and models that have never slept here,
+    keep the transient-only behaviour rather than being blocked."""
+    p = _bare_planner(_snapshot_with_host_memory(30_000.0))
+
+    ok, _eff, required = p._check_host_ram_headroom_for_sleep(1, 1, _profile(sleep_l1_transient_host_ram_mb=2_000.0))
+
+    assert ok is True
+    assert required == p.HOST_RAM_SAFETY_MARGIN_MB + 2_000.0

--- a/logos/logos-workernode/logos_worker_node/cache_planner.py
+++ b/logos/logos-workernode/logos_worker_node/cache_planner.py
@@ -18,8 +18,16 @@ Why this rule exists:
 
 The algorithm is deterministic — same inputs always produce the same output:
 
-  1. Compute ``reserve_mb = sum(host_ram of every sleepable capability)``.
-  2. ``budget_mb = available_host_ram_mb − reserve_mb − safety_margin_mb``.
+  1. Compute ``reserve_mb = sum(sleeping host_ram of every sleepable
+     capability)`` — what those lanes hold while asleep, not while awake.
+  2. ``budget_mb = (available_host_ram_mb + cache_held_mb) − reserve_mb −
+     safety_margin_mb``. The cache's own footprint is added back because it
+     is reclaimable: a budget measured from ``MemAvailable`` alone is a
+     budget measured after the cache already spent it, so a full cache
+     reports no room, declines to cache anything more, and keeps every byte
+     it has. Adding it back asks the question that matters — how much may
+     the cache hold in total — and lets the answer come out lower than what
+     it currently holds, which is what produces an eviction.
      If non-positive: budget is zero (only the unsleepable models, which are
      unaffected by the sleep reserve, may still get cached up to tmpfs limits;
      see step 4).
@@ -47,7 +55,12 @@ class CacheCandidate:
 
     name: str
     can_sleep: bool
-    host_ram_mb: float  # projected host-RAM footprint when loaded
+    # Host RAM this model holds *while asleep* — what the reserve has to
+    # cover, since the reserve exists so every sleepable model can be in
+    # sleep_l1 at once. Not the awake footprint: an awake lane's RAM is
+    # spoken for whether or not the cache is holding anything, so counting
+    # it here would reserve the same memory twice.
+    sleeping_host_ram_mb: float
     size_bytes: int  # weights on disk; surrogate for tmpfs cost
 
 
@@ -58,6 +71,7 @@ class CachePlan:
     order: list[str]
     reserved_for_sleep_mb: float
     available_host_ram_mb: float
+    cache_held_mb: float
     safety_margin_mb: float
     sleepable_tmpfs_budget_mb: float
     cached_unsleepable: list[str]
@@ -70,20 +84,25 @@ def plan_cache_order(
     *,
     available_host_ram_mb: float,
     safety_margin_mb: float,
+    cache_held_mb: float = 0.0,
 ) -> CachePlan:
     """Decide which models to pre-cache and in what order.
 
     Inputs:
       - ``candidates``: every calibrated capability model the worker knows
-        about, with its sleep capability, projected host-RAM footprint, and
+        about, with its sleep capability, sleeping host-RAM footprint, and
         tmpfs cost.
-      - ``available_host_ram_mb``: worker's MemAvailable at startup.
+      - ``available_host_ram_mb``: worker's current MemAvailable.
       - ``safety_margin_mb``: fixed host-RAM buffer for OS file cache,
         malloc fragmentation, vLLM mm processor caches, etc.
+      - ``cache_held_mb``: what the tmpfs cache already holds. Added back
+        into the pool because it is reclaimable — see the module docstring.
+        Zero reproduces the original from-scratch behaviour.
 
     Returns a CachePlan describing the ordering and the budget arithmetic
     used to derive it. ``order`` is the list to pass to
-    ``ModelRamCache.cache_models_by_priority``.
+    ``ModelRamCache.cache_models_by_priority``; anything cached but absent
+    from it is what the caller should reclaim.
     """
     unsleepable = sorted(
         (c for c in candidates if not c.can_sleep),
@@ -94,8 +113,9 @@ def plan_cache_order(
         key=lambda c: c.size_bytes,
     )
 
-    reserved_for_sleep_mb = sum(c.host_ram_mb for c in sleepable)
-    sleepable_tmpfs_budget_mb = available_host_ram_mb - reserved_for_sleep_mb - safety_margin_mb
+    reserved_for_sleep_mb = sum(c.sleeping_host_ram_mb for c in sleepable)
+    pool_mb = available_host_ram_mb + max(cache_held_mb, 0.0)
+    sleepable_tmpfs_budget_mb = pool_mb - reserved_for_sleep_mb - safety_margin_mb
 
     # Unsleepable models are always queued — they can't sleep, so they cannot
     # reduce anyone else's sleep capacity by being in the cache (the rule
@@ -122,6 +142,7 @@ def plan_cache_order(
         order=order,
         reserved_for_sleep_mb=reserved_for_sleep_mb,
         available_host_ram_mb=available_host_ram_mb,
+        cache_held_mb=cache_held_mb,
         safety_margin_mb=safety_margin_mb,
         sleepable_tmpfs_budget_mb=sleepable_tmpfs_budget_mb,
         cached_unsleepable=cached_unsleepable,

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -2586,21 +2586,38 @@ def load_existing_profiles(profiles_path: Path) -> dict[str, Any]:
     return dict(profiles)
 
 
+# Fields the probe owns outright: it either measures them or states that they
+# do not apply, and both answers are authoritative. Everything else it leaves
+# ``None`` simply because it did not look — a flag maintained elsewhere, an
+# operator override, or a sleep level this run did not exercise — and for
+# those ``None`` must not erase what is already known.
+#
+# ``sleeping_residual_mb`` is on this list because a run has exactly one
+# reason to report it null: the model is not allowed to sleep here, so the
+# sleep phases were skipped. Keeping a stale measurement then hides that. It
+# also survives an ``enable_sleep_mode`` flip back to true, where the freshness
+# check sees a value, declines to re-calibrate, and hands the planner a
+# residual measured under a configuration that no longer exists.
+_PROBE_OWNED_PROFILE_FIELDS = frozenset({"sleeping_residual_mb"})
+
+
 def merge_profile(prior: dict[str, Any] | None, measured: dict[str, Any]) -> dict[str, Any]:
     """Layer a fresh calibration result over the profile already on disk.
 
     A calibration run measures what it can reach and leaves the rest ``None``:
-    ``sleeping_residual_mb`` for a model that never sleeps, the sleep host-RAM
-    transients, and every field the probe does not look at at all
-    (``disk_size_bytes``, ``sleep_mode_disabled``, ``calibration_unsupported``,
-    the operator's overrides). Assigning the result over the entry wipes those
-    — the flags included, so a nosleep model loses the very marker that says
-    its null sleep fields are expected. A measured value replaces the stored
-    one; ``None`` means "not measured here" and keeps what was already known.
+    the sleep host-RAM transients for a level it did not run, and every field
+    the probe does not look at at all (``disk_size_bytes``,
+    ``sleep_mode_disabled``, ``calibration_unsupported``, the operator's
+    overrides). Assigning the result over the entry wipes those — the flags
+    included, so a nosleep model loses the very marker that says its null
+    sleep fields are expected. A measured value replaces the stored one;
+    ``None`` means "not measured here" and keeps what was already known,
+    except for the fields in :data:`_PROBE_OWNED_PROFILE_FIELDS`, where a null
+    is itself the measurement.
     """
     merged = dict(prior or {})
     for key, value in measured.items():
-        if value is None and key in merged:
+        if value is None and key in merged and key not in _PROBE_OWNED_PROFILE_FIELDS:
             continue
         merged[key] = value
     return merged
@@ -2609,21 +2626,16 @@ def merge_profile(prior: dict[str, Any] | None, measured: dict[str, Any]) -> dic
 def save_profiles(profiles_path: Path, profiles: dict[str, Any]) -> None:
     """Persist profiles atomically.
 
-    Written to a sibling temp file and renamed, so a crash or a concurrent
-    reader never sees a truncated store: ``open(path, "w")`` truncates first,
-    and a reader hitting that window gets a parse error — which used to be
-    answered with an empty dict and a full rewrite.
+    Written to a temp file and renamed, so a crash or a concurrent reader
+    never sees a truncated store: ``open(path, "w")`` truncates first, and a
+    reader hitting that window gets a parse error — which used to be answered
+    with an empty dict and a full rewrite. Shares the writer with
+    ``ModelProfileRegistry._persist``, which keeps the same file: a temp name
+    unique per call is what stops the two from tearing each other's output.
     """
-    profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = profiles_path.with_name(profiles_path.name + ".tmp")
-    try:
-        with tmp_path.open("w") as f:
-            yaml.safe_dump({"model_profiles": profiles}, f, default_flow_style=False)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, profiles_path)
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    from logos_worker_node.model_profiles import atomic_write_yaml  # noqa: PLC0415
+
+    atomic_write_yaml(profiles_path, {"model_profiles": profiles})
 
 
 # ---------------------------------------------------------------------------

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1213,6 +1213,13 @@ class CalibrationResult:
     # to a heuristic when missing.
     sleep_l1_transient_host_ram_mb: float | None = None
     sleep_l2_transient_host_ram_mb: float | None = None
+    # Host RAM the lane still holds once it is asleep and settled — distinct
+    # from the transients above, which are the peak *during* the call. sleep_l1
+    # relocates the weights to the host instead of dropping them, so this is
+    # roughly the weight footprint and it stays for the whole sleep. It is what
+    # makes sleeping and the model cache compete for one pool. None when the
+    # run skipped the sleep phases, or when /proc/meminfo was unreadable.
+    host_ram_residual_mb: float | None = None
     # Set when calibrate_model bails because the model itself can never
     # load on this worker (bad repo id, gated repo, unsupported architecture).
     # Caller persists the model into model_profiles.yml so the master's
@@ -2338,6 +2345,7 @@ def calibrate_model(
         # them as a capability, and no later session could recover them either.
         sleeping_residual_mb: float | None = None
         sleep_transient_mb: float | None = None
+        host_ram_residual_mb: float | None = None
         if sleep_level <= 0:
             logger.info(
                 "  [4/6 + 5/6] Sleep phases skipped (sleep mode disabled for this model) — "
@@ -2422,6 +2430,32 @@ def calibrate_model(
                     sleeping_residual_mb,
                 )
 
+            # Host RAM the lane keeps for as long as it sleeps. sleep_l1 moves
+            # the weights to the host rather than dropping them, so a sleeping
+            # lane holds roughly its weight footprint in RAM until it wakes —
+            # tens of GB per model, on a host that is also lending RAM to the
+            # model cache. Only the transient peak was ever measured, which
+            # answers "can this sleep complete" and says nothing about what it
+            # costs afterwards, so the planner sees sleeping as free on the
+            # host axis and keeps choosing it.
+            #
+            # Read after the same settle as the VRAM samples: the release is
+            # asynchronous on both axes, and sampling mid-transfer would
+            # understate it. Taken against the awake baseline, so it is the
+            # delta the sleep caused, not the host's absolute usage.
+            host_ram_residual_mb = None
+            post_sleep_available_mb = _sample_host_ram_available_mb()
+            if sleep_baseline_mb is not None and post_sleep_available_mb is not None:
+                host_ram_residual_mb = max(sleep_baseline_mb - post_sleep_available_mb, 0.0)
+                logger.info(
+                    "        sleeping host RAM = %.0f MB  (available %.0f → %.0f MB)",
+                    host_ram_residual_mb,
+                    sleep_baseline_mb,
+                    post_sleep_available_mb,
+                )
+            else:
+                logger.info("        sleeping host RAM: /proc/meminfo unavailable — skipped")
+
         logger.info("  Results:")
         logger.info(
             "    base_residency_mb    = %.0f MB  (= full loaded VRAM, weights + KV)",
@@ -2437,6 +2471,13 @@ def calibrate_model(
             logger.info(
                 "    sleeping_residual_mb = %.0f MB  (measured independently)",
                 sleeping_residual_mb,
+            )
+        if host_ram_residual_mb is None:
+            logger.info("    host_ram_residual_mb = n/a  (sleep phases skipped or /proc/meminfo unreadable)")
+        else:
+            logger.info(
+                "    host_ram_residual_mb = %.0f MB  (held on the host for the whole sleep)",
+                host_ram_residual_mb,
             )
         logger.info(
             "    Scheduler uses base_residency directly — no KV added on top",
@@ -2455,6 +2496,7 @@ def calibrate_model(
             enforce_eager=eager_mode,
             sleep_l1_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 1 else None),
             sleep_l2_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 2 else None),
+            host_ram_residual_mb=host_ram_residual_mb,
             min_kv_cache_mb=min_kv_observed_mb,
             max_kv_cache_mb=max_kv_observed_mb,
             max_model_len=partial.max_model_len,
@@ -2512,6 +2554,7 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
         "sleep_l2_transient_host_ram_mb": (
             round(r.sleep_l2_transient_host_ram_mb, 1) if r.sleep_l2_transient_host_ram_mb is not None else None
         ),
+        "host_ram_residual_mb": (round(r.host_ram_residual_mb, 1) if r.host_ram_residual_mb is not None else None),
         # Not part of ModelProfileRecord but useful for auditing
         "_calibration_kv_cache_mb": round(r.kv_cache_sent_mb, 1),
         # Discovered KV cache size for use by the lane manager at runtime

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -827,6 +827,11 @@ def _build_vllm_cmd(
     # lane can't actually honor (vLLM rejects "needs X GiB > budget" at start).
     # Calibrate the same engine config that serves so the pair curve is exact.
     enable_prefix_caching = bool(plan.get("enable_prefix_caching", True))
+    # Probe with the same sleep support the serving lane has. For a model the
+    # worker never puts to sleep, --enable-sleep-mode would swap vLLM's
+    # allocator for CuMemAllocator and measure a footprint production never
+    # runs; calibrate_model turns it off for exactly those runs.
+    enable_sleep_mode = bool(plan.get("enable_sleep_mode", True))
     extra_args: list[str] = list(plan.get("extra_args") or [])
     # Calibrate with the lane's speculative-decoding setting: a draft model adds
     # its own weights and activation peak, so a profile measured without it
@@ -850,8 +855,9 @@ def _build_vllm_cmd(
         dtype,
         "--kv-cache-memory-bytes",
         kv_bytes,
-        "--enable-sleep-mode",
     ]
+    if enable_sleep_mode:
+        cmd.append("--enable-sleep-mode")
     if enable_prefix_caching:
         cmd.append("--enable-prefix-caching")
     if explicit_gmu is not None:
@@ -1176,7 +1182,11 @@ class CalibrationResult:
     kv_cache_sent_mb: float  # what we explicitly gave vLLM during calibration
     success: bool
     loaded_vram_mb: float = 0.0  # measured: total GPU delta while awake
-    sleeping_residual_mb: float = 0.0  # measured: total GPU delta while sleeping
+    # Measured: total GPU delta while sleeping. None when the run skipped the
+    # sleep phases because sleep is disabled for this model on this worker —
+    # the value is genuinely unknowable there, and the profile records it as
+    # null rather than as a measurement.
+    sleeping_residual_mb: float | None = 0.0
     base_residency_mb: float = 0.0  # = loaded_vram_mb (weights + KV, full footprint)
     # KV cache envelope discovered during calibration on this hardware. ``min``
     # is the smallest kv_cache_memory_bytes value at which the model loaded and
@@ -1333,7 +1343,19 @@ def calibrate_model(
         logger.info(
             "  enforce_eager=False — graphs will be captured; loaded/sleeping VRAM include capture-pool overhead"
         )
-    plan = {**plan, "enforce_eager": eager_mode}
+    # A model the operator pinned awake (enable_sleep_mode: false, which
+    # plans_from_config carries through from the vLLM model overrides) has to be
+    # probed the same way it is served: --enable-sleep-mode swaps in
+    # CuMemAllocator and the /sleep in Phase 4 would fail anyway. Drop to
+    # level 0 for it, whatever the caller asked for — that is what makes the
+    # boot-time path and the session-driven one agree without either having to
+    # know the other's rules.
+    if sleep_level > 0 and not bool(plan.get("enable_sleep_mode", True)):
+        logger.info("  enable_sleep_mode=False for this model — probing at sleep_level 0")
+        sleep_level = 0
+    # sleep_level == 0 means "this model never sleeps here": the probe runs
+    # without vLLM's sleep allocator and the sleep phases are skipped.
+    plan = {**plan, "enforce_eager": eager_mode, "enable_sleep_mode": sleep_level > 0}
 
     model = plan["model"]
     gpu_devices = str(plan.get("gpu_devices") or "")
@@ -2307,83 +2329,98 @@ def calibrate_model(
             kv_cache_sent_mb,
         )
 
-        # Phase 4 — Sleep the model (with host-RAM transient sampling)
-        if cancel_event is not None and cancel_event.is_set():
-            logger.info("  Calibration cancelled before Phase 4.")
-            partial.error = "cancelled"
-            return partial
-        logger.info("  [4/6] Sleeping model (level=%d)...", sleep_level)
-        sleep_url = f"{base_url}/sleep?level={sleep_level}"
-        with _track_host_ram_transient() as host_ram_probe:
-            status, _ = _post(sleep_url, timeout_s=_SLEEP_TIMEOUT_S)
-            if status not in (200, 204):
-                partial.error = f"/sleep returned HTTP {status}"
-                logger.warning("  ERROR: %s", partial.error)
+        # Phases 4 and 5 measure sleep, and only sleep. Everything the planner
+        # needs to place a lane — base_residency_mb above — is already known,
+        # so a model that is not allowed to sleep on this worker skips them and
+        # finishes with sleeping_residual_mb unknown rather than being dropped.
+        # Dropping it is what left nosleep models (enable_sleep_mode: false)
+        # permanently uncalibrated: no profile means the worker never reports
+        # them as a capability, and no later session could recover them either.
+        sleeping_residual_mb: float | None = None
+        sleep_transient_mb: float | None = None
+        if sleep_level <= 0:
+            logger.info(
+                "  [4/6 + 5/6] Sleep phases skipped (sleep mode disabled for this model) — "
+                "sleeping_residual_mb stays unknown; base_residency is unaffected"
+            )
+        else:
+            # Phase 4 — Sleep the model (with host-RAM transient sampling)
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info("  Calibration cancelled before Phase 4.")
+                partial.error = "cancelled"
                 return partial
+            logger.info("  [4/6] Sleeping model (level=%d)...", sleep_level)
+            sleep_url = f"{base_url}/sleep?level={sleep_level}"
+            with _track_host_ram_transient() as host_ram_probe:
+                status, _ = _post(sleep_url, timeout_s=_SLEEP_TIMEOUT_S)
+                if status not in (200, 204):
+                    partial.error = f"/sleep returned HTTP {status}"
+                    logger.warning("  ERROR: %s", partial.error)
+                    return partial
+                try:
+                    wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
+                except TimeoutError as exc:
+                    partial.error = str(exc)
+                    logger.warning("  ERROR: %s", partial.error)
+                    return partial
+
+            sleep_transient_mb = host_ram_probe["transient_mb"]
+            sleep_baseline_mb = host_ram_probe["baseline_mb"]
+            if sleep_transient_mb is not None and sleep_baseline_mb is not None:
+                logger.info(
+                    "        sleep_l%d transient host RAM: baseline_available=%.0fMB, " "peak_consumption=%.0fMB",
+                    sleep_level,
+                    sleep_baseline_mb,
+                    sleep_transient_mb,
+                )
+            else:
+                logger.info(
+                    "        sleep_l%d transient host RAM: /proc/meminfo unavailable — skipped",
+                    sleep_level,
+                )
+
+            # Phase 5 — Measure sleeping VRAM. Sample twice with a settle between
+            # samples and take the max. CuMemAllocator's release is asynchronous;
+            # a single-shot sample can read mid-release and underestimate the
+            # residual (which leads to wake-time OOM when the planner trusts an
+            # artificially low value). The first sample is required; the second
+            # is a refinement and falls back silently if it fails.
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info("  Calibration cancelled before Phase 5.")
+                partial.error = "cancelled"
+                return partial
+            logger.info(
+                "  [5/6] Measuring sleeping VRAM (settling %.0fs, double-sample)...",
+                _VRAM_SETTLE_S,
+            )
+            time.sleep(_VRAM_SETTLE_S)
             try:
-                wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
-            except TimeoutError as exc:
-                partial.error = str(exc)
+                s1 = sample_vram_mb(gpu_indices)
+            except Exception as exc:
+                partial.error = f"nvidia-smi sleep failed: {exc}"
                 logger.warning("  ERROR: %s", partial.error)
                 return partial
-
-        sleep_transient_mb = host_ram_probe["transient_mb"]
-        sleep_baseline_mb = host_ram_probe["baseline_mb"]
-        if sleep_transient_mb is not None and sleep_baseline_mb is not None:
-            logger.info(
-                "        sleep_l%d transient host RAM: baseline_available=%.0fMB, " "peak_consumption=%.0fMB",
-                sleep_level,
-                sleep_baseline_mb,
-                sleep_transient_mb,
-            )
-        else:
-            logger.info(
-                "        sleep_l%d transient host RAM: /proc/meminfo unavailable — skipped",
-                sleep_level,
-            )
-
-        # Phase 5 — Measure sleeping VRAM. Sample twice with a settle between
-        # samples and take the max. CuMemAllocator's release is asynchronous;
-        # a single-shot sample can read mid-release and underestimate the
-        # residual (which leads to wake-time OOM when the planner trusts an
-        # artificially low value). The first sample is required; the second
-        # is a refinement and falls back silently if it fails.
-        if cancel_event is not None and cancel_event.is_set():
-            logger.info("  Calibration cancelled before Phase 5.")
-            partial.error = "cancelled"
-            return partial
-        logger.info(
-            "  [5/6] Measuring sleeping VRAM (settling %.0fs, double-sample)...",
-            _VRAM_SETTLE_S,
-        )
-        time.sleep(_VRAM_SETTLE_S)
-        try:
-            s1 = sample_vram_mb(gpu_indices)
-        except Exception as exc:
-            partial.error = f"nvidia-smi sleep failed: {exc}"
-            logger.warning("  ERROR: %s", partial.error)
-            return partial
-        time.sleep(3.0)
-        s2: float | None = None
-        try:
-            s2 = sample_vram_mb(gpu_indices)
-        except Exception as exc:
-            logger.info("        re-sample skipped (%s) — using single sample", exc)
-        sleeping_total_mb = max(s1, s2) if s2 is not None else s1
-        sleeping_residual_mb = max(sleeping_total_mb - baseline_mb, 0.0)
-        if s2 is not None:
-            logger.info(
-                "        sleeping samples = %.0f / %.0f MB  →  max delta = %.0f MB",
-                s1,
-                s2,
-                sleeping_residual_mb,
-            )
-        else:
-            logger.info(
-                "        sleeping sample = %.0f MB  →  delta = %.0f MB",
-                s1,
-                sleeping_residual_mb,
-            )
+            time.sleep(3.0)
+            s2: float | None = None
+            try:
+                s2 = sample_vram_mb(gpu_indices)
+            except Exception as exc:
+                logger.info("        re-sample skipped (%s) — using single sample", exc)
+            sleeping_total_mb = max(s1, s2) if s2 is not None else s1
+            sleeping_residual_mb = max(sleeping_total_mb - baseline_mb, 0.0)
+            if s2 is not None:
+                logger.info(
+                    "        sleeping samples = %.0f / %.0f MB  →  max delta = %.0f MB",
+                    s1,
+                    s2,
+                    sleeping_residual_mb,
+                )
+            else:
+                logger.info(
+                    "        sleeping sample = %.0f MB  →  delta = %.0f MB",
+                    s1,
+                    sleeping_residual_mb,
+                )
 
         logger.info("  Results:")
         logger.info(
@@ -2394,10 +2431,13 @@ def calibrate_model(
             "    kv_budget_mb         = %.0f MB  (KV portion, for auditing)",
             kv_cache_sent_mb,
         )
-        logger.info(
-            "    sleeping_residual_mb = %.0f MB  (measured independently)",
-            sleeping_residual_mb,
-        )
+        if sleeping_residual_mb is None:
+            logger.info("    sleeping_residual_mb = n/a  (sleep mode disabled for this model)")
+        else:
+            logger.info(
+                "    sleeping_residual_mb = %.0f MB  (measured independently)",
+                sleeping_residual_mb,
+            )
         logger.info(
             "    Scheduler uses base_residency directly — no KV added on top",
         )
@@ -2450,7 +2490,7 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
     """
     return {
         "loaded_vram_mb": round(r.loaded_vram_mb, 1),
-        "sleeping_residual_mb": round(r.sleeping_residual_mb, 1),
+        "sleeping_residual_mb": (round(r.sleeping_residual_mb, 1) if r.sleeping_residual_mb is not None else None),
         "disk_size_bytes": None,
         "base_residency_mb": round(r.base_residency_mb, 1),
         "kv_budget_mb": round(r.kv_cache_sent_mb, 1),
@@ -2512,22 +2552,78 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
     }
 
 
+class ProfileStoreUnreadableError(RuntimeError):
+    """Raised when model_profiles.yml exists but cannot be read back.
+
+    Callers of :func:`load_existing_profiles` write the result back over the
+    whole file, so an empty dict returned for an unreadable store deletes every
+    profile in it — including calibrated models nothing will measure again.
+    Failing loudly leaves the file alone and costs one calibration result.
+    """
+
+
 def load_existing_profiles(profiles_path: Path) -> dict[str, Any]:
+    """Read the persisted profiles, or raise if the file is there but unusable.
+
+    Returns ``{}`` only when there genuinely is no store yet.
+    """
     if not profiles_path.exists():
         return {}
     try:
         with profiles_path.open() as f:
             data = yaml.safe_load(f) or {}
-        return dict(data.get("model_profiles") or {})
     except Exception as exc:
-        logger.warning("Could not parse existing profiles (%s): %s", profiles_path, exc)
+        raise ProfileStoreUnreadableError(f"could not parse {profiles_path}: {exc}") from exc
+    profiles = data.get("model_profiles")
+    if profiles is None:
+        # A store that parsed but holds no profiles section. Distinguishable
+        # from a parse failure, and safe to treat as empty.
         return {}
+    if not isinstance(profiles, dict):
+        raise ProfileStoreUnreadableError(
+            f"{profiles_path}: model_profiles is {type(profiles).__name__}, not a mapping"
+        )
+    return dict(profiles)
+
+
+def merge_profile(prior: dict[str, Any] | None, measured: dict[str, Any]) -> dict[str, Any]:
+    """Layer a fresh calibration result over the profile already on disk.
+
+    A calibration run measures what it can reach and leaves the rest ``None``:
+    ``sleeping_residual_mb`` for a model that never sleeps, the sleep host-RAM
+    transients, and every field the probe does not look at at all
+    (``disk_size_bytes``, ``sleep_mode_disabled``, ``calibration_unsupported``,
+    the operator's overrides). Assigning the result over the entry wipes those
+    — the flags included, so a nosleep model loses the very marker that says
+    its null sleep fields are expected. A measured value replaces the stored
+    one; ``None`` means "not measured here" and keeps what was already known.
+    """
+    merged = dict(prior or {})
+    for key, value in measured.items():
+        if value is None and key in merged:
+            continue
+        merged[key] = value
+    return merged
 
 
 def save_profiles(profiles_path: Path, profiles: dict[str, Any]) -> None:
+    """Persist profiles atomically.
+
+    Written to a sibling temp file and renamed, so a crash or a concurrent
+    reader never sees a truncated store: ``open(path, "w")`` truncates first,
+    and a reader hitting that window gets a parse error — which used to be
+    answered with an empty dict and a full rewrite.
+    """
     profiles_path.parent.mkdir(parents=True, exist_ok=True)
-    with profiles_path.open("w") as f:
-        yaml.safe_dump({"model_profiles": profiles}, f, default_flow_style=False)
+    tmp_path = profiles_path.with_name(profiles_path.name + ".tmp")
+    try:
+        with tmp_path.open("w") as f:
+            yaml.safe_dump({"model_profiles": profiles}, f, default_flow_style=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, profiles_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -2866,7 +2962,18 @@ def auto_calibrate_models(
         available_gpus = 1
 
     profiles_path = state_dir / _PROFILES_FILE
-    existing_profiles = load_existing_profiles(profiles_path)
+    # Every result below is written back over the whole file, so an unreadable
+    # store must stop the run rather than be treated as empty — saving an empty
+    # dict back replaces the node's profiles with just this batch's models.
+    try:
+        existing_profiles = load_existing_profiles(profiles_path)
+    except ProfileStoreUnreadableError:
+        logger.exception(
+            "Refusing to auto-calibrate: %s exists but cannot be read, and "
+            "writing results would replace it. Fix or move the file.",
+            profiles_path,
+        )
+        return {}
     log_dir = state_dir / "calibration_logs"
 
     logger.info(
@@ -2900,7 +3007,14 @@ def auto_calibrate_models(
         results[model_name] = result
 
         if result.success:
-            existing_profiles[model_name] = result_to_profile_dict(result)
+            # Merged, not assigned: the probe leaves everything it does not
+            # measure at None, including flags maintained elsewhere
+            # (sleep_mode_disabled, calibration_unsupported) that an assignment
+            # would drop.
+            existing_profiles[model_name] = merge_profile(
+                existing_profiles.get(model_name),
+                result_to_profile_dict(result),
+            )
             # Persist after every success so a later failure doesn't lose results
             save_profiles(profiles_path, existing_profiles)
             logger.info("  Saved profile for %s → %s", model_name, profiles_path)

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -381,8 +381,11 @@ class LogosBridgeClient:
                 # derive that from the replayed event log alone, because the
                 # log is in-memory, capped, and only reaches the server a
                 # moment after the first status has already made this worker
-                # look plannable.
-                "calibrating": self._active_calibration_session is not None,
+                # look plannable. Asks the task, not the slot: a finished
+                # session lingers in _active_calibration_session until the next
+                # start clears it, and reporting that as live would exclude this
+                # worker from placement for as long as no new session begins.
+                "calibrating": self._calibration_session_is_live(),
                 "actions": [
                     "infer",
                     "infer_stream",
@@ -413,7 +416,20 @@ class LogosBridgeClient:
     async def _send_runtime_status(self, ws, force: bool = False) -> bool:
         runtime = await build_runtime_status(self._app)
         payload = runtime.model_dump(mode="json")
-        signature = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        # Every status repeats the live calibration state, so the server can
+        # settle it without depending on a lifecycle event arriving. An event
+        # is a one-shot signal: the one that ends a session can be dropped
+        # (post-connect replay filter, a connection that no longer exists) and
+        # the server is then left excluding this worker from lane placement
+        # with nothing to release it. Part of the dedupe signature because a
+        # session that starts and ends while the lanes are untouched changes
+        # nothing else in the payload, and the status would not be sent at all.
+        calibrating = self._calibration_session_is_live()
+        signature = json.dumps(
+            {"runtime": payload, "calibrating": calibrating},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
         if not force and signature == self._last_runtime_signature:
             return False
         self._last_runtime_signature = signature
@@ -426,6 +442,7 @@ class LogosBridgeClient:
                 "worker_id": self.worker_id,
                 "capabilities_models": self._cfg.capabilities_models,
                 "configured_models": self._cfg.configured_models,
+                "calibrating": calibrating,
                 "runtime": payload,
             },
         )
@@ -865,7 +882,9 @@ class LogosBridgeClient:
                     "kv_cache_sent_mb": round(result.kv_cache_sent_mb, 1),
                     "base_residency_mb": round(result.base_residency_mb, 1),
                     "loaded_vram_mb": round(result.loaded_vram_mb, 1),
-                    "sleeping_residual_mb": round(result.sleeping_residual_mb, 1),
+                    "sleeping_residual_mb": (
+                        round(result.sleeping_residual_mb, 1) if result.sleeping_residual_mb is not None else None
+                    ),
                     "min_kv_cache_mb": round(result.min_kv_cache_mb, 1),
                     "max_kv_cache_mb": round(result.max_kv_cache_mb, 1),
                     "max_model_len": result.max_model_len,
@@ -879,15 +898,18 @@ class LogosBridgeClient:
 
         Mirrors the previous server-side selection logic so behaviour is
         unchanged — only the location of the decision moves to the worker.
-        Skips models with sleep_mode_disabled (only the sleep field would
-        be N/A) only when base_residency is already known, and models
-        flagged calibration_unsupported.
+        Models that cannot sleep on this worker are judged on their non-sleep
+        fields alone, because their sleep fields stay null by design; models
+        flagged calibration_unsupported are skipped entirely.
         """
         cfg = self._app.state.config
         model_profiles = self._app.state.model_profiles
         candidates = list(self._cfg.configured_models) or list(self._cfg.capabilities_models)
 
-        sleep_level = (
+        # A session at level 0 measures no sleep field for any model, so those
+        # fields must not count as missing — a run that cannot fill them would
+        # otherwise re-pick the same models every time.
+        session_sleep_level = (
             self._active_calibration_session.sleep_level if self._active_calibration_session is not None else 1
         )
 
@@ -899,9 +921,12 @@ class LogosBridgeClient:
             sleep_na = bool(profile is not None and profile.sleep_mode_disabled)
             # Worker-side knowledge: if config now forbids sleep but profile
             # still claims it's possible, picking this model is fine — the
-            # session driver re-checks model_can_sleep before each model
-            # and persists the new flag.
-            if sleep_level > 0 and not model_can_sleep(cfg, model_name):
+            # session driver re-checks model_can_sleep before each model,
+            # persists the new flag, and calibrates it at sleep_level 0. That
+            # run leaves the sleep fields null by design, so they must not
+            # count as missing here either. Mirrors
+            # main.py::_auto_calibrate_if_needed.
+            if session_sleep_level <= 0 or not model_can_sleep(cfg, model_name):
                 sleep_na = True
             collapsed_envelope = (
                 profile is not None
@@ -947,14 +972,24 @@ class LogosBridgeClient:
 
         terminal_event = "calibration_session_finished"
         lane_manager = getattr(self._app.state, "lane_manager", None)
+        # Push a status carrying calibrating=True right away. The server holds
+        # its optimistic mark for a bounded window after dispatching the start,
+        # and this is what confirms the session inside it.
+        if lane_manager is not None:
+            try:
+                lane_manager._mark_status_dirty()  # noqa: SLF001
+            except Exception:  # noqa: BLE001
+                logger.debug("[Calibration] _mark_status_dirty failed", exc_info=True)
         try:
             from logos_worker_node.calibration import (  # noqa: PLC0415
                 _CALIBRATION_PORT,
                 _DEFAULT_VLLM,
                 _READY_TIMEOUT_S,
+                ProfileStoreUnreadableError,
                 calibrate_with_tp_escalation,
                 is_model_unsupported,
                 load_existing_profiles,
+                merge_profile,
                 plans_from_config,
                 result_to_profile_dict,
                 save_profiles,
@@ -1034,25 +1069,25 @@ class LogosBridgeClient:
                     continue
 
                 # Pre-flight: sleep gate. If the worker config forbids sleep
-                # for this model (worker kill switch or per-model override)
-                # there is no point spawning a vLLM lane with sleep_level>0 —
-                # the POST /sleep at Phase 4 of calibration will fail and the
-                # whole probe is wasted. Persist the flag and skip; the model
-                # stays uncalibrated on this worker until config or sleep
-                # level changes.
-                if session.sleep_level > 0 and not model_can_sleep(cfg, model_name):
+                # for this model (worker kill switch or per-model override),
+                # probing with sleep_level>0 would fail at the POST /sleep in
+                # Phase 4 and waste the whole run. Calibrate it at level 0
+                # instead: the sleep phases are skipped, sleeping_residual_mb
+                # is recorded as null, and everything the planner places on —
+                # base_residency_mb — is measured exactly as for any other
+                # model. Skipping the model outright, as this used to, left it
+                # permanently uncalibrated: a nosleep model is never reported
+                # as a capability without a profile, and no later session could
+                # ever produce one either.
+                model_sleep_level = session.sleep_level
+                if not model_can_sleep(cfg, model_name):
                     model_profiles.mark_sleep_mode_disabled(model_name, True)
+                    model_sleep_level = 0
                     logger.info(
-                        "[Calibration] Skipping %s — sleep mode disabled on this worker",
+                        "[Calibration] %s cannot sleep on this worker — calibrating without the sleep phases",
                         model_name,
                     )
-                    self._record_calibration_event(
-                        "calibration_model_skipped",
-                        model=model_name,
-                        details="sleep_mode_disabled",
-                    )
-                    continue
-                if model_can_sleep(cfg, model_name):
+                else:
                     # Config now permits sleep — clear any stale flag so a
                     # config flip (true → false) is picked up immediately.
                     model_profiles.mark_sleep_mode_disabled(model_name, False)
@@ -1061,12 +1096,12 @@ class LogosBridgeClient:
                 self._record_calibration_event(
                     "calibration_model_started",
                     model=model_name,
-                    details=f"sleep_level={session.sleep_level}",
+                    details=f"sleep_level={model_sleep_level}",
                 )
                 logger.info(
                     "[Calibration] Starting model=%s sleep_level=%d",
                     model_name,
-                    session.sleep_level,
+                    model_sleep_level,
                 )
 
                 # Blocking calibration runs in the default thread executor so
@@ -1077,12 +1112,12 @@ class LogosBridgeClient:
                 try:
                     result = await loop.run_in_executor(
                         None,
-                        lambda p=plan: calibrate_with_tp_escalation(
+                        lambda p=plan, sl=model_sleep_level: calibrate_with_tp_escalation(
                             p,
                             vllm_binary=_DEFAULT_VLLM,
                             port=_CALIBRATION_PORT,
                             log_dir=log_dir,
-                            sleep_level=session.sleep_level,
+                            sleep_level=sl,
                             ready_timeout_s=_READY_TIMEOUT_S,
                             nccl_p2p_available=nccl_p2p,
                             model_cache=_mc,
@@ -1111,16 +1146,34 @@ class LogosBridgeClient:
                     break
 
                 if result.success:
-                    existing = load_existing_profiles(profiles_path)
-                    prior = existing.get(model_name) or {}
-                    new_profile = result_to_profile_dict(result)
-                    for _carry in (
-                        "sleep_l1_transient_host_ram_mb",
-                        "sleep_l2_transient_host_ram_mb",
-                    ):
-                        if new_profile.get(_carry) is None and prior.get(_carry) is not None:
-                            new_profile[_carry] = prior[_carry]
-                    existing[model_name] = new_profile
+                    # An unreadable store aborts the write: load_existing_profiles
+                    # used to answer with an empty dict, and saving that back
+                    # replaced every profile on the node with this one result.
+                    # Losing one measurement is recoverable; losing the file is
+                    # not, because a model without base_residency_mb is never
+                    # announced as a capability and a model that cannot sleep
+                    # here would keep failing to be re-measured.
+                    try:
+                        existing = load_existing_profiles(profiles_path)
+                    except ProfileStoreUnreadableError as exc:
+                        logger.error(
+                            "[Calibration] %s calibrated, but %s is unreadable (%s) — "
+                            "keeping the file untouched. Fix or remove it; this model "
+                            "re-calibrates on the next session.",
+                            model_name,
+                            profiles_path,
+                            exc,
+                        )
+                        self._record_calibration_event(
+                            "calibration_model_failed",
+                            model=model_name,
+                            details=f"profile store unreadable: {exc}",
+                        )
+                        continue
+                    existing[model_name] = merge_profile(
+                        existing.get(model_name),
+                        result_to_profile_dict(result),
+                    )
                     save_profiles(profiles_path, existing)
                     model_profiles._load_persisted()  # noqa: SLF001
                     # Models that were pruned from capabilities at startup

--- a/logos/logos-workernode/logos_worker_node/main.py
+++ b/logos/logos-workernode/logos_worker_node/main.py
@@ -425,32 +425,62 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             candidates: list[CacheCandidate] = []
             for m in calibrated_caps:
                 profile = model_profiles.get_profile(m)
-                host_ram_mb = profile.estimate_host_ram_mb() if profile else 0.0
-                if host_ram_mb <= 0.0:
-                    # Fall back to on-disk size when we've never measured the
-                    # awake footprint. Underestimates by ~tokenizer + compile
-                    # cache overhead but is the right ballpark.
-                    host_ram_mb = model_cache.model_size_bytes(m) / (1024 * 1024)
+                # The reserve is for these models being *asleep* at once, so
+                # it is the sleeping residency that belongs in it. Using the
+                # awake footprint reserved RAM an awake lane already holds
+                # regardless of the cache, and left the actual sleep cost —
+                # measured all along, and never read by anything — out of the
+                # only calculation that balances the two consumers.
+                sleeping_host_ram_mb = profile.estimate_sleeping_host_ram_mb() if profile else 0.0
+                if sleeping_host_ram_mb <= 0.0:
+                    # Never measured asleep and no awake figure to fall back
+                    # on either. On-disk size underestimates by ~tokenizer +
+                    # compile cache overhead but is the right ballpark.
+                    sleeping_host_ram_mb = model_cache.model_size_bytes(m) / (1024 * 1024)
                 candidates.append(
                     CacheCandidate(
                         name=m,
                         can_sleep=_can_sleep(m),
-                        host_ram_mb=host_ram_mb,
+                        sleeping_host_ram_mb=sleeping_host_ram_mb,
                         size_bytes=model_cache.model_size_bytes(m),
                     )
                 )
 
+            # What the cache already holds is part of the pool it is being
+            # budgeted against — without it the plan reads MemAvailable after
+            # the cache has spent it, concludes there is no room, and leaves
+            # a stale cache in place forever. This is what makes the budget
+            # able to come out below the current footprint, which is what
+            # produces the reclaim below.
+            cache_held_mb = model_cache.held_bytes() / (1024 * 1024)
             plan = plan_cache_order(
                 candidates,
                 available_host_ram_mb=available_host_ram_mb,
                 safety_margin_mb=host_ram_safety_margin_mb,
+                cache_held_mb=cache_held_mb,
             )
+            # Bound every later copy by the same arithmetic, checked against
+            # live MemAvailable rather than the tmpfs size. The mount is a
+            # fixed 400G of a 503G host, so without this the cache's only
+            # limit is four fifths of the machine; with it, a lane that puts
+            # weights into host RAM shrinks the cache's room immediately and
+            # without anyone re-planning.
+            model_cache.set_host_ram_floor_mb(plan.reserved_for_sleep_mb + plan.safety_margin_mb)
+            reclaimed = model_cache.reclaim(keep=set(plan.order))
+            if reclaimed:
+                logger.info(
+                    "Reclaimed %d model(s) from the RAM cache — outside this plan's "
+                    "budget, and the RAM is worth more to the sleep reserve: %s",
+                    len(reclaimed),
+                    reclaimed,
+                )
             logger.info(
-                "Cache plan: host_ram_available=%.0fMB, reserved_for_sleep=%.0fMB "
-                "(%d sleepable model(s)), safety_margin=%.0fMB → tmpfs_budget="
-                "%.0fMB. Caching %d unsleepable + %d sleepable, skipping %d "
-                "sleepable for headroom.",
+                "Cache plan: host_ram_available=%.0fMB + cache_held=%.0fMB, "
+                "reserved_for_sleep=%.0fMB (%d sleepable model(s)), "
+                "safety_margin=%.0fMB → tmpfs_budget=%.0fMB. Caching %d "
+                "unsleepable + %d sleepable, skipping %d sleepable for headroom.",
                 plan.available_host_ram_mb,
+                plan.cache_held_mb,
                 plan.reserved_for_sleep_mb,
                 sum(1 for c in candidates if c.can_sleep),
                 plan.safety_margin_mb,

--- a/logos/logos-workernode/logos_worker_node/model_cache.py
+++ b/logos/logos-workernode/logos_worker_node/model_cache.py
@@ -4,8 +4,14 @@ When LOGOS_TMPFS_CACHE_PATH is set to a tmpfs mount (e.g. /mnt/ramcache),
 this module copies model directories from the source HF cache into the
 tmpfs for faster loading.  Only models in ``capabilities_models`` are cached.
 
-The cache copies entire ``models--org--name/`` directories using
-``rsync -aL`` (dereference symlinks) to produce a self-contained copy.
+The cache copies entire ``models--org--name/`` directories with ``rsync -a``,
+keeping HF's snapshot symlinks as symlinks. They are relative
+(``snapshots/<rev>/x -> ../../blobs/<sha>``) and ``blobs/`` is copied along
+with them, so the copy resolves inside itself and stays self-contained.
+Dereferencing them instead — which this used to do, with ``-aL`` — wrote
+every weight file twice, once as a blob and once as the snapshot entry
+pointing at it, for exactly double the RAM.
+
 Partial copies use a ``.partial`` suffix and are renamed atomically on
 completion to avoid serving incomplete data.
 """
@@ -88,6 +94,75 @@ def _has_valid_refs(model_dir: Path) -> bool:
     return False
 
 
+def _host_ram_available_bytes() -> int | None:
+    """MemAvailable in bytes, or None where /proc/meminfo is not readable.
+
+    tmpfs pages count against this: they are anonymous shared memory, not
+    reclaimable page cache, so a cache that has grown shows up here as RAM
+    the host does not have. That is exactly the property that makes this the
+    right number to bound the cache against.
+    """
+    try:
+        with open("/proc/meminfo", "rb") as f:
+            for line in f:
+                if line.startswith(b"MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _tree_size_bytes(directory: Path) -> int:
+    """Bytes a directory tree occupies, counting symlinks as links.
+
+    ``du`` semantics: a symlink costs its own entry, not its target. Used for
+    both the source estimate and the on-disk footprint of a cached copy, so
+    the two are directly comparable.
+    """
+    total = 0
+    for root, _dirs, files in os.walk(directory, followlinks=False):
+        for f in files:
+            try:
+                total += os.lstat(os.path.join(root, f)).st_size
+            except OSError:
+                pass
+    return total
+
+
+def _snapshots_are_dereferenced(model_dir: Path) -> bool:
+    """Whether a cached copy materialised the snapshot symlinks.
+
+    Copies written before the cache stopped passing ``rsync -aL`` hold every
+    weight file twice — once under ``blobs/``, once as a real file under
+    ``snapshots/`` where the source has a link. They load fine, so nothing
+    else notices; they simply cost double. Detecting one lets the normal
+    staleness path rebuild it compactly the next time the model is needed.
+    """
+    snapshots = model_dir / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    try:
+        rev_dirs = [p for p in snapshots.iterdir() if p.is_dir()]
+    except OSError:
+        return False
+    for rev_dir in rev_dirs:
+        try:
+            entries = list(rev_dir.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                st = entry.lstat()
+            except OSError:
+                continue
+            # A materialised weight shard: a regular file where the source
+            # keeps a link. Small regular files are normal (HF writes some
+            # entries directly), so only bulk ones count.
+            if not os.path.islink(entry) and entry.is_file() and st.st_size >= _BULK_FILE_THRESHOLD_BYTES:
+                return True
+    return False
+
+
 def _is_tmpfs(path: str) -> bool:
     """Check if *path* is a tmpfs mount (Linux only, best-effort)."""
     proc_mounts = Path("/proc/mounts")
@@ -129,6 +204,15 @@ class ModelRamCache:
         self._cache_hub = self._tmpfs_root / "hub"
         self._source_hub = Path(source_hf_hub_path)
         self._max_size_bytes = max_size_bytes
+        # Host RAM that must stay out of this cache's reach, set from the
+        # cache plan once the sleep reserve is known. The tmpfs size is a
+        # fixed mount option — 400G of a 503G host on the production
+        # workers — so on its own it is a licence to take four fifths of the
+        # machine. This floor is what actually bounds the cache, and it is
+        # checked against live MemAvailable, so a lane that puts weights in
+        # host RAM shrinks what the cache may take without anyone
+        # recomputing anything.
+        self._host_ram_floor_bytes = 0
         self._locks: dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
         self._cached_models: set[str] = set()
@@ -159,29 +243,54 @@ class ModelRamCache:
         except OSError:
             return 0
 
+    def set_host_ram_floor_mb(self, floor_mb: float) -> None:
+        """Set the host RAM this cache must leave alone.
+
+        Called with the sleep reserve plus the safety margin once the cache
+        plan has computed them, so the bound the cache respects is the same
+        arithmetic that decided what to cache in the first place.
+        """
+        self._host_ram_floor_bytes = max(int(floor_mb * 1024 * 1024), 0)
+
+    def _would_starve_host(self, size_bytes: int) -> tuple[bool, int]:
+        """Whether caching *size_bytes* more would eat into the floor.
+
+        Returns ``(would_starve, available_bytes)``. Fails open — no
+        /proc/meminfo, or no floor configured, means the tmpfs check is left
+        to decide on its own, as it did before.
+        """
+        if self._host_ram_floor_bytes <= 0:
+            return False, 0
+        available = _host_ram_available_bytes()
+        if available is None:
+            return False, 0
+        return available - size_bytes < self._host_ram_floor_bytes, available
+
     def cached_models(self) -> list[str]:
         """List models currently in the cache."""
         return sorted(self._cached_models)
 
     def model_size_bytes(self, model_name: str) -> int:
-        """Get total size of model on the source filesystem."""
+        """Bytes this model will occupy in the cache.
+
+        Counts the bytes a copy actually writes, which is the blobs and
+        nothing else: HF stores every snapshot entry as a relative symlink
+        into ``blobs/``, and the copy keeps them as symlinks, so a snapshot
+        costs its link and not its target. Resolving the links here — which
+        ``getsize`` does, and ``followlinks`` compounds by walking into them —
+        counted every weight file twice and returned double the real
+        footprint to the capacity check above.
+        """
         src = self._source_hub / _hf_model_dir_name(model_name)
         if not src.exists():
             return 0
-        total = 0
-        for root, _dirs, files in os.walk(src, followlinks=True):
-            for f in files:
-                try:
-                    total += os.path.getsize(os.path.join(root, f))
-                except OSError:
-                    pass
-        return total
+        return _tree_size_bytes(src)
 
     async def ensure_cached(self, model_name: str) -> str:
         """Copy model into tmpfs if not already cached and space permits.
 
         Returns the path to use for loading (tmpfs path if cached, source
-        path if not).  Uses ``rsync -aL`` (dereferences symlinks).
+        path if not).  Uses ``rsync -a`` (snapshot symlinks stay links).
         """
         lock = await self._get_model_lock(model_name)
         async with lock:
@@ -221,6 +330,19 @@ class ModelRamCache:
                     size // (1024 * 1024),
                     available // (1024 * 1024),
                     safety_floor // (1024 * 1024),
+                )
+                return str(self._source_hub.parent)
+
+            starves, host_available = self._would_starve_host(size)
+            if starves:
+                logger.warning(
+                    "Skipping RAM cache for %s: need %d MB but only %d MB of host RAM "
+                    "is available above the %d MB reserved for sleeping lanes — "
+                    "loading from disk",
+                    model_name,
+                    size // (1024 * 1024),
+                    host_available // (1024 * 1024),
+                    self._host_ram_floor_bytes // (1024 * 1024),
                 )
                 return str(self._source_hub.parent)
 
@@ -276,6 +398,19 @@ class ModelRamCache:
             )
             return str(self._source_hub.parent)
 
+        starves, host_available = self._would_starve_host(size)
+        if starves:
+            logger.warning(
+                "Skipping RAM cache for %s: need %d MB but only %d MB of host RAM "
+                "is available above the %d MB reserved for sleeping lanes — "
+                "loading from disk",
+                model_name,
+                size // (1024 * 1024),
+                host_available // (1024 * 1024),
+                self._host_ram_floor_bytes // (1024 * 1024),
+            )
+            return str(self._source_hub.parent)
+
         ok = self._copy_model_sync(model_name)
         if ok:
             self._cached_models.add(model_name)
@@ -321,7 +456,7 @@ class ModelRamCache:
                 proc = subprocess.Popen(  # noqa: S603
                     [
                         "rsync",
-                        "-aL",
+                        "-a",
                         "--delete",
                         "--info=progress2",
                         "--no-inc-recursive",
@@ -354,7 +489,7 @@ class ModelRamCache:
                     shutil.rmtree(partial, ignore_errors=True)
                     return False
             else:
-                shutil.copytree(str(src), str(partial), symlinks=False, dirs_exist_ok=True)
+                shutil.copytree(str(src), str(partial), symlinks=True, dirs_exist_ok=True)
         except Exception:
             logger.exception("Failed to copy %s into RAM cache", model_name)
             shutil.rmtree(partial, ignore_errors=True)
@@ -551,6 +686,44 @@ class ModelRamCache:
             logger.info("Evicted %s from RAM cache", model_name)
         self._cached_models.discard(model_name)
 
+    def held_bytes(self) -> int:
+        """Host RAM this cache currently occupies.
+
+        tmpfs pages are anonymous shared memory, so everything in here is RAM
+        the host cannot use for anything else — and, unlike page cache, it is
+        never reclaimed under pressure. The number is what makes the cache's
+        share of the pool visible to a budget calculation.
+        """
+        total = 0
+        for model_name in list(self._cached_models):
+            target = self._cache_hub / _hf_model_dir_name(model_name)
+            if target.exists():
+                total += _tree_size_bytes(target)
+        return total
+
+    def reclaim(self, keep: set[str]) -> list[str]:
+        """Drop cached models outside *keep*, returning what was removed.
+
+        The cache and vLLM's sleep_l1 both hold model weights in host RAM,
+        and until this existed only one of them ever gave any back: the cache
+        filled to its tmpfs limit on first boot and stayed there, so every
+        later sleep competed against a copy of weights nobody had asked for
+        in hours. Reclaiming is safe precisely because the cache is an
+        accelerator — an evicted model still loads, just from disk.
+
+        Callers must exclude models a lane is currently serving: a lane
+        waking from sleep_l2 re-reads its weights from whatever HF_HOME it
+        was started with, and pulling that directory out from under it turns
+        a wake into a failed lane.
+        """
+        removed: list[str] = []
+        for model_name in sorted(self._cached_models):
+            if model_name in keep:
+                continue
+            self.evict(model_name)
+            removed.append(model_name)
+        return removed
+
     def get_effective_hf_home(self, model_name: str) -> str:
         """Return tmpfs-based HF_HOME if cached, else source HF_HOME."""
         if model_name in self._cached_models:
@@ -667,7 +840,7 @@ class ModelRamCache:
             if rsync_available:
                 progress_cmd = [
                     "rsync",
-                    "-aL",
+                    "-a",
                     "--delete",
                     "--info=progress2",
                     str(src) + "/",
@@ -682,7 +855,7 @@ class ModelRamCache:
                     shutil.rmtree(partial, ignore_errors=True)
                     fallback_cmd = [
                         "rsync",
-                        "-aL",
+                        "-a",
                         "--delete",
                         str(src) + "/",
                         str(partial) + "/",
@@ -702,7 +875,7 @@ class ModelRamCache:
                     shutil.copytree,
                     str(src),
                     str(partial),
-                    symlinks=False,
+                    symlinks=True,
                     dirs_exist_ok=True,
                 )
         except Exception:
@@ -791,8 +964,22 @@ class ModelRamCache:
         return proc.returncode or 0, " | ".join(output_tail[-3:])
 
     def _is_stale(self, src: Path, cached: Path) -> bool:
-        """Check if source is newer than cached copy by comparing mtimes."""
+        """Whether the cached copy should be rebuilt before it is served.
+
+        Either because the source moved on, or because the copy is one of the
+        dereferenced ones an older worker wrote: those hold every weight twice
+        and rebuilding one halves what it costs. Rebuilding is the same work
+        the copy path already does, so the reclaim happens on the next touch
+        of that model rather than as a migration step.
+        """
         try:
+            if _snapshots_are_dereferenced(cached):
+                logger.info(
+                    "Cached copy of %s materialised its snapshot symlinks (holds every "
+                    "weight twice) — rebuilding it compactly",
+                    cached.name,
+                )
+                return True
             src_mtime = self._newest_mtime(src)
             cached_mtime = self._newest_mtime(cached)
             return src_mtime > cached_mtime
@@ -849,6 +1036,15 @@ class _DisabledModelRamCache:
         pass
 
     def evict(self, model_name: str) -> None:  # noqa: ARG002
+        pass
+
+    def held_bytes(self) -> int:
+        return 0
+
+    def reclaim(self, keep: set[str]) -> list[str]:  # noqa: ARG002
+        return []
+
+    def set_host_ram_floor_mb(self, floor_mb: float) -> None:  # noqa: ARG002
         pass
 
     def get_effective_hf_home(self, model_name: str) -> str:  # noqa: ARG002

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -32,6 +33,56 @@ except ImportError:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 _EMA_ALPHA = 0.3  # weight for new measurement vs historical average
+
+
+def atomic_write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    """Write *payload* to *path* as YAML, atomically and race-free.
+
+    Two unrelated writers keep model_profiles.yml: this module's registry and
+    calibration's ``save_profiles``. A fixed ``<name>.tmp`` sidecar makes them
+    collide — both truncate the same scratch file, so one publishes the
+    other's half-written YAML, and the loser's cleanup can delete the winner's
+    temp file out from under its rename. That reintroduces exactly the torn
+    store the atomic write is here to prevent, so the temp name is unique per
+    call. The rename itself is what makes readers safe: they see the old file
+    or the new one, never a truncated one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        prior_mode: int | None = path.stat().st_mode & 0o777
+    except OSError:
+        prior_mode = None
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.safe_dump(payload, f, default_flow_style=False)
+            f.flush()
+            os.fsync(f.fileno())
+        # mkstemp creates 0600. Carry the store's own mode across the replace
+        # so writing it never quietly narrows who can read it; a store being
+        # created for the first time gets the usual umask default instead.
+        if prior_mode is not None:
+            os.chmod(tmp_path, prior_mode)
+        else:
+            os.chmod(tmp_path, 0o666 & ~_current_umask())
+        os.replace(tmp_path, path)
+    finally:
+        # A successful replace already moved it; this only catches the
+        # failure paths, and must never remove the file we just published.
+        tmp_path.unlink(missing_ok=True)
+
+
+def _current_umask() -> int:
+    """Read the process umask without leaving it changed.
+
+    os.umask both sets and returns, so reading it means setting it twice. The
+    window is tiny but real, which is why this is only used for a store that
+    does not exist yet — every later write copies the mode already on disk.
+    """
+    mask = os.umask(0o022)
+    os.umask(mask)
+    return mask
 
 
 def _ema(previous: float | None, current: float) -> float:
@@ -680,22 +731,16 @@ class ModelProfileRegistry:
             )
             return
         try:
+            # Snapshot and write under one lock. Releasing it between the two
+            # lets a second writer's older snapshot land after this one — the
+            # rename is atomic per call, but two calls still race for which
+            # version ends up on disk.
             with self._lock:
                 data = {name: profile.to_dict() for name, profile in self._profiles.items()}
-            if not data:
-                return
-
-            self._state_dir.mkdir(parents=True, exist_ok=True)
-            state_path = self._state_dir / "model_profiles.yml"
-            tmp_path = state_path.with_name(state_path.name + ".tmp")
-            try:
-                with tmp_path.open("w") as f:
-                    yaml.safe_dump({"model_profiles": data}, f, default_flow_style=False)
-                    f.flush()
-                    os.fsync(f.fileno())
-                os.replace(tmp_path, state_path)
-            finally:
-                tmp_path.unlink(missing_ok=True)
+                if not data:
+                    return
+                self._state_dir.mkdir(parents=True, exist_ok=True)
+                atomic_write_yaml(self._state_dir / "model_profiles.yml", {"model_profiles": data})
         except Exception:  # noqa: BLE001
             logger.exception("Failed to persist model profiles")
 

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -17,6 +17,7 @@ Persists in the state directory as model_profiles.yml.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 from dataclasses import dataclass
@@ -232,6 +233,10 @@ class ModelProfileRegistry:
         self._profiles: dict[str, ModelProfileRecord] = {}
         self._state_dir = state_dir
         self._lock = threading.Lock()
+        # True once a load of model_profiles.yml has failed. Blocks _persist,
+        # which rewrites the whole file from memory and would otherwise
+        # overwrite profiles it never managed to read.
+        self._load_failed = False
         self._manual_overrides: dict[str, dict[str, Any]] = {}
         if model_profile_overrides:
             for model_name, ov in model_profile_overrides.items():
@@ -656,8 +661,23 @@ class ModelProfileRegistry:
             return {name: profile.to_dict() for name, profile in self._profiles.items()}
 
     def _persist(self) -> None:
-        """Save model profiles to state directory as YAML."""
+        """Save model profiles to state directory as YAML.
+
+        Written atomically, and refused outright while the last load failed:
+        this rewrites the whole file from memory, so persisting on top of a
+        store we could not read replaces measured profiles with whatever
+        placeholder state the process built instead — the freshly seeded
+        capability stubs, carrying only the operator's config overrides.
+        """
         if self._state_dir is None or yaml is None:
+            return
+        if self._load_failed:
+            logger.error(
+                "Refusing to persist model profiles: %s could not be read, so what "
+                "is in memory is not a complete picture of it. Fix or move the file "
+                "to let the worker rebuild it.",
+                self._state_dir / "model_profiles.yml",
+            )
             return
         try:
             with self._lock:
@@ -667,10 +687,17 @@ class ModelProfileRegistry:
 
             self._state_dir.mkdir(parents=True, exist_ok=True)
             state_path = self._state_dir / "model_profiles.yml"
-            with state_path.open("w") as f:
-                yaml.safe_dump({"model_profiles": data}, f, default_flow_style=False)
+            tmp_path = state_path.with_name(state_path.name + ".tmp")
+            try:
+                with tmp_path.open("w") as f:
+                    yaml.safe_dump({"model_profiles": data}, f, default_flow_style=False)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_path, state_path)
+            finally:
+                tmp_path.unlink(missing_ok=True)
         except Exception:  # noqa: BLE001
-            logger.debug("Failed to persist model profiles", exc_info=True)
+            logger.exception("Failed to persist model profiles")
 
     def _load_persisted(self) -> None:
         """Read persisted model profiles from state file on startup."""
@@ -678,14 +705,18 @@ class ModelProfileRegistry:
             return
         state_path = self._state_dir / "model_profiles.yml"
         if not state_path.exists():
+            self._load_failed = False
             return
         try:
             with state_path.open() as f:
                 data = yaml.safe_load(f) or {}
 
             profiles = data.get("model_profiles")
-            if not isinstance(profiles, dict):
+            if profiles is None:
+                self._load_failed = False
                 return
+            if not isinstance(profiles, dict):
+                raise ValueError(f"model_profiles is {type(profiles).__name__}, not a mapping")
             for model_name, profile_data in profiles.items():
                 if not isinstance(profile_data, dict):
                     continue
@@ -752,5 +783,14 @@ class ModelProfileRegistry:
                     prof.sleeping_residual_mb or 0,
                     prof.measurement_count,
                 )
+            self._load_failed = False
         except Exception:  # noqa: BLE001
-            logger.debug("Failed to load persisted model profiles", exc_info=True)
+            # Loud, and latched: every calibrated profile on this node is in
+            # that file and nowhere else, and _persist would otherwise write
+            # the empty/partial in-memory state straight over it.
+            self._load_failed = True
+            logger.exception(
+                "Failed to load persisted model profiles from %s — profile "
+                "persistence is disabled until this is resolved",
+                state_path,
+            )

--- a/logos/logos-workernode/logos_worker_node/sharded_checkpoint.py
+++ b/logos/logos-workernode/logos_worker_node/sharded_checkpoint.py
@@ -85,6 +85,32 @@ def is_sharded_checkpoint_ready(directory: Path) -> bool:
         return False
 
 
+def invalidate_sharded_checkpoint(directory: Path) -> bool:
+    """Discard a sharded checkpoint that vLLM refused to load.
+
+    The conversion can complete — shard files written, marker placed — and
+    still produce something the loader rejects, e.g. a quantization whose
+    weight layout does not survive the round trip (a tensor comes back a
+    factor of the packing width too small). Nothing in the produced files says
+    so; only a lane trying to serve them finds out. Removing the directory
+    puts the model back on the full checkpoint and lets a later conversion,
+    against a newer vLLM, try again.
+
+    Returns True when something was removed.
+    """
+    with _lock_for(directory):
+        if not directory.exists():
+            return False
+        shutil.rmtree(directory, ignore_errors=True)
+        # rmtree(ignore_errors=True) hides a partial failure, and a directory
+        # that still has the marker would be picked up as ready again.
+        if is_sharded_checkpoint_ready(directory):
+            logger.error("[sharded] could not fully remove %s — it still looks ready", directory)
+            return False
+        logger.warning("[sharded] discarded unusable sharded checkpoint: %s", directory)
+        return True
+
+
 def _lock_for(directory: Path) -> threading.Lock:
     key = str(directory)
     with _locks_guard:

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -370,6 +370,10 @@ class VllmProcessHandle:
         # is used for a TP>1 lane; _build_cmd then serves this directory with
         # --load-format sharded_state instead of the full checkpoint.
         self._sharded_model_dir: str | None = None
+        # Set for the retry after a sharded checkpoint was rejected by the
+        # loader, so the retry serves the full checkpoint instead of rebuilding
+        # the same unusable shards. Reset at the top of every spawn().
+        self._skip_sharded_checkpoint: bool = False
         # Consecutive liveness-probe failures observed by is_sleeping().
         # The lane manager reads this to escalate to a restart when the API
         # server is alive (/v1/models, /health) but the EngineCore RPC is
@@ -398,6 +402,11 @@ class VllmProcessHandle:
         pointing inside the compile cache directory (e.g. an AOT-compiled
         graph that was specialized on a stale shape profile), the caches are
         purged again and the spawn is retried once.
+
+        The same shape of recovery covers a sharded checkpoint the loader
+        rejects: the cached conversion is discarded and the lane retried once
+        against the full checkpoint. Both are one-shot — a second failure of
+        the same kind is a real fault and propagates.
         """
         if self._process is not None and self._process.returncode is None:
             logger.info(
@@ -410,12 +419,30 @@ class VllmProcessHandle:
         self._purge_compile_caches_if_versions_changed()
 
         purged_once = False
+        unsharded_once = False
+        self._skip_sharded_checkpoint = False
         while True:
             try:
                 status = await self._spawn_once(lane_config)
                 self._write_compile_cache_stamp()
                 return status
             except RuntimeError:
+                # Checked before the compile cache: a sharded-loader failure
+                # can name a file under the compile cache too, and purging
+                # that leaves the actual cause in place for the retry.
+                if not unsharded_once and self.has_broken_sharded_checkpoint:
+                    unsharded_once = True
+                    self._invalidate_sharded_checkpoint(lane_config)
+                    # Hold off the conversion for this lane's retry as well:
+                    # rebuilding it would only reproduce the same bad output.
+                    self._skip_sharded_checkpoint = True
+                    logger.warning(
+                        "[%s] vLLM rejected the pre-sharded checkpoint for %s; "
+                        "retrying once from the full checkpoint",
+                        self.lane_id,
+                        lane_config.model,
+                    )
+                    continue
                 if purged_once or not self.has_poisoned_compile_cache:
                     raise
                 purged = self._purge_compile_caches()
@@ -550,6 +577,56 @@ class VllmProcessHandle:
     )
 
     _COMPILE_CACHE_STAMP_FILENAME: ClassVar[str] = ".logos_compile_cache_stamp.json"
+
+    # Log fragments that mean the pre-sharded checkpoint is the thing vLLM
+    # could not load. Matched only while this lane is actually serving one, so
+    # the loader-module frame is enough on its own; the payload messages cover
+    # the ways the shards can be wrong without the frame appearing in the tail
+    # we captured (a shape that doesn't match the parameter, e.g. a
+    # quantization whose packed layout doesn't survive the conversion, or
+    # shards missing for a rank).
+    _BROKEN_SHARDED_CHECKPOINT_LOG_FRAGMENTS: ClassVar[tuple[str, ...]] = (
+        "sharded_state_loader.py",
+        "only pre-sharded checkpoints are currently supported",
+        "could not find checkpoint files",
+    )
+
+    @property
+    def has_broken_sharded_checkpoint(self) -> bool:
+        """True if this lane's pre-sharded checkpoint is what failed to load.
+
+        A conversion can finish successfully and still emit shards vLLM
+        rejects, and nothing about the produced files says so — the marker is
+        written, the shard files are there, and every subsequent spawn picks
+        the same directory up as ready. For a model the worker keeps warm that
+        is a permanent outage of that model, reported only as a failed
+        add_lane.
+        """
+        if not self._sharded_model_dir or not self._recent_logs:
+            return False
+        log_blob = "\n".join(self._recent_logs).lower()
+        return any(frag in log_blob for frag in self._BROKEN_SHARDED_CHECKPOINT_LOG_FRAGMENTS)
+
+    def _invalidate_sharded_checkpoint(self, lane_config: LaneConfig) -> bool:
+        """Remove the sharded checkpoint this lane just failed to load."""
+        directory = self._sharded_model_dir
+        if not directory:
+            return False
+        try:
+            from logos_worker_node import sharded_checkpoint as sc  # noqa: PLC0415
+
+            removed = sc.invalidate_sharded_checkpoint(Path(directory))
+        except Exception:  # noqa: BLE001
+            logger.exception("[%s] Failed to discard sharded checkpoint %s", self.lane_id, directory)
+            return False
+        if removed:
+            logger.warning(
+                "[%s] Discarded sharded checkpoint for %s: %s",
+                self.lane_id,
+                lane_config.model,
+                directory,
+            )
+        return removed
 
     @property
     def has_poisoned_compile_cache(self) -> bool:
@@ -1180,6 +1257,15 @@ class VllmProcessHandle:
         """
         vc = lane_config.vllm_config
         if vc is None:
+            return
+        if self._skip_sharded_checkpoint:
+            # Set by spawn() after the loader rejected the cached conversion.
+            # Rebuilding it here would reproduce the same unusable shards.
+            logger.info(
+                "[%s] serving %s from the full checkpoint — its sharded conversion was rejected",
+                self.lane_id,
+                lane_config.model,
+            )
             return
         ec = self._vllm_engine_config
         if not getattr(ec, "sharded_checkpoint_enabled", True):

--- a/logos/logos-workernode/tests/test_cache_planner.py
+++ b/logos/logos-workernode/tests/test_cache_planner.py
@@ -5,8 +5,9 @@ The operator rule the planner enforces:
     Load as many models into the tmpfs cache as possible WITHOUT lowering
     the number of models that can be sleeping simultaneously.
 
-Concretely: reserve ``sum(host_ram of every sleepable capability model)``
-from the host's available RAM, then pack the leftover with cache candidates
+Concretely: reserve ``sum(sleeping host_ram of every sleepable capability
+model)`` from the host's available RAM plus whatever the cache already holds
+(that part is reclaimable), then pack the leftover with cache candidates
 (unsleepable first because they cannot be brought back via sleep_l1; smallest
 first within each group to maximise count).
 """
@@ -22,7 +23,7 @@ def _c(name: str, *, can_sleep: bool, host_ram_mb: float, size_bytes: int) -> Ca
     return CacheCandidate(
         name=name,
         can_sleep=can_sleep,
-        host_ram_mb=host_ram_mb,
+        sleeping_host_ram_mb=host_ram_mb,
         size_bytes=size_bytes,
     )
 
@@ -188,3 +189,66 @@ def test_smallest_first_within_each_group():
         "s-small",
         "s-big",
     ]
+
+
+# ---------------------------------------------------------------------------
+# The cache's own footprint is part of the pool it is budgeted against
+#
+# Measuring the budget from MemAvailable alone measures it after the cache has
+# already spent it. A full cache then reports no room, declines to cache
+# anything else, and — because nothing ever reclaimed — keeps every byte it
+# took on first boot, whatever the lanes needed later.
+# ---------------------------------------------------------------------------
+
+
+def test_a_full_cache_does_not_report_itself_out_of_budget():
+    """The production shape: 339 GB cached, MemAvailable down to 63 GB. Read
+    naively that is no budget at all, and the plan caches nothing — while the
+    339 GB stays exactly where it is."""
+    cands = [
+        _c("s-a", can_sleep=True, host_ram_mb=20_000.0, size_bytes=30_000 * _MB),
+        _c("s-b", can_sleep=True, host_ram_mb=20_000.0, size_bytes=30_000 * _MB),
+    ]
+
+    blind = plan_cache_order(cands, available_host_ram_mb=63_000.0, safety_margin_mb=8192.0)
+    assert blind.cached_sleepable == [], "sanity: without the held bytes there is no room"
+
+    aware = plan_cache_order(
+        cands,
+        available_host_ram_mb=63_000.0,
+        safety_margin_mb=8192.0,
+        cache_held_mb=339_000.0,
+    )
+    assert aware.cached_sleepable == ["s-a", "s-b"]
+
+
+def test_the_budget_can_come_out_below_what_is_already_cached():
+    """Which is the point: a plan that can only ever grow the cache cannot
+    hand RAM back to the sleep reserve. Models absent from `order` are what
+    the caller reclaims."""
+    cands = [
+        _c("s-huge", can_sleep=True, host_ram_mb=200_000.0, size_bytes=300_000 * _MB),
+        _c("s-small", can_sleep=True, host_ram_mb=1_000.0, size_bytes=1_000 * _MB),
+    ]
+
+    plan = plan_cache_order(
+        cands,
+        available_host_ram_mb=10_000.0,
+        safety_margin_mb=8192.0,
+        cache_held_mb=301_000.0,
+    )
+
+    assert "s-huge" in plan.skipped_sleepable
+    assert set(plan.order) != {"s-huge", "s-small"}
+
+
+def test_the_reserve_is_the_sleeping_footprint_not_the_awake_one():
+    """The reserve exists so every sleepable model can be in sleep_l1 at once,
+    so it has to be sized on what a sleeping lane holds. An awake lane's RAM
+    is spoken for whether or not the cache holds anything; counting it here
+    reserved the same memory twice and starved the cache for no gain."""
+    cands = [_c("s-a", can_sleep=True, host_ram_mb=30_000.0, size_bytes=10_000 * _MB)]
+
+    plan = plan_cache_order(cands, available_host_ram_mb=100_000.0, safety_margin_mb=4096.0)
+
+    assert plan.reserved_for_sleep_mb == 30_000.0

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -932,11 +932,11 @@ def test_list_uncalibrated_flags_calibrated_profile_missing_pairs(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_session_skips_sleep_disabled_model_and_continues(tmp_path, monkeypatch):
-    """Inside the session loop, a model that can't be slept on this worker
-    is recorded as skipped (with sleep_mode_disabled persisted on the
-    profile) and the loop moves on to the next model. The session must
-    not refuse the whole batch over one bad model."""
+async def test_session_calibrates_sleep_disabled_model_without_sleep(tmp_path, monkeypatch):
+    """A model that can't be slept on this worker is calibrated at
+    sleep_level 0 rather than skipped: base_residency is measurable without
+    sleep, and skipping left such a model permanently uncalibrated — and so
+    never announced as a capability — with no way back."""
     from logos_worker_node import config as _wcfg
     from logos_worker_node.calibration import CalibrationResult
 
@@ -954,7 +954,11 @@ async def test_session_skips_sleep_disabled_model_and_continues(tmp_path, monkey
     client = LogosBridgeClient(app, cfg)
 
     # Mock the actual calibration so we don't spawn vLLM.
+    seen_sleep_levels: dict[str, int] = {}
+
     def _fake_calibrate(plan, **kwargs):
+        sleep_level = int(kwargs["sleep_level"])
+        seen_sleep_levels[plan["model"]] = sleep_level
         return CalibrationResult(
             model=plan["model"],
             tensor_parallel_size=1,
@@ -962,8 +966,8 @@ async def test_session_skips_sleep_disabled_model_and_continues(tmp_path, monkey
             kv_cache_sent_mb=2048.0,
             success=True,
             base_residency_mb=12345.0,
-            sleeping_residual_mb=512.0,
-            sleep_l1_transient_host_ram_mb=4096.0,
+            sleeping_residual_mb=(512.0 if sleep_level > 0 else None),
+            sleep_l1_transient_host_ram_mb=(4096.0 if sleep_level > 0 else None),
         )
 
     monkeypatch.setattr(
@@ -980,14 +984,52 @@ async def test_session_skips_sleep_disabled_model_and_continues(tmp_path, monkey
     await _drain_session(client)
 
     events = [(e.event, e.model) for e in app.state.lane_manager._event_log]
-    # gpt-oss skipped, phi-4 attempted and completed.
-    assert ("calibration_model_skipped", "openai/gpt-oss-120b") in events
+    assert ("calibration_model_skipped", "openai/gpt-oss-120b") not in events
+    assert ("calibration_model_completed", "openai/gpt-oss-120b") in events
     assert ("calibration_model_completed", "microsoft/Phi-4-reasoning") in events
     assert ("calibration_session_finished", "") in events
-    # sleep_mode_disabled persisted for the skipped model.
-    skipped_profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
-    assert skipped_profile is not None
-    assert skipped_profile.sleep_mode_disabled is True
+    # The nosleep model probed without sleep; the other one kept the session level.
+    assert seen_sleep_levels == {"openai/gpt-oss-120b": 0, "microsoft/Phi-4-reasoning": 1}
+    # sleep_mode_disabled persisted, and the measurement landed.
+    nosleep_profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
+    assert nosleep_profile is not None
+    assert nosleep_profile.sleep_mode_disabled is True
+    assert nosleep_profile.base_residency_mb == 12345.0
+    assert nosleep_profile.sleeping_residual_mb is None
+    # The model is announced to Logos now that it has a profile.
+    assert "openai/gpt-oss-120b" in client._cfg.capabilities_models  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_nosleep_model_with_profile_is_not_recalibrated(tmp_path, monkeypatch):
+    """A nosleep model calibrated at level 0 has null sleep fields by
+    design. Those nulls must not read as "incomplete", or every session
+    re-picks the model forever."""
+    from logos_worker_node import config as _wcfg
+
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(
+        tmp_path,
+        per_model_overrides={"openai/gpt-oss-120b": {"enable_sleep_mode": False}},
+    )
+    app.state.model_profiles.seed_capabilities(["openai/gpt-oss-120b"])
+    profile = app.state.model_profiles.get_profile("openai/gpt-oss-120b")
+    profile.base_residency_mb = 98945.0
+    profile.residency_source = "calibrated"
+    profile.sleeping_residual_mb = None
+    profile.sleep_l1_transient_host_ram_mb = None
+    profile.sleep_mode_disabled = True
+    profile.kv_cache_to_max_model_len_pairs = [{"kv_mb": 8192.0, "max_model_len": 32768}]
+
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["openai/gpt-oss-120b"],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    assert client._list_uncalibrated_models() == []  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -1354,3 +1396,200 @@ def test_current_event_ids_snapshots_the_log():
 
     app.state.lane_manager = None
     assert client._current_event_ids() == frozenset()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# The status carries the live calibration state
+#
+# The server excludes a calibrating worker from lane placement, and used to
+# learn when that ended from a single lifecycle event. An event that never
+# lands as a live one — dropped by the post-connect replay filter, belonging
+# to a connection that is gone — left the worker excluded with nothing to
+# release it. Observed in production as three workers holding no lanes for
+# over seven hours, recovered only by restarting the container.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_reports_the_live_calibration_state(tmp_path, monkeypatch):
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    monkeypatch.setattr(
+        "logos_worker_node.logos_bridge.build_runtime_status",
+        AsyncMock(return_value=SimpleNamespace(model_dump=lambda mode="json": {"lanes": []})),
+    )
+    sends: list[dict] = []
+
+    async def _fake_send_json(_ws, payload):
+        sends.append(payload)
+
+    client._send_json = _fake_send_json  # type: ignore[method-assign]  # noqa: SLF001
+
+    await client._send_runtime_status(object(), force=True)  # noqa: SLF001
+    assert sends[-1]["calibrating"] is False
+
+    client._active_calibration_session = _CalibrationSession(sleep_level=1)  # noqa: SLF001
+    await client._send_runtime_status(object(), force=True)  # noqa: SLF001
+    assert sends[-1]["calibrating"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_session_ending_is_pushed_even_when_nothing_else_changed(tmp_path, monkeypatch):
+    """A session that starts and ends without touching a lane changes nothing
+    else in the payload. Left out of the dedupe signature, the status carrying
+    calibrating=False would never be sent and the server would stay stuck."""
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    monkeypatch.setattr(
+        "logos_worker_node.logos_bridge.build_runtime_status",
+        AsyncMock(return_value=SimpleNamespace(model_dump=lambda mode="json": {"lanes": []})),
+    )
+    sends: list[dict] = []
+
+    async def _fake_send_json(_ws, payload):
+        sends.append(payload)
+
+    client._send_json = _fake_send_json  # type: ignore[method-assign]  # noqa: SLF001
+
+    session = _CalibrationSession(sleep_level=1)
+    client._active_calibration_session = session  # noqa: SLF001
+    assert await client._send_runtime_status(object(), force=False) is True  # noqa: SLF001
+    assert await client._send_runtime_status(object(), force=False) is False  # noqa: SLF001
+
+    client._active_calibration_session = None  # noqa: SLF001
+    assert await client._send_runtime_status(object(), force=False) is True  # noqa: SLF001
+    assert [p["calibrating"] for p in sends] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_hello_reports_a_finished_session_as_not_calibrating(tmp_path, monkeypatch):
+    """_active_calibration_session lingers until the next start clears it.
+    Reporting that as live at connect would exclude the worker from placement
+    for as long as no new session begins."""
+    app = _make_app_for_calibration(tmp_path)
+    app.state.lane_manager._static_lane_ids = set()
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret")
+    client = LogosBridgeClient(app, cfg)
+
+    async def _already_done():
+        return None
+
+    done = _CalibrationSession(sleep_level=1)
+    done.task = asyncio.create_task(_already_done())
+    await done.task
+    client._active_calibration_session = done  # noqa: SLF001
+
+    sends: list[dict] = []
+
+    async def _fake_send_json(_ws, payload):
+        sends.append(payload)
+
+    client._send_json = _fake_send_json  # type: ignore[method-assign]  # noqa: SLF001
+    await client._send_hello(object())  # noqa: SLF001
+
+    assert sends[-1]["calibrating"] is False
+
+
+# ---------------------------------------------------------------------------
+# A calibration result is merged into the store, never written over it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_profile_store_is_left_alone(tmp_path, monkeypatch):
+    """load_existing_profiles used to answer an unreadable store with an empty
+    dict, and saving that back replaced every profile on the node with this one
+    result. One lost measurement is recoverable; the file is not."""
+    from logos_worker_node import config as _wcfg
+    from logos_worker_node.calibration import CalibrationResult
+
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["org/model-a"],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    profiles_path = tmp_path / "model_profiles.yml"
+    profiles_path.write_text("model_profiles:\n  org/other: {unterminated\n")
+    corrupt = profiles_path.read_text()
+
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.calibrate_with_tp_escalation",
+        lambda plan, **kwargs: CalibrationResult(
+            model=plan["model"],
+            tensor_parallel_size=1,
+            gpu_devices="0",
+            kv_cache_sent_mb=2048.0,
+            success=True,
+            base_residency_mb=12345.0,
+            sleeping_residual_mb=512.0,
+        ),
+    )
+    monkeypatch.setattr("logos_worker_node.calibration.plans_from_config", lambda _p: [])
+
+    assert (await client._handle_start_calibration_session({"sleep_level": 1}))["ok"] is True  # noqa: SLF001
+    await _drain_session(client)
+
+    assert profiles_path.read_text() == corrupt
+    events = [(e.event, e.details) for e in app.state.lane_manager._event_log]
+    assert any(e == "calibration_model_failed" and "unreadable" in d for e, d in events)
+    # The session still ends cleanly — the server must not be left waiting.
+    assert ("calibration_session_finished", "sleep_level=1") in events
+
+
+@pytest.mark.asyncio
+async def test_a_result_merges_into_the_existing_entry(tmp_path, monkeypatch):
+    """Fields the probe does not measure — here the sleep gate's flag and a
+    disk size recorded elsewhere — survive the write."""
+    from logos_worker_node import config as _wcfg
+    from logos_worker_node.calibration import CalibrationResult, load_existing_profiles, save_profiles
+
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(
+        enabled=True,
+        logos_url="https://logos.example",
+        shared_key="secret",
+        configured_models=["org/model-a"],
+    )
+    client = LogosBridgeClient(app, cfg)
+
+    profiles_path = tmp_path / "model_profiles.yml"
+    save_profiles(
+        profiles_path,
+        {
+            "org/model-a": {"base_residency_mb": 1.0, "disk_size_bytes": 42, "sleep_mode_disabled": True},
+            "org/untouched": {"base_residency_mb": 22545.0},
+        },
+    )
+
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.calibrate_with_tp_escalation",
+        lambda plan, **kwargs: CalibrationResult(
+            model=plan["model"],
+            tensor_parallel_size=1,
+            gpu_devices="0",
+            kv_cache_sent_mb=2048.0,
+            success=True,
+            base_residency_mb=12345.0,
+            sleeping_residual_mb=512.0,
+        ),
+    )
+    monkeypatch.setattr("logos_worker_node.calibration.plans_from_config", lambda _p: [])
+
+    assert (await client._handle_start_calibration_session({"sleep_level": 1}))["ok"] is True  # noqa: SLF001
+    await _drain_session(client)
+
+    stored = load_existing_profiles(profiles_path)
+    assert stored["org/model-a"]["base_residency_mb"] == 12345.0
+    assert stored["org/model-a"]["disk_size_bytes"] == 42
+    assert stored["org/model-a"]["sleep_mode_disabled"] is True
+    assert stored["org/untouched"]["base_residency_mb"] == 22545.0, "other models must be untouched"

--- a/logos/logos-workernode/tests/test_model_cache.py
+++ b/logos/logos-workernode/tests/test_model_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -149,9 +150,79 @@ async def test_ensure_cached_copies_model(ram_cache_env):
     cached_dir = os.path.join(cached_hub, "models--Qwen--Qwen2.5-7B")
     assert os.path.isdir(cached_dir)
 
-    # Blob should be a regular file (rsync -aL dereferences symlinks)
+    # The blob itself is a real file — it is the one copy of the weights.
     blob_path = os.path.join(cached_dir, "blobs", "sha256-abc123")
     assert os.path.isfile(blob_path)
+    assert not os.path.islink(blob_path)
+
+    # The snapshot entry stays a link into it. Materialising it here is what
+    # made every cached model cost twice its size.
+    snap_path = os.path.join(cached_dir, "snapshots", "abc123", "model.safetensors")
+    assert os.path.islink(snap_path), "snapshot entry was dereferenced — the copy holds the weights twice"
+    assert os.path.isfile(snap_path), "the relative link must resolve inside the copy"
+    assert os.readlink(snap_path) == "../../blobs/sha256-abc123"
+
+
+@pytest.mark.asyncio
+async def test_cached_copy_is_not_larger_than_the_source(ram_cache_env):
+    """The whole point of the cache is RAM, so a copy that inflates is a bug
+    with no symptom other than the host running out. 12 MB of weights became
+    24 MB; across six models that was ~170 GB of pure duplication."""
+    from logos_worker_node.model_cache import _tree_size_bytes
+
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    await cache.ensure_cached(ram_cache_env["model_name"])
+
+    source = Path(ram_cache_env["source_hf"]) / "models--Qwen--Qwen2.5-7B"
+    cached = Path(ram_cache_env["tmpfs"]) / "hub" / "models--Qwen--Qwen2.5-7B"
+
+    assert _tree_size_bytes(cached) <= _tree_size_bytes(source)
+
+
+def test_model_size_bytes_counts_the_weights_once(ram_cache_env):
+    """It feeds the capacity check, and resolving the snapshot links made it
+    report double — so the cache believed it needed twice the room it does."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    blob_bytes = 12 * 1024 * 1024
+
+    size = cache.model_size_bytes(ram_cache_env["model_name"])
+
+    assert blob_bytes <= size < 2 * blob_bytes
+
+
+@pytest.mark.asyncio
+async def test_a_dereferenced_copy_from_an_older_worker_is_rebuilt(ram_cache_env):
+    """Copies already on the workers hold every weight twice. They load fine,
+    so nothing else would ever notice — the staleness path has to, or the RAM
+    is only reclaimed by hand."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    model = ram_cache_env["model_name"]
+    cached = Path(ram_cache_env["tmpfs"]) / "hub" / "models--Qwen--Qwen2.5-7B"
+
+    # An old-style copy: the snapshot entry is a real file, not a link.
+    await cache.ensure_cached(model)
+    snap = cached / "snapshots" / "abc123" / "model.safetensors"
+    snap.unlink()
+    with open(snap, "wb") as f:
+        f.seek(12 * 1024 * 1024 - 1)
+        f.write(b"\x00")
+
+    source = Path(ram_cache_env["source_hf"]) / "models--Qwen--Qwen2.5-7B"
+    assert cache._is_stale(source, cached) is True
+
+    await cache._copy_model(model)
+    assert os.path.islink(snap), "the rebuild should have restored the link"
 
 
 @pytest.mark.asyncio
@@ -462,3 +533,123 @@ async def test_wait_for_cached_respects_timeout(ram_cache_env, monkeypatch):
     got = await cache.wait_for_cached(ram_cache_env["model_name"], timeout=0.1)
     assert got is False
     await cache.stop_background_caching()
+
+
+# ---------------------------------------------------------------------------
+# The cache yields host RAM back
+#
+# tmpfs pages are anonymous shared memory, so a cached model is RAM the host
+# cannot use for anything else — and unlike page cache it is never reclaimed
+# under pressure. sleep_l1 wants the same RAM for a lane's weights. Until
+# these existed the cache filled to its tmpfs limit on first boot and kept
+# every byte, whatever the lanes needed later.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_held_bytes_reports_what_the_cache_costs_the_host(ram_cache_env):
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    assert cache.held_bytes() == 0
+
+    await cache.ensure_cached(ram_cache_env["model_name"])
+
+    assert cache.held_bytes() >= 12 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_reclaim_drops_what_the_plan_no_longer_wants(ram_cache_env):
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    model = ram_cache_env["model_name"]
+    await cache.ensure_cached(model)
+    assert model in cache.cached_models()
+
+    removed = cache.reclaim(keep=set())
+
+    assert removed == [model]
+    assert cache.cached_models() == []
+    assert cache.held_bytes() == 0
+    assert not (Path(ram_cache_env["tmpfs"]) / "hub" / "models--Qwen--Qwen2.5-7B").exists()
+
+
+@pytest.mark.asyncio
+async def test_reclaim_keeps_what_it_is_told_to(ram_cache_env):
+    """Callers pass the models a lane is serving: a lane waking from sleep_l2
+    re-reads its weights from the HF_HOME it was started with, so pulling that
+    directory away turns a wake into a failed lane."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    model = ram_cache_env["model_name"]
+    await cache.ensure_cached(model)
+
+    assert cache.reclaim(keep={model}) == []
+    assert model in cache.cached_models()
+
+
+@pytest.mark.asyncio
+async def test_the_cache_refuses_to_grow_into_the_sleep_reserve(ram_cache_env, monkeypatch):
+    """The tmpfs mount is a fixed 400G of a 503G host, so tmpfs free space is
+    no bound at all. What bounds the cache is live host RAM against the RAM
+    reserved for sleeping lanes — which is why a lane putting weights in host
+    RAM shrinks the cache's room with nobody re-planning anything."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    cache.set_host_ram_floor_mb(100_000.0)
+    monkeypatch.setattr(
+        "logos_worker_node.model_cache._host_ram_available_bytes",
+        # 1 MB of slack for a 12 MB model: tmpfs has plenty of room, the host
+        # does not.
+        lambda: 100_001 * 1024 * 1024,
+    )
+
+    result = await cache.ensure_cached(ram_cache_env["model_name"])
+
+    assert result == str(Path(ram_cache_env["source_hf"]).parent), "should load from the source HF_HOME"
+    assert ram_cache_env["model_name"] not in cache.cached_models()
+
+
+@pytest.mark.asyncio
+async def test_a_roomy_host_still_gets_the_cache(ram_cache_env, monkeypatch):
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    cache._total_tmpfs_bytes = lambda: 0
+    cache.set_host_ram_floor_mb(100_000.0)
+    monkeypatch.setattr(
+        "logos_worker_node.model_cache._host_ram_available_bytes",
+        lambda: 400_000 * 1024 * 1024,
+    )
+
+    await cache.ensure_cached(ram_cache_env["model_name"])
+
+    assert ram_cache_env["model_name"] in cache.cached_models()
+
+
+def test_no_floor_configured_leaves_the_decision_to_tmpfs(ram_cache_env, monkeypatch):
+    """Fails open: a worker with no plan yet, or no /proc/meminfo, behaves
+    exactly as it did before the floor existed."""
+    cache = ModelRamCache(
+        tmpfs_path=ram_cache_env["tmpfs"],
+        source_hf_hub_path=ram_cache_env["source_hf"],
+    )
+    monkeypatch.setattr("logos_worker_node.model_cache._host_ram_available_bytes", lambda: None)
+
+    cache.set_host_ram_floor_mb(100_000.0)
+    assert cache._would_starve_host(1) == (False, 0)
+
+    cache.set_host_ram_floor_mb(0.0)
+    assert cache._would_starve_host(10**15) == (False, 0)

--- a/logos/logos-workernode/tests/test_profile_store.py
+++ b/logos/logos-workernode/tests/test_profile_store.py
@@ -1,0 +1,338 @@
+"""model_profiles.yml is the only copy of every calibrated profile on a node.
+
+Everything the planner needs to place a lane lives in that file, and for a
+model that cannot sleep on its worker there is no second route back: a
+skipped calibration leaves it without base_residency_mb, and a model without
+base_residency_mb is never announced as a capability.
+
+Observed in production: a nightly run reduced a node's store from 20 profiles
+to 5, wiping the measurements of three models that had been serving for
+months. The surviving five held nothing but the operator's config overrides —
+the shape of freshly seeded capability stubs written over the real file.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from logos_worker_node.calibration import (
+    CalibrationResult,
+    ProfileStoreUnreadableError,
+    _build_vllm_cmd,
+    load_existing_profiles,
+    merge_profile,
+    result_to_profile_dict,
+    save_profiles,
+)
+from logos_worker_node.model_profiles import ModelProfileRegistry
+
+# ---------------------------------------------------------------------------
+# Reading: an unreadable store must not read as an empty one
+# ---------------------------------------------------------------------------
+
+
+def test_missing_store_reads_as_empty(tmp_path):
+    assert load_existing_profiles(tmp_path / "model_profiles.yml") == {}
+
+
+def test_store_without_a_profiles_section_reads_as_empty(tmp_path):
+    path = tmp_path / "model_profiles.yml"
+    path.write_text("other_key: 1\n")
+    assert load_existing_profiles(path) == {}
+
+
+def test_corrupt_store_raises_instead_of_returning_empty(tmp_path):
+    """Callers write the returned dict back over the whole file, so an empty
+    dict for an unreadable store deletes every profile in it."""
+    path = tmp_path / "model_profiles.yml"
+    path.write_text("model_profiles:\n  org/model: {unterminated\n")
+
+    with pytest.raises(ProfileStoreUnreadableError):
+        load_existing_profiles(path)
+
+
+def test_truncated_store_raises(tmp_path):
+    """What a reader could see mid-write before the save became atomic:
+    open(path, "w") truncates first, so the window holds a partial file."""
+    path = tmp_path / "model_profiles.yml"
+    path.write_text('model_profiles:\n  org/model:\n    engine: "vll')
+
+    with pytest.raises(ProfileStoreUnreadableError):
+        load_existing_profiles(path)
+
+
+def test_store_holding_a_non_mapping_raises(tmp_path):
+    path = tmp_path / "model_profiles.yml"
+    path.write_text("model_profiles:\n  - org/model\n")
+
+    with pytest.raises(ProfileStoreUnreadableError):
+        load_existing_profiles(path)
+
+
+# ---------------------------------------------------------------------------
+# Writing: atomic, and never a partial file
+# ---------------------------------------------------------------------------
+
+
+def test_save_profiles_round_trips(tmp_path):
+    path = tmp_path / "model_profiles.yml"
+    save_profiles(path, {"org/model": {"base_residency_mb": 98945.0}})
+
+    assert load_existing_profiles(path) == {"org/model": {"base_residency_mb": 98945.0}}
+
+
+def test_save_profiles_leaves_no_temp_file_behind(tmp_path):
+    path = tmp_path / "model_profiles.yml"
+    save_profiles(path, {"org/model": {"base_residency_mb": 1.0}})
+
+    assert [p.name for p in tmp_path.iterdir()] == ["model_profiles.yml"]
+
+
+def test_a_failed_save_leaves_the_previous_store_intact(tmp_path, monkeypatch):
+    """The write goes to a temp file and is renamed, so a failure mid-dump
+    cannot truncate the store that is already there."""
+    path = tmp_path / "model_profiles.yml"
+    save_profiles(path, {"org/model": {"base_residency_mb": 98945.0}})
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("logos_worker_node.calibration.yaml.safe_dump", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        save_profiles(path, {"org/other": {}})
+
+    assert load_existing_profiles(path) == {"org/model": {"base_residency_mb": 98945.0}}
+
+
+# ---------------------------------------------------------------------------
+# Merging: a measurement updates a profile, it does not replace it
+# ---------------------------------------------------------------------------
+
+
+def test_merge_keeps_fields_the_probe_never_measures():
+    """These are set elsewhere — by the sleep gate, the unsupported list, the
+    host-RAM tracker — and assigning the result over the entry dropped them.
+    A nosleep model losing sleep_mode_disabled is the worst case: the flag is
+    what marks its null sleep fields as expected rather than as missing."""
+    prior = {
+        "base_residency_mb": 98945.0,
+        "sleep_mode_disabled": True,
+        "calibration_unsupported": False,
+        "disk_size_bytes": 123456789,
+        "host_ram_mb": 4096.0,
+    }
+    merged = merge_profile(prior, {"base_residency_mb": 99000.0, "disk_size_bytes": None})
+
+    assert merged["base_residency_mb"] == 99000.0, "a measured value wins"
+    assert merged["sleep_mode_disabled"] is True
+    assert merged["calibration_unsupported"] is False
+    assert merged["disk_size_bytes"] == 123456789, "None means not measured, not cleared"
+    assert merged["host_ram_mb"] == 4096.0
+
+
+def test_merge_writes_new_fields_including_nulls():
+    merged = merge_profile({}, {"base_residency_mb": 1.0, "sleeping_residual_mb": None})
+
+    assert merged == {"base_residency_mb": 1.0, "sleeping_residual_mb": None}
+
+
+def test_merge_without_a_prior_entry():
+    assert merge_profile(None, {"base_residency_mb": 1.0}) == {"base_residency_mb": 1.0}
+
+
+def test_merge_does_not_mutate_the_prior_entry():
+    prior = {"base_residency_mb": 1.0}
+    merge_profile(prior, {"base_residency_mb": 2.0})
+    assert prior == {"base_residency_mb": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# The registry's own persistence
+# ---------------------------------------------------------------------------
+
+
+def test_registry_refuses_to_persist_over_a_store_it_could_not_read(tmp_path, caplog):
+    """_persist rewrites the whole file from memory. After a failed load that
+    memory is not a picture of the file — at startup it is a set of empty
+    capability stubs carrying only config overrides, which is exactly what
+    replaced 20 real profiles with 5 hollow ones in production."""
+    path = tmp_path / "model_profiles.yml"
+    path.write_text("model_profiles:\n  org/model: {unterminated\n")
+    corrupt = path.read_text()
+
+    registry = ModelProfileRegistry(
+        state_dir=tmp_path,
+        model_profile_overrides={"org/model": {"kv_budget_mb": 8192}},
+    )
+    assert registry._load_failed is True
+
+    registry.seed_capabilities(["org/model"])
+
+    assert path.read_text() == corrupt, "the unreadable store must be left alone"
+
+
+def test_registry_persists_normally_once_the_store_reads(tmp_path):
+    registry = ModelProfileRegistry(state_dir=tmp_path)
+    assert registry._load_failed is False
+
+    registry.record_loaded_vram("org/model", 8000.0, engine="vllm", kv_cache_sent_mb=2048.0)
+
+    stored = yaml.safe_load((tmp_path / "model_profiles.yml").read_text())["model_profiles"]
+    assert "org/model" in stored
+
+
+def test_registry_reload_clears_the_failure_latch(tmp_path):
+    """Repairing the file must re-enable persistence without a restart."""
+    path = tmp_path / "model_profiles.yml"
+    path.write_text("model_profiles:\n  org/model: {unterminated\n")
+    registry = ModelProfileRegistry(state_dir=tmp_path)
+    assert registry._load_failed is True
+
+    save_profiles(path, {"org/model": {"base_residency_mb": 98945.0}})
+    registry._load_persisted()
+
+    assert registry._load_failed is False
+    assert registry.get_profile("org/model").base_residency_mb == 98945.0
+
+
+def test_registry_write_is_atomic(tmp_path):
+    registry = ModelProfileRegistry(state_dir=tmp_path)
+    registry.record_loaded_vram("org/model", 8000.0, engine="vllm", kv_cache_sent_mb=2048.0)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["model_profiles.yml"]
+
+
+# ---------------------------------------------------------------------------
+# Calibrating a model that is not allowed to sleep
+#
+# Sleep is used by one of the six calibration phases, to measure
+# sleeping_residual_mb. base_residency_mb — the value every placement decision
+# reads — comes out of the awake measurement one phase earlier and does not
+# depend on sleep at all. Refusing to calibrate without sleep left nosleep
+# models permanently uncalibrated, and therefore permanently unavailable.
+# ---------------------------------------------------------------------------
+
+
+def _plan() -> dict:
+    return {"model": "openai/gpt-oss-120b", "tensor_parallel_size": 2}
+
+
+def test_probe_enables_sleep_mode_by_default():
+    cmd = _build_vllm_cmd(_plan(), "vllm", "127.0.0.1", 18000, "8G")
+    assert "--enable-sleep-mode" in cmd
+
+
+def test_probe_omits_sleep_mode_for_a_nosleep_run():
+    """Left on, vLLM swaps in CuMemAllocator and the probe measures a footprint
+    production never runs — the serving lane has sleep off too."""
+    plan = {**_plan(), "enable_sleep_mode": False}
+    cmd = _build_vllm_cmd(plan, "vllm", "127.0.0.1", 18000, "8G")
+    assert "--enable-sleep-mode" not in cmd
+
+
+def test_a_result_without_a_sleep_measurement_persists_as_null():
+    """Not 0.0 — that would read as "measured, and it releases everything"."""
+    result = CalibrationResult(
+        model="openai/gpt-oss-120b",
+        tensor_parallel_size=2,
+        gpu_devices="0,1",
+        kv_cache_sent_mb=8192.0,
+        success=True,
+        base_residency_mb=98945.0,
+        sleeping_residual_mb=None,
+    )
+    profile = result_to_profile_dict(result)
+
+    assert profile["base_residency_mb"] == 98945.0
+    assert profile["sleeping_residual_mb"] is None
+    assert profile["residency_source"] == "calibrated"
+
+
+def test_a_result_with_a_sleep_measurement_persists_it():
+    result = CalibrationResult(
+        model="org/model",
+        tensor_parallel_size=1,
+        gpu_devices="0",
+        kv_cache_sent_mb=2048.0,
+        success=True,
+        base_residency_mb=12345.0,
+        sleeping_residual_mb=512.44,
+    )
+    assert result_to_profile_dict(result)["sleeping_residual_mb"] == 512.4
+
+
+def test_the_config_carries_enable_sleep_mode_into_the_plan(tmp_path):
+    """This is what lets calibrate_model decide for itself, so the boot-time
+    path (which asks for level 1 for everything) and the session-driven one
+    agree without either knowing the other's rules."""
+    from logos_worker_node.calibration import plans_from_config
+
+    config = tmp_path / "config.yml"
+    config.write_text(
+        "logos:\n"
+        "  capabilities_models:\n"
+        "    - openai/gpt-oss-120b\n"
+        "    - org/sleeper\n"
+        "engines:\n"
+        "  vllm:\n"
+        "    model_overrides:\n"
+        "      openai/gpt-oss-120b:\n"
+        "        enable_sleep_mode: false\n"
+        "        tensor_parallel_size: 2\n"
+    )
+
+    plans = {p["model"]: p for p in plans_from_config(config)}
+    assert plans["openai/gpt-oss-120b"]["enable_sleep_mode"] is False
+    assert "enable_sleep_mode" not in plans["org/sleeper"]
+
+
+def test_a_plan_that_forbids_sleep_probes_at_level_zero(tmp_path, monkeypatch):
+    """Asked for level 1, calibrate_model must still drop a nosleep model to
+    level 0 — otherwise the probe carries --enable-sleep-mode and the /sleep in
+    Phase 4 fails, wasting the whole run."""
+    from logos_worker_node import calibration
+
+    class _StopProbe(Exception):
+        pass
+
+    seen: dict = {}
+
+    def _capture(plan, *_a, **_k):
+        seen["plan"] = plan
+        raise _StopProbe
+
+    monkeypatch.setattr(calibration, "_kill_stale_vllm_workers", lambda: None)
+    monkeypatch.setattr(calibration, "sample_vram_mb", lambda _i: 1000.0)
+    monkeypatch.setattr(calibration, "spawn_vllm", _capture)
+
+    with pytest.raises(_StopProbe):
+        calibration.calibrate_model(
+            {"model": "openai/gpt-oss-120b", "enable_sleep_mode": False},
+            vllm_binary="vllm",
+            port=18000,
+            log_dir=tmp_path,
+            sleep_level=1,
+            ready_timeout_s=1.0,
+        )
+
+    assert seen["plan"]["enable_sleep_mode"] is False
+
+
+def test_auto_calibration_refuses_to_run_against_an_unreadable_store(tmp_path, monkeypatch):
+    """The boot-time path writes results back over the whole file too."""
+    from logos_worker_node import calibration
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "model_profiles.yml").write_text("model_profiles:\n  org/model: {unterminated\n")
+    corrupt = (state_dir / "model_profiles.yml").read_text()
+
+    def _boom(*_a, **_k):
+        raise AssertionError("must not calibrate when the store cannot be read")
+
+    monkeypatch.setattr(calibration, "calibrate_with_tp_escalation", _boom)
+    monkeypatch.setattr(calibration, "query_gpu_vram", lambda: [{"index": 0}])
+
+    assert calibration.auto_calibrate_models(["org/model"], tmp_path / "config.yml", state_dir) == {}
+    assert (state_dir / "model_profiles.yml").read_text() == corrupt

--- a/logos/logos-workernode/tests/test_profile_store.py
+++ b/logos/logos-workernode/tests/test_profile_store.py
@@ -356,6 +356,43 @@ def test_a_result_with_a_sleep_measurement_persists_it():
     assert result_to_profile_dict(result)["sleeping_residual_mb"] == 512.4
 
 
+def test_a_result_carries_the_sleeping_host_ram_measurement():
+    """The number the cache planner's sleep reserve is sized on. It was being
+    measured from lane telemetry and stored, but calibration never produced a
+    figure of its own — so a model that had not yet slept on this worker had
+    no reserve at all, and the cache was free to take the RAM it would need."""
+    result = CalibrationResult(
+        model="org/model",
+        tensor_parallel_size=1,
+        gpu_devices="0",
+        kv_cache_sent_mb=2048.0,
+        success=True,
+        base_residency_mb=12345.0,
+        sleeping_residual_mb=512.0,
+        host_ram_residual_mb=16384.44,
+    )
+
+    assert result_to_profile_dict(result)["host_ram_residual_mb"] == 16384.4
+
+
+def test_a_nosleep_result_leaves_the_sleeping_host_ram_unknown():
+    """A level-0 run never sleeps the model, so it has nothing to say about
+    what sleeping would cost — null, not zero, which would read as "measured,
+    and it holds nothing"."""
+    result = CalibrationResult(
+        model="openai/gpt-oss-120b",
+        tensor_parallel_size=2,
+        gpu_devices="0,1",
+        kv_cache_sent_mb=8192.0,
+        success=True,
+        base_residency_mb=98945.0,
+        sleeping_residual_mb=None,
+        host_ram_residual_mb=None,
+    )
+
+    assert result_to_profile_dict(result)["host_ram_residual_mb"] is None
+
+
 def test_the_config_carries_enable_sleep_mode_into_the_plan(tmp_path):
     """This is what lets calibrate_model decide for itself, so the boot-time
     path (which asks for level 1 for everything) and the session-driven one

--- a/logos/logos-workernode/tests/test_profile_store.py
+++ b/logos/logos-workernode/tests/test_profile_store.py
@@ -137,6 +137,32 @@ def test_merge_writes_new_fields_including_nulls():
     assert merged == {"base_residency_mb": 1.0, "sleeping_residual_mb": None}
 
 
+def test_merge_clears_a_stale_sleep_measurement():
+    """A run reports sleeping_residual_mb null for exactly one reason: the
+    model is not allowed to sleep here, so the sleep phases were skipped.
+    Keeping the old number hides that, and survives an enable_sleep_mode flip
+    back to true — the freshness check sees a value, declines to re-calibrate,
+    and the planner sizes a wake from a configuration that no longer exists."""
+    prior = {"base_residency_mb": 98945.0, "sleeping_residual_mb": 1400.0, "sleep_mode_disabled": False}
+
+    merged = merge_profile(prior, {"base_residency_mb": 99000.0, "sleeping_residual_mb": None})
+
+    assert merged["sleeping_residual_mb"] is None
+    assert merged["sleep_mode_disabled"] is False, "still a field the probe does not own"
+
+
+def test_merge_keeps_the_sleep_transient_of_a_level_it_did_not_run():
+    """Unlike the residual, the per-level host-RAM transients are each only
+    measurable by their own level — an L1 run saying nothing about L2 is not
+    a statement that L2 has no transient."""
+    prior = {"sleep_l1_transient_host_ram_mb": 900.0, "sleep_l2_transient_host_ram_mb": 7000.0}
+
+    merged = merge_profile(prior, {"sleep_l1_transient_host_ram_mb": 950.0, "sleep_l2_transient_host_ram_mb": None})
+
+    assert merged["sleep_l1_transient_host_ram_mb"] == 950.0
+    assert merged["sleep_l2_transient_host_ram_mb"] == 7000.0
+
+
 def test_merge_without_a_prior_entry():
     assert merge_profile(None, {"base_residency_mb": 1.0}) == {"base_residency_mb": 1.0}
 
@@ -201,6 +227,74 @@ def test_registry_write_is_atomic(tmp_path):
     registry.record_loaded_vram("org/model", 8000.0, engine="vllm", kv_cache_sent_mb=2048.0)
 
     assert sorted(p.name for p in tmp_path.iterdir()) == ["model_profiles.yml"]
+
+
+def test_concurrent_writers_do_not_share_a_temp_file(tmp_path, monkeypatch):
+    """Two unrelated writers keep this file — calibration's save_profiles and
+    ModelProfileRegistry._persist. A fixed <name>.tmp sidecar makes them
+    collide: the inner write truncates the outer one's scratch file and then
+    renames it away, so the outer rename fails and whatever landed on disk is
+    a blend of the two. Atomicity per call is not enough; the temp name has to
+    be unique per call."""
+    path = tmp_path / "model_profiles.yml"
+    real_dump = yaml.safe_dump
+    calls = 0
+    temps_in_flight: set[str] = set()
+
+    def _scratch_files() -> set[str]:
+        return {p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")}
+
+    def _dump_nesting_a_second_write(data, stream, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            # A second, complete write while the first one is still open.
+            save_profiles(path, {"org/inner": {"base_residency_mb": 2.0}})
+        else:
+            temps_in_flight.update(_scratch_files())
+        return real_dump(data, stream, **kwargs)
+
+    monkeypatch.setattr(yaml, "safe_dump", _dump_nesting_a_second_write)
+    save_profiles(path, {"org/outer": {"base_residency_mb": 1.0}})
+
+    # Both writes were open at once, so each needed its own scratch file. With
+    # a shared <name>.tmp there is one, and the outer rename then fails
+    # outright because the inner write already renamed it away.
+    assert len(temps_in_flight) == 2, f"writers shared a temp file: {temps_in_flight}"
+    # The outer write renamed last, so it is what is on disk — intact, and
+    # readable rather than a blend of the two.
+    assert load_existing_profiles(path) == {"org/outer": {"base_residency_mb": 1.0}}
+    assert [p.name for p in tmp_path.iterdir()] == ["model_profiles.yml"]
+
+
+def test_writing_the_store_does_not_narrow_its_permissions(tmp_path):
+    """mkstemp creates 0600. Publishing that mode over a store other processes
+    read would lock them out on the next write, not at deploy time."""
+    path = tmp_path / "model_profiles.yml"
+    save_profiles(path, {"org/model": {"base_residency_mb": 1.0}})
+    path.chmod(0o644)
+
+    save_profiles(path, {"org/model": {"base_residency_mb": 2.0}})
+
+    assert path.stat().st_mode & 0o777 == 0o644
+
+
+def test_registry_holds_its_lock_across_snapshot_and_write(tmp_path, monkeypatch):
+    """Releasing the lock between building the snapshot and writing it lets a
+    second writer's older snapshot land after this one. The rename is atomic
+    per call; which call wins is not."""
+    registry = ModelProfileRegistry(state_dir=tmp_path)
+    real_dump = yaml.safe_dump
+    locked_during_write: list[bool] = []
+
+    def _spy(data, stream, **kwargs):
+        locked_during_write.append(registry._lock.locked())
+        return real_dump(data, stream, **kwargs)
+
+    monkeypatch.setattr(yaml, "safe_dump", _spy)
+    registry.record_loaded_vram("org/model", 8000.0, engine="vllm", kv_cache_sent_mb=2048.0)
+
+    assert locked_during_write and all(locked_during_write)
 
 
 # ---------------------------------------------------------------------------

--- a/logos/logos-workernode/tests/test_sharded_checkpoint.py
+++ b/logos/logos-workernode/tests/test_sharded_checkpoint.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from logos_worker_node import sharded_checkpoint as sc
 from logos_worker_node.models import LaneConfig, OllamaConfig, VllmConfig, VllmEngineConfig
 from logos_worker_node.vllm_process import VllmProcessHandle
@@ -163,3 +165,113 @@ def test_maybe_prepare_convert_on_spawn_disabled(tmp_path: Path, monkeypatch) ->
     monkeypatch.setattr(sc, "ensure_sharded_checkpoint", _boom)
     asyncio.run(handle._maybe_prepare_sharded_checkpoint(lane))
     assert handle._sharded_model_dir is None
+
+
+# ---------------------------------------------------------------------------
+# A checkpoint the loader rejects
+#
+# The conversion can report success — shards written, marker placed — and still
+# produce something vLLM refuses to load (observed with an MXFP4 model at tp=2:
+# "size of tensor a (1536) must match the size of tensor b (6144)"). Nothing in
+# the produced files says so, so every later spawn picks the same directory up
+# as ready. For a model the worker keeps warm that is a permanent outage of
+# that model, surfacing only as a failed add_lane.
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_removes_a_ready_checkpoint(tmp_path: Path) -> None:
+    target = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    target.mkdir(parents=True)
+    (target / sc._COMPLETION_MARKER).write_text("ok")
+    (target / "model-rank-0-part-0.safetensors").write_bytes(b"junk")
+
+    assert sc.invalidate_sharded_checkpoint(target) is True
+    assert not target.exists()
+    assert sc.is_sharded_checkpoint_ready(target) is False
+
+
+def test_invalidate_is_a_noop_when_nothing_is_cached(tmp_path: Path) -> None:
+    target = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    assert sc.invalidate_sharded_checkpoint(target) is False
+
+
+def test_a_rejected_checkpoint_is_detected_from_the_logs(tmp_path: Path) -> None:
+    handle = VllmProcessHandle("lane-s", 19020, OllamaConfig(), VllmEngineConfig())
+    handle._recent_logs = [
+        'File ".../vllm/model_executor/model_loader/sharded_state_loader.py", line 154, in load_weights',
+        "RuntimeError: The size of tensor a (1536) must match the size of tensor b (6144)",
+    ]
+
+    # Only while this lane actually serves a sharded checkpoint — the same
+    # traceback for a lane on the full checkpoint means something else.
+    assert handle.has_broken_sharded_checkpoint is False
+    handle._sharded_model_dir = "/cache/.sharded_cache/org__Model-A/tp2"
+    assert handle.has_broken_sharded_checkpoint is True
+
+
+def test_an_unrelated_startup_failure_is_not_blamed_on_the_checkpoint() -> None:
+    handle = VllmProcessHandle("lane-s", 19021, OllamaConfig(), VllmEngineConfig())
+    handle._sharded_model_dir = "/cache/.sharded_cache/org__Model-A/tp2"
+    handle._recent_logs = ["torch.OutOfMemoryError: CUDA out of memory."]
+
+    assert handle.has_broken_sharded_checkpoint is False
+
+
+def test_spawn_retries_from_the_full_checkpoint_after_a_rejection(tmp_path: Path, monkeypatch) -> None:
+    """The lane must come up on the full checkpoint instead of failing. Without
+    this a rejected conversion takes the model down for good: a model pinned
+    awake (enable_sleep_mode: false) has no other path back up."""
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-r", 19022, gc, VllmEngineConfig())
+    lane = _lane(2, tmp_path)
+    target = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    target.mkdir(parents=True)
+    (target / sc._COMPLETION_MARKER).write_text("ok")
+
+    monkeypatch.setattr(handle, "_purge_compile_caches_if_versions_changed", lambda: [])
+    monkeypatch.setattr(handle, "_write_compile_cache_stamp", lambda: None)
+    attempts: list[str | None] = []
+
+    async def _spawn_once(lane_config):
+        handle._sharded_model_dir = None  # as the real _spawn_once does
+        await handle._maybe_prepare_sharded_checkpoint(lane_config)
+        attempts.append(handle._sharded_model_dir)
+        if handle._sharded_model_dir:
+            handle._recent_logs = ["... sharded_state_loader.py, line 154, in load_weights"]
+            raise RuntimeError("vLLM exited during startup (return_code=1)")
+        return "ok"
+
+    monkeypatch.setattr(handle, "_spawn_once", _spawn_once)
+
+    assert asyncio.run(handle.spawn(lane)) == "ok"
+    assert attempts == [str(target), None], "second attempt must serve the full checkpoint"
+    assert not target.exists(), "the unusable conversion must be discarded"
+
+
+def test_spawn_does_not_retry_twice_for_the_same_reason(tmp_path: Path, monkeypatch) -> None:
+    """One retry. A failure that survives serving the full checkpoint is a real
+    fault and has to reach the caller."""
+    gc = OllamaConfig(models_path=str(tmp_path))
+    handle = VllmProcessHandle("lane-r2", 19023, gc, VllmEngineConfig())
+    lane = _lane(2, tmp_path)
+    target = sc.sharded_checkpoint_dir(str(tmp_path), "org/Model-A", 2)
+    target.mkdir(parents=True)
+    (target / sc._COMPLETION_MARKER).write_text("ok")
+
+    monkeypatch.setattr(handle, "_purge_compile_caches_if_versions_changed", lambda: [])
+    monkeypatch.setattr(handle, "_write_compile_cache_stamp", lambda: None)
+    monkeypatch.setattr(handle, "_purge_compile_caches", lambda: [])
+    attempts: list[str | None] = []
+
+    async def _spawn_once(lane_config):
+        handle._sharded_model_dir = None  # as the real _spawn_once does
+        await handle._maybe_prepare_sharded_checkpoint(lane_config)
+        attempts.append(handle._sharded_model_dir)
+        handle._recent_logs = ["... sharded_state_loader.py, line 154, in load_weights"]
+        raise RuntimeError("vLLM exited during startup (return_code=1)")
+
+    monkeypatch.setattr(handle, "_spawn_once", _spawn_once)
+
+    with pytest.raises(RuntimeError, match="exited during startup"):
+        asyncio.run(handle.spawn(lane))
+    assert len(attempts) == 2

--- a/logos/logos-workernode/tools/calibrate_vram_profiles.py
+++ b/logos/logos-workernode/tools/calibrate_vram_profiles.py
@@ -45,9 +45,11 @@ from logos_worker_node.calibration import (
     _PROFILES_FILE,
     _READY_TIMEOUT_S,
     CalibrationResult,
+    ProfileStoreUnreadableError,
     _reset_calibration_log,
     calibrate_model,
     load_existing_profiles,
+    merge_profile,
     plans_from_config,
     result_to_profile_dict,
     save_profiles,
@@ -101,10 +103,13 @@ def main() -> int:
         "--sleep-level",
         type=int,
         default=1,
-        choices=[1, 2],
+        choices=[0, 1, 2],
         help=(
             "vLLM sleep level (default: 1, matches the worker). "
-            "Level 1 frees KV cache blocks; level 2 also offloads weights to CPU."
+            "Level 1 frees KV cache blocks; level 2 also offloads weights to CPU. "
+            "Level 0 probes without sleep support and skips the sleep phases — "
+            "use it for models the worker runs with enable_sleep_mode: false, "
+            "which is also what an automatic session picks for them."
         ),
     )
     parser.add_argument(
@@ -184,7 +189,15 @@ def main() -> int:
         print("       Hint: pass --vllm-binary /opt/venv/bin/vllm or ensure it is on PATH")
         return 1
 
-    existing_profiles = load_existing_profiles(profiles_path)
+    # Refuse to run against a store we cannot read: every result below is
+    # written back over the whole file, so continuing from an empty dict would
+    # replace the node's profiles with just this run's models.
+    try:
+        existing_profiles = load_existing_profiles(profiles_path)
+    except ProfileStoreUnreadableError as exc:
+        print(f"ERROR: {exc}")
+        print("       Fix or move the file; calibrating now would overwrite it.")
+        return 1
     results: list[CalibrationResult] = []
 
     for plan in plans:
@@ -205,7 +218,14 @@ def main() -> int:
         results.append(result)
 
         if result.success:
-            existing_profiles[result.model] = result_to_profile_dict(result)
+            # Merged, not assigned: the probe leaves every field it does not
+            # measure at None, and those include flags set elsewhere
+            # (sleep_mode_disabled, calibration_unsupported) that assigning
+            # would silently drop.
+            existing_profiles[result.model] = merge_profile(
+                existing_profiles.get(result.model),
+                result_to_profile_dict(result),
+            )
             # Persist after every success so a later failure doesn't lose prior results
             save_profiles(profiles_path, existing_profiles)
             print(f"  Saved → {profiles_path}")
@@ -227,7 +247,9 @@ def main() -> int:
                 f"{r.loaded_vram_mb:>6.0f}  "
                 f"{r.kv_cache_sent_mb:>6.0f}    "
                 f"{r.base_residency_mb:>6.0f}  "
-                f"{r.sleeping_residual_mb:>6.0f}  MB"
+                # None when the run skipped the sleep phases (--sleep-level 0,
+                # or a model this worker never sleeps).
+                f"{f'{r.sleeping_residual_mb:.0f}' if r.sleeping_residual_mb is not None else 'n/a':>6}  MB"
             )
         print()
         print("  base_residency = loaded - kv_sent  (exact)")


### PR DESCRIPTION
## Summary

A nightly calibration run left all three production workers (deioma, deimama,
deipapa) with **no lanes at all for over seven hours** on 2026-08-21. Containers
were healthy, the bridge was connected, and nothing in any log reported a
problem. Restarting a container brought its lanes straight back.

Four independent faults line up into that one outage. Each is fixed here.

## 1. The calibrating flag is a latch nothing could release

`_is_plannable` gates **every** placement on `is_calibrating(provider_id)`, and
that flag is driven only by the worker's one-shot lifecycle events. A terminal
event that never lands as a *live* event — dropped by the post-connect replay
filter, or belonging to a connection that no longer exists — leaves the worker
excluded from lane placement with nothing left to clear it. The only recovery
was a restart, which is exactly what fixed deioma.

The worker now repeats its live session state in **every status**, and the
orchestrator reconciles the flag against it. Whichever event is lost, the state
converges within one status interval. The events keep their job — they act
within the same second — the status is the periodic ground truth behind them.

The dispatch-time optimistic mark is preserved: a status built *before*
`start_calibration_session` went out cannot clear it. That window is bounded
(60 s) on purpose — an unbounded wait is the bug being fixed.

Two smaller things on the same path:

- `hello` reported `_active_calibration_session is not None`, which is true for
  a *finished* session too (it lingers until the next start clears it). It now
  asks `_calibration_session_is_live()`.
- A worker that stays unplannable is now logged. Nothing reported the outage
  because the skip is the expected path and logs at debug; after 45 minutes it
  warns, repeating on a cooldown.

## 2. Models that never sleep could not be re-calibrated — ever

`logos_bridge` skipped any model the worker won't sleep
(`enable_sleep_mode: false`, e.g. `openai/gpt-oss-120b`,
`Qwen/Qwen3-Reranker-8B`). Once such a model loses its profile it is gone for
good: without `base_residency_mb` the worker never announces it as a
capability, and every later session skips it again. Silently.

Sleep is needed by **one of six** phases, to measure `sleeping_residual_mb`.
`base_residency_mb` — the value every placement decision reads — comes out of
the awake measurement one phase earlier and does not involve sleep at all.

These models now calibrate at `sleep_level 0`: no `--enable-sleep-mode` on the
probe (so it measures the configuration that actually serves), phases 4 and 5
skipped, `sleeping_residual_mb` persisted as null. The freshness checks in
`main.py::_auto_calibrate_if_needed` and `_list_uncalibrated_models` already
accepted a null sleep value for exactly these models — only the measuring side
refused to produce one.

`calibrate_model` also honours `enable_sleep_mode` straight from the plan, so
the boot-time path (`auto_calibrate_models`, which asks for level 1 for
everything) and the session-driven one agree without either knowing the other's
rules.

## 3. model_profiles.yml could be destroyed by its own writers

The same run reduced deioma's store from 20 profiles to 5 and wiped the
measurements of three models that had been serving for months. The five
survivors held nothing but the operator's config overrides — the shape of
freshly seeded capability stubs written over the real file.

Three ways that happens, all fixed:

- `load_existing_profiles` answered an unreadable store with `{}`, and all
  three callers write the result back over the whole file. It now raises
  `ProfileStoreUnreadableError`; every caller leaves the file alone and says so.
- `ModelProfileRegistry._persist` rewrites the file from memory, and
  `_load_persisted` swallowed failures at debug level — so after a failed load
  it wrote the empty/stub state straight over the store. The failure is now
  loud and latches persistence off until a load succeeds.
- Neither writer was atomic (`open(path, "w")` truncates first), which is what
  produces the partial file the first two then act on. Both write to a temp
  file and rename.

And a calibration result is now **merged** into its entry rather than assigned
over it. The probe leaves every field it does not measure at `None`, and those
include flags maintained elsewhere — `sleep_mode_disabled`,
`calibration_unsupported`, `disk_size_bytes`. A nosleep model losing
`sleep_mode_disabled` is the worst case: that flag is what marks its null sleep
fields as expected rather than as missing.

## 4. A bad sharded checkpoint takes a model down permanently

After the restart, gpt-oss could not load at TP=2 at all:

```
RuntimeError: The size of tensor a (1536) must match the size of tensor b (6144)
    at .../sharded_state_loader.py, line 154, in load_weights
<< CMD add_lane FAILED  vLLM exited during startup (return_code=1)
```

The conversion had reported success — shards written, completion marker placed
— so every subsequent spawn picked the same unusable directory up as ready.
Nothing in the produced files says they are wrong; only a lane trying to serve
them finds out, and for a model pinned awake that is a permanent outage
reported as a failed `add_lane`.

A rejection is now detected from the loader's own output, the conversion
discarded, and the lane retried **once** from the full checkpoint — the same
recovery shape `spawn` already had for a poisoned compile cache. One retry: a
failure that survives the full checkpoint is a real fault and propagates.

The underlying question of why an MXFP4 model shards wrong on Blackwell is
**not** answered here; the workaround (`logos_vllm_sharded_checkpoint_enabled:
false` on deioma) stays in place. This change means such a checkpoint can no
longer take a model offline while it is investigated.

## Changes

| File | Change |
|------|--------|
| `logos-orchestrator/src/logos/logosnode_registry.py` | Reconcile `calibrating` from every status; bounded optimistic window after a dispatched start |
| `logos-orchestrator/src/logos/main.py` | Pass the status payload's `calibrating` through to the registry |
| `logos-orchestrator/src/logos/capacity/capacity_planner.py` | Warn about a worker that stays excluded from lane placement |
| `logos-workernode/logos_worker_node/logos_bridge.py` | Report live calibration state in hello + every status; calibrate nosleep models at level 0; merge results, fail closed on an unreadable store |
| `logos-workernode/logos_worker_node/calibration.py` | `sleep_level 0` path (phases 4/5 skipped, no `--enable-sleep-mode`); `ProfileStoreUnreadableError`; `merge_profile`; atomic `save_profiles`; same guards in `auto_calibrate_models` |
| `logos-workernode/logos_worker_node/model_profiles.py` | Atomic persist; refuse to persist over a store that failed to load; log the failure |
| `logos-workernode/logos_worker_node/vllm_process.py` | Detect a rejected sharded checkpoint, discard it, retry once from the full checkpoint |
| `logos-workernode/logos_worker_node/sharded_checkpoint.py` | `invalidate_sharded_checkpoint()` |
| `logos-workernode/tools/calibrate_vram_profiles.py` | Same merge/fail-closed behaviour; `--sleep-level 0` |

## Testing

- **+14** tests in `logos-orchestrator/tests/unit/capacity/test_calibration_lane_guard.py` — the production scenario end to end (start seen, terminal event dropped, status recovers), the in-flight-status race, the bounded window, the stuck-worker warning.
- **+23** tests in `logos-workernode/tests/test_profile_store.py` (new) — fail-closed reads, atomic writes, field-preserving merge, registry persistence guard, the nosleep probe.
- **+8** tests in `logos-workernode/tests/test_sharded_checkpoint.py` — rejection detection, invalidation, retry from the full checkpoint, no second retry.
- **+6** tests in `logos-workernode/tests/test_logos_bridge.py`, and one rewritten: `test_session_skips_sleep_disabled_model_and_continues` asserted the behaviour being fixed and is now `test_session_calibrates_sleep_disabled_model_without_sleep`.

```
logos-orchestrator:  657 passed, 1 xfailed
logos-workernode:    474 passed, 2 skipped
pre-commit:          all hooks passed
```

## Deployment notes

- Orchestrator and worker-node ship together. An older worker (no `calibrating`
  field in its status) simply gets the previous event-only behaviour.
- **deimama and deipapa were deliberately left untouched** in the failed state
  as evidence. They still hold no lanes and need a container restart —
  ideally after confirming the orchestrator log shows an `entered calibration`
  without a matching `left calibration`, which is what this PR makes
  unnecessary going forward.
- deioma was repaired by hand: profiles restored from
  `model_profiles.yml.bak.20260720`, gpt-oss back to `tensor_parallel_size: 2`,
  `logos_vllm_sharded_checkpoint_enabled: false`, corrupt `.sharded_cache`
  removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184ykKpGqaxVcAiLxQrK6oh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved worker capacity planning with configurable warnings for workers that remain unavailable.
  * Added clearer calibration status reporting and recovery for delayed or interrupted calibration sessions.
  * Added support for calibrating models with sleep mode disabled.
  * Added automatic recovery when pre-sharded checkpoints are rejected.

* **Bug Fixes**
  * Improved calibration profile durability, merging, and protection against corrupt or unreadable profile stores.
  * Prevented unavailable workers from being selected during temporary load failures.
  * Preserved existing profile data during calibration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->