### PR TITLE
`Logos`: Remove models.parallel column, rely on live vLLM lane signals

### DIFF
--- a/logos/logos-orchestrator/src/logos/classification/classification_manager.py
+++ b/logos/logos-orchestrator/src/logos/classification/classification_manager.py
@@ -126,7 +126,6 @@ class ClassificationManager:
                     i["id"],
                     i["classification_weight"].get_weight(),
                     adjusted_policy["priority"],
-                    i["parallel"],
                 )
                 for i in filtered
             ],

--- a/logos/logos-orchestrator/src/logos/classification/classification_manager.py
+++ b/logos/logos-orchestrator/src/logos/classification/classification_manager.py
@@ -60,7 +60,7 @@ class ClassificationManager:
         classifier=None,
         system=None,
         skip_laura: bool = False,
-    ) -> List[Tuple[int, int, int, int]]:
+    ) -> List[Tuple[int, float, int]]:
         """
         Classify prompts and assign them to a model.
         Returns a sorted list with the best suited model-id at the front together with

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -664,8 +664,8 @@ class DBManager:
                         text(
                             """
                         INSERT INTO models (name, weight_latency, weight_accuracy,
-                                            weight_cost, weight_quality, tags, parallel, description)
-                        VALUES (:name, 0, 0, 0, 0, '', 1, '')
+                                            weight_cost, weight_quality, tags, description)
+                        VALUES (:name, 0, 0, 0, 0, '', '')
                         RETURNING id
                     """
                         ),
@@ -774,8 +774,8 @@ class DBManager:
                         text(
                             """
                             INSERT INTO models (name, weight_latency, weight_accuracy,
-                                                weight_cost, weight_quality, tags, parallel, description)
-                            VALUES (:name, 0, 0, 0, 0, '', 1, '')
+                                                weight_cost, weight_quality, tags, description)
+                            VALUES (:name, 0, 0, 0, 0, '', '')
                             RETURNING id
                             """
                         ),
@@ -1870,7 +1870,6 @@ class DBManager:
                               m.weight_cost,
                               m.weight_quality,
                               m.tags,
-                              m.parallel,
                               m.description,
                               (
                                   SELECT ROUND(price_per_k_token::NUMERIC / 100000, 4)
@@ -1937,7 +1936,6 @@ class DBManager:
                                 m.weight_cost,
                                 m.weight_quality,
                                 m.tags,
-                                m.parallel,
                                 m.description,
                                 (
                                     SELECT ROUND(price_per_k_token::NUMERIC / 100000, 4)
@@ -1982,7 +1980,6 @@ class DBManager:
                 "weight_cost": r.weight_cost,
                 "weight_quality": r.weight_quality,
                 "tags": r.tags,
-                "parallel": r.parallel,
                 "description": r.description,
                 "input_usd_per_million": r.input_usd_per_million,
                 "output_usd_per_million": r.output_usd_per_million,
@@ -2009,7 +2006,6 @@ class DBManager:
             "weight_cost": result.weight_cost,
             "weight_quality": result.weight_quality,
             "tags": result.tags,
-            "parallel": result.parallel,
             "description": result.description,
         }
 

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
@@ -6,7 +6,6 @@ from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
     Boolean,
-    CheckConstraint,
     Column,
     Enum,
     ForeignKey,
@@ -117,9 +116,7 @@ class Model(Base):
     weight_cost = Column(Integer)
     weight_quality = Column(Integer)
     tags = Column(Text)
-    parallel = Column(Integer, default=1)
     description = Column(Text)
-    __table_args__ = (CheckConstraint("parallel BETWEEN 1 AND 256"),)
 
 
 class Provider(Base):

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2632,7 +2632,6 @@ def classifier() -> ClassificationManager:
                         "weight_cost": tpl["weight_cost"],
                         "weight_quality": tpl["weight_quality"],
                         "tags": tpl["tags"],
-                        "parallel": tpl["parallel"],
                         "description": tpl["description"],
                         "classification_weight": Balancer(),
                     }

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2560,7 +2560,6 @@ async def _register_models_with_facades(
                         "model_name": model_name,
                         "total_vram_mb": provider_config.get("total_vram_mb", 65536),
                         "provider_id": provider_id,
-                        "db_parallel": model_info.get("parallel"),
                     }
                 )
             elif cloud_provider_type == "azure":

--- a/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
@@ -92,7 +92,7 @@ class ClassificationCorrectingScheduler(BaseScheduler):
         if not self._decision_log_path:
             return
 
-        cls_weights = {mid: w for mid, w, _, _ in original_candidates}
+        cls_weights = {mid: w for mid, w, _ in original_candidates}
         cls_top = max(original_candidates, key=lambda x: x[1])[0] if original_candidates else None
 
         candidates_log = []
@@ -215,7 +215,7 @@ class ClassificationCorrectingScheduler(BaseScheduler):
 
     def _compute_candidate_scores(
         self,
-        candidates: List[Tuple[int, float, int, int]],
+        candidates: List[Tuple[int, float, int]],
         deployments: list,
     ) -> list:
         """Build scored list with ETTFT annotations.
@@ -232,13 +232,13 @@ class ClassificationCorrectingScheduler(BaseScheduler):
 
         # Apply weight overrides for controlled ablation experiments
         if self._weight_overrides:
-            candidates = [(mid, self._weight_overrides.get(mid, w), pint, par) for mid, w, pint, par in candidates]
+            candidates = [(mid, self._weight_overrides.get(mid, w), pint) for mid, w, pint in candidates]
 
         # Compute weight span across all (possibly overridden) weights
-        all_weights = [weight for _, weight, _, _ in candidates]
+        all_weights = [weight for _, weight, _ in candidates]
         weight_span = compute_weight_span(all_weights)
 
-        for model_id, weight, priority_int, parallel in candidates:
+        for model_id, weight, priority_int in candidates:
             # Multi-provider expansion: find ALL deployments for this model
             matching_deployments = [d for d in deployments if d["model_id"] == model_id]
             if not matching_deployments:

--- a/logos/logos-orchestrator/src/logos/pipeline/fcfs_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/fcfs_scheduler.py
@@ -32,7 +32,7 @@ class FcfScheduler(BaseScheduler):
             return None
 
         sorted_candidates = sorted(request.classified_models, key=lambda x: x[1], reverse=True)
-        target_model_id, weight, priority_int, _ = sorted_candidates[0]
+        target_model_id, weight, priority_int = sorted_candidates[0]
 
         # Multi-provider: find ALL deployments for the top candidate
         matching = [d for d in request.deployments if d["model_id"] == target_model_id]

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -143,7 +143,7 @@ class RequestPipeline:
             )
 
         sorted_candidates = sorted(classification_result.candidates, key=lambda x: x[1], reverse=True)
-        target_model_id, _, priority_int, _ = sorted_candidates[0]
+        target_model_id, _, priority_int = sorted_candidates[0]
         target_deployment = next(
             (d for d in request.deployments if d["model_id"] == target_model_id),
             None,
@@ -446,7 +446,7 @@ class RequestPipeline:
             "classification_time": elapsed,
             "candidate_count": len(candidates),
             "candidates": [
-                {"model_id": m, "weight": w, "priority": p} for m, w, p, _ in candidates[:5]  # Top 5 for logging
+                {"model_id": m, "weight": w, "priority": p} for m, w, p in candidates[:5]  # Top 5 for logging
             ],
         }
 

--- a/logos/logos-orchestrator/src/logos/pipeline/scheduler_interface.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/scheduler_interface.py
@@ -75,7 +75,7 @@ class SchedulingRequest:
     request_id: str
     payload: Dict[str, Any]
     deployments: list[Deployment]
-    classified_models: Optional[List[Tuple[int, float, int, int]]] = None  # (model_id, weight, priority, parallel)
+    classified_models: Optional[List[Tuple[int, float, int]]] = None  # (model_id, weight, priority)
     timeout_s: Optional[float] = None
 
 

--- a/logos/logos-orchestrator/src/logos/pipeline/utilization_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/utilization_scheduler.py
@@ -76,7 +76,7 @@ class UtilizationAwareScheduler(BaseScheduler):
         deployment = None
         target_model_id = None
         priority_int = None
-        for mid, _, pint, _ in sorted_candidates:
+        for mid, _, pint in sorted_candidates:
             matching = [d for d in request.deployments if d["model_id"] == mid]
             # Prefer logosnode for queueing (cloud providers don't queue)
             logosnode_dep = next((d for d in matching if d["type"] == "logosnode"), None)
@@ -142,14 +142,14 @@ class UtilizationAwareScheduler(BaseScheduler):
 
     def _select_best_candidate(
         self,
-        candidates: List[Tuple[int, float, int, int]],
+        candidates: List[Tuple[int, float, int]],
         deployments: list,
         request_id: str,
     ) -> Optional[Tuple[int, int, str, float, int]]:
         """Find the best immediately available model across all deployments."""
         scored_candidates = []
 
-        for model_id, weight, priority_int, parallel in candidates:
+        for model_id, weight, priority_int in candidates:
             # Multi-provider expansion: score every deployment for this model
             matching_deployments = [d for d in deployments if d["model_id"] == model_id]
             if not matching_deployments:

--- a/logos/logos-orchestrator/src/logos/sdi/logosnode_facade.py
+++ b/logos/logos-orchestrator/src/logos/sdi/logosnode_facade.py
@@ -90,9 +90,6 @@ class LogosNodeSchedulingDataFacade:
                 entry["base_url"] = registration.get("logosnode_admin_url")
                 entry["total_vram_mb"] = int(registration.get("total_vram_mb") or 0)
                 entry["models"][int(registration["model_id"])] = registration["model_name"]
-                db_parallel = registration.get("db_parallel")
-                if db_parallel is not None:
-                    entry.setdefault("db_parallel", {})[int(registration["model_id"])] = int(db_parallel)
 
             stale_provider_ids = set(self._providers) - set(desired_by_provider)
             for provider_id in stale_provider_ids:
@@ -121,9 +118,6 @@ class LogosNodeSchedulingDataFacade:
 
                 model_map = {int(model_id): model_name for model_id, model_name in dict(entry["models"]).items()}
                 provider.set_registered_models(model_map)
-                db_parallel_map = {int(k): int(v) for k, v in dict(entry.get("db_parallel") or {}).items()}
-                if db_parallel_map:
-                    provider.set_db_parallel_ceilings(db_parallel_map)
                 for model_id in model_map:
                     current = self._model_to_provider.get(model_id, set())
                     current.add(provider_id)

--- a/logos/logos-orchestrator/src/logos/sdi/models.py
+++ b/logos/logos-orchestrator/src/logos/sdi/models.py
@@ -182,7 +182,7 @@ class LaneSchedulerSignals:
     ttft_p95_seconds: float  # computed from ttft_histogram, 0.0 if unavailable
     e2e_latency_p50_seconds: float  # p50 end-to-end request latency, 0.0 if unavailable
     effective_vram_mb: float
-    num_parallel: int  # Ollama: explicit, vLLM: 0 (continuous batching)
+    num_parallel: int  # Ollama: explicit; vLLM: worker-reported engine max concurrency (0 until the worker reports it)
     gpu_memory_utilization: Optional[float] = None  # vLLM planner target
     tensor_parallel_size: Optional[int] = None  # vLLM topology hint
     gpu_devices: Optional[str] = None  # GPU device indices e.g. "0,1"

--- a/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
@@ -384,7 +384,6 @@ class LogosNodeDataProvider:
                 capacity, source = int(configured), "config"
             else:
                 capacity, source = self.DEFAULT_PARALLEL_CAPACITY, "default"
-
         return capacity, source
 
     def get_model_status(self, model_id: int) -> ModelStatus:

--- a/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
@@ -57,7 +57,6 @@ class LogosNodeDataProvider:
         self._last_refresh = 0.0
         self._model_active: Dict[int, int] = {}
         self._active_request_ids: Dict[str, int] = {}
-        self._db_parallel_ceiling: Dict[int, int] = {}
         self._lock = threading.RLock()
         self._provider_config = self._load_provider_config()
 
@@ -106,11 +105,6 @@ class LogosNodeDataProvider:
             ]
             for request_id in stale_request_ids:
                 self._active_request_ids.pop(request_id, None)
-
-    def set_db_parallel_ceilings(self, ceilings: Dict[int, int]) -> None:
-        """Set DB-configured parallel ceilings per model_id."""
-        with self._lock:
-            self._db_parallel_ceiling = dict(ceilings)
 
     def refresh_data(self) -> None:
         now = time.time()
@@ -358,22 +352,18 @@ class LogosNodeDataProvider:
             is_vllm = bool(lane.get("vllm"))
             capacity_hint = lane.get("num_parallel")
             if is_vllm and not capacity_hint:
-                # vLLM uses continuous batching — num_parallel=0 means unlimited.
-                # Default to 256 so the scheduler doesn't artificially
-                # serialize requests.  The DB parallel column is the real
-                # ceiling if one is needed.
+                # vLLM uses continuous batching.  The worker reports the
+                # engine's own max concurrency (KV-budget-derived, parsed
+                # from vLLM's startup log); 0 means it has not reported one
+                # yet (older worker or lane still starting).  Default to 256
+                # so the scheduler doesn't artificially serialize requests —
+                # vLLM's own scheduler then admits what the KV cache holds.
                 capacity_hint = 256
 
             try:
                 capacity = int(capacity_hint) if capacity_hint is not None else 0
             except (TypeError, ValueError):
                 capacity = 0
-
-            # Apply oversubscription for vLLM lanes: the reported
-            # num_parallel is based on worst-case full-context requests,
-            # but real requests typically use a fraction of context.
-            if is_vllm and capacity > 0 and capacity < 256:
-                capacity = capacity * self.VLLM_CONCURRENCY_OVERSUBSCRIPTION
 
             if capacity > 0:
                 total_capacity += capacity
@@ -395,18 +385,6 @@ class LogosNodeDataProvider:
             else:
                 capacity, source = self.DEFAULT_PARALLEL_CAPACITY, "default"
 
-        # DB parallel ceiling: hard ceiling from the models table
-        db_ceiling = self._db_parallel_ceiling.get(model_id)
-        if db_ceiling is not None and db_ceiling > 0:
-            if capacity > db_ceiling:
-                logger.debug(
-                    "Capping parallel capacity for model %d from %d (%s) to %d (db_ceiling)",
-                    model_id,
-                    capacity,
-                    source,
-                    db_ceiling,
-                )
-                return db_ceiling, "db_ceiling"
         return capacity, source
 
     def get_model_status(self, model_id: int) -> ModelStatus:
@@ -815,19 +793,10 @@ class LogosNodeDataProvider:
 
     # Maximum backend queue_waiting before we refuse new reservations.
     # Prevents piling requests on an already-backlogged vLLM process.
-    # Raised from 2→8: with oversubscription enabled, vLLM's internal
-    # scheduler (PagedAttention) handles queuing efficiently; we only
-    # need to back off when the engine is genuinely saturated.
+    # Raised from 2→8: vLLM's internal scheduler (PagedAttention) handles
+    # queuing efficiently; we only need to back off when the engine is
+    # genuinely saturated.
     BACKEND_QUEUE_PRESSURE_THRESHOLD = 8
-
-    # vLLM reports "Maximum concurrency for N tokens per request" assuming
-    # every request fills the entire context window.  In practice, requests
-    # use a fraction of context (e.g. 200/4096 = 5%), so the KV cache can
-    # safely hold many more concurrent sequences.  This multiplier is
-    # applied to the vLLM-reported num_parallel to allow higher throughput
-    # while still letting vLLM's own scheduler handle fine-grained KV
-    # admission via PagedAttention preemption.
-    VLLM_CONCURRENCY_OVERSUBSCRIPTION = 3
 
     def try_reserve_capacity(self, model_id: int, request_id: str) -> bool:
         with self._lock:

--- a/logos/logos-orchestrator/tests/data.py
+++ b/logos/logos-orchestrator/tests/data.py
@@ -24,7 +24,6 @@ models = [
         "weight_cost": 80,
         "weight_quality": 60,
         "tags": "",
-        "parallel": 2,
     },
     {
         "id": 2,
@@ -37,7 +36,6 @@ models = [
         "weight_cost": 70,
         "weight_quality": 80,
         "tags": "",
-        "parallel": 2,
     },
     {
         "id": 3,
@@ -50,6 +48,5 @@ models = [
         "weight_cost": 100,
         "weight_quality": 70,
         "tags": "",
-        "parallel": 2,
     },
 ]

--- a/logos/logos-orchestrator/tests/performance/analyze_workload_classification.py
+++ b/logos/logos-orchestrator/tests/performance/analyze_workload_classification.py
@@ -63,7 +63,6 @@ def build_classifier() -> tuple[ClassificationManager, dict[str, int]]:
                     "weight_cost": tpl["weight_cost"],
                     "weight_quality": tpl["weight_quality"],
                     "tags": tpl["tags"],
-                    "parallel": tpl["parallel"],
                     "description": tpl["description"],
                     "classification_weight": Balancer(),
                 }

--- a/logos/logos-orchestrator/tests/unit/main/test_error_handlers_integration.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_error_handlers_integration.py
@@ -105,7 +105,7 @@ def _stub_db(monkeypatch):
             return [(1, "test-model")]
 
         def get_model(self, model_id):
-            return {"id": model_id, "name": "test-model", "parallel": 1}
+            return {"id": model_id, "name": "test-model"}
 
         def get_provider_deployment_info(self, mid, pid):
             return {

--- a/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
@@ -242,7 +242,7 @@ async def test_pipeline_releases_capacity_when_context_resolution_fails():
 
     class FakeClassifier:
         def classify(self, user_prompt, policy, allowed=None, system=None, skip_laura=False):  # noqa: ARG002
-            return [(27, 1.0, 1, 1)]
+            return [(27, 1.0, 1)]
 
     class FakeScheduler:
         def __init__(self):
@@ -302,7 +302,7 @@ async def test_pipeline_releases_capacity_when_context_resolution_raises():
 
     class FakeClassifier:
         def classify(self, user_prompt, policy, allowed=None, system=None, skip_laura=False):  # noqa: ARG002
-            return [(27, 1.0, 1, 1)]
+            return [(27, 1.0, 1)]
 
     class FakeScheduler:
         def __init__(self):

--- a/logos/logos-orchestrator/tests/unit/main/test_node_controller_integration.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_node_controller_integration.py
@@ -589,7 +589,6 @@ async def test_refresh_pipeline_runtime_state_reloads_registrations(monkeypatch)
             "model_name": "Qwen/Qwen2.5-Coder-7B-Instruct",
             "total_vram_mb": 32768,
             "provider_id": 13,
-            "db_parallel": None,
         }
     ]
     assert main_mod._azure_facade.registrations == [

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_correcting_scheduler.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_correcting_scheduler.py
@@ -218,7 +218,7 @@ async def test_offline_logosnode_provider_is_skipped_in_favor_of_online_one():
         {"model_id": 1, "provider_id": offline_provider, "type": "logosnode"},
         {"model_id": 1, "provider_id": online_provider, "type": "logosnode"},
     ]
-    request = _make_request([(1, 1.0, 0, 4)], deployments)
+    request = _make_request([(1, 1.0, 0)], deployments)
 
     result = await scheduler.schedule(request)
 
@@ -239,7 +239,7 @@ async def test_offline_only_logosnode_provider_returns_no_candidate():
 
     scheduler = _make_scheduler(logosnode=logosnode)
     deployments = [{"model_id": 1, "provider_id": offline_provider, "type": "logosnode"}]
-    request = _make_request([(1, 1.0, 0, 4)], deployments)
+    request = _make_request([(1, 1.0, 0)], deployments)
 
     result = await scheduler.schedule(request)
     assert result is None
@@ -311,7 +311,7 @@ async def test_schedule_attaches_warmth_state_to_result():
     logosnode.set_view(1, 10, _make_view(model_id=1, provider_id=10, best_lane_state="running"))
     scheduler = _make_scheduler(logosnode=logosnode)
     request = _make_request(
-        [(1, 10.0, 5, 4)],
+        [(1, 10.0, 5)],
         [{"model_id": 1, "provider_id": 10, "type": "logosnode"}],
     )
     result = await scheduler.schedule(request)

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_correcting_scheduler_cloud.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_correcting_scheduler_cloud.py
@@ -72,7 +72,7 @@ async def test_cloud_candidate_selected_immediately():
     """A cloud candidate is accepted by _try_immediate_select with no queueing."""
     scheduler = _make_scheduler()
 
-    candidates = [(1, 5.0, 1, 1)]
+    candidates = [(1, 5.0, 1)]
     deployments = [{"model_id": 1, "provider_id": 20, "type": "cloud"}]
     request = SchedulingRequest(
         request_id="req-cloud",

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_pipeline_skip_classification.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_pipeline_skip_classification.py
@@ -11,7 +11,7 @@ class _RecordingClassifier:
 
     def classify(self, user_prompt, policy, allowed=None, system=None, skip_laura=False):  # noqa: ARG002
         self.calls.append({"skip_laura": skip_laura, "allowed": list(allowed or [])})
-        return [(allowed[0], 1.0, 1, 1)] if allowed else []
+        return [(allowed[0], 1.0, 1)] if allowed else []
 
 
 class _FakeScheduler:

--- a/logos/logos-orchestrator/tests/unit/sdi/test_logosnode_provider_capacity.py
+++ b/logos/logos-orchestrator/tests/unit/sdi/test_logosnode_provider_capacity.py
@@ -43,7 +43,9 @@ def _provider(monkeypatch, lanes, *, config=None, with_registry=True, model_ids=
         lambda self: {"models": []},
     )
 
-    facade = LogosNodeSchedulingDataFacade(PriorityQueueManager(), runtime_registry=_FakeRegistry() if with_registry else None)
+    facade = LogosNodeSchedulingDataFacade(
+        PriorityQueueManager(), runtime_registry=_FakeRegistry() if with_registry else None
+    )
     for model_id in model_ids or [1]:
         facade.register_model(model_id, "logosnode", "http://fake", model_name, 65536, provider_id=provider_id)
     return facade._providers[provider_id]

--- a/logos/logos-orchestrator/tests/unit/sdi/test_logosnode_provider_capacity.py
+++ b/logos/logos-orchestrator/tests/unit/sdi/test_logosnode_provider_capacity.py
@@ -1,0 +1,119 @@
+"""Tests for LogosNodeDataProvider parallel capacity gating.
+
+The orchestrator must gate request forwarding on the *worker-reported*
+per-worker limit (vLLM parses its own KV-budget-derived "Maximum
+concurrency" startup line into lane `num_parallel`).  Requests that do not
+fit stay in the orchestrator-level queue instead of piling up in the
+vLLM-side queue, so whichever worker frees a slot first gets the request.
+"""
+
+from logos.queue import PriorityQueueManager
+from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
+
+
+def _lane(model: str, num_parallel: int, *, vllm: bool = True, runtime_state: str = "loaded", queue_waiting: float = 0):
+    return {
+        "lane_id": f"lane-{model}-{num_parallel}",
+        "model": model,
+        "runtime_state": runtime_state,
+        "vllm": vllm,
+        "num_parallel": num_parallel,
+        "backend_metrics": {"queue_waiting": queue_waiting, "requests_running": 0},
+    }
+
+
+def _provider(monkeypatch, lanes, *, config=None, with_registry=True, model_ids=None, provider_id=13, model_name="m"):
+    """Build a facade + registered provider backed by a fake runtime registry."""
+
+    class _FakeRegistry:
+        @staticmethod
+        def peek_runtime_snapshot(provider_id: int):  # noqa: ARG004
+            return {"runtime": {"lanes": lanes}}
+
+        @staticmethod
+        def is_provider_online(provider_id: int) -> bool:  # noqa: ARG004
+            return True
+
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._load_provider_config",
+        lambda self: dict(config or {}),
+    )
+    monkeypatch.setattr(
+        "logos.sdi.providers.logosnode_provider.LogosNodeDataProvider._fetch_ps_data",
+        lambda self: {"models": []},
+    )
+
+    facade = LogosNodeSchedulingDataFacade(PriorityQueueManager(), runtime_registry=_FakeRegistry() if with_registry else None)
+    for model_id in model_ids or [1]:
+        facade.register_model(model_id, "logosnode", "http://fake", model_name, 65536, provider_id=provider_id)
+    return facade._providers[provider_id]
+
+
+def test_runtime_capacity_uses_vllm_reported_concurrency_as_is(monkeypatch):
+    # No ×N oversubscription: the worker's KV-budget-derived limit is the gate.
+    provider = _provider(monkeypatch, [_lane("m", 10)])
+    assert provider.get_parallel_capacity(1) == (10, "runtime")
+
+
+def test_runtime_capacity_sums_across_matching_lanes(monkeypatch):
+    provider = _provider(monkeypatch, [_lane("m", 10), _lane("m", 10)])
+    assert provider.get_parallel_capacity(1) == (20, "runtime")
+
+
+def test_runtime_capacity_unreported_vllm_lane_defaults_to_256(monkeypatch):
+    # Older worker or lane still starting: 0 means "not reported yet".
+    provider = _provider(monkeypatch, [_lane("m", 0)])
+    assert provider.get_parallel_capacity(1) == (256, "runtime")
+
+
+def test_runtime_capacity_ollama_lane_is_explicit(monkeypatch):
+    provider = _provider(monkeypatch, [_lane("m", 8, vllm=False)])
+    assert provider.get_parallel_capacity(1) == (8, "runtime")
+
+
+def test_runtime_capacity_skips_stopped_and_error_lanes(monkeypatch):
+    provider = _provider(
+        monkeypatch,
+        [_lane("m", 10, runtime_state="stopped"), _lane("m", 10, runtime_state="error")],
+    )
+    assert provider._get_runtime_parallel_capacity(1) == (None, "config")
+    assert provider.get_parallel_capacity(1) == (200, "default")
+
+
+def test_parallel_capacity_is_not_capped_below_worker_report(monkeypatch):
+    # The DB `parallel` column used to act as a hard ceiling; it no longer
+    # exists in the orchestrator.  A worker reporting 500 slots must get 500.
+    provider = _provider(monkeypatch, [_lane("m", 500)])
+    assert provider.get_parallel_capacity(1) == (500, "runtime")
+
+
+def test_parallel_capacity_without_runtime_registry_defaults(monkeypatch):
+    provider = _provider(monkeypatch, [], with_registry=False)
+    assert provider.get_parallel_capacity(1) == (200, "default")
+
+
+def test_explicit_provider_config_parallel_capacity_still_wins(monkeypatch):
+    provider = _provider(monkeypatch, [_lane("m", 10)], config={"parallel_capacity": 16})
+    assert provider.get_parallel_capacity(1) == (16, "config")
+
+
+def test_reserve_capacity_enforces_worker_reported_limit(monkeypatch):
+    # The forward gate: requests stop at the worker's true limit and keep
+    # queueing at orchestrator level until a slot frees.
+    provider = _provider(monkeypatch, [_lane("m", 2)])
+    assert provider.try_reserve_capacity(1, "r1") is True
+    assert provider.try_reserve_capacity(1, "r2") is True
+    assert provider.try_reserve_capacity(1, "r3") is False
+    assert provider.get_active_count(1) == 2
+
+    provider.decrement_active(1, request_id="r1")
+    assert provider.try_reserve_capacity(1, "r3") is True
+    assert provider.get_active_count(1) == 2
+
+
+def test_reserve_capacity_refuses_on_backend_queue_pressure(monkeypatch):
+    # Worker limit not yet reached, but the engine queue is saturated:
+    # refuse here so the request waits at orchestrator level.
+    provider = _provider(monkeypatch, [_lane("m", 10, queue_waiting=9)])
+    assert provider.try_reserve_capacity(1, "r1") is False
+    assert provider.get_active_count(1) == 0

--- a/logos/logos-ui/src/app/features/models/models.html
+++ b/logos/logos-ui/src/app/features/models/models.html
@@ -303,20 +303,6 @@
       />
     </div>
 
-    <p class="form-section-label form-section-label--mt">Routing</p>
-    <div class="form-field">
-      <label class="field-label" for="add-parallel">Parallelism</label>
-      <input
-        id="add-parallel"
-        class="field-input field-input--short"
-        type="number"
-        min="1"
-        [value]="addParallel()"
-        (input)="addParallel.set($any($event.target).value)"
-        [disabled]="addLoading()"
-      />
-    </div>
-
     <p class="form-section-label form-section-label--mt">Weights</p>
     <div class="form-row">
       <div class="form-field">
@@ -440,20 +426,6 @@
         (input)="editTags.set($any($event.target).value)"
         [disabled]="editLoading()"
         autocomplete="off"
-      />
-    </div>
-
-    <p class="form-section-label form-section-label--mt">Routing</p>
-    <div class="form-field">
-      <label class="field-label" for="edit-parallel">Parallelism</label>
-      <input
-        id="edit-parallel"
-        class="field-input field-input--short"
-        type="number"
-        min="1"
-        [value]="editParallel()"
-        (input)="editParallel.set($any($event.target).value)"
-        [disabled]="editLoading()"
       />
     </div>
 

--- a/logos/logos-ui/src/app/features/models/models.ts
+++ b/logos/logos-ui/src/app/features/models/models.ts
@@ -54,7 +54,6 @@ export class Models implements OnInit {
   addName = signal('');
   addDesc = signal('');
   addTags = signal('');
-  addParallel = signal('');
   addWtLatency = signal('');
   addWtAccuracy = signal('');
   addWtCost = signal('');
@@ -67,7 +66,6 @@ export class Models implements OnInit {
   editName = signal('');
   editDesc = signal('');
   editTags = signal('');
-  editParallel = signal('');
   editWtLatency = signal('');
   editWtAccuracy = signal('');
   editWtCost = signal('');
@@ -153,7 +151,6 @@ export class Models implements OnInit {
     this.addName.set('');
     this.addDesc.set('');
     this.addTags.set('');
-    this.addParallel.set('');
     this.addWtLatency.set('');
     this.addWtAccuracy.set('');
     this.addWtCost.set('');
@@ -176,7 +173,6 @@ export class Models implements OnInit {
       name: this.addName().trim(),
       description: this.addDesc().trim() || undefined,
       tags: this.addTags().trim() || undefined,
-      parallel: this.addParallel() ? Number(this.addParallel()) : undefined,
     };
 
     const wtLatency = this.addWtLatency() ? Number(this.addWtLatency()) : undefined;
@@ -212,7 +208,6 @@ export class Models implements OnInit {
     this.editName.set(model.name ?? '');
     this.editDesc.set(model.description ?? '');
     this.editTags.set(model.tags ?? '');
-    this.editParallel.set(model.parallel != null ? String(model.parallel) : '');
     this.editWtLatency.set(model.weight_latency != null ? String(model.weight_latency) : '');
     this.editWtAccuracy.set(model.weight_accuracy != null ? String(model.weight_accuracy) : '');
     this.editWtCost.set(model.weight_cost != null ? String(model.weight_cost) : '');
@@ -235,7 +230,6 @@ export class Models implements OnInit {
       name: this.editName().trim() || undefined,
       description: this.editDesc().trim() || undefined,
       tags: this.editTags().trim() || undefined,
-      parallel: this.editParallel() ? Number(this.editParallel()) : undefined,
       weight_latency: this.editWtLatency() ? Number(this.editWtLatency()) : undefined,
       weight_accuracy: this.editWtAccuracy() ? Number(this.editWtAccuracy()) : undefined,
       weight_cost: this.editWtCost() ? Number(this.editWtCost()) : undefined,
@@ -251,7 +245,6 @@ export class Models implements OnInit {
                 name: payload.name ?? m.name,
                 description: payload.description ?? m.description,
                 tags: payload.tags ?? m.tags,
-                parallel: payload.parallel ?? m.parallel,
                 weight_latency: payload.weight_latency ?? m.weight_latency,
                 weight_accuracy: payload.weight_accuracy ?? m.weight_accuracy,
                 weight_cost: payload.weight_cost ?? m.weight_cost,

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
@@ -80,8 +80,8 @@
                   @if (row.lane.queue_waiting != null) {
                     <span class="stat-label">Queue <span class="stat-value neutral">{{ row.lane.queue_waiting }}</span></span>
                   }
-                  @if (row.lane.requests_running != null) {
-                    <span class="stat-label">Running <span class="stat-value neutral">{{ row.lane.requests_running }}</span></span>
+                  @if (row.runningLabel != null) {
+                    <span class="stat-label" [attr.title]="row.runningTooltip">Running <span class="stat-value neutral">{{ row.runningLabel }}</span></span>
                   }
                 </div>
               </div>

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -35,6 +35,39 @@ function ttftColor(secs: number): string {
   return 'rgb(var(--color-error))';
 }
 
+/**
+ * The vLLM lane's "Running" line as "a / b (min. c)":
+ * - a: requests running right now (vLLM `num_requests_running`).
+ * - b: current concurrency capacity — the already-running requests plus how
+ *      many full-context requests fit into the free KV headroom. Request
+ *      contexts are rarely full, so this floats with the workload, usually
+ *      above c.
+ * - c: the minimum the worker guarantees — its KV budget at full context
+ *      (vLLM's startup log line "Maximum concurrency for N tokens per
+ *      request"). Shown only when b actually exceeds it; at idle "0 / 8"
+ *      would just restate the minimum.
+ *
+ * Returns null when the lane reports no running count (the line stays
+ * hidden) and plain "a" while c is unknown (lane still starting up, or the
+ * startup log not parsed yet). Ollama lanes keep their "Active" line and
+ * never reach here.
+ */
+function runningLabel(
+  lane: Pick<LaneSignalData, 'requests_running' | 'num_parallel'>,
+  kvPct: number | null,
+): string | null {
+  const a = lane.requests_running;
+  if (a == null) return null;
+  const c = lane.num_parallel;
+  if (!c || c <= 0) return String(a);
+  if (kvPct == null) return `${a} / ${c}`;
+  const free = Math.max(0, 1 - kvPct / 100);
+  // Block rounding can push the KV fraction slightly past the token ratio,
+  // so clamp b to the guaranteed minimum instead of dipping below it.
+  const b = Math.max(c, a + Math.floor(c * free));
+  return b > c ? `${a} / ${b} (min. ${c})` : `${a} / ${b}`;
+}
+
 export interface LaneRow {
   laneId: string;
   lane: LaneSignalData;
@@ -44,6 +77,10 @@ export interface LaneRow {
   ttftLabel: string | null;
   /** Served context window, abbreviated — "111k". Null when unreported. */
   contextLabel: string | null;
+  /** "2 / 11 (min. 8)" — see runningLabel(); null when the line is hidden. */
+  runningLabel: string | null;
+  /** Tooltip explaining the running/capacity numbers; null when none apply. */
+  runningTooltip: string | null;
 }
 
 /**
@@ -110,6 +147,7 @@ export class LaneHealthPanel implements OnChanges {
       .map(([laneId, lane]) => {
         const kvPct = lane.gpu_cache_usage_percent;
         const ttft = lane.ttft_p95_seconds;
+        const running = runningLabel(lane, kvPct);
         return {
           laneId,
           lane,
@@ -123,18 +161,19 @@ export class LaneHealthPanel implements OnChanges {
                 : `${ttft.toFixed(2)}s`
               : null,
           contextLabel: formatContextWindow(lane.max_model_len),
+          runningLabel: running,
+          runningTooltip:
+            running != null && lane.num_parallel != null && lane.num_parallel > 0
+              ? 'Currently running / current capacity (live KV headroom). (min. N): guaranteed at full context — the worker-reported KV budget.'
+              : null,
         };
       });
   }
 
-  /** "GPU 0-1 · ×4" style placement line; null when the lane reports none. */
+  /** "GPU 0-1" style placement line; null when the lane reports none. */
   gpuLabel(lane: LaneSignalData): string | null {
     const gpu = (lane.effective_gpu_devices || lane.gpu_devices || '').trim();
-    const np = lane.num_parallel;
-    const parts: string[] = [];
-    if (gpu) parts.push(`GPU ${gpu}`);
-    if (np != null && np > 1) parts.push(`×${np}`);
-    return parts.length > 0 ? parts.join(' · ') : null;
+    return gpu ? `GPU ${gpu}` : null;
   }
 
   get providerId(): number | null {

--- a/logos/logos-ui/src/app/features/statistics/statistics.models.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.models.ts
@@ -110,6 +110,11 @@ export type LaneSignalData = {
   sleep_state: string | null;
   gpu_devices: string | null;
   effective_gpu_devices: string | null;
+  /**
+   * Worker-reported concurrency. vLLM lanes: full-context KV budget parsed
+   * from the startup log (guaranteed minimum; 0 until the log is parsed).
+   * Ollama lanes: static slot count (legacy — the UI ignores it).
+   */
   num_parallel: number | null;
   active_requests: number;
   effective_vram_mb: number;

--- a/logos/logos-ui/src/app/shared/models/model.model.ts
+++ b/logos/logos-ui/src/app/shared/models/model.model.ts
@@ -3,7 +3,6 @@ export interface Model {
   name: string;
   description: string | null;
   tags: string | null;
-  parallel: number | null;
   weight_latency: number | null;
   weight_accuracy: number | null;
   weight_cost: number | null;
@@ -14,7 +13,6 @@ export interface AddModelPayload {
   name: string;
   description?: string;
   tags?: string;
-  parallel?: number;
   worse_latency_id?: number;
   worse_accuracy_id?: number;
   worse_cost_id?: number;
@@ -26,7 +24,6 @@ export interface UpdateModelPayload {
   name?: string;
   description?: string;
   tags?: string;
-  parallel?: number;
   weight_latency?: number;
   weight_accuracy?: number;
   weight_cost?: number;

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/AddModelRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/AddModelRequestDTO.java
@@ -7,6 +7,5 @@ public record AddModelRequestDTO(
     Integer worseCostId,
     Integer worseQualityId,
     String tags,
-    Integer parallel,
     String description
 ) {}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/UpdateModelRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/UpdateModelRequestDTO.java
@@ -5,7 +5,6 @@ public record UpdateModelRequestDTO(
     String name,
     String description,
     String tags,
-    Integer parallel,
     Integer weightLatency,
     Integer weightAccuracy,
     Integer weightCost,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/entity/Model.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/entity/Model.java
@@ -23,7 +23,6 @@ public class Model {
     private Integer weightCost = 0;
     private Integer weightQuality = 0;
     private String tags;
-    private Integer parallel = 1;
     private String description;
 
     public Integer getId() { return id; }
@@ -33,7 +32,6 @@ public class Model {
     public Integer getWeightCost() { return weightCost; }
     public Integer getWeightQuality() { return weightQuality; }
     public String getTags() { return tags; }
-    public Integer getParallel() { return parallel; }
     public String getDescription() { return description; }
 
     public void setName(String name) { this.name = name; }
@@ -42,6 +40,5 @@ public class Model {
     public void setWeightCost(Integer w) { this.weightCost = w; }
     public void setWeightQuality(Integer w) { this.weightQuality = w; }
     public void setTags(String tags) { this.tags = tags; }
-    public void setParallel(Integer parallel) { this.parallel = parallel; }
     public void setDescription(String description) { this.description = description; }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelRepository.java
@@ -12,7 +12,7 @@ public interface ModelRepository extends JpaRepository<Model, Integer> {
 
     @Query(value = """
         SELECT m.id, m.name, m.weight_latency, m.weight_accuracy, m.weight_cost,
-               m.weight_quality, m.tags, m.parallel, m.description,
+               m.weight_quality, m.tags, m.description,
                (SELECT ROUND(tp.price_per_k_token::NUMERIC / 100000, 4)
                 FROM token_prices tp JOIN token_types tt ON tt.id = tp.type_id
                 WHERE (tp.model_id = m.id OR tp.model_id IS NULL)
@@ -47,7 +47,7 @@ public interface ModelRepository extends JpaRepository<Model, Integer> {
             WHERE ak.user_id = :userId AND ak.is_active = true AND ak.use_custom_permissions = true
         )
         SELECT DISTINCT m.id, m.name, m.weight_latency, m.weight_accuracy, m.weight_cost,
-               m.weight_quality, m.tags, m.parallel, m.description,
+               m.weight_quality, m.tags, m.description,
                (SELECT ROUND(tp.price_per_k_token::NUMERIC / 100000, 4)
                 FROM token_prices tp JOIN token_types tt ON tt.id = tp.type_id
                 WHERE (tp.model_id = m.id OR tp.model_id IS NULL)

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelWithPriceProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelWithPriceProjection.java
@@ -10,7 +10,6 @@ public interface ModelWithPriceProjection {
     Integer getWeightCost();
     Integer getWeightQuality();
     String getTags();
-    Integer getParallel();
     String getDescription();
     BigDecimal getInputUsdPerMillion();
     BigDecimal getOutputUsdPerMillion();

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
@@ -50,7 +50,6 @@ public class ModelService {
         Model model = new Model();
         model.setName(req.name());
         model.setTags(req.tags() != null ? req.tags() : "");
-        model.setParallel(req.parallel() != null ? req.parallel() : 1);
         model.setDescription(req.description() != null ? req.description() : "");
         model.setWeightLatency(0);
         model.setWeightAccuracy(0);
@@ -73,7 +72,6 @@ public class ModelService {
         if (req.name() != null) model.setName(req.name());
         if (req.description() != null) model.setDescription(req.description());
         if (req.tags() != null) model.setTags(req.tags());
-        if (req.parallel() != null) model.setParallel(req.parallel());
         if (req.weightLatency() != null) model.setWeightLatency(req.weightLatency());
         if (req.weightAccuracy() != null) model.setWeightAccuracy(req.weightAccuracy());
         if (req.weightCost() != null) model.setWeightCost(req.weightCost());
@@ -103,7 +101,6 @@ public class ModelService {
             map.put("weight_cost", m.getWeightCost());
             map.put("weight_quality", m.getWeightQuality());
             map.put("tags", m.getTags());
-            map.put("parallel", m.getParallel());
             map.put("description", m.getDescription());
             return map;
         });
@@ -137,7 +134,6 @@ public class ModelService {
         m.put("weight_cost", p.getWeightCost());
         m.put("weight_quality", p.getWeightQuality());
         m.put("tags", p.getTags());
-        m.put("parallel", p.getParallel());
         m.put("description", p.getDescription());
         m.put("input_usd_per_million", p.getInputUsdPerMillion());
         m.put("output_usd_per_million", p.getOutputUsdPerMillion());

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/013_drop_models_parallel.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/013_drop_models_parallel.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- The models.parallel column was a static, per-model hard ceiling on
+         parallel capacity. It is now derived from the worker's live lane
+         signals (runtime snapshot: per-lane num_parallel plus the vLLM
+         backend metrics the worker scrapes from /metrics), so the static
+         entry is dropped entirely. Fresh installs create the column in 000
+         and this changeSet removes it again; existing databases drop it
+         here. -->
+    <changeSet id="013-drop-models-parallel-column" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="models" columnName="parallel"/>
+        </preConditions>
+        <dropColumn tableName="models" columnName="parallel"/>
+        <rollback>
+            <sql>ALTER TABLE models ADD COLUMN parallel INTEGER DEFAULT(1) CONSTRAINT minimum CHECK (parallel BETWEEN 1 and 256);</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -16,5 +16,6 @@
     <include file="liquibase/changelog/010_add_model_capabilities.xml"/>
     <include file="liquibase/changelog/011_add_fk_model_capabilities_cascade.xml"/>
     <include file="liquibase/changelog/012_log_entry_timestamp_index.xml"/>
+    <include file="liquibase/changelog/013_drop_models_parallel.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration;
 
+import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,6 +12,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -91,9 +93,37 @@ class ModelControllerTest {
         mvc.perform(post("/logosdb/add_model")
                 .with(TestJwt.logosAdmin())
                 .contentType("application/json")
-                .content("{\"name\":\"test-model\",\"parallel\":1,\"tags\":\"\",\"description\":\"\"}"))
+                .content("{\"name\":\"test-model\",\"tags\":\"\",\"description\":\"\"}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.model_id").isNumber());
+    }
+
+    @Test
+    void addModel_modelResponseExposesNoParallelField() throws Exception {
+        // models.parallel has been dropped from the schema; parallel capacity
+        // is derived by the orchestrator from the worker's live lane signals.
+        MvcResult addResult = mvc.perform(post("/logosdb/add_model")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"name\":\"no-parallel-model\"}"))
+           .andExpect(status().isOk())
+           .andReturn();
+        int modelId = JsonPath.read(addResult.getResponse().getContentAsString(), "$.model_id");
+
+        mvc.perform(post("/logosdb/get_model")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"id\":" + modelId + "}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.id").value(modelId))
+           .andExpect(jsonPath("$.parallel").doesNotExist());
+
+        mvc.perform(post("/logosdb/get_models")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$[?(@.id == %d)].parallel".formatted(modelId)).doesNotExist());
     }
 
     @Test

--- a/logos/logos-webservice/src/test/resources/sql/seed-configuration.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-configuration.sql
@@ -1,8 +1,8 @@
-INSERT INTO models (id, name, weight_latency, weight_accuracy, weight_cost, weight_quality, tags, parallel, description)
-VALUES (5001, 'gpt-4',   0, 10, -5,  8,  'cloud,gpt', 1, 'GPT-4 model');
+INSERT INTO models (id, name, weight_latency, weight_accuracy, weight_cost, weight_quality, tags, description)
+VALUES (5001, 'gpt-4',   0, 10, -5,  8,  'cloud,gpt', 'GPT-4 model');
 
-INSERT INTO models (id, name, weight_latency, weight_accuracy, weight_cost, weight_quality, tags, parallel, description)
-VALUES (5002, 'gpt-3.5', -10, 0, 10, -5, 'cloud,gpt', 1, 'GPT-3.5 model');
+INSERT INTO models (id, name, weight_latency, weight_accuracy, weight_cost, weight_quality, tags, description)
+VALUES (5002, 'gpt-3.5', -10, 0, 10, -5, 'cloud,gpt', 'GPT-3.5 model');
 
 INSERT INTO providers (id, name, base_url, provider_type, privacy_level, auth_name, auth_format)
 VALUES (6001, 'openai-provider', 'https://api.openai.com', 'cloud', 'LOCAL', 'Authorization', 'Bearer {}');


### PR DESCRIPTION
Closes #650.

The static `models.parallel` database entry is gone for good — a model's parallel capacity now comes from the live signals the vLLM worker reports per lane:

1. **Gate on worker-reported capacity** — the orchestrator refuses to forward once a worker's reported limit (KV-budget-derived max concurrency, parsed from vLLM's startup log into the lane's `num_parallel`) is reached, so requests queue at orchestrator level and go to whichever worker frees a slot first instead of piling up in the vLLM-side queue. The ×3 oversubscription of the worker-reported number is removed, and the orchestrator's DB-ceiling plumbing (registration payload, facade collection, provider ceiling logic) goes with it.
2. **Drop the DB entry** — `models.parallel` column removed (Liquibase `dropColumn` guarded by `columnExists`; `000` untouched so production checksums stay stable), and with it the entity/DTO/native-query/service surface plus the UI Parallelism field. The candidate tuple's `parallel` element — which was only ever consumed through the ceiling — is removed as well.
3. **Show it in the statistics UI** — the lane health panel's "×N" badge (which read like a replication factor and hid the useful number) is now the Running line `a / b (min. c)`: `a` = requests running right now (vLLM `num_requests_running`), `b` = capacity floating with the live KV headroom, `c` = the guaranteed minimum, i.e. the worker-reported KV budget at full context.

Kept on purpose: `providers.parallel_capacity` (explicit per-provider admin override, the "config" source), the fallbacks (unreported vLLM lane → 256, no runtime data → 200), and the live signals themselves.

Note: migration and code ship together (same compose stack); the orchestrator no longer selects the column.
