### PR TITLE
`Logos`: Implement tests for capabilities fetching

### DIFF
--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ModelController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ModelController.java
@@ -141,6 +141,10 @@ public class ModelController {
                 .body(Map.of("error", "ids are required"));
         }
 
-        return ResponseEntity.ok(modelService.getModelCapabilities(req.ids()));
+        try {
+            return ResponseEntity.ok(modelService.getModelCapabilities(req.ids()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelCapabilitiesUpdaterService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelCapabilitiesUpdaterService.java
@@ -75,6 +75,25 @@ public class ModelCapabilitiesUpdaterService {
         }
     }
 
+    boolean testExtractAndStoreCapabilities(
+            Map<String, Object> catalog,
+            int modelId,
+            String modelName) {
+        return extractAndStoreCapabilities(catalog, modelId, modelName);
+    }
+
+    String testExtractModelName(String catalogKey) {
+        return extractModelName(catalogKey);
+    }
+
+    String testNormalizeModelName(String modelName) {
+        return normalizeModelName(modelName);
+    }
+
+    boolean testModelNamesMatch(String requestedModelName, String catalogModelName) {
+        return modelNamesMatch(requestedModelName, catalogModelName);
+    }
+
     @SuppressWarnings("unchecked")
     private boolean extractAndStoreCapabilities(
             Map<String, Object> catalog,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -150,6 +151,14 @@ public class ModelService {
     }
 
     public Map<Integer, ModelCapabilitiesDTO> getModelCapabilities(List<Integer> modelIds) {
+        Set<Integer> existingModelIds = modelRepository.findAllById(modelIds).stream()
+            .map(Model::getId)
+            .collect(Collectors.toSet());
+        for (Integer modelId : modelIds) {
+            if (!existingModelIds.contains(modelId)) {
+                throw new IllegalArgumentException("Model not found: " + modelId);
+            }
+        }
         return modelCapabilitiesRepository.findByModelIdIn(modelIds)
             .stream()
             .map(ModelService::toModelCapabilitiesDTO)

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
 import de.tum.cit.aet.logos.logoswebservice.TestJwt;
+import de.tum.cit.aet.logos.logoswebservice.configuration.repository.ModelCapabilitiesRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,6 +39,7 @@ import de.tum.cit.aet.logos.logoswebservice.TestJwt;
 class ModelControllerTest {
 
     @Autowired MockMvc mvc;
+    @Autowired ModelCapabilitiesRepository modelCapabilitiesRepository;
     @MockitoBean JwtDecoder jwtDecoder;
 
     @Test
@@ -172,5 +175,85 @@ class ModelControllerTest {
                 .contentType("application/json")
                 .content("{\"id\":5001,\"category\":\"accuracy\",\"value\":1}"))
            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(statements = {
+        // Values the local catalog derives for gpt-4 (function calling via the plain
+        // "gpt-4" entry, no vision/reasoning entries)
+        "INSERT INTO model_capabilities (model_id, supports_function_calling, supports_vision, supports_reasoning) "
+            + "VALUES (5001, true, false, false)"
+    }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void getModelCapabilities_existingModelReturnsCapabilities() throws Exception {
+        mvc.perform(post("/logosdb/get_model_capabilities")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"ids\":[5001]}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.5001.model_id").value(5001))
+           .andExpect(jsonPath("$.5001.supports_function_calling").value(true))
+           .andExpect(jsonPath("$.5001.supports_vision").value(false))
+           .andExpect(jsonPath("$.5001.supports_reasoning").value(false));
+    }
+
+    @Test
+    void getModelCapabilities_unknownModelReturns404() throws Exception {
+        mvc.perform(post("/logosdb/get_model_capabilities")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"ids\":[9999]}"))
+           .andExpect(status().isNotFound())
+           .andExpect(jsonPath("$.error").value("Model not found: 9999"));
+    }
+
+    @Test
+    void getModelCapabilities_mixedKnownAndUnknownIdsReturns404() throws Exception {
+        mvc.perform(post("/logosdb/get_model_capabilities")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"ids\":[5001,9999]}"))
+           .andExpect(status().isNotFound())
+           .andExpect(jsonPath("$.error").value("Model not found: 9999"));
+    }
+
+    @Test
+    void getModelCapabilities_existingModelWithoutCapabilitiesRowReturnsEmptyMap() throws Exception {
+        // gpt-3.5 (5002) exists but has no model_capabilities row
+        mvc.perform(post("/logosdb/get_model_capabilities")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"ids\":[5002]}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void getModelCapabilities_missingIdsReturns400() throws Exception {
+        mvc.perform(post("/logosdb/get_model_capabilities")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.error").value("ids are required"));
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(statements = {
+        "INSERT INTO model_capabilities (model_id, supports_function_calling, supports_vision, supports_reasoning) "
+            + "VALUES (5001, true, false, false)"
+    }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void deleteModel_cascadesToModelCapabilities() throws Exception {
+        assertThat(modelCapabilitiesRepository.findByModelId(5001)).isPresent();
+
+        mvc.perform(post("/logosdb/delete_model")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"id\":5001}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.result").value("Deleted Model"));
+
+        assertThat(modelCapabilitiesRepository.findByModelId(5001)).isEmpty();
     }
 }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelCapabilitiesUpdaterServiceUnitTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelCapabilitiesUpdaterServiceUnitTest.java
@@ -1,0 +1,201 @@
+package de.tum.cit.aet.logos.logoswebservice.configuration.service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import de.tum.cit.aet.logos.logoswebservice.configuration.entity.ModelCapabilities;
+import de.tum.cit.aet.logos.logoswebservice.configuration.repository.ModelCapabilitiesRepository;
+
+class ModelCapabilitiesUpdaterServiceUnitTest {
+
+    private ModelCapabilitiesRepository capabilitiesRepository;
+    private ModelCapabilitiesUpdaterService svc;
+
+    @BeforeEach
+    void setUp() {
+        capabilitiesRepository = mock(ModelCapabilitiesRepository.class);
+        svc = new ModelCapabilitiesUpdaterService(
+            null,
+            null,
+            null,
+            new ModelCapabilitiesPersistenceService(capabilitiesRepository)
+        );
+    }
+
+    // --- normalizeModelName ---
+
+    @Test
+    void normalize_nullReturnsNull() {
+        assertThat(svc.testNormalizeModelName(null)).isNull();
+    }
+
+    @Test
+    void normalize_trimsAndLowercases() {
+        assertThat(svc.testNormalizeModelName("  GPT-4  ")).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void normalize_stripsProviderPath() {
+        assertThat(svc.testNormalizeModelName("openai/gpt-4")).isEqualTo("gpt-4");
+        assertThat(svc.testNormalizeModelName("openrouter/openai/gpt-4")).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void normalize_stripsTrailingPtOrItSuffix() {
+        assertThat(svc.testNormalizeModelName("gpt-4-pt")).isEqualTo("gpt-4");
+        assertThat(svc.testNormalizeModelName("llama-3-it")).isEqualTo("llama-3");
+    }
+
+    @Test
+    void normalize_leavesUnrelatedSuffixesAlone() {
+        assertThat(svc.testNormalizeModelName("gpt-4-32k")).isEqualTo("gpt-4-32k");
+        assertThat(svc.testNormalizeModelName("gpt-4")).isEqualTo("gpt-4");
+    }
+
+    // --- extractModelName ---
+
+    @Test
+    void extract_nullOrBlankKeyReturnsNull() {
+        assertThat(svc.testExtractModelName(null)).isNull();
+        assertThat(svc.testExtractModelName("   ")).isNull();
+    }
+
+    @Test
+    void extract_plainKeyIsNormalized() {
+        assertThat(svc.testExtractModelName("  GPT-4 ")).isEqualTo("gpt-4");
+        assertThat(svc.testExtractModelName("gpt-4-pt")).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void extract_takesLastPathSegment() {
+        assertThat(svc.testExtractModelName("azure/gpt-4")).isEqualTo("gpt-4");
+        assertThat(svc.testExtractModelName("openrouter/openai/gpt-4")).isEqualTo("gpt-4");
+    }
+
+    // --- modelNamesMatch ---
+
+    @Test
+    void match_identicalNormalizedNamesMatch() {
+        assertThat(svc.testModelNamesMatch("gpt-4", "gpt-4")).isTrue();
+    }
+
+    @Test
+    void match_isExactNotPrefixOrFuzzy() {
+        // matching is an exact equals on the already-normalized names
+        assertThat(svc.testModelNamesMatch("gpt-4", "gpt-4-turbo")).isFalse();
+        assertThat(svc.testModelNamesMatch("gpt-4", "gpt-4o")).isFalse();
+    }
+
+    @Test
+    void match_isCaseSensitiveBecauseNormalizationHappensBefore() {
+        assertThat(svc.testModelNamesMatch("GPT-4", "gpt-4")).isFalse();
+    }
+
+    @Test
+    void match_nullSidesNeverMatch() {
+        assertThat(svc.testModelNamesMatch(null, "gpt-4")).isFalse();
+        assertThat(svc.testModelNamesMatch("gpt-4", null)).isFalse();
+        assertThat(svc.testModelNamesMatch(null, null)).isFalse();
+    }
+
+    // --- extractAndStoreCapabilities ---
+
+    @Test
+    void extractAndStore_singleMatchPersistsFlags() {
+        Map<String, Object> catalog = Map.of(
+            "openai/gpt-4", Map.of(
+                "supports_function_calling", true,
+                "supports_vision", false,
+                "supports_reasoning", true
+            )
+        );
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "gpt-4")).isTrue();
+
+        verify(capabilitiesRepository).save(argThat((ModelCapabilities c) ->
+            c.getModelId() == 5001
+                && c.getSupportsFunctionCalling()
+                && !c.getSupportsVision()
+                && c.getSupportsReasoning()
+        ));
+    }
+
+    @Test
+    void extractAndStore_missingFlagKeysPersistFalse() {
+        Map<String, Object> catalog = Map.of(
+            "gpt-4", Map.of("max_output_tokens", 8192)
+        );
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "gpt-4")).isTrue();
+
+        verify(capabilitiesRepository).save(argThat((ModelCapabilities c) ->
+            !c.getSupportsFunctionCalling()
+                && !c.getSupportsVision()
+                && !c.getSupportsReasoning()
+        ));
+    }
+
+    @Test
+    void extractAndStore_multipleMatchesOrTheFlags() {
+        Map<String, Object> catalog = new LinkedHashMap<>();
+        catalog.put("gpt-4", Map.of("supports_function_calling", true));
+        catalog.put("azure/gpt-4", Map.of("supports_vision", true));
+        catalog.put("openrouter/openai/gpt-4", Map.of("supports_reasoning", true));
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "gpt-4")).isTrue();
+
+        verify(capabilitiesRepository).save(argThat((ModelCapabilities c) ->
+            c.getSupportsFunctionCalling()
+                && c.getSupportsVision()
+                && c.getSupportsReasoning()
+        ));
+    }
+
+    @Test
+    void extractAndStore_unknownModelIsNotStored() {
+        Map<String, Object> catalog = Map.of(
+            "gpt-4o", Map.of("supports_function_calling", true)
+        );
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "gpt-4")).isFalse();
+
+        verify(capabilitiesRepository, never()).save(any());
+    }
+
+    @Test
+    void extractAndStore_sampleSpecEntryIsSkipped() {
+        // a model literally named "sample_spec" must not match the catalog's sample_spec entry
+        Map<String, Object> catalog = new LinkedHashMap<>();
+        catalog.put("sample_spec", Map.of(
+            "supports_function_calling", true,
+            "supports_vision", true,
+            "supports_reasoning", true
+        ));
+        catalog.put("gpt-4", Map.of("supports_function_calling", true));
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "sample_spec")).isFalse();
+
+        verify(capabilitiesRepository, never()).save(any());
+    }
+
+    @Test
+    void extractAndStore_nonMapEntriesAreSkipped() {
+        Map<String, Object> catalog = new LinkedHashMap<>();
+        catalog.put("gpt-4", "not-a-model-entry");
+        catalog.put("gpt-4o", Map.of("supports_function_calling", true));
+
+        assertThat(svc.testExtractAndStoreCapabilities(catalog, 5001, "gpt-4")).isFalse();
+
+        verify(capabilitiesRepository, never()).save(any());
+    }
+}

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-configuration.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-configuration.sql
@@ -1,3 +1,4 @@
 DELETE FROM model_provider;
+DELETE FROM model_capabilities;
 DELETE FROM models;
 DELETE FROM providers;


### PR DESCRIPTION
Closes #766.

Adds the missing test coverage for model-capabilities fetching, in three groups:

**1. `get_model_capabilities` endpoint** (`ModelControllerTest`, Testcontainers)
- 200 for the seeded gpt-4 model (5001) with seeded capability row — asserts the snake_case DTO shape the UI's `ModelCapability` interface expects
- 404 for an unknown model id, and for a mixed known+unknown id list (pins the any-unknown-id → 404 semantics)
- 200 + empty map for an existing model without a capability row (gpt-3.5 / 5002)
- 400 when `ids` is missing
- `delete_model` FK cascade: a capability row present before deletion is gone after

**2. Name-matching logic** (new pure unit test `ModelCapabilitiesUpdaterServiceUnitTest`, Mockito)
- `normalizeModelName`: trim/lowercase, provider-path stripping, `-pt`/`-it` suffix strip, unrelated suffixes untouched
- `extractModelName`: null/blank handling, plain keys, last path segment
- `modelNamesMatch`: exact-not-prefix, normalization order, null sides
- `extractAndStoreCapabilities`: flag persistence, missing keys → false, OR-reduction across multiple catalog matches, no save for unknown models, `sample_spec` and non-map catalog entries skipped

**3. FK cascade on model delete** — see endpoint tests above (`fk_model_capabilities_model` ON DELETE CASCADE).

Test infrastructure: `cleanup-configuration.sql` also gained `DELETE FROM model_capabilities;` so the seeded rows don't leak between test methods.

**One minimal production change, called out explicitly:** `get_model_capabilities` previously returned 200 with an empty map for unknown model ids — the issue explicitly requires a 404 case, which did not exist. `ModelService.getModelCapabilities(List)` now throws `IllegalArgumentException` when any requested id is absent from `models`, and the controller maps it to 404 `{"error": "Model not found: <id>"}` using the same local try/catch pattern as `delete_model`/`update_model_info`. The controller is the only production call site of this overload, so nothing else changes behavior. Four package-private `testXxx` delegating wrappers expose the private matching functions, following the existing `ModelWeightService.testInsertModel` idiom.

Verified locally: full `mvn -B test` (JDK 25) → 245/245 pass (baseline on this branch 221/221; +24 = exactly the new tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for unknown model IDs now return a clear 404 response instead of an unhandled error.
  * Requests containing a mix of valid and unknown model IDs are handled consistently.
  * Model capability data is properly cleared when models are deleted.

* **Tests**
  * Added coverage for model capability retrieval, validation, empty results, invalid requests, and capability synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->