### PR TITLE
`Logos`: Keep account button visible when Safari toolbar expands

### DIFF
--- a/logos/logos-ui/src/app/core/layout/shell/shell.scss
+++ b/logos/logos-ui/src/app/core/layout/shell/shell.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: flex;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 
   background: rgb(var(--shell-background));
@@ -233,6 +234,7 @@
     top: 0;
     width: 220px;
     height: 100vh;
+    height: 100dvh;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 25;


### PR DESCRIPTION
Closes #774.

**Root cause:** iOS Safari's dynamic viewport. On iPad, `100vh` resolves to the *large* viewport (as if the bottom tab/URL bar were hidden). When the bar is expanded, the actually-visible viewport is shorter, and because the app shell uses `overflow: hidden`, the bottom of the sidebar — the account/user-info button (`.sidebar-footer`) — sits behind the expanded bar and can't be scrolled into view.

**Fix:** dynamic viewport units with a plain-`vh` fallback, at the two trapped places in `shell.scss`:

- `.shell-layout` (≥1024px layout, i.e. iPad landscape)
- the fixed drawer `.sidebar` inside `@media (max-width: 1024px)` (iPad portrait / narrow windows)

```scss
height: 100vh;   /* fallback */
height: 100dvh;
```

`dvh` tracks the live toolbar state: the shell/drawer shrinks when the bar expands (button visible) and grows when it collapses. `100dvh` is supported in iOS Safari 15.4+, Chrome 108+, Firefox 101+; older browsers keep the previous behavior via the fallback line. No viewport-meta or safe-area changes.

**Scope:** deliberately limited to these two rules. The other `vh` usages (`login.scss` `min-height` on a scrollable page, modal `max-height` bounds, confetti animation) are not trapped by `overflow: hidden` and are not part of this bug.

**Verified:** `npm run build` green (the size-budget warnings are pre-existing in untouched files); compiled bundle contains exactly the two new `height:100dvh` declarations, in the `.shell-layout` and mobile `.sidebar` rules.
