### PR TITLE
`Logos`: Place lanes on GPUs without awake models, ignore sleep_l1 residues

### DIFF
--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1524,24 +1524,36 @@ class LaneManager:
         tp_size: int,
         per_gpu_threshold_mb: float,
         multi_gpu_indices: set[int] | None = None,
+        awake_lanes_by_gpu: dict[int, int] | None = None,
+        awake_used_mb_by_gpu: dict[int, float] | None = None,
     ) -> list[int] | None:
         feasible = [row for row in device_rows if float(row["free_mb"]) >= per_gpu_threshold_mb]
         if len(feasible) < tp_size:
             return None
 
         occupied = multi_gpu_indices or set()
+        awake_lanes = awake_lanes_by_gpu or {}
+        awake_used = awake_used_mb_by_gpu or {}
         best_indices: list[int] | None = None
-        best_score: tuple[int, float, float, float, tuple[int, ...]] | None = None
+        best_score: tuple[int, int, float, float, tuple[int, ...]] | None = None
         for combo in combinations(feasible, tp_size):
             indices = tuple(sorted(int(row["index"]) for row in combo))
             # Penalise combos that share GPUs with active TP>1 lane shards.
             # A non-collocated placement always beats a collocated one regardless
             # of free-memory leftover.
             collocated = int(bool(set(indices) & occupied))
-            leftover = sum(float(row["free_mb"]) - per_gpu_threshold_mb for row in combo)
-            utilization = sum(float(row["utilization"]) for row in combo)
-            widest_free = max(float(row["free_mb"]) for row in combo)
-            score = (collocated, leftover, utilization, widest_free, indices)
+            # Prefer GPUs that hold no awake lane. Lanes in sleep_l1 do not
+            # count: their weights sit in host RAM and their ~GB-sized VRAM
+            # residue must not anchor new lanes onto a GPU that is otherwise
+            # empty (deioma incident: an embedding lane was stacked next to a
+            # sleeping 27B while a fully free GPU sat unused).
+            awake_lane_count = sum(awake_lanes.get(i, 0) for i in indices)
+            awake_used_mb = sum(awake_used.get(i, 0.0) for i in indices)
+            # Among equally unoccupied combos take the most free VRAM
+            # (spread): it maximises headroom for the new lane and keeps the
+            # emptiest GPUs intact for larger models.
+            free_mb = sum(float(row["free_mb"]) for row in combo)
+            score = (collocated, awake_lane_count, awake_used_mb, -free_mb, indices)
             if best_score is None or score < best_score:
                 best_score = score
                 best_indices = list(indices)
@@ -1553,8 +1565,10 @@ class LaneManager:
         Strategy:
         - Respect explicit lane gpu_devices.
         - Preserve the current placement when it still fits.
-        - Otherwise choose the smallest feasible GPU subset by free-memory
-          leftover (best fit) within the worker's allowed GPU pool.
+        - Otherwise choose the feasible GPU subset in the worker's allowed
+          GPU pool that shares the least with awake lanes, breaking ties
+          toward the most free VRAM (spread, not best-fit packing: a GPU
+          whose only occupants are sleeping lanes is treated as empty).
         """
         if not lane_config.vllm or lane_config.vllm_config is None:
             return lane_config
@@ -1657,7 +1671,14 @@ class LaneManager:
         # Collect GPU indices occupied by active TP>1 lanes so placement can
         # prefer GPUs that aren't already shared with multi-GPU model shards.
         multi_gpu_indices: set[int] = set()
-        for h in self._handles.values():
+        # Per-GPU occupancy of awake vLLM lanes, so the subset picker can keep
+        # one active model per GPU and ignore sleep_l1 residues (weights in
+        # host RAM are not VRAM occupancy).
+        awake_lanes_by_gpu: dict[int, int] = {}
+        awake_used_mb_by_gpu: dict[int, float] = {}
+        for other_id, h in self._handles.items():
+            if other_id == lane_id:
+                continue  # this lane's own (old) footprint is being replaced
             lc = h.lane_config
             if (
                 lc
@@ -1670,6 +1691,26 @@ class LaneManager:
                     s = s.strip()
                     if s.isdigit():
                         multi_gpu_indices.add(int(s))
+            if lc is None or not lc.vllm or not lc.gpu_devices:
+                continue
+            try:
+                if h.status().state != ProcessState.RUNNING:
+                    continue
+            except Exception:
+                continue
+            try:
+                if (await h.is_sleeping()) is True:
+                    continue
+            except Exception:
+                pass  # unknown sleep state — count the lane as awake
+            indices = [int(s) for s in lc.gpu_devices.split(",") if s.strip().isdigit()]
+            if not indices:
+                continue
+            est_mb = self._estimate_lane_vram_mb(lc)
+            share_mb = est_mb / len(indices)
+            for i in indices:
+                awake_lanes_by_gpu[i] = awake_lanes_by_gpu.get(i, 0) + 1
+                awake_used_mb_by_gpu[i] = awake_used_mb_by_gpu.get(i, 0.0) + share_mb
 
         current_handle = self._handles.get(lane_id)
         current_selector = ""
@@ -1690,6 +1731,8 @@ class LaneManager:
                 tp_size,
                 per_gpu_threshold_mb,
                 multi_gpu_indices,
+                awake_lanes_by_gpu,
+                awake_used_mb_by_gpu,
             )
         if selected_indices is None:
             # Fail fast: an unset gpu_devices makes vLLM default to cuda:0,

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -669,11 +669,12 @@ async def test_auto_place_gpu_devices_picks_best_fit_single_gpu() -> None:
 async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> None:
     """A kv-pinned lane must NOT be gated by the 0.5 GMU floor.
 
-    Same GPUs as the floor test: GPU 2 (7.6 GB free) was eliminated by the
-    12.3 GB floor. But when the lane pins kv_cache_memory_bytes, vLLM ignores
-    gpu_memory_utilization and only grabs weights + KV (~6 GB), so GPU 2 becomes
-    feasible — and best-fit (smallest leftover) now selects it. This is the fix
-    that lets small models (e.g. gemma-3-4b) place into tight free VRAM.
+    All three GPUs fall below the 0.5 × 24576 = 12288 MB floor vLLM would
+    attempt, so with the floor applied placement raises. With the lane pinning
+    kv_cache_memory_bytes, vLLM ignores gpu_memory_utilization and only grabs
+    weights + KV (~6 GB), so every GPU becomes feasible and the emptiest one
+    (GPU 0) is selected. This is the fix that lets small models (e.g.
+    gemma-3-4b) place into tight free VRAM.
     """
     from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
 
@@ -693,7 +694,7 @@ async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> No
                     device_id="gpu0",
                     kind="nvidia",
                     memory_total_mb=24576.0,
-                    memory_free_mb=16000.0,
+                    memory_free_mb=12000.0,
                     extra={"index": 0},
                 ),
                 DeviceInfo(
@@ -712,7 +713,7 @@ async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> No
                 ),
             ],
             total_memory_mb=3 * 24576.0,
-            free_memory_mb=35600.0,
+            free_memory_mb=31600.0,
         )
 
     manager = LaneManager(
@@ -729,9 +730,9 @@ async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> No
     )
 
     placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
-    # Floor skipped → threshold ≈ footprint (~6 GB); GPU 2 (7600) fits and is the
-    # tightest best-fit, so it is chosen rather than being eliminated.
-    assert placed.gpu_devices == "2"
+    # Floor skipped → threshold ≈ footprint (~6 GB) instead of 12288 MB, so the
+    # GPU-0/1 pair (12000 free each) is feasible and the emptiest one wins.
+    assert placed.gpu_devices == "0"
 
 
 @pytest.mark.asyncio
@@ -892,7 +893,9 @@ async def test_auto_place_gpu_devices_keeps_sticky_gpu_when_it_still_fits() -> N
 
 
 @pytest.mark.asyncio
-async def test_auto_place_gpu_devices_picks_smallest_feasible_tp_subset() -> None:
+async def test_auto_place_gpu_devices_picks_emptiest_feasible_tp_subset() -> None:
+    """A TP=2 lane takes the feasible GPU pair with the most free VRAM
+    (spread), so the emptiest GPUs stay intact for larger models."""
     from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
 
     profiles = ModelProfileRegistry()
@@ -956,7 +959,337 @@ async def test_auto_place_gpu_devices_picks_smallest_feasible_tp_subset() -> Non
     )
 
     placed = await manager._auto_place_gpu_devices("planner-big-model_70B", lane)  # noqa: SLF001
-    assert placed.gpu_devices == "1,2"
+    # Feasible pairs (GMU floor 12288 MB): (0,1)=39000, (0,2)=40000, (0,3)=64000,
+    # (1,2)=31000, (1,3)=55000, (2,3)=56000. Spread picks the emptiest pair.
+    assert placed.gpu_devices == "0,3"
+
+
+class _OccupyingLaneStub:
+    """Minimal ProcessHandle stand-in for placement-occupancy tests."""
+
+    def __init__(
+        self,
+        lane_id: str,
+        lane_config: LaneConfig,
+        *,
+        sleeping: bool = False,
+        state: ProcessState = ProcessState.RUNNING,
+    ) -> None:
+        self.lane_id = lane_id
+        self.port = 15100
+        self.lane_config = lane_config
+        self._sleeping = sleeping
+        self._state = state
+
+    def status(self) -> ProcessStatus:
+        return ProcessStatus(state=self._state)
+
+    async def is_sleeping(self) -> bool | None:
+        return self._sleeping
+
+
+@pytest.mark.asyncio
+async def test_auto_place_prefers_empty_gpu_over_sleeping_lane_residue() -> None:
+    """Reproduces the deioma incident (2026-08-25): the 27B lane on GPU 0 is
+    in sleep_l1 (weights in host RAM, ~3 GB VRAM residue), gpt-oss-120b fills
+    GPU 1, and GPU 2 is fully free. The new 22 GB embedding lane must go to
+    the truly empty GPU 2, not be stacked next to the sleeping lane's
+    residue on GPU 0.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen3.8-27B"] = ModelProfileRecord(loaded_vram_mb=64_000.0, engine="vllm")  # noqa: SLF001
+    profiles._profiles["openai/gpt-oss-120b"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=82_000.0, engine="vllm"
+    )
+    profiles._profiles["Qwen/Qwen3-Embedding-8B"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=22_545.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: sleeping 27B residue + worker CUDA context (~3.2 GB used).
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=94_687.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: gpt-oss-120b.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=15_565.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: fully free.
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=97_883.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=94_687.0 + 15_565.0 + 97_883.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-Qwen_Qwen3.8-27B"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-Qwen_Qwen3.8-27B",
+        LaneConfig(model="Qwen/Qwen3.8-27B", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=True,
+    )
+    manager._handles["planner-openai_gpt-oss-120b"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-openai_gpt-oss-120b",
+        LaneConfig(model="openai/gpt-oss-120b", vllm=True, gpu_devices="1", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    lane = LaneConfig(
+        model="Qwen/Qwen3-Embedding-8B",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, kv_cache_memory_bytes="6G"),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen3-Embedding-8B", lane)  # noqa: SLF001
+    # GPU 1 is infeasible (15.5 GB < 22.7 GB threshold). GPU 0 and GPU 2 both
+    # hold no awake lane — the sleeping 27B must not count — so the tie breaks
+    # toward the more free GPU 2.
+    assert placed.gpu_devices == "2"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_treats_sleeping_lane_gpu_as_empty() -> None:
+    """Inverse of the deioma case: when the GPU next to a sleeping lane has
+    MORE free VRAM than the alternative, it must win. Had the sleeping lane
+    counted as an awake occupant, the lane-free (but more filled) GPU would
+    have won instead — so this pins the sleep exclusion itself.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen3.8-27B"] = ModelProfileRecord(loaded_vram_mb=64_000.0, engine="vllm")  # noqa: SLF001
+    profiles._profiles["Qwen/Qwen3-Embedding-8B"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=22_545.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: sleeping 27B residue only.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=94_687.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: infeasible filler.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=15_565.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: no lane, but 7.9 GB of unknown usage.
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=90_000.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=94_687.0 + 15_565.0 + 90_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-Qwen_Qwen3.8-27B"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-Qwen_Qwen3.8-27B",
+        LaneConfig(model="Qwen/Qwen3.8-27B", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=True,
+    )
+    lane = LaneConfig(
+        model="Qwen/Qwen3-Embedding-8B",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, kv_cache_memory_bytes="6G"),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen3-Embedding-8B", lane)  # noqa: SLF001
+    # GPU 0 is "empty" of awake lanes and has more free VRAM than GPU 2.
+    assert placed.gpu_devices == "0"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_spreads_new_lane_away_from_awake_lane() -> None:
+    """A new lane must avoid a GPU that already holds an awake lane, even when
+    that GPU still has more free VRAM than the alternative — one active model
+    per GPU is the primary goal of the scoring.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["small/embed"] = ModelProfileRecord(loaded_vram_mb=22_500.0, engine="vllm")  # noqa: SLF001
+    profiles._profiles["small/rerank"] = ModelProfileRecord(loaded_vram_mb=10_000.0, engine="vllm")  # noqa: SLF001
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: one awake 22.5 GB lane, 70 GB free.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=70_000.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: infeasible filler.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=9_000.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: empty, 60 GB free (37.9 GB unknown usage).
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=60_000.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=70_000.0 + 9_000.0 + 60_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-small_embed"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-small_embed",
+        LaneConfig(model="small/embed", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    lane = LaneConfig(
+        model="small/rerank",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, kv_cache_memory_bytes="1G"),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-small_rerank", lane)  # noqa: SLF001
+    # GPU 0 has more free VRAM but one awake lane; GPU 2 is empty. The awake
+    # lane count (1 vs 0) must outweigh the free-VRAM tiebreak.
+    assert placed.gpu_devices == "2"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_breaks_awake_ties_by_least_awake_vram() -> None:
+    """When two GPUs each hold exactly one awake lane, the one with the
+    smaller awake footprint wins — it leaves the most room for the new lane.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["small/embed"] = ModelProfileRecord(loaded_vram_mb=20_000.0, engine="vllm")  # noqa: SLF001
+    profiles._profiles["small/big"] = ModelProfileRecord(loaded_vram_mb=35_000.0, engine="vllm")  # noqa: SLF001
+    profiles._profiles["small/rerank"] = ModelProfileRecord(loaded_vram_mb=10_000.0, engine="vllm")  # noqa: SLF001
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: one awake 20 GB lane, 80 GB free.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=80_000.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: infeasible filler.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=9_000.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: one awake 35 GB lane, 60 GB free.
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=60_000.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=80_000.0 + 9_000.0 + 60_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-small_embed"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-small_embed",
+        LaneConfig(model="small/embed", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    manager._handles["planner-small_big"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-small_big",
+        LaneConfig(model="small/big", vllm=True, gpu_devices="2", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    lane = LaneConfig(
+        model="small/rerank",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, kv_cache_memory_bytes="1G"),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-small_rerank", lane)  # noqa: SLF001
+    # Both GPUs hold one awake lane; the smaller footprint (20 GB) wins over
+    # the larger one (35 GB) despite its lower free VRAM.
+    assert placed.gpu_devices == "0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #786.

## What & why

Auto-placement scored feasible GPU subsets by *least leftover free VRAM*
(best-fit packing), blind to *why* the VRAM is filled. A GPU holding only a
sleep_l1 lane's ~3 GB residue — plus the worker's warmup CUDA context on
`cuda:0` — ranked as the "fullest" GPU, so new lanes were stacked next to
sleeping models while a fully free GPU sat unused.

## Change

`logos/logos-workernode/logos_worker_node/lane_manager.py`:

- `_auto_place_gpu_devices` now collects the per-GPU occupancy from *awake*
  vLLM lanes: for every `RUNNING` handle it queries `is_sleeping()` (unknown
  state counts as awake) and attributes the lane's estimated VRAM — the same
  `_estimate_lane_vram_mb` estimator placement already uses, split across its
  GPUs — to those GPUs.
- `_pick_best_gpu_subset` scores by
  `(collocated_with_tp_shard, awake_lane_count↓, awake_used_mb↓, free_mb↑, index)`:
  one active model per GPU first, then sleep_l1 residues don't count, and ties
  break toward the *emptiest* GPU (spread, not best-fit packing).
  The TP-shard co-location penalty and the sticky-GPU / GMU-floor logic stay
  untouched.

Only new or reconfigured lanes are affected; existing lanes keep their
current GPU assignment.

## Tests

- **new** `deioma repro`: 27B sleeping on GPU 0 + gpt-oss on GPU 1 + free
  GPU 2 → embedding must land on GPU 2.
- **new** `sleep_exclusion`: inverts the case so the sleep exclusion is pinned
  even when free-VRAM tiebreak would choose another way.
- **new** `spread`: awake lane count must beat free-VRAM tiebreak.
- **new** `awake_vram_tiebreak`: same awake count → pick the smaller used
  VRAM.
- **adjusted** kv-pinned GMU-floor test: redesigned to still fail if the
  floor regresses.
- **adjusted** TP-subset test: now asserts the *emptiest* feasible pair.
- `logos-workernode` full suite: **497 passed, 2 skipped**.
- `black` / `isort` / `flake8` clean.
