### PR TITLE
`Logos`: Prune stale model provider links and filter lanes by live capabilities

### DIFF
--- a/logos/logos-orchestrator/src/logos/logosnode_registry.py
+++ b/logos/logos-orchestrator/src/logos/logosnode_registry.py
@@ -529,9 +529,10 @@ class LogosNodeRuntimeRegistry:
                     accent=GREEN,
                 )
             )
-        # Sync announced capabilities to DB on session attach
-        if session.capabilities_models:
-            self._fire_capabilities_changed(ticket.provider_id, sorted(session.capabilities_models))
+        # Sync announced capabilities to DB on session attach. An empty list
+        # is a real state ("this worker serves nothing right now") — it must
+        # fire so stale model_provider links from earlier sessions get pruned.
+        self._fire_capabilities_changed(ticket.provider_id, sorted(session.capabilities_models))
         return session
 
     async def get_conflicting_session(

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2331,6 +2331,22 @@ async def _register_models_with_facades(
                 continue
 
             if provider_type == "logosnode":
+                # A connected worker is the source of truth for what it serves:
+                # skip DB deployments it no longer announces (stale
+                # model_provider link, e.g. from a manual connect_model_provider)
+                # so the planner doesn't spawn lanes for non-capable models.
+                # Without a live session (worker offline, or boot before first
+                # connect) the DB deployments stay registered as before.
+                snapshot = _logosnode_registry.peek_runtime_snapshot(provider_id)
+                if snapshot is not None and model_name not in snapshot["capabilities_models"]:
+                    logger.warning(
+                        "Skipping deployment model %s for connected logosnode provider %s (%s): "
+                        "not in the worker's live capabilities (stale DB link)",
+                        model_name,
+                        provider_name,
+                        provider_id,
+                    )
+                    continue
                 logosnode_registrations.append(
                     {
                         "model_id": model_id,

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2331,22 +2331,26 @@ async def _register_models_with_facades(
                 continue
 
             if provider_type == "logosnode":
-                # A connected worker is the source of truth for what it serves:
+                # A live worker is the source of truth for what it serves:
                 # skip DB deployments it no longer announces (stale
                 # model_provider link, e.g. from a manual connect_model_provider)
                 # so the planner doesn't spawn lanes for non-capable models.
-                # Without a live session (worker offline, or boot before first
-                # connect) the DB deployments stay registered as before.
-                snapshot = _logosnode_registry.peek_runtime_snapshot(provider_id)
-                if snapshot is not None and model_name not in snapshot["capabilities_models"]:
-                    logger.warning(
-                        "Skipping deployment model %s for connected logosnode provider %s (%s): "
-                        "not in the worker's live capabilities (stale DB link)",
-                        model_name,
-                        provider_name,
-                        provider_id,
-                    )
-                    continue
+                # Only applied to providers the scheduler also treats as
+                # online (fresh heartbeat): a stale session (worker hung,
+                # connection still open) counts as offline and its DB
+                # deployments stay registered as before, matching the
+                # scheduler's is_provider_online view of the same state.
+                if _logosnode_registry.is_provider_online(provider_id):
+                    snapshot = _logosnode_registry.peek_runtime_snapshot(provider_id)
+                    if snapshot is not None and model_name not in snapshot["capabilities_models"]:
+                        logger.warning(
+                            "Skipping deployment model %s for connected logosnode provider %s (%s): "
+                            "not in the worker's live capabilities (stale DB link)",
+                            model_name,
+                            provider_name,
+                            provider_id,
+                        )
+                        continue
                 logosnode_registrations.append(
                     {
                         "model_id": model_id,

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_logosnode_capability_sync.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_logosnode_capability_sync.py
@@ -1,0 +1,115 @@
+"""Tests for DBManager.sync_logosnode_capabilities (worker capabilities -> DB).
+
+Statements are identified by their position in the call sequence and their
+bind params (conftest may stub sqlalchemy, so the SQL text itself is not
+asserted — same approach as test_api_key_queries.py).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from logos import DBManager
+
+
+class MockRow:
+    def __init__(self, data):
+        self._data_dict = data
+
+    def __getattr__(self, name):
+        if name in self._data_dict:
+            return self._data_dict[name]
+        raise AttributeError(f"MockRow has no attribute '{name}'")
+
+
+def _db_with_execute_side_effects(side_effects):
+    db = DBManager.__new__(DBManager)
+    session = MagicMock()
+    session.execute.side_effect = side_effects
+    db.session = session
+    return db, session
+
+
+def _bind_params(session):
+    return [call.args[1] for call in session.execute.call_args_list]
+
+
+def test_sync_empty_capabilities_prunes_existing_link():
+    """model_names=[] must delete the provider's stale model_provider links,
+    touch no models rows, and return no newly inserted names."""
+    existing = MockRow({"model_id": 10, "name": "model-a"})
+    side_effects = [
+        MagicMock(),  # logosnode_provider_keys upsert
+        MagicMock(fetchall=MagicMock(return_value=[existing])),  # existing links
+        MagicMock(),  # DELETE stale link
+    ]
+    db, session = _db_with_execute_side_effects(side_effects)
+
+    result = db.sync_logosnode_capabilities(provider_id=1, model_names=[])
+
+    assert result == []
+    params = _bind_params(session)
+    assert params == [
+        {"pid": 1},  # provider-keys upsert
+        {"pid": 1},  # select existing links
+        {"pid": 1, "mid": 10},  # delete model-a's link
+    ]
+    # No models row lookups or inserts: only 3 statements were executed
+    assert len(params) == 3
+    session.commit.assert_called_once()
+
+
+def test_sync_replaces_stale_link_and_adds_missing_model():
+    """Existing links for [A, B] + announced [B, C]: A's link is deleted, B's
+    kept, C gets a new models row (returned) and a model_provider link."""
+    existing = [
+        MockRow({"model_id": 10, "name": "model-a"}),
+        MockRow({"model_id": 11, "name": "model-b"}),
+    ]
+    side_effects = [
+        MagicMock(),  # logosnode_provider_keys upsert
+        MagicMock(fetchall=MagicMock(return_value=existing)),  # existing links
+        MagicMock(),  # DELETE stale link (model-a)
+        MagicMock(fetchone=MagicMock(return_value=None)),  # model-c not in models yet
+        MagicMock(fetchone=MagicMock(return_value=MockRow({"id": 12}))),  # INSERT models RETURNING id
+        MagicMock(),  # model_provider upsert for model-c
+    ]
+    db, session = _db_with_execute_side_effects(side_effects)
+
+    result = db.sync_logosnode_capabilities(provider_id=1, model_names=["model-b", "model-c"])
+
+    assert result == ["model-c"]
+    params = _bind_params(session)
+    assert params == [
+        {"pid": 1},  # provider-keys upsert
+        {"pid": 1},  # select existing links
+        {"pid": 1, "mid": 10},  # delete model-a's link (stale)
+        {"name": "model-c"},  # models lookup
+        {"name": "model-c"},  # models insert (new row, id 12)
+        {"pid": 1, "mid": 12},  # model_provider upsert for model-c
+    ]
+    # model-b's link (mid 11) is never touched
+    assert not any(p.get("mid") == 11 for p in params)
+    session.commit.assert_called_once()
+
+
+def test_sync_empty_capabilities_without_existing_links():
+    """model_names=[] with no pre-existing links: no crash, provider-keys row
+    is still created (upsert issued), nothing deleted."""
+    side_effects = [
+        MagicMock(),  # logosnode_provider_keys upsert
+        MagicMock(fetchall=MagicMock(return_value=[])),  # no existing links
+    ]
+    db, session = _db_with_execute_side_effects(side_effects)
+
+    result = db.sync_logosnode_capabilities(provider_id=7, model_names=[])
+
+    assert result == []
+    params = _bind_params(session)
+    assert params == [
+        {"pid": 7},  # provider-keys upsert
+        {"pid": 7},  # select existing links (none)
+    ]
+    # No deletes, no models lookups or inserts
+    assert not any("mid" in p for p in params)
+    session.commit.assert_called_once()

--- a/logos/logos-orchestrator/tests/unit/main/test_node_controller_integration.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_node_controller_integration.py
@@ -811,3 +811,32 @@ async def test_sync_response_falls_back_to_direct_http_for_logosnode_without_lan
         scheduling_stats=None,
     )
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_attach_session_fires_capabilities_changed_with_empty_list():
+    """A worker reconnecting with no capabilities must still fire the DB sync
+    callback (with []) so stale model_provider links get pruned."""
+    calls: list[tuple[int, list[str]]] = []
+    registry = LogosNodeRuntimeRegistry(on_capabilities_changed=lambda pid, names: calls.append((pid, names)))
+    token = await registry.issue_ticket(41, "worker-empty", [])
+    ticket = await registry.consume_ticket(token)
+    assert ticket is not None
+
+    await registry.attach_session(ticket, _FakeWebSocket())
+
+    assert calls == [(41, [])]
+
+
+@pytest.mark.asyncio
+async def test_attach_session_fires_capabilities_changed_with_sorted_names():
+    """Non-empty capabilities still fire the callback with the sorted list."""
+    calls: list[tuple[int, list[str]]] = []
+    registry = LogosNodeRuntimeRegistry(on_capabilities_changed=lambda pid, names: calls.append((pid, names)))
+    token = await registry.issue_ticket(42, "worker-caps", ["model-b", "model-a"])
+    ticket = await registry.consume_ticket(token)
+    assert ticket is not None
+
+    await registry.attach_session(ticket, _FakeWebSocket())
+
+    assert calls == [(42, ["model-a", "model-b"])]

--- a/logos/logos-orchestrator/tests/unit/main/test_register_models_with_facades.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_register_models_with_facades.py
@@ -1,0 +1,99 @@
+"""Tests for _register_models_with_facades (DB deployments -> SDI facades)."""
+
+from __future__ import annotations
+
+import pytest
+
+import logos as main_mod
+from logos import LogosNodeRuntimeRegistry
+from logos.queue.priority_queue import PriorityQueueManager
+from logos.sdi.azure_facade import AzureSchedulingDataFacade
+from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
+
+
+class _FakeWebSocket:
+    async def close(self):
+        pass
+
+
+class _FakeDB:
+    """Minimal DBManager stub with a fixed set of deployments."""
+
+    def __init__(self, deployments, models, providers):
+        self._deployments = deployments
+        self._models = {m["id"]: m for m in models}
+        self._providers = {p["id"]: p for p in providers}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get_all_deployments(self):
+        return self._deployments
+
+    def get_model(self, model_id):
+        return self._models.get(model_id)
+
+    def get_provider(self, provider_id):
+        return self._providers.get(provider_id)
+
+    def get_provider_config(self, provider_id):
+        return {}
+
+    def get_endpoint_for_deployment(self, model_id, provider_id):
+        return None
+
+
+async def _attach(registry, provider_id, worker_id, capabilities):
+    ticket = await registry.consume_ticket(
+        await registry.issue_ticket(provider_id, worker_id, list(capabilities))
+    )
+    assert ticket is not None
+    await registry.attach_session(ticket, _FakeWebSocket())
+
+
+@pytest.mark.asyncio
+async def test_register_models_filters_connected_logosnode_by_live_capabilities(monkeypatch):
+    """Deployments of a connected logosnode worker are filtered to its live
+    capabilities (stale links are skipped), while a disconnected worker's DB
+    deployments stay registered as before."""
+    registry = LogosNodeRuntimeRegistry()
+    # worker-a is connected and only serves model-b
+    await _attach(registry, 100, "worker-a", ["model-b"])
+    # worker-empty is connected with no capabilities — its stale DB link
+    # must not be registered
+    await _attach(registry, 102, "worker-empty", [])
+    # worker-offline (101) has no session at all
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    db = _FakeDB(
+        deployments=[
+            {"model_id": 1, "provider_id": 100, "type": "logosnode"},  # stale for connected worker-a
+            {"model_id": 2, "provider_id": 100, "type": "logosnode"},  # in worker-a's live capabilities
+            {"model_id": 3, "provider_id": 101, "type": "logosnode"},  # offline worker: unfiltered
+            {"model_id": 4, "provider_id": 102, "type": "logosnode"},  # stale for empty-caps worker
+        ],
+        models=[
+            {"id": 1, "name": "model-a", "parallel": 1},
+            {"id": 2, "name": "model-b", "parallel": 1},
+            {"id": 3, "name": "model-c", "parallel": 1},
+            {"id": 4, "name": "model-d", "parallel": 1},
+        ],
+        providers=[
+            {"id": 100, "name": "worker-a", "provider_type": "logosnode", "base_url": "http://a:8080"},
+            {"id": 101, "name": "worker-offline", "provider_type": "logosnode", "base_url": "http://o:8080"},
+            {"id": 102, "name": "worker-empty", "provider_type": "logosnode", "base_url": "http://e:8080"},
+        ],
+    )
+    monkeypatch.setattr(main_mod, "DBManager", lambda: db)
+
+    facade = LogosNodeSchedulingDataFacade(PriorityQueueManager(), db)
+    azure_facade = AzureSchedulingDataFacade(None)
+
+    await main_mod._register_models_with_facades(facade, azure_facade)
+
+    # model-a (100) and model-d (102) are skipped; model-b (100) and
+    # model-c (101) are registered
+    assert facade._model_to_provider == {2: {100}, 3: {101}}

--- a/logos/logos-orchestrator/tests/unit/main/test_register_models_with_facades.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_register_models_with_facades.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 import logos as main_mod
@@ -47,9 +49,7 @@ class _FakeDB:
 
 
 async def _attach(registry, provider_id, worker_id, capabilities):
-    ticket = await registry.consume_ticket(
-        await registry.issue_ticket(provider_id, worker_id, list(capabilities))
-    )
+    ticket = await registry.consume_ticket(await registry.issue_ticket(provider_id, worker_id, list(capabilities)))
     assert ticket is not None
     await registry.attach_session(ticket, _FakeWebSocket())
 
@@ -97,3 +97,42 @@ async def test_register_models_filters_connected_logosnode_by_live_capabilities(
     # model-a (100) and model-d (102) are skipped; model-b (100) and
     # model-c (101) are registered
     assert facade._model_to_provider == {2: {100}, 3: {101}}
+
+
+@pytest.mark.asyncio
+async def test_register_models_keeps_deployments_of_stale_logosnode_session(monkeypatch):
+    """A session whose heartbeat is older than the stale threshold counts as
+    offline: its DB deployments stay registered (offline fallback) instead of
+    being filtered against the frozen, stale capability list — the same view
+    the scheduler gets from is_provider_online."""
+    registry = LogosNodeRuntimeRegistry()
+    await _attach(registry, 100, "worker-a", ["model-b"])
+    # Simulate a hung worker: session still in the registry, heartbeat long gone
+    session = registry._sessions[100]  # noqa: SLF001
+    session.last_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=120)
+    assert not registry.is_provider_online(100)
+
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+    db = _FakeDB(
+        deployments=[
+            {"model_id": 1, "provider_id": 100, "type": "logosnode"},  # not in stale snapshot
+            {"model_id": 2, "provider_id": 100, "type": "logosnode"},  # in stale snapshot
+        ],
+        models=[
+            {"id": 1, "name": "model-a", "parallel": 1},
+            {"id": 2, "name": "model-b", "parallel": 1},
+        ],
+        providers=[
+            {"id": 100, "name": "worker-a", "provider_type": "logosnode", "base_url": "http://a:8080"},
+        ],
+    )
+    monkeypatch.setattr(main_mod, "DBManager", lambda: db)
+
+    facade = LogosNodeSchedulingDataFacade(PriorityQueueManager(), db)
+    azure_facade = AzureSchedulingDataFacade(None)
+
+    await main_mod._register_models_with_facades(facade, azure_facade)
+
+    # The stale snapshot must not trigger filtering: both deployments are
+    # registered, model-a included, exactly as for a fully offline worker.
+    assert facade._model_to_provider == {1: {100}, 2: {100}}


### PR DESCRIPTION
Closes #542.

A `model_provider` DB entry alone was enough to make the orchestrator spawn vLLM lanes for a model the connected worker node does not actually serve. Per the issue: *"it is only the db entry (mapping from provider to model) which lets the server spawn a lane for the non-capable model."*

Two halves, both in `logos-orchestrator`:

**A. Empty capabilities now prune the DB** (`logosnode_registry.py`, `attach_session`)

The capability→DB sync callback was guarded by `if session.capabilities_models:` — so a worker that (re)connected with an *empty* capability list never triggered a sync, and its stale `model_provider` links from earlier sessions (or from a manual `connect_model_provider`) lived on forever. The guard is removed: an empty list is a real state ("this worker serves nothing right now") and must fire `sync_logosnode_capabilities` with `[]`, which deletes the provider's stale links.

**B. Live worker is the source of truth at registration** (`main.py`, `_register_models_with_facades`)

Even with A, a stale link can exist in the DB while the worker is connected with a different capability set (the sync prunes asynchronously on attach, and manual links can appear anytime). When registering DB deployments for a `logosnode` provider that has a **live session**, deployments whose model is not in the worker's live `capabilities_models` (via `peek_runtime_snapshot`) are skipped with a warning, so the planner no longer spawns lanes for non-capable models. Without a live session (worker offline, boot before first connect) behavior is unchanged — DB deployments stay registered.

## Tests

Full orchestrator suite, same invocation as CI (`uv` venv on Python 3.13, `coverage run -m pytest`): **739 passed, 1 xfailed** (the xfail is the pre-existing documented `test_heterogeneous_gpu_tie_breaks_to_faster` gap, unrelated). New/updated:

- `test_attach_session_fires_capabilities_changed_with_empty_list` / `..._with_sorted_names` — the callback fires for empty and non-empty capabilities with the sorted list
- `tests/unit/dbutils/test_logosnode_capability_sync.py` (new) — `DBManager.sync_logosnode_capabilities`: empty list prunes existing links without touching `models` rows; mixed announce deletes stale links and inserts only genuinely new models
- `tests/unit/main/test_register_models_with_facades.py` (new) — connected worker filters its DB deployments to live capabilities (stale links skipped, empty-caps worker fully skipped), offline worker unfiltered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capability synchronization when connected workers report no models.
  * Live model filtering now applies only to workers with a fresh connection heartbeat.
  * Preserved database deployment registration when workers are disconnected or have stale sessions.

* **Tests**
  * Added coverage for empty and non-empty capability synchronization.
  * Added validation for online, offline, and stale-session deployment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->