### PR TITLE
`Logos`: Balance-wake — wake sleeping replica when the best-first winner is saturated

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -94,6 +94,21 @@ class CapacityPlanner:
     # developer abandoned before sending anything stops holding a lane open.
     ANNOUNCED_USE_TTL_SECONDS = 300.0
 
+    # Balance wake: when the best-first winner is under queue pressure for a
+    # model (>= this many active+queued requests on it), the planner wakes a
+    # sleeping replica on a NON-winning worker (no eviction, no cold load, at
+    # most one per model per cycle). Without it, a hot model with N-1 awake
+    # replicas and one sleeping standby stays at N-1 capacity forever: the
+    # ranker always prefers the 0.0s awake lanes over the 2.0s wake and the
+    # standby just idle-sleeps (observed in production: Qwen3.8-27B on
+    # deimama/deipapa saturated with queue 2-8 while the deioma replica slept
+    # for 7h with GPU 2 fully free).
+    # The floor keeps single-request blips from flapping the lane against the
+    # 120s idle tier: at >=4 concurrent the next arrival would wait a full
+    # request duration (60-120s for long-context completions), which a ~2s
+    # wake + VRAM reservation pays back.
+    BALANCE_WAKE_QUEUE_FLOOR = 4
+
     # Competitive ratios: applied when eviction IS required.
     # target_effective_demand > max(eviction_set_demand) * RATIO to proceed.
     WAKE_COMPETITIVE_RATIO = 1.5  # target must beat eviction set by 50%
@@ -677,6 +692,11 @@ class CapacityPlanner:
         # providers, so two providers don't independently agree to load the
         # same model in the same cycle.
         cycle_planned_models: set[str] = set()
+        # Balance-wake tracking: at most one balance-wake per model per cycle,
+        # so a saturated winner doesn't fan out wakes to every sleeping
+        # replica at once (one extra replica per cycle is the escalation step;
+        # the next cycle re-evaluates with the updated queues).
+        cycle_balance_wake_models: set[str] = set()
 
         provider_ids = list(self._facade.provider_ids())
         # Sort providers by current queue pressure so the worker most under
@@ -742,6 +762,7 @@ class CapacityPlanner:
                     cycle_planned_models=cycle_planned_models,
                     best_provider_for_model=best_provider_for_model,
                     cluster_lanes_by_model=cluster_lanes_by_model,
+                    cycle_balance_wake_models=cycle_balance_wake_models,
                 )
             )
             all_actions.extend(self._compute_demand_drain_actions(provider_id, lanes))
@@ -2979,6 +3000,84 @@ class CapacityPlanner:
     # Demand-based actions
     # ------------------------------------------------------------------
 
+    def _balance_wake_reason(
+        self,
+        provider_id: int,
+        model_name: str,
+        lanes: List[LaneSchedulerSignals],
+        winner_pid: int,
+        cycle_balance_wake_models: Optional[set[str]],
+    ) -> Optional[str]:
+        """Decide whether this NON-winning provider should balance-wake.
+
+        Called from the demand loop when the best-first ranker picked a
+        different (cheaper) worker for the model. Returns the planned
+        action's reason when a balance-wake is warranted, else None.
+
+        Eligibility (all required):
+          - the model was not already balance-woken elsewhere this cycle
+            (one extra replica per cycle is the escalation step),
+          - the winner is AWAKE for the model (it is the saturated incumbent,
+            not a replica that also needs waking itself),
+          - the winner's combined demand for the model (active + vLLM queue
+            + scheduler queue) is >= BALANCE_WAKE_QUEUE_FLOOR,
+          - this provider has a sleeping lane for the model (wake path only —
+            a cold load is a replication decision, not a balance one).
+
+        Balance-wake is always on (no flag): it only spends VRAM an
+        idle-slept replica already parked, and the guardrails above keep it
+        from evicting, cold-loading, or fanning out.
+
+        VRAM feasibility and the no-eviction rule are enforced by the caller:
+        the WAKE branch only proceeds with the pre-computed reason when the
+        eviction set is empty.
+        """
+        if cycle_balance_wake_models is not None and model_name in cycle_balance_wake_models:
+            logger.info(
+                "Skipping balance-wake of %s on worker=%s: already balance-woken this cycle",
+                model_name,
+                self._facade.get_provider_name(provider_id) or provider_id,
+            )
+            return None
+        # Local check first — the common skip case (this worker has no
+        # sleeping lane for the model) exits before touching the winner.
+        sleeping = [
+            lane
+            for lane in lanes
+            if lane.model_name == model_name
+            and lane.sleep_state == "sleeping"
+            and not self._lane_is_in_wake_failure_cooldown(provider_id, lane.lane_id)
+        ]
+        if not sleeping:
+            return None
+        try:
+            winner_lanes = self._facade.get_all_provider_lane_signals(winner_pid)
+        except Exception:
+            return None
+        winner_awake = any(
+            lane.model_name == model_name
+            and lane.runtime_state in ("loaded", "running")
+            and lane.sleep_state != "sleeping"
+            for lane in winner_lanes
+        )
+        if not winner_awake:
+            return None
+        winner_queue = self._get_queue_depth_for_model(winner_pid, model_name, winner_lanes)
+        if winner_queue < self.BALANCE_WAKE_QUEUE_FLOOR:
+            logger.info(
+                "Skipping balance-wake of %s on worker=%s: winner queue=%d < floor=%d",
+                model_name,
+                self._facade.get_provider_name(provider_id) or provider_id,
+                winner_queue,
+                self.BALANCE_WAKE_QUEUE_FLOOR,
+            )
+            return None
+        winner_name = self._facade.get_provider_name(winner_pid) or winner_pid
+        return (
+            f"Balance-wake: winner={winner_name} queue_depth={winner_queue} "
+            f"≥ floor={self.BALANCE_WAKE_QUEUE_FLOOR}; VRAM free"
+        )
+
     def _compute_demand_actions(
         self,
         provider_id: int,
@@ -2987,6 +3086,7 @@ class CapacityPlanner:
         cycle_planned_models: Optional[set[str]] = None,
         best_provider_for_model: Optional[dict[str, int]] = None,
         cluster_lanes_by_model: Optional[dict[str, int]] = None,
+        cycle_balance_wake_models: Optional[set[str]] = None,
     ) -> List[CapacityPlanAction]:
         """Compute wake/load actions based on demand patterns.
 
@@ -3095,19 +3195,36 @@ class CapacityPlanner:
             # different worker as the cheapest for this model, skip here so
             # the winner can serve it (wake on a sleeping lane beats a cold
             # load on a different worker even when both have capability).
+            #
+            # Exception: balance wake. The ranker's cost model answers
+            # "which worker is cheapest to make able to serve" — an awake
+            # lane costs 0.0s and always wins over a 2.0s wake, so a
+            # sleeping standby replica of a hot model is skipped forever
+            # while the awake incumbent's queue grows. When the winner is
+            # saturated, fall through so the WAKE branch can spread the
+            # load (wake path only, never evicts — enforced below).
+            balance_wake_reason: Optional[str] = None
             if (
                 self._cross_provider_best_first
                 and best_provider_for_model is not None
                 and best_provider_for_model.get(model_name, provider_id) != provider_id
             ):
-                logger.info(
-                    "Skipping demand action for worker=%s model=%s: best-first" " ranker picked worker=%s",
-                    self._facade.get_provider_name(provider_id) or provider_id,
+                winner_pid = best_provider_for_model[model_name]
+                balance_wake_reason = self._balance_wake_reason(
+                    provider_id,
                     model_name,
-                    self._facade.get_provider_name(best_provider_for_model[model_name])
-                    or best_provider_for_model[model_name],
+                    lanes,
+                    winner_pid,
+                    cycle_balance_wake_models,
                 )
-                continue
+                if balance_wake_reason is None:
+                    logger.info(
+                        "Skipping demand action for worker=%s model=%s: best-first" " ranker picked worker=%s",
+                        self._facade.get_provider_name(provider_id) or provider_id,
+                        model_name,
+                        self._facade.get_provider_name(winner_pid) or winner_pid,
+                    )
+                    continue
             model_lanes = lanes_by_model.get(model_name, [])
             # Phase 3.4: per-lane VRAM ledger gate — under v2, only skip this
             # model when an in-flight reservation overlaps the GPUs its target
@@ -3250,6 +3367,41 @@ class CapacityPlanner:
                         target_model_name=model_name,
                         target_lane_id=target.lane_id,
                     )
+
+                if balance_wake_reason is not None:
+                    # Balance wakes only spend free VRAM: the action spreads
+                    # load for the saturated winner, but no request is waiting
+                    # on this lane — evicting another model's lane for it
+                    # would be speculative preemption. Infeasible or
+                    # eviction-needing wakes are simply retried next cycle.
+                    if eviction_set is None:
+                        logger.info(
+                            "Skipping balance-wake of %s on worker=%s: " "needed VRAM not available",
+                            model_name,
+                            self._facade.get_provider_name(provider_id) or provider_id,
+                        )
+                    elif eviction_set:
+                        logger.info(
+                            "Skipping balance-wake of %s on worker=%s: "
+                            "would evict other models' lanes "
+                            "(balance-wake is eviction-free)",
+                            model_name,
+                            self._facade.get_provider_name(provider_id) or provider_id,
+                        )
+                    else:
+                        actions.append(
+                            CapacityPlanAction(
+                                action="wake",
+                                provider_id=provider_id,
+                                lane_id=target.lane_id,
+                                model_name=model_name,
+                                reason=balance_wake_reason,
+                            )
+                        )
+                        planned_models.add(model_name)
+                        if cycle_balance_wake_models is not None:
+                            cycle_balance_wake_models.add(model_name)
+                    continue
 
                 if eviction_set is None:
                     logger.info(

--- a/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
@@ -1769,3 +1769,230 @@ class TestWakeTargetSelfEviction:
         assert all(a.action != "wake" for a in actions)
         # Order: destructive stop before the recovering load.
         assert kinds.index(("stop", "planner-X")) < kinds.index(("load", "planner-X"))
+
+
+class TestBalanceWake:
+    """Balance wake: the best-first winner is awake but saturated (queue
+    >= BALANCE_WAKE_QUEUE_FLOOR) → the planner wakes a sleeping replica of
+    the same model on a NON-winning worker. Wake path only, never evicts,
+    at most one per model per cycle.
+
+    Regression for the deioma production case (2026-08-25): Qwen3.8-27B ran
+    on three workers; deimama and deipapa were awake and served the entire
+    queue (2-8 waiting, demand eff 2.12) while the deioma replica idle-slept
+    for ~7h with GPU 2 fully free. The ranker's cost model (awake lane 0.0s
+    vs wake 2.0s) can never let the standby win, and nothing else was
+    looking at the winner's queue depth.
+    """
+
+    def _full_path_planner(self, providers, ranked=("X", 2.0)):
+        """``_planner`` plus the attributes only the full demand path touches."""
+        planner = _planner(providers)
+        planner._cross_provider_dedup = False
+        planner._announced_use = {}
+        planner._provider_capacity_lock = lambda pid: SimpleNamespace(locked=lambda: False)
+        planner._vram_ledger = SimpleNamespace(
+            get_committed_mb=lambda pid: 0.0,
+            has_overlapping_reservation=lambda *a, **k: False,
+            get_gpu_effective_available_mb=lambda pid, g, f: f,
+        )
+        planner._demand.get_ranked_models.return_value = [ranked]
+        planner._demand.get_score.return_value = ranked[1]
+        return planner
+
+    def _winner_a(self, *, queue_active=3, queue_wait=5):
+        """Awake incumbent with a deep queue — the best-first winner (cost 0)."""
+        return _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[
+                _lane(
+                    lane_id="A-x",
+                    model_name="X",
+                    runtime_state="running",
+                    active_requests=queue_active,
+                    queue_waiting=queue_wait,
+                )
+            ],
+            capabilities=["X"],
+            available_vram_mb=5_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+
+    def _sleeper_b(self, provider_id=2, name="B", available_vram_mb=50_000):
+        """Sleeping standby replica (L1) with free VRAM for the wake."""
+        return _MockProvider(
+            provider_id=provider_id,
+            name=name,
+            lanes=[
+                _lane(
+                    lane_id=f"{name}-x",
+                    model_name="X",
+                    runtime_state="sleeping",
+                    sleep_state="sleeping",
+                    effective_vram_mb=500,
+                )
+            ],
+            capabilities=["X"],
+            available_vram_mb=available_vram_mb,
+            profiles={"X": _profile(loaded_vram_mb=20_000, sleeping_residual_mb=500)},
+        )
+
+    def test_wakes_sleeper_when_winner_is_saturated(self):
+        """Production case: A awake with queue depth 8 (winner), B has a
+        sleeping lane with free VRAM. B's LOCAL demand is below the regular
+        wake floor (score 0.3, no local queue) — only the winner's queue
+        justifies the wake, which is exactly what the balance path is for."""
+        a = self._winner_a(queue_active=3, queue_wait=5)  # depth 8 >= floor 4
+        b = self._sleeper_b()
+        planner = self._full_path_planner([a, b], ranked=("X", 0.3))
+        # Sanity: the ranker really picks the awake incumbent over the wake.
+        assert planner._rank_providers_for_demanded_models([1, 2], [("X", 0.3)]) == {"X": 1}
+
+        planned = set()
+        balance = set()
+        actions = planner._compute_demand_actions(
+            b.provider_id,
+            b.lanes,
+            cycle_planned_models=planned,
+            best_provider_for_model={"X": a.provider_id},
+            cycle_balance_wake_models=balance,
+        )
+        assert [(x.action, x.provider_id, x.lane_id) for x in actions] == [
+            ("wake", b.provider_id, "B-x"),
+        ]
+        assert "Balance-wake" in actions[0].reason
+        # Feeds both cycle-scoped dedup sets.
+        assert planned == {"X"}
+        assert balance == {"X"}
+
+    def test_no_balance_wake_below_queue_floor(self):
+        """Winner queue 3 < floor 4 → standby stays asleep (legacy skip).
+        A 1-3 request blip must not flap the lane against the 120s idle tier."""
+        a = self._winner_a(queue_active=2, queue_wait=1)  # depth 3
+        b = self._sleeper_b()
+        planner = self._full_path_planner([a, b])
+        actions = planner._compute_demand_actions(
+            b.provider_id,
+            b.lanes,
+            best_provider_for_model={"X": a.provider_id},
+        )
+        assert actions == []
+
+    def test_balance_wake_never_evicts(self):
+        """Wake on B needs VRAM that only an eviction frees → no action.
+        A balance wake spreads load for the incumbent; nothing is waiting on
+        B's lane, so preempting another model's lane would be speculative."""
+        a = self._winner_a()
+        b = self._sleeper_b(available_vram_mb=5_000)
+        planner = self._full_path_planner([a, b])
+        other = _lane(lane_id="B-emb", model_name="Embed", runtime_state="loaded")
+        planner._find_eviction_set = lambda *_, **__: [(other, "sleep", 0.0)]
+        actions = planner._compute_demand_actions(
+            b.provider_id,
+            b.lanes,
+            best_provider_for_model={"X": a.provider_id},
+        )
+        assert actions == []
+
+    def test_balance_wake_skipped_when_vram_infeasible(self):
+        """No eviction set can cover the deficit at all → no action (the
+        regular wake path would log the same, the balance path must not
+        plan anything either)."""
+        a = self._winner_a()
+        b = self._sleeper_b(available_vram_mb=5_000)
+        planner = self._full_path_planner([a, b])
+        planner._find_eviction_set = lambda *_, **__: None
+        actions = planner._compute_demand_actions(
+            b.provider_id,
+            b.lanes,
+            best_provider_for_model={"X": a.provider_id},
+        )
+        assert actions == []
+
+    def test_at_most_one_balance_wake_per_model_per_cycle(self):
+        """Two sleeping standbys → exactly one wakes this cycle; the second
+        is re-evaluated next cycle with the updated queues (escalation step,
+        not fan-out)."""
+        a = self._winner_a()
+        b1 = self._sleeper_b(provider_id=2, name="B")
+        b2 = self._sleeper_b(provider_id=3, name="C")
+        planner = self._full_path_planner([a, b1, b2])
+        planned = set()
+        balance = set()
+        best = {"X": a.provider_id}
+        actions_1 = planner._compute_demand_actions(
+            b1.provider_id,
+            b1.lanes,
+            cycle_planned_models=planned,
+            best_provider_for_model=best,
+            cycle_balance_wake_models=balance,
+        )
+        actions_2 = planner._compute_demand_actions(
+            b2.provider_id,
+            b2.lanes,
+            cycle_planned_models=planned,
+            best_provider_for_model=best,
+            cycle_balance_wake_models=balance,
+        )
+        wakes = [x for x in actions_1 + actions_2 if x.action == "wake"]
+        assert len(wakes) == 1
+        assert wakes[0].provider_id == b1.provider_id
+        assert balance == {"X"}
+
+    def test_no_cold_load_for_balance(self):
+        """A non-winner WITHOUT a lane for X must not cold-load it just
+        because the winner is saturated — a cold load is a replication
+        decision, not a balance one. C hosts an unrelated model Y (so it is
+        not an empty worker and the capability-seeding path is out of scope);
+        it has no sleeping X replica to wake."""
+        a = self._winner_a()
+        c = _MockProvider(
+            provider_id=3,
+            name="C",
+            lanes=[_lane(lane_id="C-y", model_name="Y", runtime_state="loaded")],
+            capabilities=["X", "Y"],
+            available_vram_mb=80_000,
+            profiles={
+                "X": _profile(loaded_vram_mb=20_000),
+                "Y": _profile(loaded_vram_mb=20_000),
+            },
+        )
+        planner = self._full_path_planner([a, c])
+        actions = planner._compute_demand_actions(
+            c.provider_id,
+            c.lanes,
+            best_provider_for_model={"X": a.provider_id},
+        )
+        assert actions == []
+
+    def test_no_balance_wake_when_winner_is_sleeping(self):
+        """If the winner itself is sleeping, it wakes via the regular demand
+        path (has_queued bypass) — the balance path only targets an awake,
+        saturated incumbent and must not double-plan on top of it."""
+        a = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[
+                _lane(
+                    lane_id="A-x",
+                    model_name="X",
+                    runtime_state="sleeping",
+                    sleep_state="sleeping",
+                    effective_vram_mb=500,
+                )
+            ],
+            capabilities=["X"],
+            available_vram_mb=50_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000, sleeping_residual_mb=500)},
+        )
+        b = self._sleeper_b()
+        planner = self._full_path_planner([a, b])
+        # Both sleeping: cost tie (2.0s) → free-VRAM tie (50k) → lowest id.
+        assert planner._rank_providers_for_demanded_models([1, 2], [("X", 2.0)]) == {"X": 1}
+        actions = planner._compute_demand_actions(
+            b.provider_id,
+            b.lanes,
+            best_provider_for_model={"X": 1},
+        )
+        assert actions == []


### PR DESCRIPTION
## Problem

Qwen3.8-27B runs on all three workers (deioma, deimama, deipapa). On 2026-08-25,
deimama/deipapa were awake and served the entire request stream — saturated,
with the demand eval at `eff=2.12` and a queue of 2–8 waiting requests on
deimama — while the deioma replica **idle-slept at L1 for ~7h with GPU 2 fully
free**. The cluster ran at 2/3 capacity with nothing to use the standby.

Root cause: the cross-provider best-first ranker picks the cheapest worker per
demanded model. An awake lane costs `0.0s`, a wake costs `2.0s`
(`TARGET_ACTION_COST_S`), so an awake incumbent *always* wins the ranking and
the non-winning provider's demand action is skipped unconditionally
(`"Skipping demand action … best-first ranker picked worker=deimama"` in every
planner cycle). The ranker's cost model answers "which worker is cheapest to
make able to serve" — it never looks at the winner's queue depth. The
request-time scheduler (ETTF) stays with the warm workers as long as either
one's estimated wait is under the sleeper's fixed 2.5s, which with two warm
replicas is rarely true simultaneously. So the standby only wakes on a
failover, never under load.

## Change

New **balance-wake** path in the demand loop (`capacity_planner.py`):

- When this provider is **not** the best-first winner, but
  1. the winner is **awake** for the model,
  2. the winner's combined queue for the model (active + vLLM queue +
     scheduler queue, same metric as `queue_here`) is **≥ `BALANCE_WAKE_QUEUE_FLOOR` (4)**,
  3. this provider has a **sleeping lane** for the model (not in wake-failure
     cooldown),
  → plan a `wake` for the sleeping lane.
- Guardrails (balance-wake is wake-path only):
  - **Never evicts** — if the wake would need another model's lane, it is
    skipped and retried next cycle. A balance wake spreads load for the
    incumbent; nothing is waiting on this lane, so preempting another model
    would be speculative.
  - **No cold load** — a provider without a lane must not cold-load just
    because the winner is busy (that is the replication decision,
    `LOGOS_REPLICATE_ON_FREE_VRAM`).
  - **At most one balance-wake per model per cycle** (`cycle_balance_wake_models`)
    — one extra replica per cycle is the escalation step; the next cycle
    re-evaluates with the updated queues.
- **No feature flag** — balance-wake is unconditional. The guardrails above
  are inherent, so there is no sensible off-switch.

The floor (4) keeps 1–3 request blips from flapping the lane against the 120s
idle tier — at ≥4 concurrent, the next arrival waits a full request duration
(60–120s for long-context completions), which a ~2s wake + free VRAM pays
back.

Self-regulation: after the wake, ETTF routes new requests to the now-warm
replica (tier=warm beats tier=sleeping), the incumbent's queue drains below
the floor, and the 120s idle tier re-sleeps the replica when it goes quiet.
The wake/sleep cycle is bounded by the idle tier — no thrashing.

## Tests

7 new scenario tests in `TestBalanceWake` (`test_best_first_scenarios.py`),
including the production case with the sleeper's *local* demand below the
regular wake floor (only the winner's queue justifies the wake), the queue
floor, the no-eviction rule, infeasible VRAM, the per-cycle cap, no cold
load, and the sleeping-winner case. Orchestrator unit suite:
**771 passed, 1 xfailed** (pre-existing documented gap). Black + flake8 clean.

## Rollout / verification

Deploy the orchestrator image (no worker-node change). In production the
first `Balance-wake:` lines should appear for Qwen3.8-27B on deioma when
deimama's `queue_here` reaches 4; the deioma lane then flips to
`running / awake` and ETTF starts reserving requests for it. Revert by
redeploying the previous orchestrator image.