### PR TITLE
`Logos`: Route profile-level keys out of vLLM model_overrides instead of failing add_lane

### DIFF
--- a/logos/logos-workernode/config.example.yml
+++ b/logos/logos-workernode/config.example.yml
@@ -310,6 +310,11 @@ engines:
     #   extra_args: list           — arbitrary extra CLI flags passed verbatim to
     #     "vllm serve". Use for features not yet exposed as first-class fields.
 
+    # Profile-level keys (min_context_fraction, base_residency_mb, kv_budget_mb,
+    # ...) do NOT belong in model_overrides: they are not vLLM engine settings.
+    # If one slips in here it is auto-routed to the model profile registry with
+    # a warning; the documented home is an inline entry under
+    # logos.capabilities_models (see above).
     model_overrides:
       Qwen/Qwen2.5-Coder-7B-Instruct-AWQ:
         quantization: awq

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1288,6 +1288,14 @@ class LaneManager:
         SM-specific workarounds (e.g. disable_custom_all_reduce, quantization: awq
         on Turing) without requiring changes to the Logos server.
 
+        Keys are split by the VllmConfig schema itself: real vLLM engine keys
+        are merged and validated strictly (a type error there still fails the
+        lane), while profile-level keys an operator misplaced here
+        (min_context_fraction, base_residency_mb, ...) are routed to the model
+        profile registry instead of aborting lane creation — a single misplaced
+        knob must not kill add_lane for the whole model. Their documented home
+        is an inline entry under logos.capabilities_models in config.yml.
+
         The worker-wide engines.vllm.disable_sleep_mode kill switch is applied
         last so it cannot be re-enabled by a per-model override or by what the
         Logos server sends.
@@ -1298,11 +1306,26 @@ class LaneManager:
         disable_sleep = self._vllm_engine_config.disable_sleep_mode
         if not overrides and not disable_sleep:
             return lane_config
-        merged = {**lane_config.vllm_config.model_dump(), **overrides}
+        engine_fields = VllmConfig.model_fields
+        engine_overrides = {k: v for k, v in overrides.items() if k in engine_fields}
+        profile_overrides = {k: v for k, v in overrides.items() if k not in engine_fields}
+        if profile_overrides:
+            logger.warning(
+                "engines.vllm.model_overrides for %s contains profile-level key(s) %s — "
+                "routing them to the model profile registry. Their documented home is an "
+                "inline entry under logos.capabilities_models in config.yml.",
+                lane_config.model,
+                sorted(profile_overrides),
+            )
+            if self._model_profiles is not None:
+                self._model_profiles.add_overrides({lane_config.model: profile_overrides})
+        merged = {**lane_config.vllm_config.model_dump(), **engine_overrides}
         if disable_sleep:
             merged["enable_sleep_mode"] = False
         new_vc = VllmConfig.model_validate(merged)
-        applied = list(overrides)
+        applied = list(engine_overrides)
+        if profile_overrides:
+            applied.append(f"routed to profile registry: {sorted(profile_overrides)}")
         if disable_sleep:
             applied.append("enable_sleep_mode=false (engines.vllm.disable_sleep_mode)")
         logger.info(

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -334,21 +334,35 @@ class ModelProfileRegistry:
         return tp_changed
 
     def add_overrides(self, overrides: dict[str, dict[str, Any]]) -> None:
-        """Merge additional manual overrides (e.g. from capabilities_overrides)."""
-        for model_name, ov in overrides.items():
-            if not isinstance(ov, dict) or not ov:
-                continue
-            existing = self._manual_overrides.get(model_name)
-            if existing is not None:
-                existing.update(ov)
-            else:
-                self._manual_overrides[model_name] = dict(ov)
-        if overrides:
-            logger.info(
-                "Added inline profile overrides for %d model(s): %s",
-                len(overrides),
-                ", ".join(sorted(overrides)),
-            )
+        """Merge additional manual overrides (e.g. from capabilities_overrides).
+
+        Re-applies the merged overrides to profile records that already exist:
+        records loaded from the persisted model_profiles.yml are otherwise
+        never revisited after startup, so an override that arrives late — this
+        method is also called from the lane-spawn path for profile-level keys
+        routed out of engines.vllm.model_overrides — would be missing from the
+        live record and from the runtime snapshot the server planner reads.
+        """
+        if not overrides:
+            return
+        with self._lock:
+            for model_name, ov in overrides.items():
+                if not isinstance(ov, dict) or not ov:
+                    continue
+                existing = self._manual_overrides.get(model_name)
+                if existing is not None:
+                    existing.update(ov)
+                else:
+                    self._manual_overrides[model_name] = dict(ov)
+            for model_name in overrides:
+                profile = self._profiles.get(model_name)
+                if profile is not None:
+                    self._apply_manual_overrides(model_name, profile)
+        logger.info(
+            "Added inline profile overrides for %d model(s): %s",
+            len(overrides),
+            ", ".join(sorted(overrides)),
+        )
 
     def _apply_manual_overrides(self, model_name: str, profile: ModelProfileRecord) -> bool:
         """Apply operator-provided overrides from config.yml."""

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -7,8 +7,10 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from pydantic import ValidationError
 
 from logos_worker_node.lane_manager import LaneManager, PortAllocator
+from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.models import (
     DeviceInfo,
     DeviceSummary,
@@ -1857,3 +1859,68 @@ def test_model_overrides_can_set_chat_template() -> None:
 
     assert merged.vllm_config is not None
     assert merged.vllm_config.chat_template == "qwen3-tools.jinja"
+
+
+def test_model_overrides_profile_keys_are_routed_to_registry() -> None:
+    """A profile-level key in model_overrides must not fail lane creation.
+
+    Production incident: an operator placed min_context_fraction under
+    engines.vllm.model_overrides; the extra="forbid" VllmConfig validation
+    aborted the whole add_lane. The key must instead be routed to the model
+    profile registry, where the server planner reads it from the runtime
+    snapshot — even when the profile record already exists (calibrated model).
+    """
+    registry = ModelProfileRegistry()
+    registry.record_loaded_vram("org/model-27b", 50000.0, engine="vllm", kv_cache_sent_mb=8000.0)
+    manager = LaneManager(
+        OllamaConfig(),
+        VllmEngineConfig(
+            model_overrides={
+                "org/model-27b": {
+                    "min_context_fraction": 1.0,
+                    "enable_sleep_mode": False,
+                }
+            }
+        ),
+        lane_port_start=15000,
+        lane_port_end=15010,
+        model_profiles=registry,
+    )
+    lane = LaneConfig(model="org/model-27b", vllm=True, vllm_config=VllmConfig())
+
+    merged = manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
+
+    assert merged.vllm_config is not None
+    assert merged.vllm_config.enable_sleep_mode is False
+    profile = registry.get_profile("org/model-27b")
+    assert profile is not None
+    assert profile.min_context_fraction == 1.0
+
+
+def test_model_overrides_invalid_engine_value_still_fails() -> None:
+    """A genuinely type-invalid engine value must keep failing loudly."""
+    manager = LaneManager(
+        OllamaConfig(),
+        VllmEngineConfig(model_overrides={"org/model-27b": {"max_num_seqs": "abc"}}),
+        lane_port_start=15000,
+        lane_port_end=15010,
+    )
+    lane = LaneConfig(model="org/model-27b", vllm=True, vllm_config=VllmConfig())
+
+    with pytest.raises(ValidationError):
+        manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
+
+
+def test_model_overrides_unknown_key_does_not_fail_lane_creation() -> None:
+    """An unrecognized key must not abort lane creation either."""
+    manager = LaneManager(
+        OllamaConfig(),
+        VllmEngineConfig(model_overrides={"org/model-27b": {"totally_bogus_key": 1}}),
+        lane_port_start=15000,
+        lane_port_end=15010,
+    )
+    lane = LaneConfig(model="org/model-27b", vllm=True, vllm_config=VllmConfig())
+
+    merged = manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
+
+    assert merged.vllm_config is not None

--- a/logos/logos-workernode/tests/test_model_profiles.py
+++ b/logos/logos-workernode/tests/test_model_profiles.py
@@ -669,3 +669,34 @@ def test_kv_max_model_len_pairs_persist_across_restart(tmp_path):
         {"kv_mb": 1024.0, "max_model_len": 1000},
         {"kv_mb": 2048.0, "max_model_len": 2000},
     ]
+
+
+def test_add_overrides_reapplies_to_existing_record():
+    """Overrides arriving after a record exists must reach the live record.
+
+    Records loaded from the persisted model_profiles.yml are otherwise never
+    revisited after startup, so a late override would stay in the store but
+    not on the record — and the runtime snapshot the server planner reads
+    would miss it.
+    """
+    registry = ModelProfileRegistry()
+    registry.record_loaded_vram("org/model-27b", 50000.0, engine="vllm", kv_cache_sent_mb=8000.0)
+    profile = registry.get_profile("org/model-27b")
+    assert profile is not None
+    assert profile.min_context_fraction is None
+
+    registry.add_overrides({"org/model-27b": {"min_context_fraction": 0.5}})
+
+    profile = registry.get_profile("org/model-27b")
+    assert profile.min_context_fraction == 0.5
+
+
+def test_add_overrides_before_record_creation_lands_on_seeded_record():
+    """Overrides registered before the record exists apply at seed time."""
+    registry = ModelProfileRegistry()
+    registry.add_overrides({"org/model-7b": {"min_context_fraction": 1.0}})
+    registry.seed_capabilities(["org/model-7b"], engine="vllm")
+
+    profile = registry.get_profile("org/model-7b")
+    assert profile is not None
+    assert profile.min_context_fraction == 1.0


### PR DESCRIPTION
## Background — production incident

On 2026-08-25 a worker node rejected a server-initiated `add_lane` with:

```
validation error for VllmConfig
min_context_fraction
  Extra inputs are not permitted [type=extra_forbidden, input_value=1.0, input_type=float]
```

The operator had set `min_context_fraction: 1.0` (a **profile-level** knob introduced in #775) under `engines.vllm.model_overrides.<model>` in the worker's `config.yml` — the same entry that already carries the model's vLLM-specific overrides. At lane spawn, `_apply_model_vllm_overrides` merges *all* keys of that entry on top of the lane's `vllm_config` and validates against `VllmConfig`, which declares `extra="forbid"` → the entire `add_lane` command failed with a pydantic error and the lane could never spawn.

## Root cause

Two independent defects in the same code path:

1. **`lane_manager.py` — `_apply_model_vllm_overrides`**: unconditionally merges every key from `engines.vllm.model_overrides` into the `vllm_config` dict and validates with `extra="forbid"`. Any non-engine key (including profile-level keys and plain typos) hard-fails the whole lane creation.
2. **`model_profiles.py` — `ModelProfileRegistry.add_overrides`**: only stores into `_manual_overrides`, but never re-applies onto profile records that **already exist** (e.g. loaded from the persisted `model_profiles.yml`). For an already-calibrated model, a `min_context_fraction` set in the *documented* location (`logos.capabilities_models`) therefore never reached the live record — and thus never the runtime snapshot the server's capacity planner reads.

## Changes

- **`lane_manager.py`** — split the per-model override by the `VllmConfig` schema itself (`VllmConfig.model_fields`, no hardcoded key list):
  - real engine keys: merged + strictly validated **exactly as before** (type-invalid values like `max_num_seqs: "abc"` still fail loudly);
  - any other key: routed to `ModelProfileRegistry.add_overrides` with a clear WARNING that names the keys and the documented home (`logos.capabilities_models`). A misplaced knob can no longer kill `add_lane` for a whole model.
- **`model_profiles.py`** — `add_overrides` now, under `self._lock` (deadlock-free; `_apply_manual_overrides` is lock-free and idempotent), re-applies the merged overrides onto existing records, so late-arriving overrides immediately reach the live record and the runtime snapshot.
- **`config.example.yml`** — one documentation note: profile-level keys do not belong in `model_overrides`.
- **Tests** (5 new): profile key in `model_overrides` is routed to an *existing* registry record (incident reproduction) + engine key still merged; type-invalid engine value still raises `ValidationError`; unknown key no longer aborts lane creation; `add_overrides` re-applies to an existing record; `add_overrides` before record creation lands on the seeded record.

## Verification

- Volle Worker-Testsuite: `498 passed, 2 skipped in 14.03s` (python 3.x, pydantic 2.12, pytest 9).

## Compatibility

- Drahtprotokoll (Server → Worker, `LaneConfig`/`VllmConfig`) bleibt strikt: ein vom Server gesendetes `min_context_fraction` in `vllm_config` wird weiterhin abgelehnt — gewollt.
- Behavior change nur für lokal im Worker-`config.yml` unter `engines.vllm.model_overrides` stehende Nicht-Engine-Keys: bisher hartes Fehlsignal, künftig Routing + Warning-Log.
