### PR TITLE
`Logos`: Update vLLM to v0.28.0

### DIFF
--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -65,7 +65,7 @@
 
 ARG BASE_IMAGE=python:3.14-slim
 ARG INSTALL_VLLM=0
-ARG VLLM_PIP_SPEC="vllm==v0.27.1"
+ARG VLLM_PIP_SPEC="vllm==v0.28.0"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.


### PR DESCRIPTION
## Motivation

Keep the workernode's inference stack current: bump the default vLLM pin to [v0.28.0](https://github.com/vllm-project/vllm/releases/tag/v0.28.0).

## Description

Updates the `VLLM_PIP_SPEC` build arg default in `logos/logos-workernode/Dockerfile` to `vllm==v0.28.0`. Torch and FlashInfer are resolved from vLLM's own dependency pins at build time, so no other changes are needed.

---
*This PR was created automatically by the `Logos - Update vLLM` workflow.*