### PR TITLE
`Logos`: Calibration verifies sleep capability via wake and post-wake test request

### DIFF
--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -12,10 +12,10 @@ sleeping states and persists the results to ``model_profiles.yml``.
 
 Sleep capability is verified, not assumed: after the sleep measurement the
 model is woken again (``/wake_up``) and must answer a second test request.
-The capacity planner puts this lane to sleep in production on the strength
-of the profile, so a model that cannot wake — or cannot serve once awake
-again — fails the run and gets no profile rather than one that authorises
-an irreversible sleep.
+A model that cannot sleep or wake safely does not fail the run — it gets a
+profile with ``sleep_mode_disabled`` recorded, so it is still served (awake)
+while the capacity planner never puts it to sleep. Only a failure before the
+awake measurement (VRAM sampling, KV search) fails the run.
 
 VRAM decomposition (exact, no guessing)::
 
@@ -1192,8 +1192,21 @@ class CalibrationResult:
     # Measured: total GPU delta while sleeping. None when the run skipped the
     # sleep phases because sleep is disabled for this model on this worker —
     # the value is genuinely unknowable there, and the profile records it as
-    # null rather than as a measurement.
+    # null rather than as a measurement. Also None when the sleep phases ran
+    # but failed verification (see sleep_mode_disabled): a residual measured
+    # for a sleep that cannot be reversed must not reach the planner.
     sleeping_residual_mb: float | None = 0.0
+    # Measured verdict on this model's sleep capability, persisted into the
+    # profile as ``sleep_mode_disabled``. True when the sleep phases ran and
+    # proved the model unsafe to sleep on this worker (``/sleep`` or
+    # ``/wake_up`` failed, a sleep/awake state never reached, or the model
+    # stopped serving after wake). False when the full sleep → wake → serve
+    # cycle completed. None when the run skipped the sleep phases
+    # (sleep_level 0), where the probe has no verdict and the profile keeps
+    # whatever is already known. The run itself still succeeds in both
+    # True/False cases: base_residency_mb is measured either way, and a
+    # model that cannot sleep is still worth serving — awake, never slept.
+    sleep_mode_disabled: bool | None = None
     base_residency_mb: float = 0.0  # = loaded_vram_mb (weights + KV, full footprint)
     # KV cache envelope discovered during calibration on this hardware. ``min``
     # is the smallest kv_cache_memory_bytes value at which the model loaded and
@@ -1350,8 +1363,10 @@ def calibrate_model(
     Runs the full probe sequence for *plan*: baseline VRAM, the KV-cache
     sweep, the awake measurement (with a 1-token warmup request), and — when
     ``sleep_level > 0`` — the sleep phases, which end with a wake verification
-    (Phase 5.5): the model must wake and answer a second test request, or the
-    run fails so no profile authorises an irreversible sleep.
+    (Phase 5.5): the model must wake and answer a second test request. A
+    model that cannot sleep or wake safely still yields a successful result
+    with ``sleep_mode_disabled=True`` and null sleep measurements — the
+    profile records the verdict instead of the run failing.
 
     Args:
         plan: Calibration plan (model name plus vLLM settings), as merged by
@@ -2383,12 +2398,24 @@ def calibrate_model(
         sleeping_residual_mb: float | None = None
         sleep_transient_mb: float | None = None
         host_ram_residual_mb: float | None = None
+        sleep_mode_disabled: bool | None = None
         if sleep_level <= 0:
             logger.info(
                 "  [4/6 + 5/6 + 5.5/6] Sleep phases skipped (sleep mode disabled for this model) — "
                 "sleeping_residual_mb stays unknown; base_residency is unaffected"
             )
         else:
+            # Phases 4 to 5.5 run the sleep-capability check and record its
+            # verdict in sleep_mode_disabled instead of failing the run: the
+            # planner needs base_residency_mb to serve this model, and a model
+            # that cannot be slept safely is still worth serving — awake. The
+            # sleeping measurements stay null when the verdict is "do not
+            # sleep this model", so the planner never sees a residual for a
+            # sleep that cannot be reversed.
+            sleep_phase_failed = False
+            sleep_failure_reason = ""
+            sleep_baseline_mb = None
+
             # Phase 4 — Sleep the model (with host-RAM transient sampling)
             if cancel_event is not None and cancel_event.is_set():
                 logger.info("  Calibration cancelled before Phase 4.")
@@ -2399,135 +2426,155 @@ def calibrate_model(
             with _track_host_ram_transient() as host_ram_probe:
                 status, _ = _post(sleep_url, timeout_s=_SLEEP_TIMEOUT_S)
                 if status not in (200, 204):
-                    partial.error = f"/sleep returned HTTP {status}"
-                    logger.warning("  ERROR: %s", partial.error)
+                    sleep_phase_failed = True
+                    sleep_failure_reason = f"/sleep returned HTTP {status}"
+                else:
+                    try:
+                        wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
+                    except TimeoutError as exc:
+                        sleep_phase_failed = True
+                        sleep_failure_reason = str(exc)
+
+            if not sleep_phase_failed:
+                sleep_transient_mb = host_ram_probe["transient_mb"]
+                sleep_baseline_mb = host_ram_probe["baseline_mb"]
+                if sleep_transient_mb is not None and sleep_baseline_mb is not None:
+                    logger.info(
+                        "        sleep_l%d transient host RAM: baseline_available=%.0fMB, " "peak_consumption=%.0fMB",
+                        sleep_level,
+                        sleep_baseline_mb,
+                        sleep_transient_mb,
+                    )
+                else:
+                    logger.info(
+                        "        sleep_l%d transient host RAM: /proc/meminfo unavailable — skipped",
+                        sleep_level,
+                    )
+
+                # Phase 5 — Measure sleeping VRAM. Sample twice with a settle
+                # between samples and take the max. CuMemAllocator's release is
+                # asynchronous; a single-shot sample can read mid-release and
+                # underestimate the residual (which leads to wake-time OOM when
+                # the planner trusts an artificially low value). The first
+                # sample is required; the second is a refinement and falls back
+                # silently if it fails.
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info("  Calibration cancelled before Phase 5.")
+                    partial.error = "cancelled"
                     return partial
+                logger.info(
+                    "  [5/6] Measuring sleeping VRAM (settling %.0fs, double-sample)...",
+                    _VRAM_SETTLE_S,
+                )
+                time.sleep(_VRAM_SETTLE_S)
                 try:
-                    wait_sleep_state(base_url, True, _SLEEP_TIMEOUT_S)
-                except TimeoutError as exc:
-                    partial.error = str(exc)
+                    s1 = sample_vram_mb(gpu_indices)
+                except Exception as exc:
+                    partial.error = f"nvidia-smi sleep failed: {exc}"
                     logger.warning("  ERROR: %s", partial.error)
                     return partial
+                time.sleep(3.0)
+                s2: float | None = None
+                try:
+                    s2 = sample_vram_mb(gpu_indices)
+                except Exception as exc:
+                    logger.info("        re-sample skipped (%s) — using single sample", exc)
+                sleeping_total_mb = max(s1, s2) if s2 is not None else s1
+                sleeping_residual_mb = max(sleeping_total_mb - baseline_mb, 0.0)
+                if s2 is not None:
+                    logger.info(
+                        "        sleeping samples = %.0f / %.0f MB  →  max delta = %.0f MB",
+                        s1,
+                        s2,
+                        sleeping_residual_mb,
+                    )
+                else:
+                    logger.info(
+                        "        sleeping sample = %.0f MB  →  delta = %.0f MB",
+                        s1,
+                        sleeping_residual_mb,
+                    )
 
-            sleep_transient_mb = host_ram_probe["transient_mb"]
-            sleep_baseline_mb = host_ram_probe["baseline_mb"]
-            if sleep_transient_mb is not None and sleep_baseline_mb is not None:
-                logger.info(
-                    "        sleep_l%d transient host RAM: baseline_available=%.0fMB, " "peak_consumption=%.0fMB",
-                    sleep_level,
-                    sleep_baseline_mb,
-                    sleep_transient_mb,
-                )
-            else:
-                logger.info(
-                    "        sleep_l%d transient host RAM: /proc/meminfo unavailable — skipped",
-                    sleep_level,
-                )
-
-            # Phase 5 — Measure sleeping VRAM. Sample twice with a settle between
-            # samples and take the max. CuMemAllocator's release is asynchronous;
-            # a single-shot sample can read mid-release and underestimate the
-            # residual (which leads to wake-time OOM when the planner trusts an
-            # artificially low value). The first sample is required; the second
-            # is a refinement and falls back silently if it fails.
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("  Calibration cancelled before Phase 5.")
-                partial.error = "cancelled"
-                return partial
-            logger.info(
-                "  [5/6] Measuring sleeping VRAM (settling %.0fs, double-sample)...",
-                _VRAM_SETTLE_S,
-            )
-            time.sleep(_VRAM_SETTLE_S)
-            try:
-                s1 = sample_vram_mb(gpu_indices)
-            except Exception as exc:
-                partial.error = f"nvidia-smi sleep failed: {exc}"
-                logger.warning("  ERROR: %s", partial.error)
-                return partial
-            time.sleep(3.0)
-            s2: float | None = None
-            try:
-                s2 = sample_vram_mb(gpu_indices)
-            except Exception as exc:
-                logger.info("        re-sample skipped (%s) — using single sample", exc)
-            sleeping_total_mb = max(s1, s2) if s2 is not None else s1
-            sleeping_residual_mb = max(sleeping_total_mb - baseline_mb, 0.0)
-            if s2 is not None:
-                logger.info(
-                    "        sleeping samples = %.0f / %.0f MB  →  max delta = %.0f MB",
-                    s1,
-                    s2,
-                    sleeping_residual_mb,
-                )
-            else:
-                logger.info(
-                    "        sleeping sample = %.0f MB  →  delta = %.0f MB",
-                    s1,
-                    sleeping_residual_mb,
-                )
-
-            # Host RAM the lane keeps for as long as it sleeps. sleep_l1 moves
-            # the weights to the host rather than dropping them, so a sleeping
-            # lane holds roughly its weight footprint in RAM until it wakes —
-            # tens of GB per model, on a host that is also lending RAM to the
-            # model cache. Only the transient peak was ever measured, which
-            # answers "can this sleep complete" and says nothing about what it
-            # costs afterwards, so the planner sees sleeping as free on the
-            # host axis and keeps choosing it.
-            #
-            # Read after the same settle as the VRAM samples: the release is
-            # asynchronous on both axes, and sampling mid-transfer would
-            # understate it. Taken against the awake baseline, so it is the
-            # delta the sleep caused, not the host's absolute usage.
-            host_ram_residual_mb = None
-            post_sleep_available_mb = _sample_host_ram_available_mb()
-            if sleep_baseline_mb is not None and post_sleep_available_mb is not None:
-                host_ram_residual_mb = max(sleep_baseline_mb - post_sleep_available_mb, 0.0)
-                logger.info(
-                    "        sleeping host RAM = %.0f MB  (available %.0f → %.0f MB)",
-                    host_ram_residual_mb,
-                    sleep_baseline_mb,
-                    post_sleep_available_mb,
-                )
-            else:
-                logger.info("        sleeping host RAM: /proc/meminfo unavailable — skipped")
+                # Host RAM the lane keeps for as long as it sleeps. sleep_l1
+                # moves the weights to the host rather than dropping them, so a
+                # sleeping lane holds roughly its weight footprint in RAM until
+                # it wakes — tens of GB per model, on a host that is also
+                # lending RAM to the model cache. Only the transient peak was
+                # ever measured, which answers "can this sleep complete" and
+                # says nothing about what it costs afterwards, so the planner
+                # sees sleeping as free on the host axis and keeps choosing it.
+                #
+                # Read after the same settle as the VRAM samples: the release
+                # is asynchronous on both axes, and sampling mid-transfer would
+                # understate it. Taken against the awake baseline, so it is the
+                # delta the sleep caused, not the host's absolute usage.
+                post_sleep_available_mb = _sample_host_ram_available_mb()
+                if sleep_baseline_mb is not None and post_sleep_available_mb is not None:
+                    host_ram_residual_mb = max(sleep_baseline_mb - post_sleep_available_mb, 0.0)
+                    logger.info(
+                        "        sleeping host RAM = %.0f MB  (available %.0f → %.0f MB)",
+                        host_ram_residual_mb,
+                        sleep_baseline_mb,
+                        post_sleep_available_mb,
+                    )
+                else:
+                    logger.info("        sleeping host RAM: /proc/meminfo unavailable — skipped")
 
             # Phase 5.5 — Wake verification. Phase 4 proved the model can go
-            # to sleep; this proves it can come back. The planner sleeps this
-            # lane in production on the strength of the profile, so a model
-            # whose wake fails — or that cannot serve a request once awake
-            # again — must fail the run: a persisted profile would authorise
-            # a sleep the lane can never reverse (the lane manager kills a
-            # lane whose wake OOMs, and a wedged engine wedges the node).
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("  Calibration cancelled before Phase 5.5.")
-                partial.error = "cancelled"
-                return partial
-            logger.info("  [5.5/6] Waking model and verifying it serves again...")
-            wake_status, _ = _post(f"{base_url}/wake_up", timeout_s=_SLEEP_TIMEOUT_S)
-            if wake_status not in (200, 204):
-                partial.error = f"/wake_up returned HTTP {wake_status}"
-                logger.warning("  ERROR: %s", partial.error)
-                return partial
-            try:
-                wait_sleep_state(base_url, False, _SLEEP_TIMEOUT_S)
-            except TimeoutError as exc:
-                partial.error = str(exc)
-                logger.warning("  ERROR: %s", partial.error)
-                return partial
-            # Test request 2: a lane that wakes but cannot serve is as
-            # unusable as one that never wakes. Same call as the Phase 2.5
-            # warmup — one 1-token completion.
-            post_wake_ok = warmup_inference(base_url, model, timeout_s=600.0)
-            if not post_wake_ok:
-                partial.error = (
-                    "post-wake test request failed — model does not serve after "
-                    "sleep/wake, sleep capability not verified"
+            # to sleep; this proves it can come back. A model whose wake
+            # fails — or that cannot serve a request once awake again — is
+            # recorded as sleep_mode_disabled instead of failing the run: it
+            # is still served awake, and the planner is told to never sleep it
+            # on this worker.
+            if not sleep_phase_failed:
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info("  Calibration cancelled before Phase 5.5.")
+                    partial.error = "cancelled"
+                    return partial
+                logger.info("  [5.5/6] Waking model and verifying it serves again...")
+                wake_status, _ = _post(f"{base_url}/wake_up", timeout_s=_SLEEP_TIMEOUT_S)
+                if wake_status not in (200, 204):
+                    sleep_phase_failed = True
+                    sleep_failure_reason = f"/wake_up returned HTTP {wake_status}"
+                else:
+                    try:
+                        wait_sleep_state(base_url, False, _SLEEP_TIMEOUT_S)
+                    except TimeoutError as exc:
+                        sleep_phase_failed = True
+                        sleep_failure_reason = str(exc)
+                if not sleep_phase_failed:
+                    # Test request 2: a lane that wakes but cannot serve is as
+                    # unusable as one that never wakes. Same call as the Phase
+                    # 2.5 warmup — one 1-token completion.
+                    post_wake_ok = warmup_inference(base_url, model, timeout_s=600.0)
+                    if not post_wake_ok and warmup_ok:
+                        # Served before sleep but not after: the sleep/wake
+                        # cycle broke serving.
+                        sleep_phase_failed = True
+                        sleep_failure_reason = "post-wake test request failed — model does not serve after sleep/wake"
+                    elif not post_wake_ok:
+                        # Did not serve one before sleep either — this model
+                        # does not support the request type (embedding-only
+                        # lanes expose no /v1/completions). The wake itself is
+                        # verified by /is_sleeping above, so accept it.
+                        logger.warning(
+                            "        post-wake test request failed, but the pre-sleep warmup "
+                            "did not serve either — request type unsupported by this model "
+                            "(e.g. embedding lane); accepting wake on /is_sleeping evidence"
+                        )
+            if sleep_phase_failed:
+                # A residual measured for a sleep that cannot be reversed must
+                # not reach the planner.
+                sleeping_residual_mb = None
+                sleep_mode_disabled = True
+                logger.warning(
+                    "  Sleep/wake verification failed: %s — recording sleep_mode_disabled=True "
+                    "in the profile instead of failing the run (model is still served awake)",
+                    sleep_failure_reason,
                 )
-                logger.warning("  ERROR: %s", partial.error)
-                return partial
-            logger.info("        wake verified — model serves a request after the sleep/wake cycle")
+            else:
+                sleep_mode_disabled = False
+                logger.info("        wake verified — model serves a request after the sleep/wake cycle")
 
         logger.info("  Results:")
         logger.info(
@@ -2539,12 +2586,18 @@ def calibrate_model(
             kv_cache_sent_mb,
         )
         if sleeping_residual_mb is None:
-            logger.info("    sleeping_residual_mb = n/a  (sleep mode disabled for this model)")
+            logger.info("    sleeping_residual_mb = n/a  (sleep phases skipped or sleep cannot be verified safe)")
         else:
             logger.info(
                 "    sleeping_residual_mb = %.0f MB  (measured independently)",
                 sleeping_residual_mb,
             )
+        if sleep_mode_disabled is None:
+            logger.info("    sleep_mode_disabled  = n/a  (sleep phases skipped)")
+        elif sleep_mode_disabled:
+            logger.info("    sleep_mode_disabled  = True  (sleep/wake verification failed — never sleep this model)")
+        else:
+            logger.info("    sleep_mode_disabled  = False  (sleep/wake cycle verified)")
         if host_ram_residual_mb is None:
             logger.info("    host_ram_residual_mb = n/a  (sleep phases skipped or /proc/meminfo unreadable)")
         else:
@@ -2567,6 +2620,7 @@ def calibrate_model(
             base_residency_mb=base_residency_mb,
             calibrated_at=time.time(),
             enforce_eager=eager_mode,
+            sleep_mode_disabled=sleep_mode_disabled,
             sleep_l1_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 1 else None),
             sleep_l2_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 2 else None),
             host_ram_residual_mb=host_ram_residual_mb,
@@ -2606,6 +2660,12 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
     return {
         "loaded_vram_mb": round(r.loaded_vram_mb, 1),
         "sleeping_residual_mb": (round(r.sleeping_residual_mb, 1) if r.sleeping_residual_mb is not None else None),
+        # Measured sleep verdict (True = cannot be slept safely here,
+        # False = sleep/wake cycle verified, None = the run skipped the sleep
+        # phases and the stored value stands). Non-None values override the
+        # stored one through merge_profile; a successful sleep re-verification
+        # is what clears a stale True after e.g. a vLLM upgrade.
+        "sleep_mode_disabled": r.sleep_mode_disabled,
         "disk_size_bytes": None,
         "base_residency_mb": round(r.base_residency_mb, 1),
         "kv_budget_mb": round(r.kv_cache_sent_mb, 1),
@@ -2708,9 +2768,10 @@ def load_existing_profiles(profiles_path: Path) -> dict[str, Any]:
 # operator override, or a sleep level this run did not exercise — and for
 # those ``None`` must not erase what is already known.
 #
-# ``sleeping_residual_mb`` is on this list because a run has exactly one
-# reason to report it null: the model is not allowed to sleep here, so the
-# sleep phases were skipped. Keeping a stale measurement then hides that. It
+# ``sleeping_residual_mb`` is on this list because a run reports it null
+# exactly when the model must not be slept here: the sleep phases were
+# skipped (sleep disabled) or they ran but failed verification
+# (sleep_mode_disabled=True). Keeping a stale measurement then hides that. It
 # also survives an ``enable_sleep_mode`` flip back to true, where the freshness
 # check sees a value, declines to re-calibrate, and hands the planner a
 # residual measured under a configuration that no longer exists.

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -14,8 +14,9 @@ Sleep capability is verified, not assumed: after the sleep measurement the
 model is woken again (``/wake_up``) and must answer a second test request.
 A model that cannot sleep or wake safely does not fail the run — it gets a
 profile with ``sleep_mode_disabled`` recorded, so it is still served (awake)
-while the capacity planner never puts it to sleep. Only a failure before the
-awake measurement (VRAM sampling, KV search) fails the run.
+while the capacity planner never puts it to sleep. Failures that leave the
+measurement itself incomplete (GPU VRAM sampling in any phase, the KV-cache
+search, the model never starting) still fail the run.
 
 VRAM decomposition (exact, no guessing)::
 
@@ -1194,8 +1195,11 @@ class CalibrationResult:
     # the value is genuinely unknowable there, and the profile records it as
     # null rather than as a measurement. Also None when the sleep phases ran
     # but failed verification (see sleep_mode_disabled): a residual measured
-    # for a sleep that cannot be reversed must not reach the planner.
-    sleeping_residual_mb: float | None = 0.0
+    # for a sleep that cannot be reversed must not reach the planner. The
+    # default is None, deliberately not 0.0: a missing value must never
+    # encode itself as "sleep frees the whole footprint" if a constructor
+    # forgets the field.
+    sleeping_residual_mb: float | None = None
     # Measured verdict on this model's sleep capability, persisted into the
     # profile as ``sleep_mode_disabled``. True when the sleep phases ran and
     # proved the model unsafe to sleep on this worker (``/sleep`` or
@@ -2553,14 +2557,17 @@ def calibrate_model(
                         sleep_phase_failed = True
                         sleep_failure_reason = "post-wake test request failed — model does not serve after sleep/wake"
                     elif not post_wake_ok:
-                        # Did not serve one before sleep either — this model
-                        # does not support the request type (embedding-only
-                        # lanes expose no /v1/completions). The wake itself is
-                        # verified by /is_sleeping above, so accept it.
+                        # Did not serve one before sleep either, so this
+                        # failure carries no evidence of a wake regression —
+                        # whatever the cause (embedding-only lanes expose no
+                        # /v1/completions, a transient 5xx, ...), it predates
+                        # the sleep. The wake itself is verified by
+                        # /is_sleeping above, so accept it.
                         logger.warning(
                             "        post-wake test request failed, but the pre-sleep warmup "
-                            "did not serve either — request type unsupported by this model "
-                            "(e.g. embedding lane); accepting wake on /is_sleeping evidence"
+                            "did not serve either — no evidence of a wake regression (the "
+                            "request type may simply be unsupported by this model, e.g. an "
+                            "embedding lane); accepting wake on /is_sleeping evidence"
                         )
             if sleep_phase_failed:
                 # A residual measured for a sleep that cannot be reversed must

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -10,6 +10,13 @@ per-GPU VRAM in ``_KV_CACHE_MIN_STEP_MB`` steps) and records the
 ``(kv_cache_mb, max_model_len)`` curve. It measures real VRAM in awake and
 sleeping states and persists the results to ``model_profiles.yml``.
 
+Sleep capability is verified, not assumed: after the sleep measurement the
+model is woken again (``/wake_up``) and must answer a second test request.
+The capacity planner puts this lane to sleep in production on the strength
+of the profile, so a model that cannot wake — or cannot serve once awake
+again — fails the run and gets no profile rather than one that authorises
+an irreversible sleep.
+
 VRAM decomposition (exact, no guessing)::
 
     base_residency_mb    = loaded_vram_mb  (weights + KV cache — full footprint)
@@ -2336,19 +2343,21 @@ def calibrate_model(
             kv_cache_sent_mb,
         )
 
-        # Phases 4 and 5 measure sleep, and only sleep. Everything the planner
-        # needs to place a lane — base_residency_mb above — is already known,
-        # so a model that is not allowed to sleep on this worker skips them and
-        # finishes with sleeping_residual_mb unknown rather than being dropped.
-        # Dropping it is what left nosleep models (enable_sleep_mode: false)
-        # permanently uncalibrated: no profile means the worker never reports
-        # them as a capability, and no later session could recover them either.
+        # Phases 4 to 5.5 measure sleep and verify it: put the model to
+        # sleep, measure the sleeping footprint, wake it, and require it to
+        # serve a request again. Everything the planner needs to place a
+        # lane — base_residency_mb above — is already known, so a model that
+        # is not allowed to sleep on this worker skips them and finishes with
+        # sleeping_residual_mb unknown rather than being dropped. Dropping it
+        # is what left nosleep models (enable_sleep_mode: false) permanently
+        # uncalibrated: no profile means the worker never reports them as a
+        # capability, and no later session could recover them either.
         sleeping_residual_mb: float | None = None
         sleep_transient_mb: float | None = None
         host_ram_residual_mb: float | None = None
         if sleep_level <= 0:
             logger.info(
-                "  [4/6 + 5/6] Sleep phases skipped (sleep mode disabled for this model) — "
+                "  [4/6 + 5/6 + 5.5/6] Sleep phases skipped (sleep mode disabled for this model) — "
                 "sleeping_residual_mb stays unknown; base_residency is unaffected"
             )
         else:
@@ -2455,6 +2464,42 @@ def calibrate_model(
                 )
             else:
                 logger.info("        sleeping host RAM: /proc/meminfo unavailable — skipped")
+
+            # Phase 5.5 — Wake verification. Phase 4 proved the model can go
+            # to sleep; this proves it can come back. The planner sleeps this
+            # lane in production on the strength of the profile, so a model
+            # whose wake fails — or that cannot serve a request once awake
+            # again — must fail the run: a persisted profile would authorise
+            # a sleep the lane can never reverse (the lane manager kills a
+            # lane whose wake OOMs, and a wedged engine wedges the node).
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info("  Calibration cancelled before Phase 5.5.")
+                partial.error = "cancelled"
+                return partial
+            logger.info("  [5.5/6] Waking model and verifying it serves again...")
+            wake_status, _ = _post(f"{base_url}/wake_up", timeout_s=_SLEEP_TIMEOUT_S)
+            if wake_status not in (200, 204):
+                partial.error = f"/wake_up returned HTTP {wake_status}"
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
+            try:
+                wait_sleep_state(base_url, False, _SLEEP_TIMEOUT_S)
+            except TimeoutError as exc:
+                partial.error = str(exc)
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
+            # Test request 2: a lane that wakes but cannot serve is as
+            # unusable as one that never wakes. Same call as the Phase 2.5
+            # warmup — one 1-token completion.
+            post_wake_ok = warmup_inference(base_url, model, timeout_s=600.0)
+            if not post_wake_ok:
+                partial.error = (
+                    "post-wake test request failed — model does not serve after "
+                    "sleep/wake, sleep capability not verified"
+                )
+                logger.warning("  ERROR: %s", partial.error)
+                return partial
+            logger.info("        wake verified — model serves a request after the sleep/wake cycle")
 
         logger.info("  Results:")
         logger.info(

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1345,6 +1345,34 @@ def calibrate_model(
     model_cache: Any | None = None,
     cancel_event: threading.Event | None = None,
 ) -> CalibrationResult:
+    """Calibrate one model on this worker and return a :class:`CalibrationResult`.
+
+    Runs the full probe sequence for *plan*: baseline VRAM, the KV-cache
+    sweep, the awake measurement (with a 1-token warmup request), and — when
+    ``sleep_level > 0`` — the sleep phases, which end with a wake verification
+    (Phase 5.5): the model must wake and answer a second test request, or the
+    run fails so no profile authorises an irreversible sleep.
+
+    Args:
+        plan: Calibration plan (model name plus vLLM settings), as merged by
+            ``plans_from_config``.
+        vllm_binary: vLLM executable to spawn.
+        port: Port the calibration probe listens on.
+        log_dir: Directory for the per-model vLLM log and the blacklist files.
+        sleep_level: vLLM sleep level to probe; 0 skips the sleep phases.
+        ready_timeout_s: Seconds to wait for a probe to become ready.
+        nccl_p2p_available: True on NVLink topologies (keeps P2P enabled).
+        hf_home: tmpfs HF cache to load from, when provided.
+        model_cache: Optional model cache; the first real spawn copies the
+            model into it.
+        cancel_event: When set, aborts the run at the next checkpoint.
+
+    Returns:
+        A ``CalibrationResult`` with ``success=True`` and the measured
+        footprints, or ``success=False`` with ``error`` (and optionally
+        ``unsupported_reason`` / ``node_unhealthy_reason``) when any phase
+        fails.
+    """
     # Honor the production enforce_eager setting (default False, matching the
     # worker schema). Calibrating in a different mode than production runs
     # produces systematically wrong loaded_vram_mb / sleeping_residual_mb

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -780,7 +780,7 @@ def _patch_calibration_infra(
     return patches
 
 
-def _run_calibrate(patches, plan=None):
+def _run_calibrate(patches, plan=None, sleep_level=1):
     """Enter all patches and call calibrate_model. Returns (result, mocks_dict)."""
     plan = plan or _make_plan()
     log_dir = Path("/tmp/test-calibration-logs")
@@ -792,7 +792,7 @@ def _run_calibrate(patches, plan=None):
             vllm_binary="vllm",
             port=11499,
             log_dir=log_dir,
-            sleep_level=1,
+            sleep_level=sleep_level,
             ready_timeout_s=60.0,
         )
     finally:
@@ -2336,3 +2336,129 @@ def test_plans_from_config_never_takes_internal_bookkeeping(tmp_path: Path) -> N
     plan = next(p for p in plans_from_config(cfg) if p["model"] == "m")
     assert "_max_model_len_retry_count" not in plan
     assert plan["dtype"] == "bfloat16"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Group 10 — Wake verification (Phase 5.5, issue #702)
+#
+# The calibration sequence is: test request 1 (Phase 2.5 warmup) → sleep
+# (Phase 4) → sleeping measurement (Phase 5) → wake (Phase 5.5) → test
+# request 2 (Phase 5.5) → shutdown. A model that cannot wake, or that
+# cannot serve after waking, must fail the run so no profile authorises
+# an irreversible sleep.
+# ═══════════════════════════════════════════════════════════════════════
+
+_CALIB_BASE_URL = "http://127.0.0.1:11499"
+
+
+def _capturing_post(**routing):
+    """Build a _post side effect that records URLs and routes by suffix.
+
+    ``routing`` maps a URL suffix to a (status, payload) return value;
+    everything else answers (200, {}).
+    """
+    urls: list[str] = []
+
+    def post_side_effect(url, body=None, timeout_s=30.0):
+        urls.append(url)
+        for suffix, response in routing.items():
+            if url.endswith(suffix):
+                if callable(response):
+                    return response()
+                return response
+        return (200, {})
+
+    return post_side_effect, urls
+
+
+def test_calibrate_wakes_model_and_serves_second_request():
+    """Happy path: sleep, then wake, then a second test request — in that order."""
+    post, urls = _capturing_post()
+    wait_sleep_calls: list[bool] = []
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+    patches["wait_sleep"] = patch(
+        "logos_worker_node.calibration.wait_sleep_state",
+        side_effect=lambda base_url, target, timeout_s: wait_sleep_calls.append(target),
+    )
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    sleep_idx = urls.index(f"{_CALIB_BASE_URL}/sleep?level=1")
+    wake_idx = urls.index(f"{_CALIB_BASE_URL}/wake_up")
+    completions = [i for i, u in enumerate(urls) if u.endswith("/v1/completions")]
+    # Two test requests: the Phase 2.5 warmup and the post-wake verification.
+    assert len(completions) == 2
+    # Test request 1 → sleep → wake → test request 2.
+    assert completions[0] < sleep_idx < wake_idx < completions[1]
+    # /is_sleeping polled for asleep after /sleep, for awake after /wake_up.
+    assert wait_sleep_calls == [True, False]
+
+
+def test_calibrate_fails_when_wake_up_returns_error():
+    """/wake_up must fail the run — no profile for a sleep that cannot be reversed."""
+    post, urls = _capturing_post(**{"/wake_up": (500, {})})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert not result.success
+    assert "wake_up" in result.error
+    # No test request 2 after a failed wake.
+    assert sum(1 for u in urls if u.endswith("/v1/completions")) == 1
+
+
+def test_calibrate_fails_when_model_stays_asleep_after_wake():
+    """A wake that never reaches the awake state fails the run."""
+    patches = _patch_calibration_infra()
+
+    def wait_sleep_side_effect(base_url, target, timeout_s):
+        if target is False:
+            raise TimeoutError(f"/is_sleeping did not reach {target} within {timeout_s:.0f}s")
+
+    patches["wait_sleep"] = patch(
+        "logos_worker_node.calibration.wait_sleep_state",
+        side_effect=wait_sleep_side_effect,
+    )
+
+    result, _ = _run_calibrate(patches)
+
+    assert not result.success
+    assert "is_sleeping" in result.error
+
+
+def test_calibrate_fails_when_post_wake_request_fails():
+    """A model that wakes but cannot serve is as bad as one that never wakes."""
+
+    def completions_response():
+        # post_side_effect appends the URL before routing, so the count
+        # includes the current call: 1 = Phase 2.5 warmup, 2 = post-wake.
+        completions_so_far = sum(1 for u in urls if u.endswith("/v1/completions"))
+        return (200, {}) if completions_so_far == 1 else (500, {})
+
+    post, urls = _capturing_post(**{"/v1/completions": completions_response})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert not result.success
+    assert "post-wake" in result.error
+    # /wake_up itself succeeded — it is the follow-up request that failed.
+    assert f"{_CALIB_BASE_URL}/wake_up" in urls
+
+
+def test_calibrate_sleep_level_zero_skips_wake():
+    """Sleep disabled for the model: no sleep, no wake, one test request only."""
+    post, urls = _capturing_post()
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches, sleep_level=0)
+
+    assert result.success, result.error
+    assert not any(u.endswith("/sleep") or u.endswith("/wake_up") for u in urls)
+    assert sum(1 for u in urls if u.endswith("/v1/completions")) == 1
+    assert result.sleeping_residual_mb is None

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2343,9 +2343,11 @@ def test_plans_from_config_never_takes_internal_bookkeeping(tmp_path: Path) -> N
 #
 # The calibration sequence is: test request 1 (Phase 2.5 warmup) → sleep
 # (Phase 4) → sleeping measurement (Phase 5) → wake (Phase 5.5) → test
-# request 2 (Phase 5.5) → shutdown. A model that cannot wake, or that
-# cannot serve after waking, must fail the run so no profile authorises
-# an irreversible sleep.
+# request 2 (Phase 5.5) → shutdown. A model that cannot sleep or wake
+# safely does not fail the run — it gets a successful result with
+# sleep_mode_disabled=True and null sleeping measurements, so the profile
+# (and the master's sleep_na view) records "serve awake, never sleep"
+# instead of the model vanishing from the worker's capabilities.
 # ═══════════════════════════════════════════════════════════════════════
 
 _CALIB_BASE_URL = "http://127.0.0.1:11499"
@@ -2395,24 +2397,33 @@ def test_calibrate_wakes_model_and_serves_second_request():
     assert completions[0] < sleep_idx < wake_idx < completions[1]
     # /is_sleeping polled for asleep after /sleep, for awake after /wake_up.
     assert wait_sleep_calls == [True, False]
+    # The sleep/wake cycle verified — the profile may record the model as sleepable.
+    assert result.sleep_mode_disabled is False
+    assert result.sleeping_residual_mb is not None
 
 
-def test_calibrate_fails_when_wake_up_returns_error():
-    """/wake_up must fail the run — no profile for a sleep that cannot be reversed."""
+def test_calibrate_records_sleep_disabled_when_wake_up_returns_error():
+    """A failed /wake_up must not fail the run — it records sleep_mode_disabled=True.
+
+    The model still gets its profile (base_residency measured) so it is
+    served awake, while the master's sleep_na view keeps it out of sleep.
+    """
     post, urls = _capturing_post(**{"/wake_up": (500, {})})
     patches = _patch_calibration_infra()
     patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
 
     result, _ = _run_calibrate(patches)
 
-    assert not result.success
-    assert "wake_up" in result.error
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is True
+    # No residual for a sleep that cannot be reversed.
+    assert result.sleeping_residual_mb is None
     # No test request 2 after a failed wake.
     assert sum(1 for u in urls if u.endswith("/v1/completions")) == 1
 
 
-def test_calibrate_fails_when_model_stays_asleep_after_wake():
-    """A wake that never reaches the awake state fails the run."""
+def test_calibrate_records_sleep_disabled_when_model_stays_asleep_after_wake():
+    """A wake that never reaches the awake state records sleep_mode_disabled=True."""
     patches = _patch_calibration_infra()
 
     def wait_sleep_side_effect(base_url, target, timeout_s):
@@ -2427,12 +2438,13 @@ def test_calibrate_fails_when_model_stays_asleep_after_wake():
 
     result, _ = _run_calibrate(patches)
 
-    assert not result.success
-    assert "is_sleeping" in result.error
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is True
+    assert result.sleeping_residual_mb is None
 
 
-def test_calibrate_fails_when_post_wake_request_fails():
-    """A model that wakes but cannot serve is as bad as one that never wakes."""
+def test_calibrate_records_sleep_disabled_when_post_wake_request_fails():
+    """A model that served before sleep but not after records sleep_mode_disabled=True."""
 
     def completions_response():
         """200 for the Phase 2.5 warmup, 500 for the post-wake request."""
@@ -2447,10 +2459,47 @@ def test_calibrate_fails_when_post_wake_request_fails():
 
     result, _ = _run_calibrate(patches)
 
-    assert not result.success
-    assert "post-wake" in result.error
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is True
+    assert result.sleeping_residual_mb is None
     # /wake_up itself succeeded — it is the follow-up request that failed.
     assert f"{_CALIB_BASE_URL}/wake_up" in urls
+
+
+def test_calibrate_embedding_model_with_unsupported_request_type():
+    """A model that never serves completions (embedding lane) is not a false positive.
+
+    The Phase 2.5 warmup already fails for such a model (request type
+    unsupported, not a serving failure), so a failed post-wake request must
+    not be read as a wake failure — the wake is verified by /is_sleeping.
+    """
+    post, urls = _capturing_post(**{"/v1/completions": (405, {})})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is False
+    # The sleep itself worked — the residual is measured and kept.
+    assert result.sleeping_residual_mb is not None
+    # Both test requests went out and both got 405.
+    assert sum(1 for u in urls if u.endswith("/v1/completions")) == 2
+
+
+def test_calibrate_records_sleep_disabled_when_sleep_call_fails():
+    """A failed /sleep records sleep_mode_disabled=True without a wake attempt."""
+    post, urls = _capturing_post(**{"/sleep?level=1": (500, {})})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is True
+    assert result.sleeping_residual_mb is None
+    # Nothing was slept, so nothing was woken either.
+    assert not any(u.endswith("/wake_up") for u in urls)
 
 
 def test_calibrate_sleep_level_zero_skips_wake():
@@ -2465,3 +2514,13 @@ def test_calibrate_sleep_level_zero_skips_wake():
     assert not any(u.endswith("/sleep") or u.endswith("/wake_up") for u in urls)
     assert sum(1 for u in urls if u.endswith("/v1/completions")) == 1
     assert result.sleeping_residual_mb is None
+    # The probe has no verdict when it skips the sleep phases — the stored
+    # value (e.g. the operator gate's) must stand.
+    assert result.sleep_mode_disabled is None
+
+
+def test_result_to_profile_dict_maps_sleep_mode_disabled() -> None:
+    """The measured verdict maps 1:1 into the profile dict (None = no verdict)."""
+    assert result_to_profile_dict(_success_result("m"))["sleep_mode_disabled"] is None
+    assert result_to_profile_dict(_success_result("m", sleep_mode_disabled=True))["sleep_mode_disabled"] is True
+    assert result_to_profile_dict(_success_result("m", sleep_mode_disabled=False))["sleep_mode_disabled"] is False

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2511,7 +2511,9 @@ def test_calibrate_sleep_level_zero_skips_wake():
     result, _ = _run_calibrate(patches, sleep_level=0)
 
     assert result.success, result.error
-    assert not any(u.endswith("/sleep") or u.endswith("/wake_up") for u in urls)
+    # Substring, not endswith: the sleep URL carries a query string
+    # (/sleep?level=1), which an endswith("/sleep") check would miss.
+    assert not any("/sleep" in u or "/wake_up" in u for u in urls)
     assert sum(1 for u in urls if u.endswith("/v1/completions")) == 1
     assert result.sleeping_residual_mb is None
     # The probe has no verdict when it skips the sleep phases — the stored

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2360,6 +2360,7 @@ def _capturing_post(**routing):
     urls: list[str] = []
 
     def post_side_effect(url, body=None, timeout_s=30.0):
+        """Record *url*, then return its routed response or the default 200."""
         urls.append(url)
         for suffix, response in routing.items():
             if url.endswith(suffix):
@@ -2415,6 +2416,7 @@ def test_calibrate_fails_when_model_stays_asleep_after_wake():
     patches = _patch_calibration_infra()
 
     def wait_sleep_side_effect(base_url, target, timeout_s):
+        """Simulate a wake that never reaches the awake state."""
         if target is False:
             raise TimeoutError(f"/is_sleeping did not reach {target} within {timeout_s:.0f}s")
 
@@ -2433,6 +2435,7 @@ def test_calibrate_fails_when_post_wake_request_fails():
     """A model that wakes but cannot serve is as bad as one that never wakes."""
 
     def completions_response():
+        """200 for the Phase 2.5 warmup, 500 for the post-wake request."""
         # post_side_effect appends the URL before routing, so the count
         # includes the current call: 1 = Phase 2.5 warmup, 2 = post-wake.
         completions_so_far = sum(1 for u in urls if u.endswith("/v1/completions"))

--- a/logos/logos-workernode/tests/test_profile_store.py
+++ b/logos/logos-workernode/tests/test_profile_store.py
@@ -138,17 +138,34 @@ def test_merge_writes_new_fields_including_nulls():
 
 
 def test_merge_clears_a_stale_sleep_measurement():
-    """A run reports sleeping_residual_mb null for exactly one reason: the
-    model is not allowed to sleep here, so the sleep phases were skipped.
-    Keeping the old number hides that, and survives an enable_sleep_mode flip
-    back to true — the freshness check sees a value, declines to re-calibrate,
-    and the planner sizes a wake from a configuration that no longer exists."""
+    """A run reports sleeping_residual_mb null exactly when the model must not
+    be slept here: the sleep phases were skipped, or they ran but failed
+    verification (sleep_mode_disabled=True). Keeping the old number hides
+    that, and survives an enable_sleep_mode flip back to true — the freshness
+    check sees a value, declines to re-calibrate, and the planner sizes a wake
+    from a configuration that no longer exists."""
     prior = {"base_residency_mb": 98945.0, "sleeping_residual_mb": 1400.0, "sleep_mode_disabled": False}
 
     merged = merge_profile(prior, {"base_residency_mb": 99000.0, "sleeping_residual_mb": None})
 
     assert merged["sleeping_residual_mb"] is None
     assert merged["sleep_mode_disabled"] is False, "still a field the probe does not own"
+
+
+def test_merge_sleep_mode_disabled_verdict_overrides_stored_value():
+    """When the probe exercised the sleep phases, its verdict (True/False)
+    overrides the stored value: a new failure sets True, and a successful
+    re-verification clears a stale True (e.g. after a vLLM upgrade). A None
+    verdict (phases skipped at level 0) lets the stored value — e.g. the
+    operator gate's flag — stand."""
+    merged = merge_profile({"sleep_mode_disabled": False}, {"sleep_mode_disabled": True})
+    assert merged["sleep_mode_disabled"] is True, "measured failure wins"
+
+    merged = merge_profile({"sleep_mode_disabled": True}, {"sleep_mode_disabled": False})
+    assert merged["sleep_mode_disabled"] is False, "measured success clears a stale flag"
+
+    merged = merge_profile({"sleep_mode_disabled": True}, {"sleep_mode_disabled": None})
+    assert merged["sleep_mode_disabled"] is True, "no verdict keeps the stored value"
 
 
 def test_merge_keeps_the_sleep_transient_of_a_level_it_did_not_run():


### PR DESCRIPTION
## Fixes #702

## Summary

Calibration used to run *test request → sleep → shutdown*, which never checked whether a model can actually come back from sleep. This PR extends the sequence to *test request 1 → sleep → wake → test request 2 → shutdown*, so the profile only describes a sleep/wake cycle the model really completed — and, per review, a model that cannot sleep or wake safely is **recorded in the profile** (`sleep_mode_disabled`) instead of failing the run: it is still served (awake) while the planner is told to never sleep it.

## Changes

- `logos/logos-workernode/logos_worker_node/calibration.py`:
  - New **Phase 5.5** in `calibrate_model()`: after the sleeping-VRAM measurement the model is woken (`POST /wake_up`), polled to the awake state via `/is_sleeping`, and must answer a second 1-token test request (the same `warmup_inference` call as the Phase 2.5 warmup).
  - The sleep verdict is tri-state on the result (`sleep_mode_disabled`): `True` when `/sleep` or the wake/serve verification failed, `False` when the full cycle completed, `None` when the sleep phases were skipped (stored value stands). `sleeping_residual_mb` is nulled when the sleep cannot be reversed so no residual reaches the planner.
  - No false positive for embedding-only lanes: a failed post-wake request only counts as a wake failure when the pre-sleep warmup served; otherwise the wake is verified on `/is_sleeping` evidence (such lanes expose no `/v1/completions`).
  - Consumers already honor the flag end-to-end (worker `sleep_na`, orchestrator `is_sleep_mode_disabled()`), so the model keeps being served awake without a re-calibration loop; the flag re-verifies on the next session (self-heals after e.g. a vLLM upgrade).
- `logos/logos-workernode/tests/test_calibration.py`: Group 10 — sleep→wake→request ordering, `/wake_up` error, stuck-asleep after wake, post-wake request failure, `/sleep` failure, embedding-lane false-positive guard, `sleep_level=0` skip, and profile-dict mapping.
- `logos/logos-workernode/tests/test_profile_store.py`: merge semantics for the measured verdict (overrides the stored flag in both directions; `None` keeps it).

## Testing

- Full worker-node suite in `logos/logos-workernode`: **511 passed, 2 skipped** (includes `test_calibration.py`, which CI excludes and which runs locally per the workflow comment).
- pre-commit hooks (autoflake, isort, black, flake8) pass on all changed files.
- No full deployment is available in this environment (no GPUs / vLLM workers), so verification is via unit tests and code reading. The new phase reuses primitives the calibration already relies on (`_post`, `wait_sleep_state`, `warmup_inference`) and mirrors how production lane management calls `/wake_up` in `vllm_process.py`.

The change applies to every calibration entry point (boot-time `auto_calibrate_models`, the server-orchestrated `start_calibration_session` path, and the standalone `tools/calibrate_vram_profiles.py` CLI) because they all funnel into `calibrate_model`.