### PR TITLE
`Logos`: Wait for workers to reconnect during a startup grace period instead of 404ing

### DIFF
--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -68,6 +68,13 @@ services:
       # 86400 to isolate scheduling from timeout-induced failures). Empty =
       # each stage keeps its own default (prod behaviour unchanged).
       LOGOS_TIMEOUT_S: "${LOGOS_TIMEOUT_S:-}"
+      # Startup grace period: how long a request whose only deployments are
+      # on worker nodes may wait for a worker to (re)connect before failing
+      # with "No available model deployments". A redeploy leaves a window in
+      # which no worker is connected; without this wait the first requests
+      # after the cut would 404 (see issue #793). Default 120s; set 0 to
+      # fail instantly.
+      LOGOS_STARTUP_GRACE_PERIOD_SECONDS: "${LOGOS_STARTUP_GRACE_PERIOD_SECONDS:-}"
       # Nightly calibration maintenance window (CalibrationOrchestrator). Set
       # LOGOS_CALIB_ENABLED=false to suppress it — the benchmark turns it off
       # for the duration of a run so a window session can't fire mid-benchmark.

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -68,13 +68,6 @@ services:
       # 86400 to isolate scheduling from timeout-induced failures). Empty =
       # each stage keeps its own default (prod behaviour unchanged).
       LOGOS_TIMEOUT_S: "${LOGOS_TIMEOUT_S:-}"
-      # Startup grace period: how long a request whose only deployments are
-      # on worker nodes may wait for a worker to (re)connect before failing
-      # with "No available model deployments". A redeploy leaves a window in
-      # which no worker is connected; without this wait the first requests
-      # after the cut would 404 (see issue #793). Default 120s; set 0 to
-      # fail instantly.
-      LOGOS_STARTUP_GRACE_PERIOD_SECONDS: "${LOGOS_STARTUP_GRACE_PERIOD_SECONDS:-}"
       # Nightly calibration maintenance window (CalibrationOrchestrator). Set
       # LOGOS_CALIB_ENABLED=false to suppress it — the benchmark turns it off
       # for the duration of a run so a window session can't fire mid-benchmark.

--- a/logos/logos-orchestrator/src/logos/logosnode_registry.py
+++ b/logos/logos-orchestrator/src/logos/logosnode_registry.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import logging
 import secrets
+import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
@@ -337,6 +338,11 @@ class LogosNodeRuntimeRegistry:
         # Lanes pre-marked as cold by the capacity planner — excluded from
         # scheduling so new requests don't route to lanes about to be stopped.
         self._cold_marked_lanes: set[tuple[int, str]] = set()
+        # provider_id -> monotonic timestamp of the last live-session drop.
+        # A worker that went down a moment ago is mid-reboot, not dead: the
+        # request path uses this to extend the startup grace period past the
+        # orchestrator's own boot, so its models don't 404 while it comes back.
+        self._recently_disconnected: dict[int, float] = {}
         # Optional callback invoked when a worker's capabilities_models change.
         # Signature: (provider_id, sorted_model_names) -> None
         self._on_capabilities_changed = on_capabilities_changed
@@ -559,6 +565,7 @@ class LogosNodeRuntimeRegistry:
             if websocket is not None and session.websocket is not websocket:
                 return
             self._sessions.pop(provider_id, None)
+            self._recently_disconnected[int(provider_id)] = time.monotonic()
         pending_cmds = len(session.pending_commands)
         pending_streams = len(session.pending_streams)
         logger.warning(
@@ -1153,6 +1160,20 @@ class LogosNodeRuntimeRegistry:
         if session is None:
             return False
         return not session.is_stale(stale_after_seconds)
+
+    def disconnect_grace_remaining_s(self, provider_id: int, grace_period_s: float) -> float:
+        """Seconds left until a recently dropped worker's reconnect grace expires.
+
+        0.0 when the provider's worker never dropped a live session, or the
+        drop is older than ``grace_period_s``. Mirrors the orchestrator's
+        startup window, anchored to the drop instead of the server boot, so a
+        worker that reboots (or is redeployed on its own) gets the same
+        "wait, don't 404" treatment for its models as a fresh orchestrator.
+        """
+        dropped_at = self._recently_disconnected.get(int(provider_id))
+        if dropped_at is None:
+            return 0.0
+        return max(0.0, grace_period_s - (time.monotonic() - dropped_at))
 
     def get_desired_lane_set(self, provider_id: int) -> list[dict[str, Any]]:
         """Return the server's last-intended lane configuration for a provider."""

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -4145,14 +4145,15 @@ async def _execute_cancelling_on_disconnect(request: Request, **kwargs):
 
 # How often the startup grace period re-checks for a (re)connected worker.
 _WORKER_CONNECT_POLL_SECONDS = 1.0
-# How long after startup the grace period lasts. A redeploy leaves a window
-# in which no worker node is connected, during which every logosnode
-# deployment is filtered out and the request 404s with "No available model
-# deployments" — enough to kill a running consumer mid-task. Workers
-# re-attach within seconds of coming back up, so during the first 120s a
-# request for a model no worker serves yet waits instead of failing, turning
-# the outage into a delay. Once the window has run out, the instant 404
-# comes back: a worker still missing then is down, not mid-redeploy.
+# How long the grace period lasts, both for the window after the orchestrator
+# starts and for the window after an already-connected worker drops (reboot).
+# Such a window is one in which no worker node serves a model, during which
+# every logosnode deployment of it is filtered out and the request 404s with
+# "No available model deployments" — enough to kill a running consumer
+# mid-task. Workers re-attach within seconds of coming back up, so while the
+# window is open a request for a model no worker serves yet waits instead of
+# failing, turning the outage into a delay. Once it has run out, the instant
+# 404 comes back: a worker still missing then is down, not mid-redeploy.
 _STARTUP_GRACE_PERIOD_S = 120.0
 # Monotonic anchor for the grace window. The wall-clock _SERVER_START_TIME
 # can jump (NTP) and must not stretch or shrink the window with it.
@@ -4162,6 +4163,27 @@ _SERVER_START_MONOTONIC = time.monotonic()
 def _startup_grace_remaining_s() -> float:
     """How much of the startup grace period is left (0 once it has run out)."""
     return max(0.0, _STARTUP_GRACE_PERIOD_S - (time.monotonic() - _SERVER_START_MONOTONIC))
+
+
+def _worker_reconnect_grace_remaining_s(raw_deployments: list[Deployment]) -> float:
+    """How long a request may wait because one of the key's workers recently dropped.
+
+    The startup window only covers the orchestrator's own (re)start. A worker
+    node that reboots or is redeployed on its own drops its session later,
+    and its models go unroutable the moment the registry loses them — the
+    same failure, anchored to the drop instead of the boot. For every
+    logosnode deployment of the key, take the latest of the drop-grace
+    deadlines; the freshest drop dominates.
+    """
+    remaining = 0.0
+    for deployment in raw_deployments:
+        if _normalize_provider_type(deployment.get("type")) != "logosnode":
+            continue
+        remaining = max(
+            remaining,
+            _logosnode_registry.disconnect_grace_remaining_s(int(deployment["provider_id"]), _STARTUP_GRACE_PERIOD_S),
+        )
+    return remaining
 
 
 def _client_timeout_s(payload: dict) -> Optional[float]:
@@ -4185,12 +4207,14 @@ async def _wait_for_worker_connect(
     filter dropped everything because no worker is connected (redeploy). Each
     poll re-asks the registry; the moment a worker re-attaches and declares
     its capabilities, the filter hands the deployments back and the request
-    proceeds. The wait is bounded by what is left of the startup grace period
-    — it does not reset per request, and a worker that already re-attached
-    does not cancel it for the models still missing — and by the client's
-    ``timeout_s`` if it is smaller.
+    proceeds. The wait is bounded by the later of the two grace windows —
+    what is left of the startup window, and what is left of a recently
+    dropped worker's reconnect window (see ``_worker_reconnect_grace_remaining_s``)
+    — and by the client's ``timeout_s`` if it is smaller. Neither window
+    resets per request, and a worker that already re-attached does not cancel
+    the wait for the models still missing.
     """
-    wait_s = _startup_grace_remaining_s()
+    wait_s = max(_startup_grace_remaining_s(), _worker_reconnect_grace_remaining_s(raw_deployments))
     if client_timeout_s is not None:
         wait_s = min(wait_s, client_timeout_s)
     if wait_s <= 0:
@@ -4237,11 +4261,13 @@ async def handle_sync_request(path: str, request: Request):
         raise HTTPException(status_code=400, detail=str(e))
 
     if not deployments and raw_deployments:
-        # The key is granted models that no worker serves right now — the
-        # signature of a redeploy in progress. Within the first 120s after
-        # startup, give the still-missing workers a chance to (re)connect
-        # instead of failing the request instantly. The window stays in
-        # effect even though other workers may already have re-attached.
+        # The key is granted models that no worker serves right now — either
+        # the orchestrator just (re)started and the workers are still
+        # (re)attaching, or a worker dropped a moment ago (reboot) and its
+        # models are unroutable until it comes back. Give the missing
+        # workers a chance to (re)connect instead of failing instantly; the
+        # window stays in effect even though other workers may already have
+        # re-attached.
         deployments = await _wait_for_worker_connect(
             raw_deployments, payload=body, request=request, client_timeout_s=_client_timeout_s(body)
         )
@@ -4521,8 +4547,9 @@ async def execute_proxy_job(
         _, err_body = coerce_upstream_error(400, {"error": str(e)})
         return {"status_code": 400, "data": err_body}
 
-    # Same window as the sync path: a job submitted while no worker is
-    # connected (redeploy) must not fail before the workers re-attach.
+    # Same windows as the sync path: a job submitted while no worker is
+    # connected (startup or a worker reboot) must not fail before the
+    # workers re-attach.
     if not deployments and raw_deployments:
         deployments = await _wait_for_worker_connect(
             raw_deployments, payload=json_data, client_timeout_s=_client_timeout_s(json_data)

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -4143,6 +4143,73 @@ async def _execute_cancelling_on_disconnect(request: Request, **kwargs):
     return JSONResponse(status_code=499, content={"detail": "Client closed request"})
 
 
+# How often the startup grace period re-checks for a (re)connected worker.
+_WORKER_CONNECT_POLL_SECONDS = 1.0
+# Default time a request may wait for a worker to (re)connect before failing.
+# A redeploy leaves a window in which no worker node is connected, during
+# which every logosnode deployment is filtered out and the request 404s with
+# "No available model deployments" — enough to kill a running consumer
+# mid-task. Workers re-attach within seconds of coming back up, so a bounded
+# wait turns the outage into a delay instead of a failure. Set
+# LOGOS_STARTUP_GRACE_PERIOD_SECONDS=0 to fail instantly.
+_DEFAULT_STARTUP_GRACE_PERIOD_S = 120.0
+_STARTUP_GRACE_PERIOD_ENV = "LOGOS_STARTUP_GRACE_PERIOD_SECONDS"
+
+
+def _startup_grace_period_s() -> float:
+    """The startup grace period in seconds; 0 disables the wait."""
+    raw = os.getenv(_STARTUP_GRACE_PERIOD_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_STARTUP_GRACE_PERIOD_S
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _DEFAULT_STARTUP_GRACE_PERIOD_S
+
+
+def _client_timeout_s(payload: dict) -> Optional[float]:
+    """The client's ``timeout_s`` as a positive float, or None if absent/invalid."""
+    try:
+        value = float(payload.get("timeout_s"))
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+async def _wait_for_worker_connect(
+    raw_deployments: list[Deployment],
+    payload: dict,
+    request: Optional[Request] = None,
+    client_timeout_s: Optional[float] = None,
+) -> list[Deployment]:
+    """Re-run the deployment filter until a worker serves the model or the grace period expires.
+
+    ``raw_deployments`` is what the DB granted this key before the logosnode
+    filter dropped everything because no worker is connected (redeploy). Each
+    poll re-asks the registry; the moment a worker re-attaches and declares
+    its capabilities, the filter hands the deployments back and the request
+    proceeds. A client ``timeout_s`` bounds the wait too — it is how long the
+    client is willing to wait at all.
+    """
+    wait_s = _startup_grace_period_s()
+    if client_timeout_s is not None:
+        wait_s = min(wait_s, client_timeout_s)
+    if wait_s <= 0:
+        return []
+    deadline = time.monotonic() + wait_s
+    logger.info("No worker is serving the requested model right now; waiting up to %ss for one to (re)connect", wait_s)
+    deployments: list[Deployment] = []
+    while time.monotonic() < deadline:
+        if request is not None and await request.is_disconnected():
+            break
+        await asyncio.sleep(min(_WORKER_CONNECT_POLL_SECONDS, deadline - time.monotonic()))
+        deployments = await _filter_logosnode_deployments(raw_deployments, payload=payload)
+        if deployments:
+            logger.info("Worker connected during startup grace period; routing the request")
+            return deployments
+    return deployments
+
+
 async def handle_sync_request(path: str, request: Request):
     """
     Handle synchronous (non-job) requests for both /v1 and /openai endpoints.
@@ -4161,14 +4228,22 @@ async def handle_sync_request(path: str, request: Request):
                     request_id=request_id,
                     timeout_s=body.get("timeout_s"),
                 )
-            deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
-        deployments = await _filter_logosnode_deployments(deployments, payload=body)
+            raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
+        deployments = await _filter_logosnode_deployments(raw_deployments, payload=body)
     except PermissionError as e:
         _record_log_failure(log_id, request_id, str(e), result_status="error")
         raise HTTPException(status_code=401, detail=str(e))
     except ValueError as e:
         _record_log_failure(log_id, request_id, str(e), result_status="error")
         raise HTTPException(status_code=400, detail=str(e))
+
+    if not deployments and raw_deployments:
+        # The key is granted models that no worker serves right now — a
+        # redeploy leaves exactly that window. Give the workers a chance to
+        # (re)connect instead of failing the request instantly.
+        deployments = await _wait_for_worker_connect(
+            raw_deployments, payload=body, request=request, client_timeout_s=_client_timeout_s(body)
+        )
 
     if not deployments:
         requested_model = body.get("model", "unknown")
@@ -4434,8 +4509,8 @@ async def execute_proxy_job(
                     request_id=request_id,
                     timeout_s=json_data.get("timeout_s"),
                 )
-            deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
-        deployments = await _filter_logosnode_deployments(deployments, payload=json_data)
+            raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
+        deployments = await _filter_logosnode_deployments(raw_deployments, payload=json_data)
     except PermissionError as e:
         _record_log_failure(log_id, request_id, str(e), result_status="error")
         _, err_body = coerce_upstream_error(401, {"error": str(e)})
@@ -4444,6 +4519,13 @@ async def execute_proxy_job(
         _record_log_failure(log_id, request_id, str(e), result_status="error")
         _, err_body = coerce_upstream_error(400, {"error": str(e)})
         return {"status_code": 400, "data": err_body}
+
+    # Same window as the sync path: a job submitted while no worker is
+    # connected (redeploy) must not fail before the workers re-attach.
+    if not deployments and raw_deployments:
+        deployments = await _wait_for_worker_connect(
+            raw_deployments, payload=json_data, client_timeout_s=_client_timeout_s(json_data)
+        )
 
     # Force non-streaming for jobs without adding unsupported multipart fields.
     json_data = force_non_streaming_payload(json_data)

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -4145,26 +4145,23 @@ async def _execute_cancelling_on_disconnect(request: Request, **kwargs):
 
 # How often the startup grace period re-checks for a (re)connected worker.
 _WORKER_CONNECT_POLL_SECONDS = 1.0
-# Default time a request may wait for a worker to (re)connect before failing.
-# A redeploy leaves a window in which no worker node is connected, during
-# which every logosnode deployment is filtered out and the request 404s with
-# "No available model deployments" — enough to kill a running consumer
-# mid-task. Workers re-attach within seconds of coming back up, so a bounded
-# wait turns the outage into a delay instead of a failure. Set
-# LOGOS_STARTUP_GRACE_PERIOD_SECONDS=0 to fail instantly.
-_DEFAULT_STARTUP_GRACE_PERIOD_S = 120.0
-_STARTUP_GRACE_PERIOD_ENV = "LOGOS_STARTUP_GRACE_PERIOD_SECONDS"
+# How long after startup the grace period lasts. A redeploy leaves a window
+# in which no worker node is connected, during which every logosnode
+# deployment is filtered out and the request 404s with "No available model
+# deployments" — enough to kill a running consumer mid-task. Workers
+# re-attach within seconds of coming back up, so during the first 120s a
+# request for a model no worker serves yet waits instead of failing, turning
+# the outage into a delay. Once the window has run out, the instant 404
+# comes back: a worker still missing then is down, not mid-redeploy.
+_STARTUP_GRACE_PERIOD_S = 120.0
+# Monotonic anchor for the grace window. The wall-clock _SERVER_START_TIME
+# can jump (NTP) and must not stretch or shrink the window with it.
+_SERVER_START_MONOTONIC = time.monotonic()
 
 
-def _startup_grace_period_s() -> float:
-    """The startup grace period in seconds; 0 disables the wait."""
-    raw = os.getenv(_STARTUP_GRACE_PERIOD_ENV, "").strip()
-    if not raw:
-        return _DEFAULT_STARTUP_GRACE_PERIOD_S
-    try:
-        return max(0.0, float(raw))
-    except ValueError:
-        return _DEFAULT_STARTUP_GRACE_PERIOD_S
+def _startup_grace_remaining_s() -> float:
+    """How much of the startup grace period is left (0 once it has run out)."""
+    return max(0.0, _STARTUP_GRACE_PERIOD_S - (time.monotonic() - _SERVER_START_MONOTONIC))
 
 
 def _client_timeout_s(payload: dict) -> Optional[float]:
@@ -4182,16 +4179,18 @@ async def _wait_for_worker_connect(
     request: Optional[Request] = None,
     client_timeout_s: Optional[float] = None,
 ) -> list[Deployment]:
-    """Re-run the deployment filter until a worker serves the model or the grace period expires.
+    """Re-run the deployment filter until a worker serves the model, the grace period runs out, or the client leaves.
 
     ``raw_deployments`` is what the DB granted this key before the logosnode
     filter dropped everything because no worker is connected (redeploy). Each
     poll re-asks the registry; the moment a worker re-attaches and declares
     its capabilities, the filter hands the deployments back and the request
-    proceeds. A client ``timeout_s`` bounds the wait too — it is how long the
-    client is willing to wait at all.
+    proceeds. The wait is bounded by what is left of the startup grace period
+    — it does not reset per request, and a worker that already re-attached
+    does not cancel it for the models still missing — and by the client's
+    ``timeout_s`` if it is smaller.
     """
-    wait_s = _startup_grace_period_s()
+    wait_s = _startup_grace_remaining_s()
     if client_timeout_s is not None:
         wait_s = min(wait_s, client_timeout_s)
     if wait_s <= 0:
@@ -4238,9 +4237,11 @@ async def handle_sync_request(path: str, request: Request):
         raise HTTPException(status_code=400, detail=str(e))
 
     if not deployments and raw_deployments:
-        # The key is granted models that no worker serves right now — a
-        # redeploy leaves exactly that window. Give the workers a chance to
-        # (re)connect instead of failing the request instantly.
+        # The key is granted models that no worker serves right now — the
+        # signature of a redeploy in progress. Within the first 120s after
+        # startup, give the still-missing workers a chance to (re)connect
+        # instead of failing the request instantly. The window stays in
+        # effect even though other workers may already have re-attached.
         deployments = await _wait_for_worker_connect(
             raw_deployments, payload=body, request=request, client_timeout_s=_client_timeout_s(body)
         )

--- a/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
@@ -2,10 +2,10 @@
 
 While no worker node is connected, every logosnode deployment is filtered out
 and the request 404s with "No available model deployments" — enough to kill a
-running consumer mid-task. For the first 120 seconds after the orchestrator
-starts, a request for a model no worker serves yet therefore waits for the
-remaining workers to (re)attach; once the window has run out, the request
-fails instantly again.
+running consumer mid-task. Two windows protect requests instead: the first
+120 seconds after the orchestrator starts, and the 120 seconds after an
+already-connected worker drops (reboot). Once a window has run out, the
+request fails instantly again.
 """
 
 from __future__ import annotations
@@ -175,6 +175,80 @@ async def test_late_request_only_waits_the_rest_of_the_window(monkeypatch):
     assert len(empty.calls) < 100
 
 
+# ---------------------------------------------------------------------------
+# _worker_reconnect_grace_remaining_s (a worker that drops after startup)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_reconnect_grace_ignores_cloud_deployments(monkeypatch):
+    registry = MagicMock()
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+    deployments = [{"provider_id": 99, "model_id": 1, "type": "azure"}]
+
+    assert main._worker_reconnect_grace_remaining_s(deployments) == 0.0
+    registry.disconnect_grace_remaining_s.assert_not_called()
+
+
+def test_worker_reconnect_grace_takes_the_freshest_drop(monkeypatch):
+    registry = MagicMock()
+    registry.disconnect_grace_remaining_s = lambda pid, grace: {7: 10.0, 8: 45.0}[pid]
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+    deployments = [
+        {"provider_id": 7, "model_id": 1, "type": "logosnode"},
+        {"provider_id": 8, "model_id": 1, "type": "logosnode"},
+        {"provider_id": 99, "model_id": 1, "type": "azure"},
+    ]
+
+    assert main._worker_reconnect_grace_remaining_s(deployments) == 45.0
+
+
+def test_worker_reconnect_grace_zero_when_nothing_dropped(monkeypatch):
+    registry = MagicMock()
+    registry.disconnect_grace_remaining_s = lambda pid, grace: 0.0
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+
+    assert main._worker_reconnect_grace_remaining_s(RAW) == 0.0
+
+
+async def test_wait_covers_a_worker_drop_after_the_startup_window(monkeypatch):
+    """A reboot of the only worker mid-service gets the same grace as a redeploy."""
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
+    registry = MagicMock()
+    registry.disconnect_grace_remaining_s = lambda pid, grace: 0.1
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", _empty_then_raw_filter())
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+
+    assert result == RAW
+
+
+async def test_wait_expires_with_the_disconnect_window(monkeypatch):
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
+    registry = MagicMock()
+    registry.disconnect_grace_remaining_s = lambda pid, grace: 0.05
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+
+    assert result == []
+
+
+async def test_no_wait_once_both_windows_are_gone(monkeypatch):
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
+    registry = MagicMock()
+    registry.disconnect_grace_remaining_s = lambda pid, grace: 0.0
+    monkeypatch.setattr(main, "_logosnode_registry", registry)
+    empty = _always_empty_filter()
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", empty)
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+
+    assert result == []
+    assert empty.calls == []
+
+
 async def test_client_disconnect_ends_the_wait(monkeypatch):
     monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
 
@@ -280,3 +354,41 @@ async def test_job_waits_for_the_worker_to_reconnect(monkeypatch):
 
     assert result == {"status_code": 200, "data": {}}
     assert routed[0]["deployments"] == RAW
+
+
+# ---------------------------------------------------------------------------
+# LogosNodeRuntimeRegistry: a dropped session opens the reconnect window
+# ---------------------------------------------------------------------------
+
+
+def _registry_with_session(provider_id: int = 7):
+    from logos.logosnode_registry import LogosNodeRuntimeRegistry, ProviderSession
+
+    registry = LogosNodeRuntimeRegistry()
+    registry._sessions[provider_id] = ProviderSession(
+        provider_id=provider_id, worker_id="worker-1", websocket=MagicMock()
+    )
+    return registry
+
+
+async def test_detach_records_the_drop_for_the_grace_window():
+    registry = _registry_with_session()
+    assert registry.disconnect_grace_remaining_s(7, 120.0) == 0.0
+
+    await registry.detach_session(7)
+
+    remaining = registry.disconnect_grace_remaining_s(7, 120.0)
+    assert 0 < remaining <= 120.0
+
+
+async def test_a_drop_longer_ago_no_longer_extends_the_window():
+    registry = _registry_with_session()
+    await registry.detach_session(7)
+    registry._recently_disconnected[7] = time.monotonic() - 200
+
+    assert registry.disconnect_grace_remaining_s(7, 120.0) == 0.0
+
+
+async def test_a_provider_that_never_connected_has_no_window():
+    registry = _registry_with_session()
+    assert registry.disconnect_grace_remaining_s(99, 120.0) == 0.0

--- a/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
@@ -1,0 +1,254 @@
+"""Requests during a redeploy must wait for workers to reconnect.
+
+While no worker node is connected, every logosnode deployment is filtered out
+and the request 404s with "No available model deployments" — enough to kill a
+running consumer mid-task, which is exactly what a redeploy used to do. The
+startup grace period re-checks the filter until a worker (re)attaches or the
+period expires, so the outage becomes a delay instead of a failure.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import logos as main
+
+RAW = [{"provider_id": 7, "model_id": 42, "type": "logosnode"}]
+MODEL_NAME = "qwen-27b"
+
+
+class _Client:
+    """Stand-in for the disconnect probe Starlette exposes on Request."""
+
+    def __init__(self, *, leaves: bool = False):
+        self._leaves = leaves
+        self.probes = 0
+
+    async def is_disconnected(self) -> bool:
+        self.probes += 1
+        return self._leaves
+
+
+class _FakeDB:
+    """Minimal stand-in for the DBManager context manager."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _fast_polling(monkeypatch):
+    monkeypatch.setattr(main, "_WORKER_CONNECT_POLL_SECONDS", 0.001)
+
+
+def _always_empty_filter():
+    """A filter that never finds a worker; records how often it ran."""
+    calls = []
+
+    async def fake_filter(deployments, payload=None):
+        calls.append(1)
+        return []
+
+    fake_filter.calls = calls
+    return fake_filter
+
+
+def _empty_then_raw_filter():
+    """Empty on the first check (worker offline), then the worker re-attaches."""
+    results = [[], RAW]
+
+    async def fake_filter(deployments, payload=None):
+        return results.pop(0) if results else deployments
+
+    return fake_filter
+
+
+def _stub_sync_path(monkeypatch, body, raw, filter_fn):
+    async def fake_auth_parse_log(request, use_profile_auth=False):
+        auth = MagicMock()
+        auth.api_key_id = 88
+        return {}, auth, body, "127.0.0.1", None
+
+    monkeypatch.setattr(main, "auth_parse_log", fake_auth_parse_log)
+    monkeypatch.setattr(main, "DBManager", _FakeDB)
+    monkeypatch.setattr(main, "request_setup", lambda headers, api_key_id, db=None: (raw, [MODEL_NAME]))
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", filter_fn)
+
+
+# ---------------------------------------------------------------------------
+# _startup_grace_period_s / _client_timeout_s
+# ---------------------------------------------------------------------------
+
+
+def test_grace_period_env_parsing(monkeypatch):
+    monkeypatch.delenv(main._STARTUP_GRACE_PERIOD_ENV, raising=False)
+    assert main._startup_grace_period_s() == main._DEFAULT_STARTUP_GRACE_PERIOD_S
+
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0")
+    assert main._startup_grace_period_s() == 0.0
+
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "30")
+    assert main._startup_grace_period_s() == 30.0
+
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "-5")
+    assert main._startup_grace_period_s() == 0.0
+
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "garbage")
+    assert main._startup_grace_period_s() == main._DEFAULT_STARTUP_GRACE_PERIOD_S
+
+
+def test_client_timeout_parsing():
+    assert main._client_timeout_s({"timeout_s": 5}) == 5.0
+    assert main._client_timeout_s({"timeout_s": "10"}) == 10.0
+    assert main._client_timeout_s({}) is None
+    assert main._client_timeout_s({"timeout_s": None}) is None
+    assert main._client_timeout_s({"timeout_s": "nope"}) is None
+    assert main._client_timeout_s({"timeout_s": -3}) is None
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_worker_connect
+# ---------------------------------------------------------------------------
+
+
+async def test_wait_returns_as_soon_as_a_worker_connects(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
+    calls = []
+
+    async def fake_filter(deployments, payload=None):
+        calls.append(1)
+        return [] if len(calls) < 3 else RAW
+
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", fake_filter)
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME}, request=_Client())
+
+    assert result == RAW
+    assert len(calls) == 3
+
+
+async def test_wait_gives_up_when_the_grace_period_expires(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0.05")
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+
+    assert result == []
+
+
+async def test_zero_grace_period_never_polls(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0")
+    empty = _always_empty_filter()
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", empty)
+
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+
+    assert result == []
+    assert empty.calls == []
+
+
+async def test_client_disconnect_ends_the_wait(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
+
+    client = _Client(leaves=True)
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME}, request=client)
+
+    assert result == []
+    assert client.probes >= 1
+
+
+async def test_client_timeout_caps_the_grace_wait(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "60")
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
+
+    started = time.monotonic()
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME}, client_timeout_s=0.05)
+    elapsed = time.monotonic() - started
+
+    assert result == []
+    # The 60s grace period must not outlive the 50ms the client is willing to wait.
+    assert elapsed < 5.0
+
+
+# ---------------------------------------------------------------------------
+# handle_sync_request
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_request_waits_for_the_worker_to_reconnect(monkeypatch):
+    """The reported failure: no worker connected for a moment during a redeploy."""
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
+    # First check (before the wait) finds no worker; the re-check inside the
+    # wait finds the worker that just re-attached.
+    _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _empty_then_raw_filter())
+
+    guarded = []
+
+    async def fake_guard(request, **kwargs):
+        guarded.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(main, "_execute_cancelling_on_disconnect", fake_guard)
+
+    result = await main.handle_sync_request("chat/completions", _Client())
+
+    assert result == "ok"
+    assert guarded[0]["deployments"] == RAW
+
+
+async def test_sync_request_fails_after_the_grace_period(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0.05")
+    _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _always_empty_filter())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await main.handle_sync_request("chat/completions", _Client())
+
+    assert excinfo.value.status_code == 404
+    assert "No available model deployments" in excinfo.value.detail
+
+
+async def test_sync_request_fails_immediately_when_the_key_has_no_deployments(monkeypatch):
+    """Nothing can connect that the DB does not grant, so no waiting."""
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
+    empty = _always_empty_filter()
+    _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, [], empty)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await main.handle_sync_request("chat/completions", _Client())
+
+    assert excinfo.value.status_code == 404
+    # Only the initial filter ran; the grace-period loop was never entered.
+    assert len(empty.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# execute_proxy_job
+# ---------------------------------------------------------------------------
+
+
+async def test_job_waits_for_the_worker_to_reconnect(monkeypatch):
+    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
+    _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _empty_then_raw_filter())
+
+    routed = []
+
+    async def fake_route_and_execute(**kwargs):
+        routed.append(kwargs)
+        return {"status_code": 200, "data": {}}
+
+    monkeypatch.setattr(main, "route_and_execute", fake_route_and_execute)
+
+    auth = MagicMock()
+    auth.api_key_id = 88
+    result = await main.execute_proxy_job("chat/completions", {}, {"model": MODEL_NAME}, "127.0.0.1", auth, None)
+
+    assert result == {"status_code": 200, "data": {}}
+    assert routed[0]["deployments"] == RAW

--- a/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py
@@ -2,9 +2,10 @@
 
 While no worker node is connected, every logosnode deployment is filtered out
 and the request 404s with "No available model deployments" — enough to kill a
-running consumer mid-task, which is exactly what a redeploy used to do. The
-startup grace period re-checks the filter until a worker (re)attaches or the
-period expires, so the outage becomes a delay instead of a failure.
+running consumer mid-task. For the first 120 seconds after the orchestrator
+starts, a request for a model no worker serves yet therefore waits for the
+remaining workers to (re)attach; once the window has run out, the request
+fails instantly again.
 """
 
 from __future__ import annotations
@@ -44,8 +45,11 @@ class _FakeDB:
 
 
 @pytest.fixture(autouse=True)
-def _fast_polling(monkeypatch):
+def _fresh_server(monkeypatch):
+    """Shrink the 120s window and pretend the orchestrator just started."""
     monkeypatch.setattr(main, "_WORKER_CONNECT_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(main, "_STARTUP_GRACE_PERIOD_S", 0.2)
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic())
 
 
 def _always_empty_filter():
@@ -83,25 +87,28 @@ def _stub_sync_path(monkeypatch, body, raw, filter_fn):
 
 
 # ---------------------------------------------------------------------------
-# _startup_grace_period_s / _client_timeout_s
+# _startup_grace_remaining_s / _client_timeout_s
 # ---------------------------------------------------------------------------
 
 
-def test_grace_period_env_parsing(monkeypatch):
-    monkeypatch.delenv(main._STARTUP_GRACE_PERIOD_ENV, raising=False)
-    assert main._startup_grace_period_s() == main._DEFAULT_STARTUP_GRACE_PERIOD_S
+def test_grace_window_starts_full_at_server_start():
+    # The autouse fixture set the start time to "now".
+    remaining = main._startup_grace_remaining_s()
+    assert 0 < remaining <= main._STARTUP_GRACE_PERIOD_S
 
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0")
-    assert main._startup_grace_period_s() == 0.0
 
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "30")
-    assert main._startup_grace_period_s() == 30.0
+def test_grace_window_runs_out(monkeypatch):
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
+    assert main._startup_grace_remaining_s() == 0.0
 
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "-5")
-    assert main._startup_grace_period_s() == 0.0
 
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "garbage")
-    assert main._startup_grace_period_s() == main._DEFAULT_STARTUP_GRACE_PERIOD_S
+def test_late_request_only_sees_the_rest_of_the_window(monkeypatch):
+    """The window is anchored to server start, not to each request."""
+    elapsed = main._STARTUP_GRACE_PERIOD_S - 0.05
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - elapsed)
+    remaining = main._startup_grace_remaining_s()
+    # ~0.05s left of the 0.2s window: well under half.
+    assert remaining < 0.1
 
 
 def test_client_timeout_parsing():
@@ -119,7 +126,6 @@ def test_client_timeout_parsing():
 
 
 async def test_wait_returns_as_soon_as_a_worker_connects(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
     calls = []
 
     async def fake_filter(deployments, payload=None):
@@ -134,8 +140,7 @@ async def test_wait_returns_as_soon_as_a_worker_connects(monkeypatch):
     assert len(calls) == 3
 
 
-async def test_wait_gives_up_when_the_grace_period_expires(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0.05")
+async def test_wait_gives_up_when_the_window_expires(monkeypatch):
     monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
 
     result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
@@ -143,8 +148,8 @@ async def test_wait_gives_up_when_the_grace_period_expires(monkeypatch):
     assert result == []
 
 
-async def test_zero_grace_period_never_polls(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0")
+async def test_no_wait_after_the_window_has_run_out(monkeypatch):
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
     empty = _always_empty_filter()
     monkeypatch.setattr(main, "_filter_logosnode_deployments", empty)
 
@@ -154,8 +159,23 @@ async def test_zero_grace_period_never_polls(monkeypatch):
     assert empty.calls == []
 
 
+async def test_late_request_only_waits_the_rest_of_the_window(monkeypatch):
+    """A request arriving late must not get a fresh, full grace period."""
+    empty = _always_empty_filter()
+    monkeypatch.setattr(main, "_filter_logosnode_deployments", empty)
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - (main._STARTUP_GRACE_PERIOD_S - 0.05))
+
+    started = time.monotonic()
+    result = await main._wait_for_worker_connect(RAW, {"model": MODEL_NAME})
+    elapsed = time.monotonic() - started
+
+    assert result == []
+    # ~50ms left in the window: the wait must stop long before the full 0.2s.
+    assert elapsed < 0.15
+    assert len(empty.calls) < 100
+
+
 async def test_client_disconnect_ends_the_wait(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
     monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
 
     client = _Client(leaves=True)
@@ -166,7 +186,6 @@ async def test_client_disconnect_ends_the_wait(monkeypatch):
 
 
 async def test_client_timeout_caps_the_grace_wait(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "60")
     monkeypatch.setattr(main, "_filter_logosnode_deployments", _always_empty_filter())
 
     started = time.monotonic()
@@ -174,8 +193,8 @@ async def test_client_timeout_caps_the_grace_wait(monkeypatch):
     elapsed = time.monotonic() - started
 
     assert result == []
-    # The 60s grace period must not outlive the 50ms the client is willing to wait.
-    assert elapsed < 5.0
+    # The 0.2s window must not outlive the 50ms the client is willing to wait.
+    assert elapsed < 0.1
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +204,6 @@ async def test_client_timeout_caps_the_grace_wait(monkeypatch):
 
 async def test_sync_request_waits_for_the_worker_to_reconnect(monkeypatch):
     """The reported failure: no worker connected for a moment during a redeploy."""
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
     # First check (before the wait) finds no worker; the re-check inside the
     # wait finds the worker that just re-attached.
     _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _empty_then_raw_filter())
@@ -204,8 +222,7 @@ async def test_sync_request_waits_for_the_worker_to_reconnect(monkeypatch):
     assert guarded[0]["deployments"] == RAW
 
 
-async def test_sync_request_fails_after_the_grace_period(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "0.05")
+async def test_sync_request_fails_after_the_window_expires(monkeypatch):
     _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _always_empty_filter())
 
     with pytest.raises(HTTPException) as excinfo:
@@ -217,7 +234,6 @@ async def test_sync_request_fails_after_the_grace_period(monkeypatch):
 
 async def test_sync_request_fails_immediately_when_the_key_has_no_deployments(monkeypatch):
     """Nothing can connect that the DB does not grant, so no waiting."""
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
     empty = _always_empty_filter()
     _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, [], empty)
 
@@ -229,13 +245,25 @@ async def test_sync_request_fails_immediately_when_the_key_has_no_deployments(mo
     assert len(empty.calls) == 1
 
 
+async def test_sync_request_fails_immediately_once_the_window_is_gone(monkeypatch):
+    """After the first 120s, a missing worker is a failure, not a redeploy."""
+    monkeypatch.setattr(main, "_SERVER_START_MONOTONIC", time.monotonic() - main._STARTUP_GRACE_PERIOD_S - 10)
+    empty = _always_empty_filter()
+    _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, empty)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await main.handle_sync_request("chat/completions", _Client())
+
+    assert excinfo.value.status_code == 404
+    assert len(empty.calls) == 1
+
+
 # ---------------------------------------------------------------------------
 # execute_proxy_job
 # ---------------------------------------------------------------------------
 
 
 async def test_job_waits_for_the_worker_to_reconnect(monkeypatch):
-    monkeypatch.setenv(main._STARTUP_GRACE_PERIOD_ENV, "5")
     _stub_sync_path(monkeypatch, {"model": MODEL_NAME}, RAW, _empty_then_raw_filter())
 
     routed = []


### PR DESCRIPTION
## Fixes #793

## Summary

During a redeploy there is a window in which no worker node is connected. In that window every `logosnode` deployment is filtered out by `_filter_logosnode_deployments` (the worker registry reports the model as not served), so the orchestrator answered **every** request with `404 No available model deployments for model '...' for this key`. For a consumer like Claude Code that is fatal: the session dies with "There's an issue with the selected model" and has to be resumed manually. The same 404 storm happens when a worker node reboots and is the only one serving a model — the model goes unroutable the moment the session drops.

This PR adds a **120s grace period** to the logos-orchestrator, in effect for two kinds of windows:

1. **Startup window** — the first 120s after the orchestrator starts (anchored to a monotonic server-start clock).
2. **Disconnect window** — the 120s after an already-connected worker drops its session (reboot / worker-only redeploy), recorded by the registry on detach.

While one of the windows is open, a request for a model that no worker serves yet no longer fails instantly: the orchestrator re-checks the deployment filter once per second and routes the request the moment a worker (re)attaches and declares its capabilities. A request arriving late into a window only waits for the rest of it, a worker that has already re-attached does not cancel the wait for the models still missing, and a client-supplied `timeout_s` caps the wait. Once all windows have run out, behaviour is exactly as before: instant 404 — a worker still missing then is down, not mid-redeploy.

## Changes

- `logos/logos-orchestrator/src/logos/logosnode_registry.py`:
  - `detach_session` records the drop (monotonic timestamp) per provider in `_recently_disconnected`.
  - New `disconnect_grace_remaining_s(provider_id, grace_period_s)`: seconds left of a dropped worker's reconnect window (0 when it never connected or the drop is too old).
- `logos/logos-orchestrator/src/logos/main.py`:
  - `_STARTUP_GRACE_PERIOD_S = 120` (hardcoded on purpose — no new env var), `_SERVER_START_MONOTONIC` anchor, `_startup_grace_remaining_s()`.
  - New `_worker_reconnect_grace_remaining_s(raw_deployments)`: for every logosnode deployment of the key, asks the registry how long its drop-window has left and takes the freshest.
  - New `_wait_for_worker_connect()`: re-runs `_filter_logosnode_deployments` on a 1s poll until a deployment appears, the client disconnects, the client's `timeout_s` is reached, or the later of the two windows runs out.
  - Wired into both request entry points that hit the same root cause: `handle_sync_request` (all `/v1`, `/openai`, audio endpoints) and `execute_proxy_job` (async jobs). The wait only triggers when the DB granted deployments (`raw_deployments` non-empty) but the filter dropped all of them — a key with no deployments at all still fails instantly, since nothing can connect to grant it any.
- `logos/logos-orchestrator/tests/unit/main/test_startup_grace_period.py`: 24 new unit tests.

## Behavior

| Situation | Before | After |
|---|---|---|
| Orchestrator restart, worker re-attaches within 120s | 404, client session dies | Request waits, is routed as soon as the worker re-attaches |
| Only worker of a model reboots (drops mid-service), comes back within 120s | 404, client session dies | Same grace as above, anchored to the drop |
| Worker still missing after the 120s window | 404 instantly | 404 after at most the rest of the window (or the client's `timeout_s`, if smaller) |
| Key has no deployments in the DB | 404 instantly | 404 instantly (unchanged) |
| Client disconnects while waiting | n/a | Wait stops, request is abandoned |

## Testing

- 24 new unit tests in `tests/unit/main/test_startup_grace_period.py`: window math (full at start, runs out, late requests see only the remainder), disconnect recording in the registry (drop opens the window, stale drop does not, never-connected provider has none), the reconnect-grace helper (cloud deployments ignored, freshest drop wins, zero when nothing dropped), wait behaviour across both windows, client-disconnect and client-timeout caps, and both entry points end-to-end.
- Full unit suite: `802 passed, 1 xfailed` (the xfail is pre-existing on main) — `cd logos/logos-orchestrator && .venv/bin/pytest tests/unit -q`.
- Lint/format gate: `pre-commit run --config logos/.pre-commit-config.yaml` (autoflake, isort, black, flake8, yaml) passes on all changed files.
- No live deployment is available in this environment, so end-to-end redeploy/reboot behaviour was verified through the unit tests of the exact code paths (`handle_sync_request` → `_wait_for_worker_connect` → `_filter_logosnode_deployments`, `detach_session` → `disconnect_grace_remaining_s`) and careful code reading instead.