### PR TITLE
`Logos`: Apply API-key default_priority in queue scheduling

### DIFF
--- a/logos/logos-orchestrator/src/logos/auth.py
+++ b/logos/logos-orchestrator/src/logos/auth.py
@@ -56,7 +56,10 @@ class AuthContext:
     environment: Optional[str]
     log_level: str
     settings: Optional[dict]
-    default_priority: int = 1
+    # Queue priority the key owner configured for this key (1/5/10 scale, see
+    # queue.models.Priority). 0 means "not set": the request falls back to the
+    # policy-level priority (see pipeline.resolve_queue_priority).
+    default_priority: int = 0
     cloud_rl: Optional[dict] = None
     local_rl: Optional[dict] = None
 
@@ -83,5 +86,7 @@ def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
         environment=row["environment"],
         log_level=row.get("log") or "BILLING",
         settings=row.get("settings") if row.get("settings") is not None else {},
-        default_priority=row.get("default_priority") or 1,
+        # Preserve 0 (the webservice/UI "not set" sentinel) so the pipeline
+        # can fall back to the policy-level priority.
+        default_priority=row.get("default_priority") or 0,
     )

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -3776,7 +3776,7 @@ async def _execute_resource_mode(
         deployments=deployments,
         skip_laura=skip_laura,
         request_path=request_path,
-        # The key owner's queue priority (issue #673); 0 falls back to the
+        # The key owner's queue priority; 0 falls back to the
         # policy-level priority inside the pipeline.
         default_priority=auth.default_priority,
     )

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -3649,7 +3649,6 @@ async def _execute_proxy_mode(
     is_async_job: bool,
     request_id: Optional[str] = None,
     request_path: Optional[str] = None,
-    priority: int = 1,
 ):
     """
     Direct model execution: skip classification, reuse scheduling/SDI, resolve auth from DB.
@@ -3710,7 +3709,6 @@ async def _execute_proxy_mode(
         request_id=request_id,
         request_path=request_path,
         skip_laura=True,
-        priority=priority,
     )
 
 
@@ -3725,7 +3723,6 @@ async def _execute_resource_mode(
     request_id: Optional[str] = None,
     request_path: Optional[str] = None,
     skip_laura: bool = False,
-    priority: int = 1,
 ):
     """
     Execute request in RESOURCE mode (classification + scheduling).
@@ -3779,6 +3776,9 @@ async def _execute_resource_mode(
         deployments=deployments,
         skip_laura=skip_laura,
         request_path=request_path,
+        # The key owner's queue priority (issue #673); 0 falls back to the
+        # policy-level priority inside the pipeline.
+        default_priority=auth.default_priority,
     )
 
     # Process through classification and scheduling
@@ -3958,7 +3958,6 @@ async def route_and_execute(
     log_id: Optional[int],
     is_async_job: bool = False,
     request_id: Optional[str] = None,
-    priority: int = 1,
 ):
     """
     Route request to PROXY or RESOURCE mode and execute.
@@ -3990,7 +3989,6 @@ async def route_and_execute(
         is_async_job: Whether this is a background job (affects error handling)
             - False: Direct endpoint - client waits, raises HTTPException for errors
             - True: Background job - client gets job_id, returns error dict for errors
-        priority: Scheduling priority for the pipeline queue
 
     Returns:
         - For direct endpoints (is_async_job=False):
@@ -4034,7 +4032,6 @@ async def route_and_execute(
                 is_async_job=is_async_job,
                 request_id=request_id,
                 request_path=path,
-                priority=priority,
             )
 
         # RESOURCE mode (no body["model"] → classification + scheduling)
@@ -4047,7 +4044,6 @@ async def route_and_execute(
             is_async_job=is_async_job,
             request_id=request_id,
             request_path=path,
-            priority=priority,
         )
     except HTTPException as exc:
         _record_log_failure(log_id, request_id, str(exc.detail), result_status="error")
@@ -4146,8 +4142,9 @@ async def _execute_cancelling_on_disconnect(request: Request, **kwargs):
 async def handle_sync_request(path: str, request: Request):
     """
     Handle synchronous (non-job) requests for both /v1 and /openai endpoints.
-    Performs authentication, model setup, and routing/execution with
-    hierarchical priority resolution.
+    Performs authentication, model setup, and routing/execution. Queue
+    priority is derived from the authenticated API key's default_priority
+    (falling back to the policy-level priority inside the pipeline).
     """
     # Authenticate with profile-based auth (REQUIRED for v1/openai/jobs endpoints)
     headers, auth, body, client_ip, log_id = await auth_parse_log(request, use_profile_auth=True)

--- a/logos/logos-orchestrator/src/logos/pipeline/README.md
+++ b/logos/logos-orchestrator/src/logos/pipeline/README.md
@@ -73,6 +73,15 @@ When a request names a model, `main.py` first verifies access and limits deploym
 
 `ContextResolver` resolves an execution context that includes the forward URL and credential header/value. Later, the response helper uses that context to assemble the headers and provider-adjusted payload. Readiness retries are deliberately narrow: the pipeline retries an absent execution context only for a scheduled LogosNode provider while a lane is becoming available. Cloud providers do not inherit that local-lane retry behavior.
 
+### Queue priority resolution
+
+The priority a request is queued with is resolved by `resolve_queue_priority()` in `pipeline.py` before scheduling:
+
+- **The API key's `default_priority` wins** when set (non-zero). It is configured per key in the admin UI ("Queue Priority"), so a key owner's explicit choice determines where that key's traffic sits in the queue, regardless of the policy.
+- **The policy-level `priority` is the fallback** when the key has none set (`0`, the default for newly created keys): the request queues with the priority of the policy selected for it (or `0` → NORMAL when no policy applies).
+
+Both values use the same 1/5/10 scale (LOW/NORMAL/HIGH, see `queue/models.py`); non-canonical values are normalized by `Priority.from_int`. The resolved value is applied to every classified candidate, so the schedulers, the priority queues, the monitoring events, and the logged classification stats all agree on it.
+
 ## Pipeline Components
 
 ### Core Files in `src/logos/pipeline/`

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -25,6 +25,35 @@ from .scheduler_interface import QueueTimeoutError, SchedulerInterface, Scheduli
 logger = logging.getLogger(__name__)
 
 
+def resolve_queue_priority(default_priority: Optional[int], policy_priority: Optional[int]) -> int:
+    """
+    Resolve the effective queue priority for a request.
+
+    The API key's ``default_priority`` (set per key, editable in the admin UI)
+    takes precedence over the policy-level ``priority``: a key that has a
+    priority set (non-zero) queues its requests at that priority regardless of
+    the policy, so a key owner's explicit choice is always honoured. A key
+    without a priority set (0, the default for newly created keys) falls back
+    to the policy's priority, preserving the historical policy-only behaviour.
+
+    Both values use the same 1/5/10 scale consumed by ``Priority.from_int``
+    (1=LOW, 5=NORMAL, 10=HIGH; other values normalise to NORMAL).
+
+    Args:
+        default_priority: The requesting API key's default_priority, or 0/None
+            when the key has none set.
+        policy_priority: The policy's ``priority`` value (may be 0/None).
+
+    Returns:
+        The effective integer priority for the request's queue entry.
+    """
+    if default_priority:
+        return int(default_priority)
+    if policy_priority:
+        return int(policy_priority)
+    return 0
+
+
 @dataclass
 class PipelineRequest:
     """Input to the pipeline."""
@@ -43,6 +72,10 @@ class PipelineRequest:
     # context resolver to build the forward URL for cloud upstream providers,
     # which serve the same OpenAI-shaped surface as our /v1 routes.
     request_path: Optional[str] = None
+    # The requesting API key's default_priority (see auth.AuthContext). The key
+    # owner's queue-priority choice for their traffic. 0 means "not set": the
+    # policy-level priority applies instead (see resolve_queue_priority).
+    default_priority: int = 0
 
 
 @dataclass
@@ -435,6 +468,16 @@ class RequestPipeline:
             system=system_prompt,
             skip_laura=request.skip_laura,
         )
+
+        # The classifier bakes the policy's priority into every candidate, but
+        # the key owner's default_priority takes precedence (issue #673):
+        # resolve the effective priority here so all downstream consumers
+        # (schedulers, queueing, monitoring, log stats) agree on it.
+        effective_priority = resolve_queue_priority(request.default_priority, policy.get("priority"))
+        if candidates:
+            candidates = [
+                (model_id, weight, effective_priority, parallel) for model_id, weight, _, parallel in candidates
+            ]
 
         elapsed = time.time() - start
 

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -475,9 +475,7 @@ class RequestPipeline:
         # queueing, monitoring, log stats) agree on it.
         effective_priority = resolve_queue_priority(request.default_priority, policy.get("priority"))
         if candidates:
-            candidates = [
-                (model_id, weight, effective_priority, parallel) for model_id, weight, _, parallel in candidates
-            ]
+            candidates = [(model_id, weight, effective_priority) for model_id, weight, _ in candidates]
 
         elapsed = time.time() - start
 

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -470,9 +470,9 @@ class RequestPipeline:
         )
 
         # The classifier bakes the policy's priority into every candidate, but
-        # the key owner's default_priority takes precedence (issue #673):
-        # resolve the effective priority here so all downstream consumers
-        # (schedulers, queueing, monitoring, log stats) agree on it.
+        # the key owner's default_priority takes precedence: resolve the
+        # effective priority here so all downstream consumers (schedulers,
+        # queueing, monitoring, log stats) agree on it.
         effective_priority = resolve_queue_priority(request.default_priority, policy.get("priority"))
         if candidates:
             candidates = [

--- a/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
@@ -71,7 +71,7 @@ async def test_execute_resource_mode_failure_records_error(monkeypatch):
 
 
 async def test_execute_resource_mode_forwards_api_key_priority_to_pipeline(monkeypatch):
-    """The authenticated key's default_priority reaches the PipelineRequest (issue #673)."""
+    """The authenticated key's default_priority reaches the PipelineRequest."""
 
     captured = {}
 

--- a/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_execute_modes.py
@@ -70,6 +70,45 @@ async def test_execute_resource_mode_failure_records_error(monkeypatch):
     assert exc.value.status_code == 503
 
 
+async def test_execute_resource_mode_forwards_api_key_priority_to_pipeline(monkeypatch):
+    """The authenticated key's default_priority reaches the PipelineRequest (issue #673)."""
+
+    captured = {}
+
+    class Result:
+        success = False
+        error = "boom"
+        execution_context = None
+        provider_id = None
+        model_id = None
+        classification_stats = {}
+        scheduling_stats = {"request_id": "req-1"}
+
+    async def fake_process(pipeline_req):
+        captured["request"] = pipeline_req
+        return Result()
+
+    monkeypatch.setattr(
+        main,
+        "_pipeline",
+        type("P", (), {"process": fake_process, "record_completion": lambda *a, **k: None}),
+        raising=False,
+    )
+    monkeypatch.setattr(main, "_extract_policy", lambda *args, **kwargs: {"p": "ok"})
+
+    with pytest.raises(main.HTTPException) as exc:
+        await main._execute_resource_mode(
+            deployments=[{"model_id": 10, "provider_id": 1}],
+            body={},
+            headers={"h": "v"},
+            auth=MagicMock(key_value="lg-test", api_key_id=1, default_priority=10),
+            log_id=1,
+            is_async_job=False,
+        )
+    assert exc.value.status_code == 503
+    assert captured["request"].default_priority == 10
+
+
 async def test_execute_resource_mode_uses_sync_response_for_resolved_whisper_alias(monkeypatch):
     """A client alias resolving to Whisper must not be framed as SSE."""
 

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
@@ -30,7 +30,7 @@ class _FakeClassifier:
 
     def classify(self, user_prompt, policy, allowed=None, system=None, skip_laura=False):  # noqa: ARG002
         priority = policy.get("priority", 0)
-        return [(mid, 1.0, priority, 1) for mid in (allowed or [])]
+        return [(mid, 1.0, priority) for mid in (allowed or [])]
 
 
 class _FakeScheduler:
@@ -121,7 +121,7 @@ async def test_key_priority_overrides_policy_priority():
     result = await pipeline.process(_request(default_priority=10))
 
     assert result.success is True
-    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [10]
+    assert [prio for _, _, prio in scheduler.last_request.classified_models] == [10]
 
 
 async def test_key_priority_wins_even_when_lower_than_policy():
@@ -129,7 +129,7 @@ async def test_key_priority_wins_even_when_lower_than_policy():
 
     await pipeline.process(_request(default_priority=1))
 
-    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [1]
+    assert [prio for _, _, prio in scheduler.last_request.classified_models] == [1]
 
 
 async def test_unset_key_falls_back_to_policy_priority():
@@ -138,7 +138,7 @@ async def test_unset_key_falls_back_to_policy_priority():
 
     await pipeline.process(_request(default_priority=0))
 
-    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [5]
+    assert [prio for _, _, prio in scheduler.last_request.classified_models] == [5]
 
 
 async def test_unset_key_without_policy_keeps_prior_behavior():
@@ -147,7 +147,7 @@ async def test_unset_key_without_policy_keeps_prior_behavior():
 
     await pipeline.process(_request(policy=None, default_priority=0))
 
-    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [0]
+    assert [prio for _, _, prio in scheduler.last_request.classified_models] == [0]
 
 
 async def test_enqueue_monitoring_uses_effective_priority():

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
@@ -1,4 +1,4 @@
-"""API-key default_priority drives queue ordering (issue #673).
+"""API-key default_priority drives queue ordering.
 
 The classifier bakes the policy's priority into every candidate; the pipeline
 then applies the requesting key's default_priority on top, so the key owner's

--- a/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
+++ b/logos/logos-orchestrator/tests/unit/pipeline/test_key_priority.py
@@ -1,0 +1,167 @@
+"""API-key default_priority drives queue ordering (issue #673).
+
+The classifier bakes the policy's priority into every candidate; the pipeline
+then applies the requesting key's default_priority on top, so the key owner's
+explicit choice wins and an unset key (0) keeps the policy's priority.
+"""
+
+from logos import PipelineRequest, RequestPipeline, SchedulingResult
+from logos.pipeline.pipeline import resolve_queue_priority
+
+
+def test_resolve_queue_priority_key_wins_when_set():
+    assert resolve_queue_priority(10, 5) == 10
+    # Even a lower key priority is honoured — it is the key owner's choice.
+    assert resolve_queue_priority(1, 10) == 1
+    # Arbitrary values pass through (Priority.from_int normalises them later).
+    assert resolve_queue_priority(7, 5) == 7
+
+
+def test_resolve_queue_priority_unset_key_falls_back_to_policy():
+    assert resolve_queue_priority(0, 5) == 5
+    assert resolve_queue_priority(None, 10) == 10
+    # Both unset: 0 (ProxyPolicy default), which Priority.from_int maps to NORMAL.
+    assert resolve_queue_priority(0, 0) == 0
+    assert resolve_queue_priority(0, None) == 0
+
+
+class _FakeClassifier:
+    """Mimics ClassificationManager: bakes the policy's priority into candidates."""
+
+    def classify(self, user_prompt, policy, allowed=None, system=None, skip_laura=False):  # noqa: ARG002
+        priority = policy.get("priority", 0)
+        return [(mid, 1.0, priority, 1) for mid in (allowed or [])]
+
+
+class _FakeScheduler:
+    def __init__(self):
+        self.last_request = None
+
+    async def schedule(self, request):
+        self.last_request = request
+        return SchedulingResult(
+            model_id=request.classified_models[0][0],
+            provider_id=request.deployments[0]["provider_id"],
+            provider_type=request.deployments[0]["type"],
+            queue_entry_id=None,
+            was_queued=False,
+            queue_depth_at_schedule=0,
+        )
+
+    def release(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+    def get_total_queue_depth(self):
+        return 0
+
+    def update_provider_stats(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
+class _StubExecutionContext:
+    def __init__(self, model_id, provider_id):
+        self.model_id = model_id
+        self.provider_id = provider_id
+
+
+class _FakeContextResolver:
+    async def resolve_context(self, model_id, provider_id, request_path=None):  # noqa: ARG002
+        return _StubExecutionContext(model_id, provider_id)
+
+
+class _RecordingMonitoring:
+    def __init__(self):
+        self.enqueue_kwargs = None
+
+    def record_enqueue(self, **kwargs):
+        self.enqueue_kwargs = kwargs
+
+    def record_scheduled(self, **kwargs):  # noqa: ARG002
+        pass
+
+    def record_provider(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+    def record_complete(self, **kwargs):  # noqa: ARG002
+        pass
+
+    def record_provider_metrics(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+
+def _build_pipeline():
+    scheduler = _FakeScheduler()
+    monitoring = _RecordingMonitoring()
+    pipeline = RequestPipeline(
+        classifier=_FakeClassifier(),
+        scheduler=scheduler,
+        executor=object(),
+        context_resolver=_FakeContextResolver(),
+        monitoring=monitoring,
+    )
+    return pipeline, scheduler, monitoring
+
+
+def _request(**overrides):
+    kwargs = dict(
+        payload={"messages": [{"role": "user", "content": "hi"}]},
+        headers={},
+        allowed_models=[27],
+        deployments=[{"model_id": 27, "provider_id": 12, "type": "cloud"}],
+        policy={"priority": 5},
+    )
+    kwargs.update(overrides)
+    return PipelineRequest(**kwargs)
+
+
+async def test_key_priority_overrides_policy_priority():
+    """A key with a set default_priority queues at that priority, not the policy's."""
+    pipeline, scheduler, _monitoring = _build_pipeline()
+
+    result = await pipeline.process(_request(default_priority=10))
+
+    assert result.success is True
+    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [10]
+
+
+async def test_key_priority_wins_even_when_lower_than_policy():
+    pipeline, scheduler, _monitoring = _build_pipeline()
+
+    await pipeline.process(_request(default_priority=1))
+
+    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [1]
+
+
+async def test_unset_key_falls_back_to_policy_priority():
+    """default_priority=0 (webservice/UI default) keeps the policy's priority."""
+    pipeline, scheduler, _monitoring = _build_pipeline()
+
+    await pipeline.process(_request(default_priority=0))
+
+    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [5]
+
+
+async def test_unset_key_without_policy_keeps_prior_behavior():
+    """No key priority and no policy: priority stays 0 (→ NORMAL) as before."""
+    pipeline, scheduler, _monitoring = _build_pipeline()
+
+    await pipeline.process(_request(policy=None, default_priority=0))
+
+    assert [prio for _, _, prio, _ in scheduler.last_request.classified_models] == [0]
+
+
+async def test_enqueue_monitoring_uses_effective_priority():
+    pipeline, _scheduler, monitoring = _build_pipeline()
+
+    await pipeline.process(_request(default_priority=10))
+
+    assert monitoring.enqueue_kwargs is not None
+    assert monitoring.enqueue_kwargs["initial_priority"] == "high"
+
+
+async def test_classification_stats_report_effective_priority():
+    pipeline, _scheduler, _monitoring = _build_pipeline()
+
+    result = await pipeline.process(_request(default_priority=10))
+
+    assert result.classification_stats["candidates"][0]["priority"] == 10

--- a/logos/logos-orchestrator/tests/unit/test_auth.py
+++ b/logos/logos-orchestrator/tests/unit/test_auth.py
@@ -80,6 +80,29 @@ def test_authenticate_api_key_missing_key_raises_401(monkeypatch):
     assert exc.value.status_code == 401
 
 
+def test_authenticate_api_key_preserves_zero_default_priority(monkeypatch):
+    """A key without a configured priority stays 0 (falls back to policy in the pipeline)."""
+    row = _api_key_row("lg-test-zero")
+    row["default_priority"] = 0
+
+    _patch_db(monkeypatch, row)
+
+    ctx = auth.authenticate_api_key({"logos-key": "lg-test-zero"})
+
+    assert ctx.default_priority == 0
+
+
+def test_authenticate_api_key_missing_default_priority_defaults_to_zero(monkeypatch):
+    row = _api_key_row("lg-test-noprio")
+    del row["default_priority"]
+
+    _patch_db(monkeypatch, row)
+
+    ctx = auth.authenticate_api_key({"logos-key": "lg-test-noprio"})
+
+    assert ctx.default_priority == 0
+
+
 def test_authenticate_logos_key_shim_returns_key_and_api_key_id(monkeypatch):
     _patch_db(monkeypatch, _api_key_row("lg-test-abc"))
 


### PR DESCRIPTION
Fixes #673

## Summary

`api_keys.default_priority` was stored, editable in the admin UI, and loaded into `AuthContext`, but never consulted in scheduling — queue priority came only from the policy. This wires the key's priority into queue ordering in `logos-orchestrator` and documents how it interacts with the policy-level priority.

## Interaction with the policy-level priority

Resolved by a new `resolve_queue_priority()` in `logos-orchestrator/src/logos/pipeline/pipeline.py`:

- **The API key's `default_priority` wins when set (non-zero).** It is the key owner's explicit "Queue Priority" choice for their traffic, so it determines where that key's requests sit in the queue regardless of the policy.
- **The policy's `priority` is the fallback** when the key has none set (`0` — the webservice/UI default for newly created keys). Requests from such keys queue exactly as before, so existing deployments are unaffected.

Both use the same 1/5/10 scale (LOW/NORMAL/HIGH, `Priority.from_int` normalises other values). The resolved value is applied to every classified candidate before scheduling, so the schedulers, the priority queues, the monitoring events (`initial_priority`), and the logged classification stats all agree on it.

## Changes

- `src/logos/auth.py`: keep `0` as the "not set" sentinel for `default_priority` instead of coercing it to `1` (the coercion would have silently downgraded every unset key to LOW).
- `src/logos/pipeline/pipeline.py`: new `resolve_queue_priority()` helper; new `PipelineRequest.default_priority` field; `_classify()` applies the resolved priority to all candidates.
- `src/logos/main.py`: `_execute_resource_mode` forwards `auth.default_priority` into the `PipelineRequest`; removes the `priority: int = 1` parameter that was threaded through `route_and_execute` / `_execute_proxy_mode` / `_execute_resource_mode` but never applied (the half-finished wiring that made this bug easy to miss).
- `src/logos/pipeline/README.md`: documents the key-vs-policy precedence under "Queue priority resolution".

## Testing

- 11 new unit tests:
  - `tests/unit/pipeline/test_key_priority.py`: key priority overrides policy (also when lower than the policy's), unset key falls back to the policy, no-policy behaviour unchanged, monitoring `initial_priority` and classification stats reflect the effective priority, plus direct `resolve_queue_priority` cases.
  - `tests/unit/test_auth.py`: `0` and missing `default_priority` stay `0` in `AuthContext`.
  - `tests/unit/main/test_execute_modes.py`: `_execute_resource_mode` forwards `auth.default_priority` into the `PipelineRequest`.
- Full unit suite: `pytest tests/unit` → **789 passed, 1 xfailed** (the xfail is pre-existing on main).
- Lint gate: `pre-commit run --config logos/.pre-commit-config.yaml --all-files` → all hooks pass (black, isort, autoflake, flake8, hygiene checks).

No database schema changes, no new endpoints, no configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Queue priority now correctly honors an API key’s configured priority.
  * When no API key priority is set, the applicable policy priority is used instead.
  * Priority handling is applied consistently across scheduling, queues, monitoring, and classification.

* **Bug Fixes**
  * Explicit priority value `0` is now preserved rather than replaced with a default value.

* **Tests**
  * Added coverage for priority resolution, propagation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->