### PR TITLE
`Logos`: Let operators wake and sleep lanes from the statistics page

### DIFF
--- a/logos/docker-compose.dev.yaml
+++ b/logos/docker-compose.dev.yaml
@@ -225,7 +225,7 @@ services:
       # Exact paths in front of the orchestrator's logosnode catch-all (201), so
       # every action added to the UI has to be named here too — see the prod
       # compose for what happens when one is missed.
-      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`)"
+      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
       - "traefik.http.routers.webservice-logosnode-admin.entrypoints=web8080"
       - "traefik.http.routers.webservice-logosnode-admin.service=logos-webservice-svc"
       - "traefik.http.routers.webservice-logosnode-admin.middlewares=strip-api"

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -272,7 +272,7 @@ services:
       # and to both services but not to this line is still routed straight to the
       # orchestrator — which does not serve Spring's paths and answers 404. That
       # is what happened to lanes/add: present end to end, unreachable in prod.
-      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`)"
+      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
       - "traefik.http.routers.webservice-logosnode-admin.entrypoints=websecure"
       - "traefik.http.routers.webservice-logosnode-admin.tls=true"
       - "traefik.http.routers.webservice-logosnode-admin.tls.certresolver=letsencrypt"

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2203,6 +2203,13 @@ async def internal_logosnode_sleep_lane(data: _InternalSleepLaneRequest, request
     seconds; level 2 would release them and pay for a full reload on the next
     wake — a choice most operators cannot make well, so the button does not
     offer it and neither does this endpoint.
+
+    In-flight requests are not refused: mode="wait" makes the worker drain
+    them first and only sleep once the lane is idle (a request admitted
+    between drain and sleep makes the worker skip the sleep and stay awake).
+    The command therefore takes as long as the drain — the dispatch budget
+    must cover it, which is why sleep_lane gets the same 120 s as the
+    planner's own sleep commands.
     """
     if not _INTERNAL_SECRET:
         raise HTTPException(status_code=403, detail="Internal endpoint disabled")
@@ -2230,15 +2237,15 @@ async def internal_logosnode_sleep_lane(data: _InternalSleepLaneRequest, request
     )
     if lane is None:
         return JSONResponse(status_code=404, content={"error": f"Lane '{data.lane_id}' not found on this worker"})
-    # A lane mid-generation cannot sleep without cutting requests off. The
-    # worker's mode="wait" drain would just wait it out (30 s budget) and end
-    # in a no-op, so answer the refusal synchronously with a reason the panel
-    # can display — same shape as manual_load_rejection_reason for loads.
-    active = int(lane.get("active_requests", 0) or 0)
-    if active > 0:
+    # "unsupported" is the worker's resolved answer for "cannot sleep this
+    # lane": enable_sleep_mode off for its model (per-model override or the
+    # node-wide kill switch) or a non-vLLM lane. Dispatching would burn the
+    # command budget to fail on the worker, so refuse synchronously with the
+    # reason the panel can display.
+    if str(lane.get("sleep_state", "")).strip().lower() == "unsupported":
         raise HTTPException(
             status_code=409,
-            detail=f"Lane is serving {active} active request(s); wait for them to finish before sleeping it.",
+            detail="Lane does not support sleep mode; its model is configured without enable_sleep_mode.",
         )
     return await _dispatch_logosnode_command(
         provider_id=data.provider_id,
@@ -4988,7 +4995,10 @@ async def logosnode_lanes(data: LogosNodeStatusRequest):
 _LOGOSNODE_CMD_TIMEOUTS: dict[str, int] = {
     "apply_lanes": 180,
     "reconfigure_lane": 180,
-    "sleep_lane": 30,
+    # sleep_lane with mode="wait" first drains in-flight requests (the worker
+    # budgets 30 s for that), so a fixed 30 s here would time out exactly when
+    # a busy lane actually drains. The planner uses 120 s for its own sleeps.
+    "sleep_lane": 120,
     "wake_lane": 120,
     "delete_lane": 30,
 }

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2015,6 +2015,16 @@ class _InternalAddLaneRequest(BaseModel):
     lane: dict[str, Any]
 
 
+class _InternalSleepLaneRequest(BaseModel):
+    provider_id: int
+    lane_id: str
+
+
+class _InternalWakeLaneRequest(BaseModel):
+    provider_id: int
+    lane_id: str
+
+
 @app.post("/internal/logosnode/calibrate_uncalibrated", tags=["admin"])
 async def internal_logosnode_calibrate_uncalibrated(data: _InternalCalibrateRequest, request: Request):
     """Calibrate uncalibrated models on a worker, called by Spring after JWT validation."""
@@ -2124,6 +2134,78 @@ async def internal_logosnode_add_lane(data: _InternalAddLaneRequest, request: Re
     return JSONResponse(
         status_code=202,
         content={"status": "accepted", "model": model, "provider_id": data.provider_id},
+    )
+
+
+@app.post("/internal/logosnode/lanes/sleep", tags=["admin"])
+async def internal_logosnode_sleep_lane(data: _InternalSleepLaneRequest, request: Request):
+    """Sleep a lane on a worker, called by Spring after JWT validation.
+
+    Level 1 keeps the weights resident in host memory, so the lane wakes in
+    seconds; level 2 would release them and pay for a full reload on the next
+    wake — a choice most operators cannot make well, so the button does not
+    offer it and neither does this endpoint.
+    """
+    if not _INTERNAL_SECRET:
+        raise HTTPException(status_code=403, detail="Internal endpoint disabled")
+    auth_header = request.headers.get("authorization", "")
+    token = (
+        auth_header.removeprefix("Bearer ").strip()
+        if auth_header.lower().startswith("bearer ")
+        else auth_header.strip()
+    )
+    if not hmac.compare_digest(token, _INTERNAL_SECRET):
+        raise HTTPException(status_code=401, detail="Invalid or missing internal secret")
+
+    snap = _logosnode_registry.peek_runtime_snapshot(data.provider_id)
+    if snap is None:
+        return JSONResponse(status_code=503, content={"error": "Worker not connected"})
+    if not snap.get("first_status_received"):
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Worker has not sent its first status yet"},
+        )
+    lanes = (snap.get("runtime") or {}).get("lanes") or []
+    lane = next(
+        (item for item in lanes if isinstance(item, dict) and str(item.get("lane_id", "")) == data.lane_id),
+        None,
+    )
+    if lane is None:
+        return JSONResponse(status_code=404, content={"error": f"Lane '{data.lane_id}' not found on this worker"})
+    # A lane mid-generation cannot sleep without cutting requests off. The
+    # worker's mode="wait" drain would just wait it out (30 s budget) and end
+    # in a no-op, so answer the refusal synchronously with a reason the panel
+    # can display — same shape as manual_load_rejection_reason for loads.
+    active = int(lane.get("active_requests", 0) or 0)
+    if active > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Lane is serving {active} active request(s); wait for them to finish before sleeping it.",
+        )
+    return await _dispatch_logosnode_command(
+        provider_id=data.provider_id,
+        action="sleep_lane",
+        params={"lane_id": data.lane_id, "level": 1, "mode": "wait"},
+    )
+
+
+@app.post("/internal/logosnode/lanes/wake", tags=["admin"])
+async def internal_logosnode_wake_lane(data: _InternalWakeLaneRequest, request: Request):
+    """Wake a sleeping lane on a worker, called by Spring after JWT validation."""
+    if not _INTERNAL_SECRET:
+        raise HTTPException(status_code=403, detail="Internal endpoint disabled")
+    auth_header = request.headers.get("authorization", "")
+    token = (
+        auth_header.removeprefix("Bearer ").strip()
+        if auth_header.lower().startswith("bearer ")
+        else auth_header.strip()
+    )
+    if not hmac.compare_digest(token, _INTERNAL_SECRET):
+        raise HTTPException(status_code=401, detail="Invalid or missing internal secret")
+    return await _dispatch_logosnode_command(
+        provider_id=data.provider_id,
+        action="wake_lane",
+        params={"lane_id": data.lane_id},
     )
 
 

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_sleep_wake_lane_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_sleep_wake_lane_endpoints.py
@@ -81,8 +81,8 @@ async def test_sleep_returns_503_when_worker_not_connected(monkeypatch):
 async def test_sleep_returns_503_before_the_worker_sent_its_first_status(monkeypatch):
     """No status means no lanes, so the guard has nothing to read.
 
-    Dispatching anyway would burn the 30 s command timeout only to fail on the
-    worker — say so up front, the same way calibrate_uncalibrated does.
+    Dispatching anyway would burn the 120 s command timeout only to fail on
+    the worker — say so up front, the same way calibrate_uncalibrated does.
     """
     monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
     monkeypatch.setattr(main_mod, "_logosnode_registry", _registry(snap=_snapshot(first_status=False)))
@@ -107,37 +107,38 @@ async def test_sleep_returns_404_for_a_lane_the_worker_does_not_report(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_sleep_refuses_a_lane_that_is_serving(monkeypatch):
-    """Sleeping a busy lane cuts requests off mid-stream.
-
-    The worker's mode="wait" drain would wait out the 30 s budget and end in a
-    silent no-op; the operator instead gets the reason synchronously, in the
-    shape the panel already displays for refusals.
-    """
+async def test_sleep_does_not_refuse_a_lane_that_is_serving(monkeypatch):
+    """A busy lane is not refused: mode="wait" drains in-flight requests
+    first and sleeps once the lane is idle, so the dispatch must go through
+    even with active traffic — the response just takes longer."""
     monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
-    registry = _registry(snap=_snapshot(lanes=[_lane(active_requests=2, sleep_state="awake")]))
+    registry = _registry(
+        snap=_snapshot(lanes=[_lane(active_requests=2, sleep_state="awake")]),
+        command_result={"lane_id": "lane-1"},
+    )
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
+
+    assert response == {"lane_id": "lane-1"}
+    registry.send_command.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sleep_refuses_a_lane_that_cannot_sleep(monkeypatch):
+    """The worker reports sleep_state "unsupported" when its model is
+    configured without enable_sleep_mode (or the lane is not a vLLM lane).
+    Refuse synchronously instead of dispatching to fail on the worker."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(snap=_snapshot(lanes=[_lane(sleep_state="unsupported")]))
     monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
 
     with pytest.raises(HTTPException) as exc_info:
         await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
 
     assert exc_info.value.status_code == 409
-    assert "2 active request" in exc_info.value.detail
+    assert "enable_sleep_mode" in exc_info.value.detail
     registry.send_command.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_sleep_treats_a_missing_active_requests_count_as_idle(monkeypatch):
-    """Older workers may omit the field; absence is not evidence of traffic."""
-    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
-    registry = _registry(
-        snap=_snapshot(lanes=[_lane(active_requests=None)]), command_result={"sleep_state": "sleeping"}
-    )
-    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
-
-    response = await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
-
-    assert response == {"sleep_state": "sleeping"}
 
 
 @pytest.mark.asyncio
@@ -158,7 +159,7 @@ async def test_sleep_dispatches_level_1_wait(monkeypatch):
         7,
         action="sleep_lane",
         params={"lane_id": "lane-1", "level": 1, "mode": "wait"},
-        timeout_seconds=30,
+        timeout_seconds=120,
     )
 
 

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_sleep_wake_lane_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_sleep_wake_lane_endpoints.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import logos as main_mod
+from logos.logosnode_registry import LogosNodeOfflineError
+
+
+def _make_request(authorization: str = "") -> MagicMock:
+    request = MagicMock()
+    request.headers.get = lambda key, default="": authorization if key == "authorization" else default
+    return request
+
+
+def _lane(lane_id: str = "lane-1", active_requests: int | None = 0, sleep_state: str = "awake") -> dict:
+    lane = {"lane_id": lane_id, "model": "org/model-a", "sleep_state": sleep_state}
+    if active_requests is not None:
+        lane["active_requests"] = active_requests
+    return lane
+
+
+def _snapshot(lanes: list[dict] | None = None, first_status: bool = True) -> dict:
+    return {
+        "provider_id": 1,
+        "worker_id": "worker-1",
+        "first_status_received": first_status,
+        "runtime": {"lanes": lanes if lanes is not None else []},
+    }
+
+
+def _registry(snap: dict | None = None, command_result: dict | None = None) -> MagicMock:
+    registry = MagicMock()
+    registry.peek_runtime_snapshot = lambda pid: snap
+    registry.send_command = AsyncMock(return_value=command_result if command_result is not None else {})
+    return registry
+
+
+def _sleep_payload(provider_id: int = 1, lane_id: str = "lane-1"):
+    return main_mod._InternalSleepLaneRequest(provider_id=provider_id, lane_id=lane_id)
+
+
+def _wake_payload(provider_id: int = 1, lane_id: str = "lane-1"):
+    return main_mod._InternalWakeLaneRequest(provider_id=provider_id, lane_id=lane_id)
+
+
+# ── sleep ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_403_when_secret_not_configured(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer secret"))
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_401_when_secret_is_wrong(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer wrong-secret"))
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_503_when_worker_not_connected(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    monkeypatch.setattr(main_mod, "_logosnode_registry", _registry(snap=None))
+
+    response = await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
+
+    assert response.status_code == 503
+    assert json.loads(response.body) == {"error": "Worker not connected"}
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_503_before_the_worker_sent_its_first_status(monkeypatch):
+    """No status means no lanes, so the guard has nothing to read.
+
+    Dispatching anyway would burn the 30 s command timeout only to fail on the
+    worker — say so up front, the same way calibrate_uncalibrated does.
+    """
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    monkeypatch.setattr(main_mod, "_logosnode_registry", _registry(snap=_snapshot(first_status=False)))
+
+    response = await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_sleep_returns_404_for_a_lane_the_worker_does_not_report(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(snap=_snapshot(lanes=[_lane(lane_id="lane-2")]))
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_sleep_lane(
+        _sleep_payload(lane_id="lane-1"), _make_request("Bearer correct-secret")
+    )
+
+    assert response.status_code == 404
+    registry.send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sleep_refuses_a_lane_that_is_serving(monkeypatch):
+    """Sleeping a busy lane cuts requests off mid-stream.
+
+    The worker's mode="wait" drain would wait out the 30 s budget and end in a
+    silent no-op; the operator instead gets the reason synchronously, in the
+    shape the panel already displays for refusals.
+    """
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(snap=_snapshot(lanes=[_lane(active_requests=2, sleep_state="awake")]))
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
+
+    assert exc_info.value.status_code == 409
+    assert "2 active request" in exc_info.value.detail
+    registry.send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sleep_treats_a_missing_active_requests_count_as_idle(monkeypatch):
+    """Older workers may omit the field; absence is not evidence of traffic."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(
+        snap=_snapshot(lanes=[_lane(active_requests=None)]), command_result={"sleep_state": "sleeping"}
+    )
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_sleep_lane(_sleep_payload(), _make_request("Bearer correct-secret"))
+
+    assert response == {"sleep_state": "sleeping"}
+
+
+@pytest.mark.asyncio
+async def test_sleep_dispatches_level_1_wait(monkeypatch):
+    """Level 1 keeps the weights resident so the wake is fast; the endpoint
+    does not expose the level — see the endpoint docstring for why.
+    """
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(snap=_snapshot(lanes=[_lane(active_requests=0)]), command_result={"lane_id": "lane-1"})
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_sleep_lane(
+        _sleep_payload(provider_id=7), _make_request("Bearer correct-secret")
+    )
+
+    assert response == {"lane_id": "lane-1"}
+    registry.send_command.assert_called_once_with(
+        7,
+        action="sleep_lane",
+        params={"lane_id": "lane-1", "level": 1, "mode": "wait"},
+        timeout_seconds=30,
+    )
+
+
+# ── wake ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wake_returns_403_when_secret_not_configured(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_logosnode_wake_lane(_wake_payload(), _make_request("Bearer secret"))
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_wake_returns_401_when_secret_is_wrong(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_logosnode_wake_lane(_wake_payload(), _make_request("Bearer wrong-secret"))
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wake_dispatches_to_the_worker(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = _registry(command_result={"lane_id": "lane-1", "sleep_state": "awake"})
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_wake_lane(
+        _wake_payload(provider_id=7), _make_request("Bearer correct-secret")
+    )
+
+    assert response == {"lane_id": "lane-1", "sleep_state": "awake"}
+    registry.send_command.assert_called_once_with(
+        7,
+        action="wake_lane",
+        params={"lane_id": "lane-1"},
+        timeout_seconds=120,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wake_returns_503_when_the_worker_is_offline(monkeypatch):
+    """No snapshot guard for wake: an offline worker is a transport failure,
+    and _dispatch_logosnode_command already answers it with a 503."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    registry = MagicMock()
+    registry.send_command = AsyncMock(side_effect=LogosNodeOfflineError("No active logosnode worker session"))
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    response = await main_mod.internal_logosnode_wake_lane(_wake_payload(), _make_request("Bearer correct-secret"))
+
+    assert response.status_code == 503
+    assert json.loads(response.body) == {"error": "No active logosnode worker session"}

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
@@ -5,6 +5,9 @@
     @if (unloadError()) {
       <div class="action-error">{{ unloadError() }}</div>
     }
+    @if (sleepWakeError()) {
+      <div class="action-error">{{ sleepWakeError() }}</div>
+    }
     @if (lanes.length === 0) {
       <div class="lane-empty">No lanes loaded.</div>
     }
@@ -30,6 +33,33 @@
                   >
                     {{ unloadingLaneId() === row.laneId ? 'Unloading…' : 'Unload' }}
                   </button>
+                  <!-- Wake/Sleep reach the two states the capacity planner also
+                       reaches on its own — the tooltip says so outright, because
+                       a woken lane with no demand goes back to sleep on the next
+                       idle check, and a slept lane with queued demand is woken
+                       straight back up. -->
+                  @switch (sleepAction(row.lane)) {
+                    @case ('wake') {
+                      <button
+                        class="btn-lane-action"
+                        [disabled]="wakingLaneId() === row.laneId"
+                        (click)="handleWake(row.laneId)"
+                        title="Wake this lane (weights stay resident, no cold load). The capacity planner decides on its own and may put it back to sleep once it goes idle."
+                      >
+                        {{ wakingLaneId() === row.laneId ? 'Waking…' : 'Wake' }}
+                      </button>
+                    }
+                    @case ('sleep') {
+                      <button
+                        class="btn-lane-action"
+                        [disabled]="sleepingLaneId() === row.laneId"
+                        (click)="handleSleep(row.laneId)"
+                        title="Put this lane to sleep (weights stay resident, no cold load on wake). The capacity planner decides on its own and may wake it as soon as demand returns."
+                      >
+                        {{ sleepingLaneId() === row.laneId ? 'Sleeping…' : 'Sleep' }}
+                      </button>
+                    }
+                  }
                 }
               </div>
             </div>

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.html
@@ -39,10 +39,14 @@
                        idle check, and a slept lane with queued demand is woken
                        straight back up. -->
                   @switch (sleepAction(row.lane)) {
+                    <!-- The handlers take only one wake/sleep at a time and drop a
+                         second silently, so while one is in flight the buttons of
+                         the other lanes are disabled instead of looking clickable.
+                         The spinner stays on the lane that was actually clicked. -->
                     @case ('wake') {
                       <button
                         class="btn-lane-action"
-                        [disabled]="wakingLaneId() === row.laneId"
+                        [disabled]="wakingLaneId() !== null"
                         (click)="handleWake(row.laneId)"
                         title="Wake this lane (weights stay resident, no cold load). The capacity planner decides on its own and may put it back to sleep once it goes idle."
                       >
@@ -52,7 +56,7 @@
                     @case ('sleep') {
                       <button
                         class="btn-lane-action"
-                        [disabled]="sleepingLaneId() === row.laneId"
+                        [disabled]="sleepingLaneId() !== null"
                         (click)="handleSleep(row.laneId)"
                         title="Put this lane to sleep (weights stay resident, no cold load on wake). The capacity planner decides on its own and may wake it as soon as demand returns."
                       >

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.scss
@@ -117,6 +117,29 @@
   }
 }
 
+// Wake/Sleep: unlike Unload they are not destructive, so they share one
+// neutral treatment — the labels (and tooltips) carry the semantics.
+.btn-lane-action {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: rgb(var(--color-typography-500));
+  background: transparent;
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-strong));
+  border-radius: 8px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover:not(:disabled) {
+    background: rgb(var(--color-outline-200) / var(--opacity-soft));
+  }
+
+  &:disabled {
+    opacity: var(--opacity-disabled);
+    cursor: not-allowed;
+  }
+}
+
 .lane-model {
   font-size: var(--font-size-sm);
   color: rgb(var(--color-typography-500));

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -1,4 +1,5 @@
-import { formatContextWindow, messageIn } from './lane-health-panel';
+import { formatContextWindow, laneSleepAction, messageIn } from './lane-health-panel';
+import { LaneSignalData } from '../../statistics.models';
 
 /**
  * Pulling the reason out of a failed lane action.
@@ -97,5 +98,64 @@ describe('formatContextWindow', () => {
     expect(formatContextWindow(0)).toBeNull();
     expect(formatContextWindow(-1)).toBeNull();
     expect(formatContextWindow(Number.NaN)).toBeNull();
+  });
+});
+
+function lane(overrides: Partial<LaneSignalData> = {}): LaneSignalData {
+  return {
+    model: 'org/model-a',
+    vllm: true,
+    runtime_state: 'loaded',
+    sleep_state: 'awake',
+    gpu_devices: null,
+    effective_gpu_devices: null,
+    num_parallel: null,
+    active_requests: 0,
+    effective_vram_mb: 0,
+    gpu_cache_usage_percent: null,
+    ttft_p95_seconds: null,
+    queue_waiting: null,
+    requests_running: null,
+    prefix_cache_hit_rate: null,
+    mtp_acceptance_rate: null,
+    max_model_len: null,
+    ...overrides,
+  };
+}
+
+/**
+ * The Wake/Sleep buttons beside Unload.
+ *
+ * The buttons reach the two states the capacity planner also reaches on its
+ * own, so they are offered only where they mean something: Wake on a lane
+ * that is actually asleep, Sleep on one that is awake and idle. A busy lane
+ * gets no Sleep button — the server would refuse it anyway, and the panel
+ * would just display the refusal.
+ */
+describe('laneSleepAction', () => {
+  it('offers Wake on a sleeping lane', () => {
+    expect(laneSleepAction(lane({ sleep_state: 'sleeping' }))).toBe('wake');
+  });
+
+  it('still offers Wake while a sleeping lane reports in-flight requests', () => {
+    // A sleeping lane should serve nothing; if the counters say otherwise,
+    // the lane is mid-transition and waking it is still the useful action.
+    expect(laneSleepAction(lane({ sleep_state: 'sleeping', active_requests: 3 }))).toBe('wake');
+  });
+
+  it('offers Sleep on an awake, idle lane', () => {
+    expect(laneSleepAction(lane({ sleep_state: 'awake' }))).toBe('sleep');
+  });
+
+  it('withholds Sleep from a lane that is serving', () => {
+    expect(laneSleepAction(lane({ sleep_state: 'awake', active_requests: 1 }))).toBeNull();
+  });
+
+  it('withholds both actions from a lane the backend cannot sleep', () => {
+    // Ollama lanes report "unsupported"; a vLLM lane that never slept reports
+    // "unknown" until its first transition.
+    expect(laneSleepAction(lane({ sleep_state: 'unsupported' }))).toBeNull();
+    expect(laneSleepAction(lane({ sleep_state: 'unknown' }))).toBeNull();
+    expect(laneSleepAction(lane({ sleep_state: null }))).toBeNull();
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -104,11 +104,12 @@ export type LaneSleepAction = 'sleep' | 'wake' | null;
  *
  * Wake only on a lane that is actually asleep: vLLM's /wake_up on an awake
  * engine is a no-op at best, so the button would promise a transition that is
- * not coming. Sleep only on a lane that is awake and idle: the server refuses
- * a sleep while requests are in flight, so a busy lane gets no button rather
- * than a guaranteed failure. Lanes whose backend has no sleep mode (Ollama
- * reports sleep_state "unsupported", a vLLM lane that never slept reports
- * "unknown") offer neither.
+ * not coming. Sleep only on a lane that is awake and idle: the server first
+ * drains in-flight requests (mode="wait"), so on a busy lane the click would
+ * block for as long as the drain takes — the panel offers the action only
+ * where it takes effect immediately. Lanes whose backend has no sleep mode
+ * (Ollama reports sleep_state "unsupported", a vLLM lane that never slept
+ * reports "unknown") offer neither.
  */
 export function laneSleepAction(lane: LaneSignalData): LaneSleepAction {
   if (lane.sleep_state === 'sleeping') return 'wake';

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -59,6 +59,26 @@ export function formatContextWindow(tokens: number | null | undefined): string |
   return tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : String(tokens);
 }
 
+/** Which manual sleep/wake action a lane row offers, if any. */
+export type LaneSleepAction = 'sleep' | 'wake' | null;
+
+/**
+ * Which manual sleep/wake action a lane row offers.
+ *
+ * Wake only on a lane that is actually asleep: vLLM's /wake_up on an awake
+ * engine is a no-op at best, so the button would promise a transition that is
+ * not coming. Sleep only on a lane that is awake and idle: the server refuses
+ * a sleep while requests are in flight, so a busy lane gets no button rather
+ * than a guaranteed failure. Lanes whose backend has no sleep mode (Ollama
+ * reports sleep_state "unsupported", a vLLM lane that never slept reports
+ * "unknown") offer neither.
+ */
+export function laneSleepAction(lane: LaneSignalData): LaneSleepAction {
+  if (lane.sleep_state === 'sleeping') return 'wake';
+  if (lane.sleep_state === 'awake' && !(lane.active_requests > 0)) return 'sleep';
+  return null;
+}
+
 @Component({
   selector: 'app-stats-lane-health-panel',
   standalone: true,
@@ -76,6 +96,11 @@ export class LaneHealthPanel implements OnChanges {
 
   unloadingLaneId = signal<string | null>(null);
   unloadError = signal<string | null>(null);
+
+  // ── Sleep/wake state ─────────────────────────────────────────────────────
+  sleepingLaneId = signal<string | null>(null);
+  wakingLaneId = signal<string | null>(null);
+  sleepWakeError = signal<string | null>(null);
 
   // ── Load-lane state ──────────────────────────────────────────────────────
   pickerOpen = signal(false);
@@ -125,6 +150,11 @@ export class LaneHealthPanel implements OnChanges {
           contextLabel: formatContextWindow(lane.max_model_len),
         };
       });
+  }
+
+  /** Which sleep/wake button the row offers; the rules live in laneSleepAction. */
+  sleepAction(lane: LaneSignalData): LaneSleepAction {
+    return laneSleepAction(lane);
   }
 
   /** "GPU 0-1 · ×4" style placement line; null when the lane reports none. */
@@ -215,6 +245,53 @@ export class LaneHealthPanel implements OnChanges {
         this.unloadError.set(`Unload of ${laneId} failed: ${this.failureDetail(err)}`);
       }
     }
+  }
+
+  async handleSleep(laneId: string): Promise<void> {
+    const pid = this.providerId;
+    if (pid == null || this.sleepingLaneId() != null) return;
+    this.sleepingLaneId.set(laneId);
+    this.sleepWakeError.set(null);
+
+    try {
+      await this.statisticsService.sleepLane(pid, laneId);
+      this.sleepingLaneId.set(null);
+    } catch (err: unknown) {
+      this.sleepingLaneId.set(null);
+      this.sleepWakeError.set(this.sleepWakeErrorText('Sleep', laneId, err));
+    }
+  }
+
+  async handleWake(laneId: string): Promise<void> {
+    const pid = this.providerId;
+    if (pid == null || this.wakingLaneId() != null) return;
+    this.wakingLaneId.set(laneId);
+    this.sleepWakeError.set(null);
+
+    try {
+      await this.statisticsService.wakeLane(pid, laneId);
+      this.wakingLaneId.set(null);
+    } catch (err: unknown) {
+      this.wakingLaneId.set(null);
+      this.sleepWakeError.set(this.sleepWakeErrorText('Wake', laneId, err));
+    }
+  }
+
+  /**
+   * The human-readable reason out of a failed sleep/wake.
+   *
+   * Same mapping as handleUnload, with one twist: a 404 here can carry the
+   * orchestrator's own reason ("lane not found on this worker"), and that
+   * must win over the stale-server hint. The hint only applies when the
+   * status came with no body to read at all.
+   */
+  private sleepWakeErrorText(verb: string, laneId: string, err: unknown): string {
+    const e = err as { status?: number };
+    const detail = this.failureDetail(err);
+    if ((e.status === 404 || e.status === 501 || e.status === 0) && detail === `HTTP ${e?.status ?? 0}`) {
+      return 'Action not available on this server yet.';
+    }
+    return `${verb} of ${laneId} failed: ${detail}`;
   }
 
   // ── Load-lane handlers ───────────────────────────────────────────────────

--- a/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
+++ b/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
@@ -130,6 +130,26 @@ export class StatisticsService {
     }));
   }
 
+  /**
+   * Put an awake, idle lane to sleep. The server refuses with a reason while
+   * the lane still serves requests — that refusal is what this rejects with.
+   * Sleep level 1 is fixed server-side: the weights stay resident, so the
+   * wake below does not pay for a cold load.
+   */
+  sleepLane(providerId: number, laneId: string): Promise<unknown> {
+    return firstValueFrom(this.http.post<unknown>('/api/logosdb/providers/logosnode/lanes/sleep', {
+      provider_id: providerId,
+      lane_id: laneId,
+    }));
+  }
+
+  wakeLane(providerId: number, laneId: string): Promise<unknown> {
+    return firstValueFrom(this.http.post<unknown>('/api/logosdb/providers/logosnode/lanes/wake', {
+      provider_id: providerId,
+      lane_id: laneId,
+    }));
+  }
+
   calibrateUncalibrated(providerId: number): Promise<{ count?: number; models?: string[]; error?: string }> {
     return firstValueFrom(this.http.post<{ count?: number; models?: string[]; error?: string }>(
       '/api/logosdb/providers/logosnode/calibrate_uncalibrated',

--- a/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
+++ b/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
@@ -131,10 +131,12 @@ export class StatisticsService {
   }
 
   /**
-   * Put an awake, idle lane to sleep. The server refuses with a reason while
-   * the lane still serves requests — that refusal is what this rejects with.
-   * Sleep level 1 is fixed server-side: the weights stay resident, so the
-   * wake below does not pay for a cold load.
+   * Put an awake lane to sleep. The server first drains in-flight requests
+   * (mode="wait"), so the call can take as long as the drain — and rejects
+   * with a reason only when the lane cannot sleep at all (its model is
+   * configured without enable_sleep_mode). Sleep level 1 is fixed
+   * server-side: the weights stay resident, so the wake below does not pay
+   * for a cold load.
    */
   sleepLane(providerId: number, laneId: string): Promise<unknown> {
     return firstValueFrom(this.http.post<unknown>('/api/logosdb/providers/logosnode/lanes/sleep', {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
@@ -2,12 +2,17 @@ package de.tum.cit.aet.logos.logoswebservice.common;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
 
+    // @Primary: the worker admin client qualifies its way to the long-timeout
+    // bean below; every other RestTemplate injection resolves to this one
+    // explicitly instead of by parameter-name fallback.
+    @Primary
     @Bean
     public RestTemplate restTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
@@ -15,4 +15,20 @@ public class RestTemplateConfig {
         factory.setReadTimeout(5_000);
         return new RestTemplate(factory);
     }
+
+    /**
+     * Template for the worker admin endpoints (lane add/sleep/wake/delete).
+     *
+     * A sleep with mode="wait" first drains the lane's in-flight requests and
+     * a wake can take up to the orchestrator's 120 s command budget, so the
+     * shared 5 s read timeout above would cut them off exactly when the worker
+     * is doing the real work.
+     */
+    @Bean
+    public RestTemplate workerAdminRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3_000);
+        factory.setReadTimeout(130_000);
+        return new RestTemplate(factory);
+    }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
@@ -174,7 +174,7 @@ public class ProviderController {
         } catch (RestClientResponseException e) {
             return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
         } catch (Exception e) {
-            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(503).body(errorBody(e));
         }
     }
 
@@ -188,8 +188,13 @@ public class ProviderController {
         } catch (RestClientResponseException e) {
             return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
         } catch (Exception e) {
-            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(503).body(errorBody(e));
         }
+    }
+
+    /** e.getMessage() is null for some exceptions, and Map.of rejects null values. */
+    private Object errorBody(Exception e) {
+        return Map.of("error", e.getMessage() != null ? e.getMessage() : e.toString());
     }
 
     private Object parseOrWrap(String body) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
@@ -22,7 +22,9 @@ import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DeleteLaneRequestD
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DeleteProviderRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DisconnectModelProviderRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.GetProviderModelsRequestDTO;
+import de.tum.cit.aet.logos.logoswebservice.configuration.dto.SleepLaneRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.UpdateProviderRequestDTO;
+import de.tum.cit.aet.logos.logoswebservice.configuration.dto.WakeLaneRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.service.PriceUpdaterService;
 import de.tum.cit.aet.logos.logoswebservice.configuration.service.ProviderService;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.Role;
@@ -155,6 +157,34 @@ public class ProviderController {
             return ResponseEntity.badRequest().body(Map.of("error", "provider_id and lane_id are required"));
         try {
             return workerAdminClient.deleteLane(req.providerId(), req.laneId());
+        } catch (RestClientResponseException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
+        } catch (Exception e) {
+            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/providers/logosnode/lanes/sleep")
+    @PreAuthorize("hasAuthority('" + Role.Names.LOGOS_ADMIN + "')")
+    public ResponseEntity<?> sleepLane(@RequestBody SleepLaneRequestDTO req) {
+        if (req.providerId() == null || req.laneId() == null)
+            return ResponseEntity.badRequest().body(Map.of("error", "provider_id and lane_id are required"));
+        try {
+            return workerAdminClient.sleepLane(req.providerId(), req.laneId());
+        } catch (RestClientResponseException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
+        } catch (Exception e) {
+            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/providers/logosnode/lanes/wake")
+    @PreAuthorize("hasAuthority('" + Role.Names.LOGOS_ADMIN + "')")
+    public ResponseEntity<?> wakeLane(@RequestBody WakeLaneRequestDTO req) {
+        if (req.providerId() == null || req.laneId() == null)
+            return ResponseEntity.badRequest().body(Map.of("error", "provider_id and lane_id are required"));
+        try {
+            return workerAdminClient.wakeLane(req.providerId(), req.laneId());
         } catch (RestClientResponseException e) {
             return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
         } catch (Exception e) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/SleepLaneRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/SleepLaneRequestDTO.java
@@ -1,0 +1,6 @@
+package de.tum.cit.aet.logos.logoswebservice.configuration.dto;
+
+public record SleepLaneRequestDTO(
+        Integer providerId,
+        String laneId
+) {}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/WakeLaneRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/WakeLaneRequestDTO.java
@@ -1,0 +1,6 @@
+package de.tum.cit.aet.logos.logoswebservice.configuration.dto;
+
+public record WakeLaneRequestDTO(
+        Integer providerId,
+        String laneId
+) {}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
@@ -38,6 +38,14 @@ public class OrchestratorWorkerAdminClient {
         return post("/internal/logosnode/lanes/delete", Map.of("provider_id", providerId, "lane_id", laneId));
     }
 
+    public ResponseEntity<Map> sleepLane(int providerId, String laneId) {
+        return post("/internal/logosnode/lanes/sleep", Map.of("provider_id", providerId, "lane_id", laneId));
+    }
+
+    public ResponseEntity<Map> wakeLane(int providerId, String laneId) {
+        return post("/internal/logosnode/lanes/wake", Map.of("provider_id", providerId, "lane_id", laneId));
+    }
+
     /**
      * Requests a lane load. The orchestrator only accepts the request and loads
      * in the background — a model can take minutes — so this returns as quickly

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -26,7 +27,7 @@ public class OrchestratorWorkerAdminClient {
     @Value("${logos.orchestrator.internal-secret:}")
     private String internalSecret;
 
-    public OrchestratorWorkerAdminClient(RestTemplate restTemplate) {
+    public OrchestratorWorkerAdminClient(@Qualifier("workerAdminRestTemplate") RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
@@ -49,7 +50,7 @@ public class OrchestratorWorkerAdminClient {
     /**
      * Requests a lane load. The orchestrator only accepts the request and loads
      * in the background — a model can take minutes — so this returns as quickly
-     * as any other admin call and the shared read timeout is enough.
+     * as any other admin call and this client's read timeout is enough.
      */
     public ResponseEntity<Map> addLane(int providerId, Map<String, Object> lane) {
         return post("/internal/logosnode/lanes/add", Map.of("provider_id", providerId, "lane", lane));

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
@@ -184,4 +184,56 @@ class ProviderControllerTest {
            .andExpect(status().isBadRequest())
            .andExpect(jsonPath("$.error").value("provider_id and lane are required"));
     }
+
+    @Test
+    void sleepLane_rejectsNonAdmin() throws Exception {
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/sleep")
+                .with(TestJwt.testUser())
+                .contentType("application/json")
+                .content("{\"provider_id\":6001,\"lane_id\":\"lane-1\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void sleepLane_requiresProviderAndLane() throws Exception {
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/sleep")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"provider_id\":6001}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.error").value("provider_id and lane_id are required"));
+
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/sleep")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"lane_id\":\"lane-1\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.error").value("provider_id and lane_id are required"));
+    }
+
+    @Test
+    void wakeLane_rejectsNonAdmin() throws Exception {
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/wake")
+                .with(TestJwt.testUser())
+                .contentType("application/json")
+                .content("{\"provider_id\":6001,\"lane_id\":\"lane-1\"}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void wakeLane_requiresProviderAndLane() throws Exception {
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/wake")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"provider_id\":6001}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.error").value("provider_id and lane_id are required"));
+
+        mvc.perform(post("/logosdb/providers/logosnode/lanes/wake")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"lane_id\":\"lane-1\"}"))
+           .andExpect(status().isBadRequest())
+           .andExpect(jsonPath("$.error").value("provider_id and lane_id are required"));
+    }
 }


### PR DESCRIPTION
## Fixes #788

## Summary

The lane health panel on the statistics page could load a lane and unload one, but the two states in between — asleep and awake — were only reachable by waiting for the capacity planner. This adds a **Wake** button (shown on lanes whose `sleep_state` is `sleeping`) and a **Sleep** button (shown on lanes that are `awake` and serving nothing) next to `Unload`, wired end to end. Both actions reuse the worker commands the planner already dispatches daily, so this is wiring rather than new mechanism.

## Changes

**Orchestrator** (`logos-orchestrator/src/logos/main.py`)
- `POST /internal/logosnode/lanes/sleep` and `POST /internal/logosnode/lanes/wake`, built the same way as `lanes/delete` and `calibrate_uncalibrated`: internal-secret check, then `_dispatch_logosnode_command` (timeouts `sleep_lane: 30` / `wake_lane: 120` already existed in `_LOGOSNODE_CMD_TIMEOUTS`).
- **Sleep refuses a lane that is serving.** The endpoint reads the lane from the worker's runtime snapshot and answers `409` with a reason synchronously (`active_requests > 0`), the same shape as `manual_load_rejection_reason` for loads — the worker's `mode="wait"` drain would otherwise wait out the 30 s command budget and end in a silent no-op. Unknown lane → `404`; worker not connected / no first status → `503`, mirroring `calibrate_uncalibrated`.
- **Sleep level is fixed to 1** (weights stay resident in host memory, wake stays fast), no level picker — a level-2 choice releases the weights and costs a full cold load on wake, a trade-off most operators cannot make well.

**Webservice**
- `ProviderController`: `POST /providers/logosnode/lanes/{sleep,wake}` with the existing `LOGOS_ADMIN` rule, mirroring `deleteLane` (same validation, same error pass-through).
- `OrchestratorWorkerAdminClient`: `sleepLane` / `wakeLane` mirroring `deleteLane`; `SleepLaneRequestDTO` / `WakeLaneRequestDTO`.

**UI** (`logos-ui` statistics feature)
- `lane-health-panel`: two buttons per row beside `Unload`, driven by a new pure `laneSleepAction(lane)` (Wake on `sleeping`; Sleep on `awake` with no active requests; neither on `unsupported`/`unknown` — Ollama lanes and lanes whose sleep state is not yet known offer neither). Per-lane in-flight state and error display follow the `handleUnload` pattern.
- **Tooltip says the planner has the last word**: a woken lane with no demand goes back to sleep on the next idle check, and a slept lane with queued demand is woken straight back up. The button does not promise permanence.
- `statistics.service.ts`: `sleepLane` / `wakeLane` mirroring `unloadLane`.

**Traefik routing (the part that is easy to miss)**
- `logos/docker-compose.yaml` and `logos/docker-compose.dev.yaml`: both new paths added to the `webservice-logosnode-admin` exact-Path carve-out. `/api/logosdb/providers/logosnode` is a PathPrefix router at priority 201 pointed at the orchestrator; the JWT-protected admin actions are carved back out at 202 by that exact-Path list, so an action missing from it is routed to the orchestrator, which does not serve Spring's paths and answers 404. This is exactly how `lanes/add` shipped broken (fixed in #785).

## New Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/internal/logosnode/lanes/sleep` | internal secret (Spring) | Sleep a lane (level 1, wait drain); 409 while it serves |
| POST | `/internal/logosnode/lanes/wake` | internal secret (Spring) | Wake a sleeping lane |
| POST | `/api/logosdb/providers/logosnode/lanes/sleep` | JWT, `logos-admin` | Spring mirror of the internal endpoint |
| POST | `/api/logosdb/providers/logosnode/lanes/wake` | JWT, `logos-admin` | Spring mirror of the internal endpoint |

## Testing

- Orchestrator: 12 new tests in `tests/unit/main/test_internal_sleep_wake_lane_endpoints.py` (auth 403/401, offline 503, pre-first-status 503, unknown-lane 404, serving-lane 409 with no dispatch, level-1/wait dispatch, wake dispatch, offline wake 503). Full unit suite: **790 passed, 1 xfailed** (`pytest` in `logos-orchestrator`, Python 3.13).
- Webservice: 4 new `ProviderControllerTest` cases (non-admin 403, missing-field 404→400 for both endpoints). Full suite: **250 passed, 0 failures** (`mvn -B test`, JDK 25, Testcontainers).
- UI: 5 new spec cases for `laneSleepAction` (16 in `lane-health-panel.spec.ts`, 21 across the feature); static export **`npm run build` succeeds** (same job as CI).
- pre-commit (black, isort, autoflake, flake8, hygiene): clean on all changed files.
- No full deployment (docker compose, vLLM workers, GPUs, Keycloak) is available in this environment, so the end-to-end path was verified by code reading: worker `sleep_lane`/`wake_lane` dispatch in `logos_bridge.py` already exists and is exercised by the planner; the new endpoints dispatch exactly those actions.