### PR TITLE
`Logos`: Show latest used date for models in admin UI

### DIFF
--- a/logos/logos-ui/src/app/features/models/models.html
+++ b/logos/logos-ui/src/app/features/models/models.html
@@ -28,15 +28,18 @@
     'DESCRIPTION',
     ...(role() === 'logos_admin' ? ['TAGS'] : []),
     'CAPABILITIES',
-    ...(role() === 'logos_admin' ? ['WEIGHTS', ''] : [])
+    ...(role() === 'logos_admin' ? ['LAST USED', 'WEIGHTS', ''] : [])
   ]"
   [gridCols]="
     role() === 'logos_admin'
-      ? '220fr 260fr 160fr 220fr 180fr 72px'
+      ? '220fr 260fr 160fr 220fr 130fr 180fr 72px'
       : '220fr 260fr 220fr'
   "
   [loading]="loading()"
   [empty]="filteredModels().length === 0"
+  [sortableColumn]="role() === 'logos_admin' ? 4 : -1"
+  [sortDirection]="lastUsedSortDirection"
+  (sortToggle)="toggleLastUsedSort()"
   emptyMessage="No models match your search."
 >
   @for (model of filteredModels(); track model.id) {
@@ -158,6 +161,23 @@
           <span>-</span>
         }
       </div>
+
+      <!-- Last used: logos_admin only -->
+      @if (role() === 'logos_admin') {
+        <div
+          class="col-last-used last-used-cell"
+          role="cell"
+          data-label="Last used"
+        >
+          <span
+            class="last-used"
+            [class.last-used--stale]="isStaleModel(model.last_used_at)"
+            [attr.title]="lastUsedTooltip(model.last_used_at)"
+          >
+            {{ formatLastUsed(model.last_used_at) }}
+          </span>
+        </div>
+      }
 
       <!-- Weights: logos_admin only -->
       @if (role() === 'logos_admin') {

--- a/logos/logos-ui/src/app/features/models/models.scss
+++ b/logos/logos-ui/src/app/features/models/models.scss
@@ -96,6 +96,17 @@
   }
 }
 
+// Last used: models without recent traffic are deprecation candidates.
+.last-used {
+  font-size: var(--font-size-md);
+  color: rgb(var(--color-typography-700));
+  white-space: nowrap;
+
+  &--stale {
+    color: rgb(var(--color-warning));
+  }
+}
+
 // ── Form dialogs ──────────────────────────────────────────────────────────
 .form-body {
   display: flex;

--- a/logos/logos-ui/src/app/features/models/models.ts
+++ b/logos/logos-ui/src/app/features/models/models.ts
@@ -16,6 +16,7 @@ import { DataTableComponent } from '../../shared/components/data-table/data-tabl
 import { ErrorMessageComponent } from '../../shared/components/error-message/error-message';
 import { AuthService } from '../../core/auth/services/auth.service';
 import { Router } from '@angular/router';
+import { daysSince, formatLastUsed as formatLastUsedLabel } from '../../shared/utils/date';
 
 @Component({
   selector: 'app-models',
@@ -37,12 +38,26 @@ export class Models implements OnInit {
   readonly role = inject(AuthService).role;
   private router = inject(Router);
 
+  /**
+   * A model without a single logged request for this long is highlighted as a
+   * deprecation candidate.
+   */
+  private static readonly STALE_AFTER_DAYS = 30;
+
   // ── List state ──────────────────────────────────────────────────────────
   models = signal<Model[]>([]);
   capabilities = signal<Record<number, ModelCapability>>({});
   loading = signal(true);
   search = signal('');
   loadError = signal(false);
+  /** Sort of the last-used column: unsorted, oldest first or newest first. */
+  lastUsedSort = signal<'none' | 'asc' | 'desc'>('none');
+
+  /** Sort direction for the table header; null while unsorted. */
+  get lastUsedSortDirection(): 'asc' | 'desc' | null {
+    const dir = this.lastUsedSort();
+    return dir === 'asc' || dir === 'desc' ? dir : null;
+  }
 
   // ── Delete modal ────────────────────────────────────────────────────────
   deleteTarget = signal<Model | null>(null);
@@ -76,12 +91,22 @@ export class Models implements OnInit {
   // ── Computed ─────────────────────────────────────────────────────────────
   filteredModels = computed(() => {
     const q = this.search().toLowerCase().trim();
-    if (!q) return this.models();
-    return this.models().filter(
-      (m) =>
-        m.name.toLowerCase().includes(q) ||
-        (m.description ?? '').toLowerCase().includes(q) ||
-        (m.tags ?? '').toLowerCase().includes(q),
+    const list = q
+      ? this.models().filter(
+          (m) =>
+            m.name.toLowerCase().includes(q) ||
+            (m.description ?? '').toLowerCase().includes(q) ||
+            (m.tags ?? '').toLowerCase().includes(q),
+        )
+      : this.models();
+    const dir = this.lastUsedSort();
+    if (dir === 'none') return list;
+    // ISO-8601 UTC timestamps sort lexicographically; the empty string (never
+    // used) lands first in ascending order, surfacing the quietest models.
+    return [...list].sort((a, b) =>
+      dir === 'asc'
+        ? (a.last_used_at ?? '').localeCompare(b.last_used_at ?? '')
+        : (b.last_used_at ?? '').localeCompare(a.last_used_at ?? ''),
     );
   });
 
@@ -114,7 +139,28 @@ export class Models implements OnInit {
   getCapabilities(modelId: number): ModelCapability | undefined {
     return this.capabilities()[modelId];
   }
-  
+
+  // ── Last used ─────────────────────────────────────────────────────────────
+  /** Cycles unsorted → oldest first (deprecation candidates) → newest first. */
+  toggleLastUsedSort(): void {
+    this.lastUsedSort.update((dir) => (dir === 'none' ? 'asc' : dir === 'asc' ? 'desc' : 'none'));
+  }
+
+  formatLastUsed(iso: string | null | undefined): string {
+    return formatLastUsedLabel(iso);
+  }
+
+  isStaleModel(iso: string | null | undefined): boolean {
+    return iso == null || daysSince(iso) >= Models.STALE_AFTER_DAYS;
+  }
+
+  /** Tooltip explaining why the model is highlighted; null while it is fresh. */
+  lastUsedTooltip(iso: string | null | undefined): string | null {
+    if (!this.isStaleModel(iso)) return null;
+    if (iso == null) return 'Never used';
+    return `Not used for ${daysSince(iso)} days`;
+  }
+
   openReport(model: Model): void {
     this.router.navigate(['/models', model.id, 'errors']);
   }

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
@@ -16,6 +16,7 @@ import { TeamManagementService } from '../../core/services/team-management.servi
 import { AuthService } from '../../core/auth/services/auth.service';
 import { MyKey, ModelAccess } from '../../shared/models/my-key.model';
 import { MyTeam } from '../../shared/models/team.model';
+import { formatLastUsed as formatLastUsedLabel } from '../../shared/utils/date';
 import { isInteractiveClick } from '../../shared/utils/interactive-click';
 
 interface TeamWorkspace {
@@ -321,12 +322,6 @@ export class MyWorkspace implements OnInit {
   }
 
   formatLastUsed(iso: string | null): string {
-    if (!iso) return 'Never';
-    const d = new Date(iso);
-    const today = new Date();
-    const diffDays = Math.floor((today.getTime() - d.getTime()) / 86_400_000);
-    if (diffDays === 0) return 'Today';
-    if (diffDays === 1) return 'Yesterday';
-    return d.toLocaleDateString();
+    return formatLastUsedLabel(iso);
   }
 }

--- a/logos/logos-ui/src/app/shared/components/data-table/data-table.html
+++ b/logos/logos-ui/src/app/shared/components/data-table/data-table.html
@@ -9,7 +9,19 @@
   } @else {
     <div class="table-header" role="row">
       @for (col of columns; track $index) {
-        <div role="columnheader">{{ col }}</div>
+        @if ($index === sortableColumn) {
+          <div
+            role="columnheader"
+            [attr.aria-sort]="sortDirection === 'asc' ? 'ascending' : sortDirection === 'desc' ? 'descending' : 'none'"
+          >
+            <button type="button" class="th-sort" (click)="sortToggle.emit()">
+              {{ col }}
+              <i class="pi {{ sortIcon }}" aria-hidden="true"></i>
+            </button>
+          </div>
+        } @else {
+          <div role="columnheader">{{ col }}</div>
+        }
       }
     </div>
 

--- a/logos/logos-ui/src/app/shared/components/data-table/data-table.scss
+++ b/logos/logos-ui/src/app/shared/components/data-table/data-table.scss
@@ -29,6 +29,28 @@
   }
 }
 
+// Sortable column header: the button resets to the inherited header look
+.th-sort {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    color: rgb(var(--color-text-accent));
+  }
+
+  i {
+    font-size: var(--font-size-sm);
+  }
+}
+
 .table-row {
   min-height: 52px;
   height: auto;

--- a/logos/logos-ui/src/app/shared/components/data-table/data-table.ts
+++ b/logos/logos-ui/src/app/shared/components/data-table/data-table.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-data-table',
@@ -15,4 +15,17 @@ export class DataTableComponent {
   @Input() loading = false;
   @Input() empty = false;
   @Input() emptyMessage = 'No data.';
+
+  /** Index of the column whose header toggles sorting (-1: no sortable column). */
+  @Input() sortableColumn = -1;
+  /** Current sort direction of the sortable column (null: unsorted). */
+  @Input() sortDirection: 'asc' | 'desc' | null = null;
+  /** Emitted when the sortable column header is clicked. */
+  @Output() sortToggle = new EventEmitter<void>();
+
+  get sortIcon(): string {
+    if (this.sortDirection === 'asc') return 'pi-sort-up';
+    if (this.sortDirection === 'desc') return 'pi-sort-down';
+    return 'pi-sort';
+  }
 }

--- a/logos/logos-ui/src/app/shared/models/model.model.ts
+++ b/logos/logos-ui/src/app/shared/models/model.model.ts
@@ -7,6 +7,8 @@ export interface Model {
   weight_accuracy: number | null;
   weight_cost: number | null;
   weight_quality: number | null;
+  /** Only present for logos_admin (the endpoint is open to all roles). */
+  last_used_at?: string | null;
 }
 
 export interface AddModelPayload {

--- a/logos/logos-ui/src/app/shared/utils/date.spec.ts
+++ b/logos/logos-ui/src/app/shared/utils/date.spec.ts
@@ -1,0 +1,34 @@
+import { daysSince, formatLastUsed } from './date';
+
+describe('date utils', () => {
+  const now = new Date('2026-08-26T12:00:00');
+
+  describe('formatLastUsed', () => {
+    it('renders "Never" for a missing timestamp', () => {
+      expect(formatLastUsed(null, now)).toBe('Never');
+      expect(formatLastUsed(undefined, now)).toBe('Never');
+    });
+
+    it('renders "Today" for a timestamp less than a day ago', () => {
+      expect(formatLastUsed('2026-08-26T09:00:00', now)).toBe('Today');
+    });
+
+    it('renders the German date with the age in brackets', () => {
+      expect(formatLastUsed('2026-08-25T12:00:00', now)).toBe('25.08.2026 (1 day ago)');
+      expect(formatLastUsed('2026-08-24T09:00:00', now)).toBe('24.08.2026 (2 days ago)');
+      expect(formatLastUsed('1996-06-02T00:00:00', now)).toBe('02.06.1996 (11042 days ago)');
+    });
+  });
+
+  describe('daysSince', () => {
+    it('counts whole days between the timestamp and now', () => {
+      expect(daysSince('2026-08-26T12:00:00', now)).toBe(0);
+      expect(daysSince('2026-08-25T11:59:59', now)).toBe(1);
+      expect(daysSince('2026-07-27T12:00:00', now)).toBe(30);
+    });
+
+    it('clamps future timestamps to 0', () => {
+      expect(daysSince('2026-08-27T12:00:00', now)).toBe(0);
+    });
+  });
+});

--- a/logos/logos-ui/src/app/shared/utils/date.ts
+++ b/logos/logos-ui/src/app/shared/utils/date.ts
@@ -1,0 +1,26 @@
+const MS_PER_DAY = 86_400_000;
+
+/** Whole days between the ISO timestamp and now (clamped to 0 for future/rounding). */
+export function daysSince(iso: string, now: Date = new Date()): number {
+  return Math.max(0, Math.floor((now.getTime() - new Date(iso).getTime()) / MS_PER_DAY));
+}
+
+/** Local date as "DD.MM.YYYY", e.g. "02.06.1996". */
+function formatGermanDate(d: Date): string {
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  return `${day}.${month}.${d.getFullYear()}`;
+}
+
+/**
+ * "Last used" display for an ISO timestamp: "Never", "Today" or the German
+ * date with the age in brackets, e.g. "24.08.2026 (2 days ago)".
+ */
+export function formatLastUsed(iso: string | null | undefined, now: Date = new Date()): string {
+  if (!iso) return 'Never';
+  const d = new Date(iso);
+  const diffDays = Math.floor((now.getTime() - d.getTime()) / MS_PER_DAY);
+  if (diffDays <= 0) return 'Today';
+  const age = diffDays === 1 ? '(1 day ago)' : `(${diffDays} days ago)`;
+  return `${formatGermanDate(d)} ${age}`;
+}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelRepository.java
@@ -24,7 +24,11 @@ public interface ModelRepository extends JpaRepository<Model, Integer> {
                 WHERE (tp.model_id = m.id OR tp.model_id IS NULL)
                   AND tt.name = 'completion_tokens' AND tp.valid_from <= NOW()
                 ORDER BY (tp.model_id = m.id) DESC NULLS LAST, tp.valid_from DESC LIMIT 1
-               ) AS output_usd_per_million
+               ) AS output_usd_per_million,
+               (SELECT MAX(le.timestamp_request)
+                FROM log_entry le
+                WHERE le.model_id = m.id
+               ) AS last_used_at
         FROM models m ORDER BY m.id
         """, nativeQuery = true)
     List<ModelWithPriceProjection> findAllWithPricing();
@@ -46,6 +50,9 @@ public interface ModelRepository extends JpaRepository<Model, Integer> {
             JOIN api_key_provider_permissions akpp ON akpp.api_key_id = ak.id AND akpp.provider_id = mp.provider_id
             WHERE ak.user_id = :userId AND ak.is_active = true AND ak.use_custom_permissions = true
         )
+        -- last_used_at is deliberately not computed here: it is only exposed to
+        -- Logos admins (see ModelService), so the per-model MAX subselect would
+        -- be wasted work on every other model list request.
         SELECT DISTINCT m.id, m.name, m.weight_latency, m.weight_accuracy, m.weight_cost,
                m.weight_quality, m.tags, m.description,
                (SELECT ROUND(tp.price_per_k_token::NUMERIC / 100000, 4)

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelWithPriceProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/repository/ModelWithPriceProjection.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration.repository;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 
 public interface ModelWithPriceProjection {
     Integer getId();
@@ -13,4 +14,5 @@ public interface ModelWithPriceProjection {
     String getDescription();
     BigDecimal getInputUsdPerMillion();
     BigDecimal getOutputUsdPerMillion();
+    Instant getLastUsedAt();
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ModelService.java
@@ -39,10 +39,13 @@ public class ModelService {
     }
 
     public List<Map<String, Object>> getModels(AuthContext auth) {
-        List<ModelWithPriceProjection> projections = isLogosAdmin(auth)
+        // last_used_at is a platform-wide usage figure, so it is only exposed to
+        // Logos admins; everyone else gets the same list without that field.
+        boolean includeLastUsed = isLogosAdmin(auth);
+        List<ModelWithPriceProjection> projections = includeLastUsed
             ? modelRepository.findAllWithPricing()
             : modelRepository.findAllWithPricingForUser(auth.userId());
-        return projections.stream().map(ModelService::toModelMap).toList();
+        return projections.stream().map(p -> toModelMap(p, includeLastUsed)).toList();
     }
 
     @Transactional
@@ -123,7 +126,7 @@ public class ModelService {
         return Role.LOGOS_ADMIN.matches(auth.role());
     }
 
-    private static Map<String, Object> toModelMap(ModelWithPriceProjection p) {
+    private static Map<String, Object> toModelMap(ModelWithPriceProjection p, boolean includeLastUsed) {
         Map<String, Object> m = new LinkedHashMap<>();
         int id = p.getId();
         String name = p.getName();
@@ -137,6 +140,9 @@ public class ModelService {
         m.put("description", p.getDescription());
         m.put("input_usd_per_million", p.getInputUsdPerMillion());
         m.put("output_usd_per_million", p.getOutputUsdPerMillion());
+        if (includeLastUsed) {
+            m.put("last_used_at", p.getLastUsedAt() != null ? p.getLastUsedAt().toString() : null);
+        }
         return m;
     }
 

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/014_log_entry_model_id_timestamp_index.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/014_log_entry_model_id_timestamp_index.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- ModelRepository derives each model's last_used_at from log_entry for the
+         /logosdb/get_models list, so admins can spot models that have gone quiet
+         and should be deprecated. The subselect
+         filters on model_id and takes MAX(timestamp_request); with no index covering
+         both columns Postgres has to scan the whole log_entry table on every model
+         list load, and it only gets worse as log_entry grows.
+
+         The composite index lets the MAX be answered by an index seek:
+         timestamp_request is NOT NULL, so the latest request of a model is the last
+         entry of that model's range in the index.
+
+         Runs outside a transaction so CONCURRENTLY can build the index without
+         locking log_entry against the logos-orchestrator, which keeps writing to
+         this table while logos-webservice is redeployed via `docker compose up -d`.
+         A maintenance window (plain CREATE INDEX) is only needed if writes to
+         log_entry are stopped for the duration of the migration. -->
+    <changeSet id="014-log-entry-model-id-timestamp-index" author="logos" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists tableName="log_entry" indexName="idx_log_entry_model_id_timestamp_request"/></not>
+        </preConditions>
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_log_entry_model_id_timestamp_request
+                ON log_entry (model_id, timestamp_request);
+        </sql>
+        <rollback>
+            <sql>DROP INDEX CONCURRENTLY IF EXISTS idx_log_entry_model_id_timestamp_request;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -17,5 +17,6 @@
     <include file="liquibase/changelog/011_add_fk_model_capabilities_cascade.xml"/>
     <include file="liquibase/changelog/012_log_entry_timestamp_index.xml"/>
     <include file="liquibase/changelog/013_drop_models_parallel.xml"/>
+    <include file="liquibase/changelog/014_log_entry_model_id_timestamp_index.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ModelControllerTest.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +17,10 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -69,6 +76,62 @@ class ModelControllerTest {
            .andExpect(jsonPath("$.length()").value(1))
            .andExpect(jsonPath("$[0].id").value(5001))
            .andExpect(jsonPath("$[0].name").value("gpt-4"));
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(statements = """
+        INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
+                               timestamp_request, timestamp_forwarding, timestamp_response)
+        VALUES
+          (9501, 'req-last-used-old', 3001, 5001, 6001, 'success',
+           NOW() - INTERVAL '31 days', NOW() - INTERVAL '31 days', NOW() - INTERVAL '31 days'),
+          (9502, 'req-last-used-new', 3001, 5001, 6001, 'error',
+           NOW() - INTERVAL '2 hours', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '1 hour');
+        INSERT INTO team_model_permissions (team_id, model_id) VALUES (2001, 5001);
+        INSERT INTO team_provider_permissions (team_id, provider_id) VALUES (2001, 6001);
+        """, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(statements = {
+        "DELETE FROM log_entry WHERE id IN (9501, 9502)",
+        "DELETE FROM team_model_permissions WHERE team_id = 2001 AND model_id = 5001",
+        "DELETE FROM team_provider_permissions WHERE team_id = 2001 AND provider_id = 6001"
+    }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void getModels_exposesLastUsedAtToLogosAdminsOnly() throws Exception {
+        String body = mvc.perform(post("/logosdb/get_models")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andReturn().getResponse().getContentAsString();
+
+        JsonNode models = new ObjectMapper().readTree(body);
+        JsonNode gpt4 = null;
+        JsonNode gpt35 = null;
+        for (JsonNode model : models) {
+            if (model.get("id").asInt() == 5001) gpt4 = model;
+            if (model.get("id").asInt() == 5002) gpt35 = model;
+        }
+
+        assertThat(gpt4).isNotNull();
+        assertThat(gpt35).isNotNull();
+        // The newest request wins — the 2h-old row, not the 31d-old one — and an
+        // errored request still counts as usage.
+        assertThat(gpt4.get("last_used_at").isNull()).isFalse();
+        Instant lastUsed = Instant.parse(gpt4.get("last_used_at").asText());
+        assertThat(Duration.between(lastUsed, Instant.now()).abs()).isLessThan(Duration.ofHours(3));
+        // A model without any log entry was never used.
+        assertThat(gpt35.get("last_used_at").isNull()).isTrue();
+
+        // The field is filtered server-side: non-admins never receive it, even
+        // though the endpoint itself is open to all authenticated users.
+        mvc.perform(post("/logosdb/get_models")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.length()").value(1))
+           .andExpect(jsonPath("$[0].id").value(5001))
+           .andExpect(jsonPath("$[0].last_used_at").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
Fixes #539

## Summary

Models that have gone quiet should be visible to admins so they can be deprecated. The admin UI's **Model Management** page now shows, per model, when it was last used — derived from the request log (`log_entry`) — and highlights models that have not seen a single request for 30+ days (or never at all) in the warning color with an explanatory tooltip.

The data is exposed through the existing `POST /logosdb/get_models` endpoint: each model entry now carries `last_used_at` (ISO-8601 UTC timestamp of the model's newest logged request, or `null` if it was never used). **The field is only included for the `logos_admin` role — server-side**, so other roles never receive the platform-wide usage figures even though the endpoint itself is open to all authenticated users. No new endpoint was needed.

## Changes

### logos-webservice
- `configuration/repository/ModelRepository.java`: the admin model-list query (`findAllWithPricing`) selects `MAX(log_entry.timestamp_request)` per model as `last_used_at`; the per-user query does not compute it at all, since non-admins never receive the field. `timestamp_request` is `NOT NULL` and is the moment a request was made, which is what "last used" should mean (an errored request still counts as usage).
- `configuration/repository/ModelWithPriceProjection.java`: new `Instant getLastUsedAt()`.
- `configuration/service/ModelService.java`: `getModels` only includes `last_used_at` for Logos admins (`toModelMap` emits it as an ISO string or `null`, stringified like the existing per-key `last_used_at` in `MeKeysService`, since the custom `ObjectMapper` has no JavaTimeModule).
- `liquibase/changelog/014_log_entry_model_id_timestamp_index.xml` (+ `master.xml`): composite index `(model_id, timestamp_request)` so the `MAX` is an index seek instead of a full `log_entry` scan on every model-list load — the same rationale as the existing `012` changeset for `timestamp_request` range scans. Built with `CREATE INDEX CONCURRENTLY` like `012`.

### logos-ui
- `shared/utils/date.ts` (new): `formatLastUsed` ("Never" / "Today" / German date with the age in brackets, e.g. `24.08.2026 (2 days ago)`, moved out of `my-workspace.ts`, which now delegates) and `daysSince`.
- `features/models/`: new admin-only **Last used** column between Capabilities and Weights; values without a request for 30+ days (or never used) get the warning color (same `--stale` pattern as the VRAM chart) plus a tooltip ("Never used" / "Not used for N days"). The **LAST USED** header is sortable: clicking it cycles oldest first (deprecation candidates on top) → newest first → unsorted.
- `shared/components/data-table/`: optional sortable column header (`sortableColumn` / `sortDirection` / `(sortToggle)` with `aria-sort`); inert by default, so the other 11 usages of the table are unaffected.
- `shared/models/model.model.ts`: optional `last_used_at?: string | null` on `Model` (absent for non-admins).

## New Endpoints

None — `last_used_at` was added to the existing `POST /logosdb/get_models` response, filtered to Logos admins server-side.

## Database Changes

- Migration: `014_log_entry_model_id_timestamp_index.xml` — `CREATE INDEX CONCURRENTLY idx_log_entry_model_id_timestamp_request ON log_entry (model_id, timestamp_request)` (idempotent precondition, `CONCURRENTLY` so it does not lock `log_entry` against the orchestrator during deploy).

## Testing

- Webservice test `ModelControllerTest.getModels_exposesLastUsedAtToLogosAdminsOnly`: seeds two `log_entry` rows for model 5001 (31 days old + 2 h old, the latter an error) and asserts the admin response returns the *newest* timestamp for 5001 and `null` for the unused model 5002, and that the field is **absent** from the non-admin response.
- New UI spec `shared/utils/date.spec.ts` covering `formatLastUsed` and `daysSince`.
- Full webservice suite: `mvn -B test` — 248 tests, 0 failures (Testcontainers Postgres 17 + Liquibase, including the new changeset).
- UI: `npm run build` (static export, as in CI) passes; `ng test` — 21/21 unit tests pass.
- `pre-commit` (logos config) passes on all changed files.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can view when each model was last used.
  * Last-used values can be sorted in ascending or descending order.
  * Stale model activity is clearly highlighted, with helpful tooltips.
  * Dates are displayed in a consistent, user-friendly format.

* **Bug Fixes**
  * Last-used information is restricted to authorized administrators.

* **Tests**
  * Added coverage for date formatting, stale activity, sorting, and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->