### PR TITLE
`Logos`: Close out app-admin live stats with activity view tests

### DIFF
--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -1,0 +1,338 @@
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RequestItem } from '../../../statistics/statistics.models';
+import { TeamActivityPayload } from './activity-tab.models';
+import { ActivityTabComponent } from './activity-tab';
+import { TeamActivityService } from './activity-tab.service';
+
+/**
+ * The team activity view app administrators asked for (issue #776).
+ *
+ * The numbers it shows are load-bearing in both directions: the live tiles
+ * tell an owner whether the cluster is working for them right now, and the
+ * per-key table tells them where the tokens went. A drift in either reading —
+ * an in-flight count that double-counts, a token total that renders a
+ * nine-digit number without abbreviation, a filter that widens past the team —
+ * would make an owner misread what their team is doing.
+ */
+
+const makeRequest = (overrides: Partial<RequestItem> = {}): RequestItem => ({
+  request_id: 'req-1',
+  model_name: 'gpt-test',
+  provider_name: 'test-provider',
+  is_cloud: null,
+  status: 'success',
+  timestamp: '2026-08-26T12:00:00Z',
+  duration: null,
+  cold_start: null,
+  enqueue_ts: '2026-08-26T12:00:00Z',
+  scheduled_ts: null,
+  request_complete_ts: null,
+  queue_seconds: null,
+  total_seconds: null,
+  initial_priority: null,
+  priority_when_scheduled: null,
+  queue_depth_at_enqueue: null,
+  error_message: null,
+  team_name: null,
+  username: 'test.user',
+  full_name: 'Test User',
+  prompt_tokens: null,
+  completion_tokens: null,
+  total_tokens: null,
+  cost_microcents: null,
+  ...overrides,
+});
+
+const makePayload = (overrides: Partial<TeamActivityPayload> = {}): TeamActivityPayload => ({
+  team_id: 2001,
+  days: 7,
+  since: '2026-08-19T12:00:00Z',
+  live: { queued: 0, running: 0, finished: 0, failed: 0 },
+  keys: [],
+  total_tokens: 0,
+  total_requests: 0,
+  requesters: [],
+  requests: [makeRequest()],
+  requests_total: 1,
+  requests_has_more: true,
+  requests_next_cursor: { ts: '2026-08-26T12:00:00Z', request_id: 'req-1' },
+  ...overrides,
+});
+
+describe('ActivityTabComponent', () => {
+  let fixture: ComponentFixture<ActivityTabComponent>;
+  let component: ActivityTabComponent;
+  const getActivity = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getActivity.mockResolvedValue(makePayload());
+
+    await TestBed.configureTestingModule({
+      imports: [ActivityTabComponent],
+      providers: [{ provide: TeamActivityService, useValue: { getActivity } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActivityTabComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    // The tab polls on its own while mounted; drop the interval so no test
+    // keeps a timer alive past the one that started it.
+    component.ngOnDestroy();
+  });
+
+  /** Mount the tab for one team and wait for the first load to settle. */
+  const loadForTeam = async (): Promise<void> => {
+    component.teamId = 2001;
+    component.ngOnChanges({ teamId: new SimpleChange(0, 2001, true) });
+    await vi.waitFor(() => expect(getActivity).toHaveBeenCalledTimes(1));
+  };
+
+  // ── Reading the numbers ────────────────────────────────────────────────────
+
+  describe('formatTokens', () => {
+    it('shows nothing for a team that used nothing', () => {
+      // The payload says zero and the server also sends null for a key whose
+      // requests recorded no usage — both must read as "0", never blank.
+      expect(component.formatTokens(0)).toBe('0');
+      expect(component.formatTokens(null)).toBe('0');
+      expect(component.formatTokens(undefined)).toBe('0');
+    });
+
+    it('keeps exact counts while they fit on one screen', () => {
+      expect(component.formatTokens(999)).toBe('999');
+    });
+
+    it('abbreviates the totals that run past it', () => {
+      // A busy team clears nine figures over a quarter; the tile holds a
+      // figure plus a suffix, not ten digits.
+      expect(component.formatTokens(1_500)).toBe('1.5k');
+      expect(component.formatTokens(1_234_567)).toBe('1.2M');
+      expect(component.formatTokens(2_500_000_000)).toBe('2.5B');
+    });
+  });
+
+  describe('keyLabel', () => {
+    it('drops the environment placeholder the database carries', () => {
+      // Keys without an environment store "-", and "dev key · -" would read
+      // as a broken row to the owner.
+      expect(component.keyLabel('dev key', '-')).toBe('dev key');
+      expect(component.keyLabel('dev key', null)).toBe('dev key');
+    });
+
+    it('shows the environment when it is real', () => {
+      expect(component.keyLabel('dev key', 'prod')).toBe('dev key · prod');
+    });
+  });
+
+  describe('live figures', () => {
+    it('adds queued and running into the in-flight number', () => {
+      // The "Nothing of this team's is in the cluster" note keys on exactly
+      // this sum — finished belongs to the period, not to right now.
+      component.activity.set(
+        makePayload({ live: { queued: 2, running: 3, finished: 10, failed: 1 } }),
+      );
+      expect(component.inFlight()).toBe(5);
+    });
+
+    it('is zero before the first payload arrives', () => {
+      expect(component.inFlight()).toBe(0);
+    });
+
+    it('measures the failure rate against finished', () => {
+      // The rate answers "of what got through, how much broke" — dividing by
+      // the in-flight count would swing it with every request that starts.
+      component.activity.set(
+        makePayload({ live: { queued: 0, running: 0, finished: 100, failed: 25 } }),
+      );
+      expect(component.failureRate()).toBeCloseTo(25);
+    });
+
+    it('has no rate to show while nothing finished', () => {
+      // 1/0 is not a rate; the tile then shows the plain note instead.
+      component.activity.set(
+        makePayload({ live: { queued: 4, running: 1, finished: 0, failed: 0 } }),
+      );
+      expect(component.failureRate()).toBeNull();
+    });
+  });
+
+  describe('requester options', () => {
+    it('offers everyone first, then each requester with its count', () => {
+      // The count is what tells the owner which entry is worth opening; the
+      // empty entry is the way back out of a filter.
+      component.activity.set(
+        makePayload({ requesters: [{ id: 11, label: 'Test User', requestCount: 40 }] }),
+      );
+      expect(component.requesterOptions()).toEqual([
+        { value: '', label: 'Everyone in this team' },
+        { value: '11', label: 'Test User (40)' },
+      ]);
+    });
+  });
+
+  // ── Loading ────────────────────────────────────────────────────────────────
+
+  describe('loading', () => {
+    it('loads for the team it belongs to, on the default window', async () => {
+      await loadForTeam();
+      expect(getActivity).toHaveBeenCalledWith(2001, 7, { userId: null, cursor: null });
+      expect(component.loading()).toBe(false);
+    });
+
+    it('keeps the last good payload when a refresh fails', async () => {
+      // The refresh runs on a timer: blanking the tab over one failed poll
+      // would make a network blip look like an outage.
+      await loadForTeam();
+      const first = component.activity();
+
+      getActivity.mockRejectedValueOnce(new Error('poll failed'));
+      await component.setDays('30');
+
+      expect(component.activity()).toBe(first);
+      expect(component.error()).toBe('Could not refresh activity.');
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  // ── Window and filter ──────────────────────────────────────────────────────
+
+  describe('window', () => {
+    it('switches the window and starts the request pages over', async () => {
+      // A different window is a different set of requests, so the cursors of
+      // the old one no longer point anywhere — page 2 of 7 days is not page 2
+      // of 30 days.
+      await loadForTeam();
+      await component.nextPage();
+      expect(component.pageIndex()).toBe(1);
+
+      await component.setDays('30');
+
+      expect(getActivity).toHaveBeenLastCalledWith(2001, 30, { userId: null, cursor: null });
+      expect(component.pageIndex()).toBe(0);
+    });
+
+    it('ignores a window it cannot use', () => {
+      component.setDays('0');
+      component.setDays('abc');
+      component.setDays(null);
+      expect(component.days()).toBe(7);
+      expect(getActivity).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requester filter', () => {
+    it('narrows the request list to one requester', async () => {
+      await loadForTeam();
+      await component.setRequester('11');
+      expect(getActivity).toHaveBeenLastCalledWith(2001, 7, { userId: 11, cursor: null });
+    });
+
+    it('treats the empty pick as no filter', async () => {
+      await loadForTeam();
+      await component.setRequester('11');
+      await component.setRequester('');
+      expect(getActivity).toHaveBeenLastCalledWith(2001, 7, { userId: null, cursor: null });
+    });
+
+    it('does not reload while the pick is unchanged', async () => {
+      await loadForTeam();
+      await component.setRequester('11');
+      expect(getActivity).toHaveBeenCalledTimes(2);
+      await component.setRequester('11');
+      expect(getActivity).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Request pages ──────────────────────────────────────────────────────────
+
+  describe('request pages', () => {
+    it('walks the cursor one page at a time and back', async () => {
+      await loadForTeam();
+
+      await component.nextPage();
+      expect(component.pageIndex()).toBe(1);
+      expect(getActivity).toHaveBeenLastCalledWith(2001, 7, {
+        userId: null,
+        cursor: { ts: '2026-08-26T12:00:00Z', request_id: 'req-1' },
+      });
+
+      await component.prevPage();
+      expect(component.pageIndex()).toBe(0);
+      expect(getActivity).toHaveBeenLastCalledWith(2001, 7, { userId: null, cursor: null });
+    });
+
+    it('does not step past the last page', async () => {
+      component.teamId = 2001;
+      component.activity.set(makePayload({ requests_has_more: false, requests_next_cursor: null }));
+
+      await component.nextPage();
+
+      expect(component.pageIndex()).toBe(0);
+      expect(getActivity).not.toHaveBeenCalled();
+    });
+
+    it('numbers the rows of the page it shows', () => {
+      component.pageIndex.set(1);
+      component.activity.set(
+        makePayload({
+          requests: Array.from({ length: 20 }, (_, i) =>
+            makeRequest({ request_id: `req-${i + 1}` }),
+          ),
+        }),
+      );
+      // The "21-40 of n" line: one-based, page 0 is the newest rows.
+      expect(component.firstRowNumber()).toBe(21);
+      expect(component.lastRowNumber()).toBe(40);
+    });
+  });
+
+  // ── Request rows ───────────────────────────────────────────────────────────
+
+  describe('request rows', () => {
+    it('shows prompt and completion tokens as up and down', () => {
+      expect(component.tokensOf(makeRequest({ prompt_tokens: 120, completion_tokens: 480 }))).toBe(
+        '↑120 ↓480',
+      );
+    });
+
+    it('shows nothing a request did not record', () => {
+      // Failed before the first chunk never carried usage — "—" is the honest
+      // cell, 0 would claim the model used no tokens.
+      expect(
+        component.tokensOf(makeRequest({ prompt_tokens: null, completion_tokens: null })),
+      ).toBe('—');
+    });
+
+    it('shows the wall-clock duration when it is known', () => {
+      expect(component.durationOf(makeRequest({ total_seconds: 3.14 }))).toBe('3.14s');
+      expect(component.durationOf(makeRequest({ total_seconds: null }))).toBe('—');
+    });
+
+    it('reads the stage off the timestamps, not a status flag', () => {
+      // The server sends no stage column; the timestamps are what separates
+      // queued from executing from complete.
+      expect(component.stageOf(makeRequest())).toBe('queued');
+      expect(component.stageOf(makeRequest({ scheduled_ts: '2026-08-26T12:00:05Z' }))).toBe(
+        'executing',
+      );
+      expect(
+        component.stageOf(
+          makeRequest({
+            scheduled_ts: '2026-08-26T12:00:05Z',
+            request_complete_ts: '2026-08-26T12:00:30Z',
+          }),
+        ),
+      ).toBe('complete');
+    });
+
+    it('shows the full name, falling back to the username', () => {
+      expect(component.requesterOf(makeRequest())).toBe('Test User');
+      expect(component.requesterOf(makeRequest({ full_name: '   ' }))).toBe('test.user');
+    });
+  });
+});

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogStatsController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogStatsController.java
@@ -3,14 +3,28 @@ package de.tum.cit.aet.logos.logoswebservice.operations.controller;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.logos.logoswebservice.auth.AuthContext;
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.Role;
 import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogStatsService;
 
+/**
+ * The aggregates behind the statistics page.
+ *
+ * <p>Restricted to Logos admins like the rest of the platform's request data:
+ * an unscoped call returns the whole platform, and the scope narrows to
+ * <em>any</em> team or requester the caller names — there is no per-user
+ * fallback to hide behind. The {@code /ws/stats/v2} handshake and
+ * {@code /logosdb/latest_requests} apply the same rule to the same rows;
+ * leaving these two open would let a caller read one team's spend that the
+ * team activity endpoint (issue #776) refuses them. Team owners get their
+ * slice there, scoped and checked.
+ */
 @RestController
 public class RequestLogStatsController {
 
@@ -21,6 +35,7 @@ public class RequestLogStatsController {
     }
 
     @PostMapping("/logosdb/request_log_stats")
+    @PreAuthorize("hasAuthority('" + Role.Names.LOGOS_ADMIN + "')")
     public ResponseEntity<?> requestLogStats(@RequestAttribute("authContext") AuthContext auth,
                                              @RequestBody(required = false) Map<String, Object> body) {
         if (body == null) body = Map.of();
@@ -50,6 +65,7 @@ public class RequestLogStatsController {
      * or the selected team moves.
      */
     @PostMapping("/logosdb/request_log_scope_options")
+    @PreAuthorize("hasAuthority('" + Role.Names.LOGOS_ADMIN + "')")
     public ResponseEntity<?> requestLogScopeOptions(@RequestAttribute("authContext") AuthContext auth,
                                                     @RequestBody(required = false) Map<String, Object> body) {
         if (body == null) body = Map.of();

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogStatsControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogStatsControllerTest.java
@@ -39,7 +39,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_returnsExpectedShape() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{}"))
            .andExpect(status().isOk())
@@ -59,6 +59,51 @@ class RequestLogStatsControllerTest {
            .andExpect(status().isUnauthorized());
     }
 
+    // ── Access ───────────────────────────────────────────────────────────────
+    // Unscoped, these endpoints return the whole platform's request data — and
+    // the scope narrows to any team or requester the caller names, so a non
+    // admin calling them with a foreign team id would read exactly what the
+    // team activity endpoint (issue #776) refuses them. The rule must hold
+    // here, not only on the statistics page's router gate.
+
+    @Test
+    void requestLogStats_refusesAnAppAdmin() throws Exception {
+        mvc.perform(post("/logosdb/request_log_stats")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void requestLogStats_refusesAPlainDeveloper() throws Exception {
+        mvc.perform(post("/logosdb/request_log_stats")
+                .with(TestJwt.testUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void requestLogStats_refusesScopeOptionsForAPlainDeveloper() throws Exception {
+        // The lists name every team and requester with traffic in range — the
+        // inventory of the platform's usage, so they carry the same rule.
+        mvc.perform(post("/logosdb/request_log_scope_options")
+                .with(TestJwt.testUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void requestLogStats_refusesScopeOptionsForAnAppAdmin() throws Exception {
+        mvc.perform(post("/logosdb/request_log_scope_options")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
     // ── Scope ────────────────────────────────────────────────────────────────
     // The seed holds exactly two requests: 9001 carries user 1001 / team 2001,
     // 9002 carries neither (an application key). So an unscoped call must count
@@ -68,7 +113,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_countsEveryTeamWhenUnscoped() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{}"))
            .andExpect(status().isOk())
@@ -80,7 +125,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_narrowsEveryAggregateToTheTeam() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"team_id\": 2001}"))
            .andExpect(status().isOk())
@@ -96,7 +141,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_narrowsToTheRequester() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"user_id\": 1001}"))
            .andExpect(status().isOk())
@@ -106,7 +151,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_returnsNothingForATeamWithNoTraffic() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"team_id\": 999999}"))
            .andExpect(status().isOk())
@@ -120,14 +165,14 @@ class RequestLogStatsControllerTest {
         // in team 2001, so pairing them keeps the request, and pairing the user
         // with a different team keeps nothing.
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"user_id\": 1001, \"team_id\": 2001}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.stats.totals.requests").value(1));
 
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"user_id\": 1001, \"team_id\": 999999}"))
            .andExpect(status().isOk())
@@ -142,7 +187,7 @@ class RequestLogStatsControllerTest {
     @Test
     void scopeOptions_listOnlyWhatSentSomething() throws Exception {
         mvc.perform(post("/logosdb/request_log_scope_options")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{}"))
            .andExpect(status().isOk())
@@ -162,7 +207,7 @@ class RequestLogStatsControllerTest {
     @Test
     void scopeOptions_narrowRequestersToTheTeam() throws Exception {
         mvc.perform(post("/logosdb/request_log_scope_options")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"team_id\": 2001}"))
            .andExpect(status().isOk())
@@ -177,7 +222,7 @@ class RequestLogStatsControllerTest {
     @Test
     void scopeOptions_offerNoRequestersForASilentTeam() throws Exception {
         mvc.perform(post("/logosdb/request_log_scope_options")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"team_id\": 999999}"))
            .andExpect(status().isOk())
@@ -187,7 +232,7 @@ class RequestLogStatsControllerTest {
     @Test
     void scopeOptions_excludeARangeWithNoTraffic() throws Exception {
         mvc.perform(post("/logosdb/request_log_scope_options")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"start_date\": \"2020-01-01T00:00:00Z\", \"end_date\": \"2020-01-02T00:00:00Z\"}"))
            .andExpect(status().isOk())
@@ -206,7 +251,7 @@ class RequestLogStatsControllerTest {
     @Test
     void requestLogStats_rejectsInvalidDateRange() throws Exception {
         mvc.perform(post("/logosdb/request_log_stats")
-                .with(TestJwt.testUser())
+                .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"start_date\": \"2025-06-01T00:00:00Z\", \"end_date\": \"2025-01-01T00:00:00Z\"}"))
            .andExpect(status().isBadRequest());


### PR DESCRIPTION
## Fixes #776

## What the issue asked for

App administrators wanted the statistics page, narrowed to their own teams: a live view of which requests are currently queued/running/finished, and how many tokens the team used in the last x days, with a specific API key — i.e. team-level authorisation over the platform's request data.

## Why this PR is small

The view the issue describes already exists end to end — it shipped with #785 as the **Activity** tab on each team's detail page, and #785's body closes its own section with "a team-scoped activity view … the two questions from the issue and no more":

- **Endpoint** — `POST /api/logosdb/teams/{teamId}/activity` (webservice): live counts read from the `log_entry` lifecycle rows the orchestrator writes at every transition (queued = accepted, not yet forwarded; running = forwarded, no response yet; finished/failed over the selected window). In-flight counts stop at a 30-minute horizon so stranded rows cannot fake a backlog. Alongside them: per-API-key request counts and token totals for the window, and the individual requests behind both, cursor-paginated.
- **Authorisation** — the same rule the key-admin endpoints use: a Logos admin sees any team, an app admin only a team they own. The team id sits in the path and the check runs against it, so the body cannot widen the scope. Covered in both directions by `TeamActivityControllerTest` (13 tests).
- **UI** — the tab polls every 5 s ("refreshes on its own"), offers 1/7/30/90-day windows, a per-requester filter, and the per-key table. It is visible to the team's owners and to Logos admins, less detailed than the platform statistics page on purpose — the VRAM curves and lane health belong to whoever runs the cluster.

This PR adds the two pieces the view was missing: its frontend tests, and the one place where the authorisation the view relies on did not hold.

## Changes

1. **`logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts`** (new, 25 tests) — the figures the owner reads: token totals abbreviated at the k/M/B boundaries, the key/environment label, the in-flight sum and failure rate behind the live tiles, the requester picker, window switching resetting the request pages, the requester filter, cursor pagination in both directions, the pager row numbering, and the per-row stage/tokens/duration rendering. The UI suite covered the neighbours (key modal, lane health panel) but not the numbers this issue is about.

2. **`RequestLogStatsController`** — restricted `POST /logosdb/request_log_stats` and `POST /logosdb/request_log_scope_options` to Logos admins. The endpoints predate the Spring migration without a role check and never got one: unscoped, they return the **whole platform's** request statistics, and the opt-in `team_id`/`user_id` scope narrows to **any** team the caller names. Any authenticated user — including app developers and app admins of other teams — could therefore read one team's request counts, token usage and requester list: exactly the data the team activity endpoint's ownership rule refuses, and exactly what the issue asks to keep team-scoped. The rule now matches the rest of the platform's request data, which already required the same role: `/logosdb/latest_requests` (`@PreAuthorize` logos_admin) and the `/ws/stats/v2` handshake (LOGOS_ADMIN — its docstring says the data "carries every requester's full name, team and cloud cost, with no per-user scoping to fall back on"). The only UI consumer is the statistics page, which is logos-admin-gated in the router; team owners keep their slice via the activity endpoint, scoped and checked. Added 4 access tests (app admin and developer refused on both endpoints); the existing content tests now run as the logos admin.

## Verification

- Webservice: **250 passed** (246 pre-existing + 4 new) via `mvn test`, JDK 25, Testcontainers + real Liquibase.
- UI unit tests: **41 passed** (16 pre-existing + 25 new) via `npm run test`.
- UI production build: clean via `npm run build`.
- Orchestrator: **778 passed, 1 xfailed** via `pytest` — untouched, re-run as the baseline for the `log_entry` lifecycle the live counts read.
- Searched the repo for other callers of the two restricted endpoints: the UI statistics page (logos_admin route) is the only consumer; the orchestrator's benchmark helper `tests/performance/run_api_workload.py` posts to the same path but targets the orchestrator port, which has no such endpoint (it already silently receives a 404), so nothing regresses.
- Full-stack verification against a running deployment (Keycloak, Docker, workers) was not available in this environment; verification is through the suites above and a close read of the data path (the orchestrator inserts the `log_entry` row on request acceptance and updates `timestamp_forwarding`/`timestamp_response` at each transition, which is exactly what the endpoint's stage counting relies on).
