### PR TITLE
`Logos`: Context routing — calibrate the token estimate and never filter a model out entirely

### DIFF
--- a/logos/logos-orchestrator/src/logos/context_budget.py
+++ b/logos/logos-orchestrator/src/logos/context_budget.py
@@ -24,9 +24,14 @@ from __future__ import annotations
 from typing import Any, Iterator, Optional
 
 # Characters per token. Real tokenizers land near 3.5-4 for English prose and
-# code; 3.0 keeps the estimate above the true count for the mixed text
-# (identifiers, JSON, diffs) coding assistants actually send.
-CHARS_PER_TOKEN = 3.0
+# code. Tool-heavy agent traffic (repeated tool names, JSON framing, diffs)
+# tokenizes at ~3.6-3.7 measured against the Qwen tokenizer, so 3.5 stays
+# slightly above the true count for prose while dropping the ~20 % overshoot
+# that 3.0 produced on agent payloads. That overshoot once pushed a request
+# that fit its 256k window over the estimate's limit and 404'd the whole
+# model out of routing (#810) — so the estimate must track the traffic it
+# actually sees, not a worst case.
+CHARS_PER_TOKEN = 3.5
 
 # What a client is assumed to reserve for its own output when the payload does
 # not say. 20000 is what Claude Code reserves — it caps its reservation there

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2332,16 +2332,21 @@ def _prefer_deployments_with_context_room(
     the same 3000-token margin Claude Code keeps) and keep only the workers
     that offer it.
 
-    Two deliberate escape hatches, because this filter runs on an estimate:
+    Deliberate escape hatches, because this filter runs on an estimate:
 
     * A worker whose window is unknown is always kept. ``max_model_len`` is
       absent for cloud providers, for Ollama lanes and for a vLLM lane the
       worker has not reported a window for — none of those are evidence of a
       *narrow* window.
-    * When no worker is left, the widest ones are returned instead of nothing.
-      The request then fails upstream exactly as it did before this filter
-      existed, rather than turning into a 404 that hides which model was
-      asked for.
+    * A model is never filtered out entirely. If every lane of a model has a
+      known window that is too narrow, the widest of them is kept anyway.
+      Downstream, proxy mode narrows this list to the requested model and
+      turns an emptied model into a 404 "no deployment found" that hides the
+      real state; the engine, by contrast, either serves the request or
+      answers its own honest 400 — which is what the client should see (#810).
+    * When no worker is left, the widest ones are returned instead of nothing,
+      so the request fails upstream exactly as it did before this filter
+      existed.
     """
     required = required_context_tokens(payload)
     if required is None:
@@ -2359,27 +2364,47 @@ def _prefer_deployments_with_context_room(
             return None
         return windows.get((int(deployment["provider_id"]), model_name))
 
-    fitting = [d for d in deployments if (_window_of(d) or required) >= required]
-    if fitting:
-        if len(fitting) != len(deployments):
-            logger.info(
-                "Context routing: request needs ~%d tokens; %d of %d deployment(s) serve a wide " "enough window",
+    # Models whose known windows are all too narrow. Keep their widest lane
+    # anyway: proxy mode narrows the result to the requested model, so an
+    # emptied model would 404 "no deployment found" here, while the engine
+    # would either serve the request or answer its own honest 400.
+    rescued_widest: dict[int, int] = {}
+    by_model: dict[int, list[Deployment]] = {}
+    for deployment in deployments:
+        by_model.setdefault(int(deployment["model_id"]), []).append(deployment)
+    for model_id, model_deployment in by_model.items():
+        if any((_window_of(d) or required) >= required for d in model_deployment):
+            continue
+        widest = max((_window_of(d) for d in model_deployment), default=0)
+        if widest > 0:
+            rescued_widest[model_id] = widest
+            logger.warning(
+                "Context routing: request needs ~%d tokens but the widest served window for "
+                "model %s is %d — keeping the widest lane so the engine can answer",
                 required,
-                len(fitting),
-                len(deployments),
+                model_names.get(model_id, str(model_id)),
+                widest,
             )
-        return fitting
 
-    # Every known window is too narrow. Hand back the widest so the request
-    # gets the best available shot instead of a synthetic 404.
-    widest = max((w for w in (_window_of(d) for d in deployments) if w), default=0)
-    logger.warning(
-        "Context routing: request needs ~%d tokens but the widest served window is %d — "
-        "falling back to the widest deployment(s)",
-        required,
-        widest,
-    )
-    return [d for d in deployments if (_window_of(d) or 0) >= widest] or deployments
+    def _keep(deployment: Deployment) -> bool:
+        if (_window_of(deployment) or required) >= required:
+            return True
+        widest = rescued_widest.get(int(deployment["model_id"]))
+        return widest is not None and (_window_of(deployment) or 0) >= widest
+
+    fitting = [d for d in deployments if _keep(d)]
+    if len(fitting) != len(deployments):
+        logger.info(
+            "Context routing: request needs ~%d tokens; %d of %d deployment(s) serve a wide "
+            "enough window%s",
+            required,
+            len(fitting),
+            len(deployments),
+            f" (+{len(rescued_widest)} widest lane(s) of fully-filtered model(s) kept)"
+            if rescued_widest
+            else "",
+        )
+    return fitting or deployments
 
 
 async def start_pipeline():

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2395,14 +2395,11 @@ def _prefer_deployments_with_context_room(
     fitting = [d for d in deployments if _keep(d)]
     if len(fitting) != len(deployments):
         logger.info(
-            "Context routing: request needs ~%d tokens; %d of %d deployment(s) serve a wide "
-            "enough window%s",
+            "Context routing: request needs ~%d tokens; %d of %d deployment(s) serve a wide " "enough window%s",
             required,
             len(fitting),
             len(deployments),
-            f" (+{len(rescued_widest)} widest lane(s) of fully-filtered model(s) kept)"
-            if rescued_widest
-            else "",
+            f" (+{len(rescued_widest)} widest lane(s) of fully-filtered model(s) kept)" if rescued_widest else "",
         )
     return fitting or deployments
 

--- a/logos/logos-orchestrator/tests/unit/main/test_context_aware_routing.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_context_aware_routing.py
@@ -135,23 +135,23 @@ def test_rescue_survives_alongside_other_models(monkeypatch):
     registry.active_provider_ids = lambda: [NARROW_PROVIDER, 2]
     registry.peek_runtime_snapshot = lambda pid: {
         "runtime": {
-            "lanes": [
-                {
-                    "model": MODEL_NAME,
-                    "vllm": True,
-                    "backend_metrics": {"max_model_len": 33_000},
-                }
-            ]
-            if pid == NARROW_PROVIDER
-            else [],
+            "lanes": (
+                [
+                    {
+                        "model": MODEL_NAME,
+                        "vllm": True,
+                        "backend_metrics": {"max_model_len": 33_000},
+                    }
+                ]
+                if pid == NARROW_PROVIDER
+                else []
+            ),
             "model_profiles": {},
         }
     }
     monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
 
-    deployments = _deployments(NARROW_PROVIDER) + [
-        {"provider_id": 2, "model_id": OTHER_MODEL_ID, "type": "logosnode"}
-    ]
+    deployments = _deployments(NARROW_PROVIDER) + [{"provider_id": 2, "model_id": OTHER_MODEL_ID, "type": "logosnode"}]
     result = main_mod._prefer_deployments_with_context_room(
         deployments, _payload(150_000), {MODEL_ID: MODEL_NAME, OTHER_MODEL_ID: "embedding-8b"}
     )

--- a/logos/logos-orchestrator/tests/unit/main/test_context_aware_routing.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_context_aware_routing.py
@@ -90,6 +90,88 @@ def test_falls_back_to_the_widest_when_nothing_fits(two_workers):
     assert [d["provider_id"] for d in result] == [WIDE_PROVIDER]
 
 
+def test_fully_filtered_model_keeps_its_widest_lane(monkeypatch):
+    """Every lane of a model too narrow: keep the roomiest, not none.
+
+    Proxy mode narrows the result to the requested model, so filtering a model
+    out entirely turns the request into a 404 "no deployment found" — even
+    when the model's widest lane would have served it, and even when the
+    estimate (not the request) is what overshoots. The engine is the right
+    place to say "too long": it either serves the request or answers its own
+    honest 400 (#810).
+    """
+    registry = MagicMock()
+    registry.active_provider_ids = lambda: [NARROW_PROVIDER]
+    registry.peek_runtime_snapshot = lambda pid: {
+        "runtime": {
+            "lanes": [
+                {
+                    "model": MODEL_NAME,
+                    "vllm": True,
+                    "backend_metrics": {"max_model_len": 33_000},
+                }
+            ],
+            "model_profiles": {},
+        }
+    }
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    # ~43k prompt tokens: more than the only lane's 33k window.
+    result = _filter(_deployments(NARROW_PROVIDER), _payload(150_000))
+    assert [d["provider_id"] for d in result] == [NARROW_PROVIDER]
+
+
+def test_rescue_survives_alongside_other_models(monkeypatch):
+    """The incident shape: the pinned model is fully filtered while other
+    entitled models (no loaded lane → unknown window) survive.
+
+    Before the fix the result contained only the other models; the pinned
+    model's narrowing came up empty and the request 404'd. Now the pinned
+    model keeps its widest lane, and the invariant the proxy path relies on
+    holds: no model present in the input is missing from the output.
+    """
+    OTHER_MODEL_ID = 43
+    registry = MagicMock()
+    registry.active_provider_ids = lambda: [NARROW_PROVIDER, 2]
+    registry.peek_runtime_snapshot = lambda pid: {
+        "runtime": {
+            "lanes": [
+                {
+                    "model": MODEL_NAME,
+                    "vllm": True,
+                    "backend_metrics": {"max_model_len": 33_000},
+                }
+            ]
+            if pid == NARROW_PROVIDER
+            else [],
+            "model_profiles": {},
+        }
+    }
+    monkeypatch.setattr(main_mod, "_logosnode_registry", registry)
+
+    deployments = _deployments(NARROW_PROVIDER) + [
+        {"provider_id": 2, "model_id": OTHER_MODEL_ID, "type": "logosnode"}
+    ]
+    result = main_mod._prefer_deployments_with_context_room(
+        deployments, _payload(150_000), {MODEL_ID: MODEL_NAME, OTHER_MODEL_ID: "embedding-8b"}
+    )
+    assert {(d["model_id"], d["provider_id"]) for d in result} == {
+        (MODEL_ID, NARROW_PROVIDER),
+        (OTHER_MODEL_ID, 2),
+    }
+    assert {d["model_id"] for d in result} == {d["model_id"] for d in deployments}
+
+
+def test_rescue_keeps_only_the_widest_lane_of_a_model(two_workers):
+    """Keeping *every* too-narrow lane would undo the filter.
+
+    The request must land on the roomiest lane of the rescued model — the one
+    most likely to serve it — not on the 33k lane it would definitely reject.
+    """
+    result = _filter(_deployments(NARROW_PROVIDER, WIDE_PROVIDER), _payload(2_000_000))
+    assert [d["provider_id"] for d in result] == [WIDE_PROVIDER]
+
+
 def test_unknown_window_is_never_treated_as_narrow(monkeypatch):
     """A worker that reports no window keeps its place in the candidate list.
 
@@ -121,12 +203,13 @@ def test_output_reservation_counts_against_the_window(two_workers):
     A prompt that fits on its own can still overflow once the reply it asked
     for is reserved — which is the failure this whole path exists to avoid.
     """
-    # ~11000 prompt tokens. Plus a 4k reply and the margin that is 18k, which
-    # fits the 33000 worker; plus a 20k reply it is 34k, which does not.
-    small_reply = _filter(_deployments(NARROW_PROVIDER, WIDE_PROVIDER), _payload(33_000, 4096))
+    # ~15700 prompt tokens. Plus a 4k reply and the margin that is ~22.8k,
+    # which fits the 33000 worker; plus a 20k reply it is ~38.7k, which does
+    # not.
+    small_reply = _filter(_deployments(NARROW_PROVIDER, WIDE_PROVIDER), _payload(55_000, 4096))
     assert NARROW_PROVIDER in [d["provider_id"] for d in small_reply]
 
-    big_reply = _filter(_deployments(NARROW_PROVIDER, WIDE_PROVIDER), _payload(33_000, 20_000))
+    big_reply = _filter(_deployments(NARROW_PROVIDER, WIDE_PROVIDER), _payload(55_000, 20_000))
     assert [d["provider_id"] for d in big_reply] == [WIDE_PROVIDER]
 
 

--- a/logos/logos-orchestrator/tests/unit/test_context_budget.py
+++ b/logos/logos-orchestrator/tests/unit/test_context_budget.py
@@ -78,8 +78,7 @@ class TestEstimatePromptTokens:
             "system": "You are an assistant. " * 50,
             "messages": agent_messages,
             "tools": [
-                {"name": f"tool_{i}", "description": "d " * 30, "input_schema": {"type": "object"}}
-                for i in range(30)
+                {"name": f"tool_{i}", "description": "d " * 30, "input_schema": {"type": "object"}} for i in range(30)
             ],
         }
         true_tokens = sum(len(t) for t in _iter_text(payload)) / 3.7

--- a/logos/logos-orchestrator/tests/unit/test_context_budget.py
+++ b/logos/logos-orchestrator/tests/unit/test_context_budget.py
@@ -6,6 +6,7 @@ from logos.context_budget import (
     CHARS_PER_TOKEN,
     DEFAULT_OUTPUT_RESERVE_TOKENS,
     SAFETY_MARGIN_TOKENS,
+    _iter_text,
     estimate_prompt_tokens,
     required_context_tokens,
     reserved_output_tokens,
@@ -39,9 +40,50 @@ class TestEstimatePromptTokens:
         assert with_tools > without_tools + 400
 
     def test_reads_responses_api_and_legacy_completions(self):
-        assert estimate_prompt_tokens({"input": "a" * 90}) == 31
-        assert estimate_prompt_tokens({"prompt": "a" * 90}) == 31
-        assert estimate_prompt_tokens({"instructions": "a" * 90}) == 31
+        expected = int(90 / CHARS_PER_TOKEN) + 1
+        assert estimate_prompt_tokens({"input": "a" * 90}) == expected
+        assert estimate_prompt_tokens({"prompt": "a" * 90}) == expected
+        assert estimate_prompt_tokens({"instructions": "a" * 90}) == expected
+
+    def test_agent_traffic_stays_close_to_the_measured_tokenization_rate(self):
+        """A tool-heavy assistant payload must not overshoot the true count.
+
+        Measured against the Qwen tokenizer, a large Claude Code-style
+        conversation (hundreds of tool_use/tool_result blocks, repeated JSON
+        framing) tokenizes at ~3.7 chars per token. At the old 3.0 rate the
+        estimate ran ~20 % above the truth — enough to push a request that fit
+        its 256k window over the limit and 404 the model out of routing
+        (#810). This pins the rate so the estimate stays within a hair of the
+        measured truth for that traffic shape.
+        """
+        tool_block = {"type": "tool_result", "tool_use_id": "toolu_01", "content": "ok " * 40}
+        agent_messages = []
+        for i in range(200):
+            agent_messages.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"t{i}",
+                            "name": "Bash",
+                            "input": {"command": "ls -la " * 20},
+                        }
+                    ],
+                }
+            )
+            agent_messages.append({"role": "user", "content": [tool_block]})
+        agent_messages.append({"role": "user", "content": [{"type": "text", "text": "run the tests"}]})
+        payload = {
+            "system": "You are an assistant. " * 50,
+            "messages": agent_messages,
+            "tools": [
+                {"name": f"tool_{i}", "description": "d " * 30, "input_schema": {"type": "object"}}
+                for i in range(30)
+            ],
+        }
+        true_tokens = sum(len(t) for t in _iter_text(payload)) / 3.7
+        assert estimate_prompt_tokens(payload) <= true_tokens * 1.10
 
     def test_ignores_base64_attachments(self):
         """An encoded image is ~1.4 chars per byte of nothing readable.


### PR DESCRIPTION
Fixes #810

## What was wrong

A pinned-model request (Claude Code calling `/v1/messages` with the model named in the payload) could 404 with **"No deployment found for model …"** although a deployment of that model existed and the request actually fit its served context window. The session got stuck — every retry 404'd until the conversation was compacted.

Two interacting causes:

1. **The token estimate ran ~20 % hot on agent traffic.** `context_budget.py` counts payload characters at 3.0 chars/token. Tool-heavy assistant payloads (hundreds of `tool_use`/`tool_result` blocks, repeated JSON framing) tokenize at ~3.6–3.7 chars/token measured against the Qwen tokenizer, so a ~200k-token request was estimated at ~244k, crossing the 262,144 window limit it actually fit under.
2. **The context filter could empty out the pinned model.** `_prefer_deployments_with_context_room()` drops every deployment whose known window is below the estimate. When the key is entitled to other models whose lanes are not loaded (unknown window → always kept), those survive while *all* lanes of the pinned model are dropped. Proxy mode then narrows the list to the pinned `model_id`, finds nothing, and raises the 404 — instead of letting the engine either serve the request or answer its own honest 400.

## The fix

- **`context_budget.py`** — recalibrate `CHARS_PER_TOKEN` from 3.0 to 3.5: ~3 % above the measured agent rate, still ~14 % conservative for prose, with the existing 3k safety margin intact.
- **`main.py` — `_prefer_deployments_with_context_room()`** — a model is never filtered out entirely: if every lane of a model has a known window below the estimate, the widest of them is kept (logged as a warning). The request reaches the engine, which is the source of truth: it serves the request or answers its own 400. The orchestrator no longer synthesizes "no deployment found" for this case.

The 404 in proxy mode remains for the genuinely different case (the key has no deployment of the model at all), where it is accurate.

## Verification

- New unit tests: the estimate stays within a hair of the measured tokenization rate for tool-heavy payloads; the filter keeps the widest lane of a fully-filtered model, alongside other models, and never removes a model present in the input.
- Existing routing/budget tests re-tuned for the new rate and kept green.
- Full orchestrator unit suite: **782 passed, 1 xfailed** (pre-existing).
- Simulation with the incident's stored payload (no identifying data): estimate 266,624 → **231,821** — under the 262,144 window, all three 262,144 lanes pass the filter, the request is served. A genuinely too-large request (~302k estimated) still reaches the engine via the widest-lane rescue and gets its honest 400.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt token estimation for tool-heavy agent conversations, reducing excessive context reservations.
  * Preserved a widest deployment option when all known context windows are too narrow, preventing avoidable request failures.
  * Maintained routing coverage across available models while selecting only the best fallback lane when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->