### PR TITLE
`Logos`: Add export of consent-based logging traces

### DIFF
--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.html
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.html
@@ -134,9 +134,10 @@
         >
           <i class="pi pi-angle-right" aria-hidden="true"></i>
         </button>
-        <!-- Consent-based trace export (issue #667): only the FULL-logging
-             requests come back — the ones whose content was stored because the
-             requester opted in. Follows the period and requester filter above. -->
+        <!-- Request trace export (issue #667): every request of the window
+             comes back; the full-logging ones — the ones whose content was
+             stored because the requester opted in — carry it with them.
+             Follows the period and requester filter above. -->
         <span class="ac-export">
           <app-select
             class="ac-control"
@@ -151,8 +152,8 @@
             type="button"
             [disabled]="exporting()"
             (click)="exportTraces()"
-            title="Download this team's consent-based traces (full-logging requests, content included)"
-            aria-label="Export consent-based traces"
+            title="Download this team's requests — the full-logging ones carry their stored content"
+            aria-label="Export request traces"
           >
             <i class="pi pi-download" aria-hidden="true"></i>
           </button>
@@ -162,6 +163,10 @@
 
     @if (exportError()) {
       <p class="ac-error">{{ exportError() }}</p>
+    }
+
+    @if (fullLoggingHint()) {
+      <p class="ac-note ac-note--quiet">{{ fullLoggingHint() }}</p>
     }
 
     @if (requests().length === 0) {

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.html
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.html
@@ -134,8 +134,35 @@
         >
           <i class="pi pi-angle-right" aria-hidden="true"></i>
         </button>
+        <!-- Consent-based trace export (issue #667): only the FULL-logging
+             requests come back — the ones whose content was stored because the
+             requester opted in. Follows the period and requester filter above. -->
+        <span class="ac-export">
+          <app-select
+            class="ac-control"
+            [options]="exportFormatOptions"
+            [value]="selectedExportFormatValue()"
+            [compact]="true"
+            ariaLabel="Trace export format"
+            (valueChange)="setExportFormat($event)"
+          />
+          <button
+            class="ac-pager__btn"
+            type="button"
+            [disabled]="exporting()"
+            (click)="exportTraces()"
+            title="Download this team's consent-based traces (full-logging requests, content included)"
+            aria-label="Export consent-based traces"
+          >
+            <i class="pi pi-download" aria-hidden="true"></i>
+          </button>
+        </span>
       </div>
     </div>
+
+    @if (exportError()) {
+      <p class="ac-error">{{ exportError() }}</p>
+    }
 
     @if (requests().length === 0) {
       <p class="ac-note ac-note--quiet">

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.models.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.models.ts
@@ -58,3 +58,69 @@ export interface TeamActivityPayload {
   requests_has_more: boolean;
   requests_next_cursor: RequestCursor | null;
 }
+
+// ── Trace export (issue #667) ────────────────────────────────────────────────
+
+/**
+ * One consent-based request trace: a request the orchestrator recorded at
+ * FULL privacy, so it carries the request and response content on top of the
+ * usual lifecycle metadata.
+ *
+ * The payload fields are `unknown` on purpose — their shape is whatever the
+ * caller sent to the model, and the export must not pretend to know it.
+ */
+export interface TraceExportItem {
+  request_id: string | null;
+  timestamp_request: string | null;
+  timestamp_forwarding: string | null;
+  timestamp_response: string | null;
+  time_at_first_token: string | null;
+  privacy_level: string;
+  model_name: string | null;
+  provider_name: string | null;
+  provider_type: string | null;
+  policy_id: number | null;
+  environment: string | null;
+  api_key_id: number | null;
+  api_key_name: string | null;
+  username: string | null;
+  full_name: string | null;
+  team_name: string | null;
+  client_ip: string | null;
+  status: string;
+  error_message: string | null;
+  priority: string | null;
+  initial_priority: string | null;
+  priority_when_scheduled: string | null;
+  queue_depth_at_enqueue: number | null;
+  queue_depth_at_schedule: number | null;
+  queue_depth_at_arrival: number | null;
+  timeout_s: number | null;
+  utilization_at_arrival: number | null;
+  queue_wait_ms: number | null;
+  was_cold_start: boolean | null;
+  load_duration_ms: number | null;
+  available_vram_mb: number | null;
+  azure_rate_remaining_requests: number | null;
+  azure_rate_remaining_tokens: number | null;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+  cost_microcents: number | null;
+  classification_statistics: unknown;
+  input_payload: unknown;
+  headers: unknown;
+  response_payload: unknown;
+}
+
+/** Envelope of the trace export — the downloaded file is this object. */
+export interface TraceExport {
+  team_id: number;
+  team_name: string | null;
+  days: number;
+  since: string;
+  count: number;
+  /** True when the window held more traces than one export may carry. */
+  truncated: boolean;
+  traces: TraceExportItem[];
+}

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.models.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.models.ts
@@ -48,6 +48,12 @@ export interface TeamActivityPayload {
   team_id: number;
   days: number;
   since: string;
+  /**
+   * Whether any key of the team is opted into FULL logging — the only switch
+   * under which request and response content is stored at all, so the view
+   * can hint at an empty export before the download is started (issue #667).
+   */
+  full_logging_enabled: boolean;
   live: TeamLiveCounts;
   keys: TeamKeyUsage[];
   total_tokens: number;
@@ -62,9 +68,10 @@ export interface TeamActivityPayload {
 // ── Trace export (issue #667) ────────────────────────────────────────────────
 
 /**
- * One consent-based request trace: a request the orchestrator recorded at
- * FULL privacy, so it carries the request and response content on top of the
- * usual lifecycle metadata.
+ * One request trace of the team export. Every row carries the lifecycle
+ * metadata; only the rows the orchestrator recorded at FULL privacy (the ones
+ * the requester consented to) also carry the request and response content —
+ * for the billing-only rows the payload fields are absent.
  *
  * The payload fields are `unknown` on purpose — their shape is whatever the
  * caller sent to the model, and the export must not pretend to know it.
@@ -77,9 +84,7 @@ export interface TraceExportItem {
   time_at_first_token: string | null;
   privacy_level: string;
   model_name: string | null;
-  provider_name: string | null;
   provider_type: string | null;
-  policy_id: number | null;
   environment: string | null;
   api_key_id: number | null;
   api_key_name: string | null;
@@ -101,8 +106,6 @@ export interface TraceExportItem {
   was_cold_start: boolean | null;
   load_duration_ms: number | null;
   available_vram_mb: number | null;
-  azure_rate_remaining_requests: number | null;
-  azure_rate_remaining_tokens: number | null;
   prompt_tokens: number | null;
   completion_tokens: number | null;
   total_tokens: number | null;
@@ -120,6 +123,13 @@ export interface TraceExport {
   days: number;
   since: string;
   count: number;
+  /** Whether any key of the team has full (consent) logging activated. */
+  full_logging_enabled: boolean;
+  /**
+   * Present only when not a single row of the export carries content — the
+   * file explaining itself why the payload columns are all empty.
+   */
+  note?: string;
   /** True when the window held more traces than one export may carry. */
   truncated: boolean;
   traces: TraceExportItem[];

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.scss
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.scss
@@ -71,6 +71,15 @@
   max-width: 240px;
 }
 
+// The export acts on the whole list, not on one filter, so it sits at the end
+// of the toolbar wherever the count line wraps.
+.ac-export {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
 // ── Live tiles ────────────────────────────────────────────────────────────────
 
 .ac-tiles {

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.service.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-import { RequestCursor, TeamActivityPayload } from './activity-tab.models';
+import { RequestCursor, TeamActivityPayload, TraceExport } from './activity-tab.models';
 
 /** Narrowing of the request list. `null` means "do not narrow by it". */
 export interface ActivityFilter {
@@ -27,6 +27,24 @@ export class TeamActivityService {
         user_id: filter.userId,
         cursor_ts: filter.cursor?.ts ?? null,
         cursor_id: filter.cursor?.request_id ?? null,
+      }),
+    );
+  }
+
+  /**
+   * The team's consent-based traces (issue #667): every request recorded at
+   * FULL privacy inside the window, request and response content included.
+   *
+   * Same gate as {@link getActivity} — the team id is in the path, and the
+   * server refuses app admins who do not own the team — and the same window
+   * and requester narrowing, so the export matches the list it was started
+   * from.
+   */
+  getTraceExport(teamId: number, days: number, userId: number | null): Promise<TraceExport> {
+    return firstValueFrom(
+      this.http.post<TraceExport>(`/api/logosdb/teams/${teamId}/activity/export`, {
+        days,
+        user_id: userId,
       }),
     );
   }

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -49,6 +49,7 @@ const makePayload = (overrides: Partial<TeamActivityPayload> = {}): TeamActivity
   team_id: 2001,
   days: 7,
   since: '2026-08-19T12:00:00Z',
+  full_logging_enabled: true,
   live: { queued: 0, running: 0, finished: 0, failed: 0 },
   keys: [],
   total_tokens: 0,
@@ -335,6 +336,26 @@ describe('ActivityTabComponent', () => {
       expect(component.requesterOf(makeRequest({ full_name: '   ' }))).toBe('test.user');
     });
   });
+
+  describe('export hint', () => {
+    it('says so before the click while no key of the team has full logging', () => {
+      // The download would hold metadata without content; the hint is the
+      // difference between "nothing to export" and "no consent was given".
+      component.activity.set(makePayload({ full_logging_enabled: false }));
+      expect(component.fullLoggingHint()).toBe(
+        'Full logging is not activated for this team — the export will not contain request or response content.',
+      );
+    });
+
+    it('stays away once full logging is activated', () => {
+      component.activity.set(makePayload({ full_logging_enabled: true }));
+      expect(component.fullLoggingHint()).toBeNull();
+    });
+
+    it('has nothing to say before the first payload arrives', () => {
+      expect(component.fullLoggingHint()).toBeNull();
+    });
+  });
 });
 
 /** One unanswered service call, resolvable by the test in the order it wants. */
@@ -417,6 +438,7 @@ describe('ActivityTabComponent pagination', () => {
       team_id: 28,
       days: 7,
       since: '2026-08-19T00:00:00Z',
+      full_logging_enabled: true,
       live: { queued: 0, running: 0, finished: TOTAL, failed: 0 },
       keys: [],
       total_tokens: 0,
@@ -685,9 +707,7 @@ describe('tracesToCsv', () => {
     time_at_first_token: null,
     privacy_level: 'FULL',
     model_name: null,
-    provider_name: null,
     provider_type: null,
-    policy_id: null,
     environment: null,
     api_key_id: null,
     api_key_name: null,
@@ -709,8 +729,6 @@ describe('tracesToCsv', () => {
     was_cold_start: null,
     load_duration_ms: null,
     available_vram_mb: null,
-    azure_rate_remaining_requests: null,
-    azure_rate_remaining_tokens: null,
     prompt_tokens: null,
     completion_tokens: null,
     total_tokens: null,
@@ -727,6 +745,7 @@ describe('tracesToCsv', () => {
     days: 7,
     since: '2026-08-20T00:00:00Z',
     count: 1,
+    full_logging_enabled: true,
     truncated: false,
     traces: [trace],
   };
@@ -771,6 +790,7 @@ describe('ActivityTabComponent trace export', () => {
     days: 7,
     since: '2026-08-20T00:00:00Z',
     count: 0,
+    full_logging_enabled: true,
     truncated: false,
     traces: [],
   };

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -825,6 +825,27 @@ describe('ActivityTabComponent trace export', () => {
     expect(await lastBlob?.text()).toBe(JSON.stringify(payload, null, 2));
   });
 
+  it('names the download after the team the export was started for', async () => {
+    // A slow export is the whole race: the tab may be pointed at another team
+    // by the time the answer lands, and the file must still say where its data
+    // came from.
+    let resolveExport: (value: TraceExport) => void = () => {};
+    activityService.getTraceExport.mockImplementation(
+      () =>
+        new Promise<TraceExport>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+
+    const inFlight = component.exportTraces();
+    component.teamId = 99;
+    resolveExport(payload);
+    await inFlight;
+
+    expect(activityService.getTraceExport).toHaveBeenCalledWith(42, 7, null);
+    expect(lastAnchor?.download).toBe('logos-traces-team-42-7d.json');
+  });
+
   it('cuts the CSV from the same envelope when the format asks for it', async () => {
     component.exportFormat.set('csv');
 

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -1,0 +1,214 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TeamActivityService } from './activity-tab.service';
+import { TraceExport, TraceExportItem } from './activity-tab.models';
+import { ActivityTabComponent, TRACE_CSV_COLUMNS, traceCsvCell, tracesToCsv } from './activity-tab';
+
+// ── CSV building ─────────────────────────────────────────────────────────────
+
+describe('traceCsvCell', () => {
+  it('leaves absent values empty', () => {
+    expect(traceCsvCell(null)).toBe('');
+    expect(traceCsvCell(undefined)).toBe('');
+  });
+
+  it('keeps plain values bare', () => {
+    expect(traceCsvCell('req-aaa-111')).toBe('req-aaa-111');
+    expect(traceCsvCell(42)).toBe('42');
+    expect(traceCsvCell(true)).toBe('true');
+  });
+
+  it('quotes and doubles what would break a table', () => {
+    expect(traceCsvCell('failed, timeout')).toBe('"failed, timeout"');
+    expect(traceCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(traceCsvCell('line\nbreak')).toBe('"line\nbreak"');
+  });
+
+  it('sends structured values out as compact JSON, quoted', () => {
+    expect(traceCsvCell({ model: 'gpt-4' })).toBe('"{""model"":""gpt-4""}"');
+    // A payload full of commas and quotes must stay one cell: the value is
+    // JSON-compacted first, then every quote is doubled — the inner quotes of
+    // the content survive as JSON escapes, each of them doubled like the rest.
+    const raw = JSON.stringify({ content: 'Hello, "Logos"' });
+    expect(traceCsvCell({ content: 'Hello, "Logos"' })).toBe(
+      `"${raw.replaceAll('"', '""')}"`,
+    );
+  });
+});
+
+describe('tracesToCsv', () => {
+  const trace: TraceExportItem = {
+    request_id: 'req-ccc-333',
+    timestamp_request: null,
+    timestamp_forwarding: null,
+    timestamp_response: null,
+    time_at_first_token: null,
+    privacy_level: 'FULL',
+    model_name: null,
+    provider_name: null,
+    provider_type: null,
+    policy_id: null,
+    environment: null,
+    api_key_id: null,
+    api_key_name: null,
+    username: null,
+    full_name: null,
+    team_name: null,
+    client_ip: null,
+    status: 'success',
+    error_message: 'failed, timeout "rare"',
+    priority: null,
+    initial_priority: null,
+    priority_when_scheduled: null,
+    queue_depth_at_enqueue: null,
+    queue_depth_at_schedule: null,
+    queue_depth_at_arrival: null,
+    timeout_s: null,
+    utilization_at_arrival: null,
+    queue_wait_ms: null,
+    was_cold_start: null,
+    load_duration_ms: null,
+    available_vram_mb: null,
+    azure_rate_remaining_requests: null,
+    azure_rate_remaining_tokens: null,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    cost_microcents: null,
+    classification_statistics: null,
+    input_payload: { model: 'gpt-4', messages: [{ role: 'user', content: 'Hello, "Logos"' }] },
+    headers: null,
+    response_payload: null,
+  };
+
+  const payload: TraceExport = {
+    team_id: 2001,
+    team_name: 'test-team',
+    days: 7,
+    since: '2026-08-20T00:00:00Z',
+    count: 1,
+    truncated: false,
+    traces: [trace],
+  };
+
+  it('writes the header from the same columns the JSON envelope carries', () => {
+    const lines = tracesToCsv(payload).split('\n');
+    expect(lines[0]).toBe(TRACE_CSV_COLUMNS.join(','));
+    expect(lines).toHaveLength(2);
+  });
+
+  it('keeps one trace on one row with absent cells empty', () => {
+    const lines = tracesToCsv(payload).split('\n');
+    // request_id, then the four absent timestamps, then privacy_level —
+    // the leading shape of the row says the empty cells stayed in place
+    // rather than shifting the columns left.
+    expect(lines[1].startsWith('req-ccc-333,,,,,FULL,')).toBe(true);
+  });
+
+  it('escapes cells the way traceCsvCell promises', () => {
+    const csv = tracesToCsv(payload);
+    expect(csv).toContain('"failed, timeout ""rare"""');
+    // The payload cell goes out exactly as the cell builder spells it,
+    // unsplit across the row.
+    expect(csv).toContain(traceCsvCell(trace.input_payload));
+  });
+});
+
+// ── The component's export flow ──────────────────────────────────────────────
+
+describe('ActivityTabComponent trace export', () => {
+  let fixture: ComponentFixture<ActivityTabComponent>;
+  let component: ActivityTabComponent;
+  let activityService: {
+    getActivity: ReturnType<typeof vi.fn>;
+    getTraceExport: ReturnType<typeof vi.fn>;
+  };
+  let lastBlob: Blob | null;
+  let lastAnchor: HTMLAnchorElement | null;
+  const payload: TraceExport = {
+    team_id: 42,
+    team_name: 'test-team',
+    days: 7,
+    since: '2026-08-20T00:00:00Z',
+    count: 0,
+    truncated: false,
+    traces: [],
+  };
+
+  beforeEach(async () => {
+    activityService = {
+      getActivity: vi.fn().mockResolvedValue(null),
+      getTraceExport: vi.fn().mockResolvedValue(payload),
+    };
+    lastBlob = null;
+    lastAnchor = null;
+
+    await TestBed.configureTestingModule({
+      imports: [ActivityTabComponent],
+      providers: [{ provide: TeamActivityService, useValue: activityService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ActivityTabComponent);
+    component = fixture.componentInstance;
+    component.teamId = 42;
+    fixture.detectChanges();
+
+    vi.spyOn(URL, 'createObjectURL').mockImplementation((blob) => {
+      lastBlob = blob as Blob;
+      return 'blob:test';
+    });
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      lastAnchor = this;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('asks the server for the team, the period and the active requester filter', async () => {
+    component.filterUserId.set(7);
+
+    await component.exportTraces();
+
+    expect(activityService.getTraceExport).toHaveBeenCalledWith(42, 7, 7);
+  });
+
+  it('downloads the JSON envelope under a named file', async () => {
+    await component.exportTraces();
+
+    expect(lastAnchor?.download).toBe('logos-traces-team-42-7d.json');
+    expect(lastBlob?.type).toBe('application/json');
+    expect(await lastBlob?.text()).toBe(JSON.stringify(payload, null, 2));
+  });
+
+  it('cuts the CSV from the same envelope when the format asks for it', async () => {
+    component.exportFormat.set('csv');
+
+    await component.exportTraces();
+
+    expect(lastAnchor?.download).toBe('logos-traces-team-42-7d.csv');
+    expect(lastBlob?.type).toBe('text/csv');
+    expect(await lastBlob?.text()).toBe(tracesToCsv(payload));
+  });
+
+  it('accepts only json and csv as export formats', () => {
+    component.setExportFormat('yaml');
+    expect(component.exportFormat()).toBe('json');
+    component.setExportFormat('csv');
+    expect(component.exportFormat()).toBe('csv');
+  });
+
+  it('reports a failed export instead of downloading nothing', async () => {
+    activityService.getTraceExport.mockRejectedValue(new Error('boom'));
+
+    await component.exportTraces();
+
+    expect(component.exportError()).toBe('Could not export the traces.');
+    expect(component.exporting()).toBe(false);
+    expect(lastAnchor).toBeNull();
+  });
+});

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
@@ -15,7 +15,7 @@ import { AppSelectOption, SelectComponent } from '../../../../shared/components/
 import { RequestItem } from '../../../statistics/statistics.models';
 import { deriveStage, formatTimeAgo } from '../../../statistics/statistics.utils';
 import { TeamActivityService } from './activity-tab.service';
-import { RequestCursor, TeamActivityPayload } from './activity-tab.models';
+import { RequestCursor, TeamActivityPayload, TraceExport, TraceExportItem } from './activity-tab.models';
 
 /** How often the live counts are refreshed while the tab is open. */
 const REFRESH_MS = 5_000;
@@ -57,6 +57,19 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
   readonly error = signal<string | null>(null);
 
   readonly dayOptions = DAY_OPTIONS;
+
+  // ── Trace export (issue #667) ────────────────────────────────────────────
+
+  readonly exportFormat = signal<'json' | 'csv'>('json');
+  readonly exporting = signal(false);
+  readonly exportError = signal<string | null>(null);
+
+  readonly exportFormatOptions: AppSelectOption[] = [
+    { value: 'json', label: 'JSON' },
+    { value: 'csv', label: 'CSV' },
+  ];
+
+  readonly selectedExportFormatValue = computed(() => this.exportFormat());
 
   /**
    * Cursor of each page already visited. Page 0 is always null (start at the
@@ -139,6 +152,39 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
     this.filterUserId.set(next);
     this.resetToFirstPage();
     void this.load();
+  }
+
+  setExportFormat(value: string | null): void {
+    if (value === 'json' || value === 'csv') this.exportFormat.set(value);
+  }
+
+  /**
+   * Download the team's consent-based traces — the FULL-logging requests with
+   * their stored content — as the picked file format. The server answers the
+   * JSON envelope; the CSV is cut from it here, the same way the import
+   * credentials file is cut from the upload result.
+   */
+  async exportTraces(): Promise<void> {
+    if (!this.teamId || this.exporting()) return;
+    this.exporting.set(true);
+    this.exportError.set(null);
+    try {
+      const payload = await this.activityService.getTraceExport(
+        this.teamId,
+        this.days(),
+        this.filterUserId(),
+      );
+      const format = this.exportFormat();
+      this.downloadFile(
+        `logos-traces-team-${this.teamId}-${payload.days}d.${format}`,
+        format === 'csv' ? tracesToCsv(payload) : JSON.stringify(payload, null, 2),
+        format === 'csv' ? 'text/csv' : 'application/json',
+      );
+    } catch {
+      this.exportError.set('Could not export the traces.');
+    } finally {
+      this.exporting.set(false);
+    }
   }
 
   async nextPage(): Promise<void> {
@@ -246,4 +292,84 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
       this.loading.set(false);
     }
   }
+
+  private downloadFile(filename: string, content: string, mimeType: string): void {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+// ── Trace export helpers (issue #667) ────────────────────────────────────────
+
+/** Column order of the CSV export; the JSON envelope is the reference. */
+export const TRACE_CSV_COLUMNS: (keyof TraceExportItem)[] = [
+  'request_id',
+  'timestamp_request',
+  'timestamp_forwarding',
+  'timestamp_response',
+  'time_at_first_token',
+  'privacy_level',
+  'model_name',
+  'provider_name',
+  'provider_type',
+  'policy_id',
+  'environment',
+  'api_key_id',
+  'api_key_name',
+  'username',
+  'full_name',
+  'team_name',
+  'client_ip',
+  'status',
+  'error_message',
+  'priority',
+  'initial_priority',
+  'priority_when_scheduled',
+  'queue_depth_at_enqueue',
+  'queue_depth_at_schedule',
+  'queue_depth_at_arrival',
+  'timeout_s',
+  'utilization_at_arrival',
+  'queue_wait_ms',
+  'was_cold_start',
+  'load_duration_ms',
+  'available_vram_mb',
+  'azure_rate_remaining_requests',
+  'azure_rate_remaining_tokens',
+  'prompt_tokens',
+  'completion_tokens',
+  'total_tokens',
+  'cost_microcents',
+  'classification_statistics',
+  'input_payload',
+  'headers',
+  'response_payload',
+];
+
+/**
+ * The CSV version of a trace export. Structured fields go out as compact
+ * JSON so a trace stays one row; quoting follows the same rules as the import
+ * credentials file — escape what breaks a table, because a payload is one
+ * comma away from breaking it.
+ */
+export function tracesToCsv(payload: TraceExport): string {
+  const rows = payload.traces.map((trace) =>
+    TRACE_CSV_COLUMNS.map((column) => traceCsvCell(trace[column])).join(','),
+  );
+  return [TRACE_CSV_COLUMNS.join(','), ...rows].join('\n');
+}
+
+export function traceCsvCell(value: unknown): string {
+  const text =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'string'
+        ? value
+        : JSON.stringify(value);
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
@@ -191,17 +191,22 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
    */
   async exportTraces(): Promise<void> {
     if (!this.teamId || this.exporting()) return;
+    // The download is named after the team the export was started for, not the
+    // team the tab shows when the response lands: the tab may switch teams
+    // mid-flight, and relabeling one team's data under another's id would be
+    // worse than a stale number.
+    const teamId = this.teamId;
     this.exporting.set(true);
     this.exportError.set(null);
     try {
       const payload = await this.activityService.getTraceExport(
-        this.teamId,
+        teamId,
         this.days(),
         this.filterUserId(),
       );
       const format = this.exportFormat();
       this.downloadFile(
-        `logos-traces-team-${this.teamId}-${payload.days}d.${format}`,
+        `logos-traces-team-${teamId}-${payload.days}d.${format}`,
         format === 'csv' ? tracesToCsv(payload) : JSON.stringify(payload, null, 2),
         format === 'csv' ? 'text/csv' : 'application/json',
       );

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
@@ -99,6 +99,18 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
 
   readonly selectedDaysValue = computed(() => String(this.days()));
 
+  /**
+   * The hint the export control carries (issue #667): a team whose keys all
+   * stay on billing logging never had request or response content stored, so
+   * the download holds metadata without content — say so before the click
+   * instead of letting the empty columns speak for themselves.
+   */
+  readonly fullLoggingHint = computed<string | null>(() => {
+    const activity = this.activity();
+    if (!activity || activity.full_logging_enabled) return null;
+    return 'Full logging is not activated for this team — the export will not contain request or response content.';
+  });
+
   readonly requesterOptions = computed<AppSelectOption[]>(() => [
     { value: '', label: 'Everyone in this team' },
     ...(this.activity()?.requesters ?? []).map((r) => ({
@@ -184,9 +196,10 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
   }
 
   /**
-   * Download the team's consent-based traces — the FULL-logging requests with
-   * their stored content — as the picked file format. The server answers the
-   * JSON envelope; the CSV is cut from it here, the same way the import
+   * Download the team's request traces as the picked file format: every
+   * request of the selected window, and for the consented (FULL-logging)
+   * ones the stored request and response content with it. The server answers
+   * the JSON envelope; the CSV is cut from it here, the same way the import
    * credentials file is cut from the upload result.
    */
   async exportTraces(): Promise<void> {
@@ -358,9 +371,7 @@ export const TRACE_CSV_COLUMNS: (keyof TraceExportItem)[] = [
   'time_at_first_token',
   'privacy_level',
   'model_name',
-  'provider_name',
   'provider_type',
-  'policy_id',
   'environment',
   'api_key_id',
   'api_key_name',
@@ -382,8 +393,6 @@ export const TRACE_CSV_COLUMNS: (keyof TraceExportItem)[] = [
   'was_cold_start',
   'load_duration_ms',
   'available_vram_mb',
-  'azure_rate_remaining_requests',
-  'azure_rate_remaining_tokens',
   'prompt_tokens',
   'completion_tokens',
   'total_tokens',

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKey;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKeyType;
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.LogLevel;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.MyKeyProjection;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ModelAccessProjection;
 
@@ -19,6 +20,8 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
 
     boolean existsByTeamIdAndKeyTypeAndEnvironmentAndIsActive(
             Integer teamId, ApiKeyType keyType, String environment, boolean isActive);
+
+    boolean existsByTeamIdAndLogAndIsActive(Integer teamId, LogLevel log, boolean isActive);
 
     @Query(value = """
         SELECT id, key_value, name, key_type::text AS key_type, user_id, environment,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/TeamActivityController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/TeamActivityController.java
@@ -67,13 +67,15 @@ public class TeamActivityController {
     }
 
     /**
-     * Download of the team's consent-based traces (issue #667).
+     * Download of the team's request traces (issue #667).
      *
-     * Only the FULL-privacy requests come back — the ones whose requester
-     * agreed to full logging in the first place, and the only ones that carry
-     * request and response content. Same gate as the activity view, same
-     * window and narrowing rules, so the export never reaches further than
-     * the page it is started from.
+     * Every request of the window comes back, the same slice the activity
+     * view shows. The consented ones (recorded at FULL privacy) carry their
+     * request and response content; for the billing-only rows the content
+     * columns are empty, and the envelope says whether the team has full
+     * logging activated at all. Same gate as the activity view, same window
+     * and narrowing rules, so the export never reaches further than the page
+     * it is started from.
      */
     @PostMapping("/logosdb/teams/{teamId}/activity/export")
     @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "')")

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/TeamActivityController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/TeamActivityController.java
@@ -65,4 +65,31 @@ public class TeamActivityController {
         return ResponseEntity.ok(
             teamActivityService.getTeamActivity(teamId, days, userId, cursorTs, cursorId));
     }
+
+    /**
+     * Download of the team's consent-based traces (issue #667).
+     *
+     * Only the FULL-privacy requests come back — the ones whose requester
+     * agreed to full logging in the first place, and the only ones that carry
+     * request and response content. Same gate as the activity view, same
+     * window and narrowing rules, so the export never reaches further than
+     * the page it is started from.
+     */
+    @PostMapping("/logosdb/teams/{teamId}/activity/export")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "')")
+    public ResponseEntity<?> exportTeamTraces(@PathVariable Integer teamId,
+                                              @RequestBody(required = false) Map<String, Object> body,
+                                              @RequestAttribute("authContext") AuthContext auth) {
+        if (teamId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "team_id is required"));
+        }
+        if (Role.APP_ADMIN.matches(auth.role())
+                && (auth.userId() == null || !apiKeyAdminService.isTeamOwner(teamId, auth.userId()))) {
+            return ResponseEntity.status(403).body(Map.of("detail", "Team owner access required"));
+        }
+        Map<String, Object> payload = body != null ? body : Map.of();
+        Integer days = payload.get("days") instanceof Number n ? n.intValue() : null;
+        Integer userId = payload.get("user_id") instanceof Number n ? n.intValue() : null;
+        return ResponseEntity.ok(teamActivityService.exportTeamTraces(teamId, days, userId));
+    }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -406,13 +406,14 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
         @Param("requestIds") List<String> requestIds);
 
     /**
-     * The consent-based traces of one team for the export (issue #667).
+     * The request traces of one team for the export (issue #667).
      *
-     * A trace exists because the requester opted in: only rows the orchestrator
-     * recorded at FULL privacy carry the request and response payloads, and
-     * those are what the export is for. Billing-only rows never reach this
-     * query, so a team that never consented exports an empty file rather than
-     * an anonymous skeleton of its traffic.
+     * Every request of the window comes out — the export must describe the
+     * same slice of traffic the activity list above shows, and a download that
+     * is empty just because the team never consented reads as a bug. Only the
+     * rows the orchestrator recorded at FULL privacy carry the request and
+     * response payloads; for the billing-only ones the content columns come
+     * back NULL, and the envelope says so.
      *
      * The token and cost columns reuse the lateral joins of
      * {@link #findLatestRequests} so an exported number and the same request in
@@ -430,9 +431,7 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.time_at_first_token AS timeAtFirstToken,
                le.privacy_level::text AS privacyLevel,
                COALESCE(m.name, 'Model ' || le.model_id) AS modelName,
-               COALESCE(p.name, 'Provider ' || le.provider_id) AS providerName,
                p.provider_type::text AS providerType,
-               le.policy_id AS policyId,
                le.environment AS environment,
                k.id AS apiKeyId,
                k.name AS keyName,
@@ -454,8 +453,6 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
                le.was_cold_start AS wasColdStart,
                le.load_duration_ms AS loadDurationMs,
                le.available_vram_mb AS availableVramMb,
-               le.azure_rate_remaining_requests AS azureRateRemainingRequests,
-               le.azure_rate_remaining_tokens AS azureRateRemainingTokens,
                tk.prompt_tokens AS promptTokens,
                tk.completion_tokens AS completionTokens,
                tk.total_tokens AS totalTokens,
@@ -500,13 +497,12 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
             WHERE ut.log_entry_id = le.id
         ) c ON true
         WHERE le.team_id = :teamId
-          AND le.privacy_level = 'FULL'
           AND le.timestamp_request BETWEEN :startTs AND :endTs
           AND (CAST(:userId AS INTEGER) IS NULL OR le.user_id = CAST(:userId AS INTEGER))
         ORDER BY le.timestamp_request DESC, le.id DESC
         LIMIT :limitN
         """, nativeQuery = true)
-    List<LogExportProjection> findFullTracesForExport(
+    List<LogExportProjection> findTracesForExport(
         @Param("teamId") int teamId,
         @Param("startTs") Timestamp startTs,
         @Param("endTs") Timestamp endTs,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -405,6 +405,114 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
         @Param("apiKeyId") Integer apiKeyId,
         @Param("requestIds") List<String> requestIds);
 
+    /**
+     * The consent-based traces of one team for the export (issue #667).
+     *
+     * A trace exists because the requester opted in: only rows the orchestrator
+     * recorded at FULL privacy carry the request and response payloads, and
+     * those are what the export is for. Billing-only rows never reach this
+     * query, so a team that never consented exports an empty file rather than
+     * an anonymous skeleton of its traffic.
+     *
+     * The token and cost columns reuse the lateral joins of
+     * {@link #findLatestRequests} so an exported number and the same request in
+     * the feed can never disagree. Newest first, with the primary key as tie
+     * break: the export is capped, and the rows kept must be a stable,
+     * explainable slice of the window rather than an arbitrary one.
+     */
+    @Transactional(readOnly = true)
+    @Query(value = """
+        SELECT le.id AS id,
+               le.request_id AS requestId,
+               le.timestamp_request AS timestampRequest,
+               le.timestamp_forwarding AS timestampForwarding,
+               le.timestamp_response AS timestampResponse,
+               le.time_at_first_token AS timeAtFirstToken,
+               le.privacy_level::text AS privacyLevel,
+               COALESCE(m.name, 'Model ' || le.model_id) AS modelName,
+               COALESCE(p.name, 'Provider ' || le.provider_id) AS providerName,
+               p.provider_type::text AS providerType,
+               le.policy_id AS policyId,
+               le.environment AS environment,
+               k.id AS apiKeyId,
+               k.name AS keyName,
+               u.username AS username,
+               NULLIF(TRIM(COALESCE(u.prename, '') || ' ' || COALESCE(u.name, '')), '') AS fullName,
+               t.name AS teamName,
+               le.client_ip AS clientIp,
+               le.result_status::text AS resultStatus,
+               le.error_message AS errorMessage,
+               le.priority AS priority,
+               le.initial_priority AS initialPriority,
+               le.priority_when_scheduled AS priorityWhenScheduled,
+               le.queue_depth_at_enqueue AS queueDepthAtEnqueue,
+               le.queue_depth_at_schedule AS queueDepthAtSchedule,
+               le.queue_depth_at_arrival AS queueDepthAtArrival,
+               le.timeout_s AS timeoutS,
+               le.utilization_at_arrival AS utilizationAtArrival,
+               le.queue_wait_ms AS queueWaitMs,
+               le.was_cold_start AS wasColdStart,
+               le.load_duration_ms AS loadDurationMs,
+               le.available_vram_mb AS availableVramMb,
+               le.azure_rate_remaining_requests AS azureRateRemainingRequests,
+               le.azure_rate_remaining_tokens AS azureRateRemainingTokens,
+               tk.prompt_tokens AS promptTokens,
+               tk.completion_tokens AS completionTokens,
+               tk.total_tokens AS totalTokens,
+               c.cost_micro_cents AS costMicroCents,
+               le.classification_statistics::text AS classificationStatistics,
+               le.input_payload::text AS inputPayload,
+               le.headers::text AS headers,
+               le.response_payload::text AS responsePayload
+        FROM log_entry le
+        LEFT JOIN models m ON m.id = le.model_id
+        LEFT JOIN providers p ON p.id = le.provider_id
+        LEFT JOIN api_keys k ON k.id = le.api_key_id
+        LEFT JOIN teams t ON t.id = le.team_id
+        LEFT JOIN users u ON u.id = le.user_id
+        LEFT JOIN LATERAL (
+            SELECT MAX(CASE WHEN tt.name = 'prompt_tokens'     THEN ut.token_count END) AS prompt_tokens,
+                   MAX(CASE WHEN tt.name = 'completion_tokens' THEN ut.token_count END) AS completion_tokens,
+                   MAX(CASE WHEN tt.name = 'total_tokens'      THEN ut.token_count END) AS total_tokens
+            FROM usage_tokens ut
+            JOIN token_types tt ON tt.id = ut.type_id
+            WHERE ut.log_entry_id = le.id
+        ) tk ON true
+        LEFT JOIN LATERAL (
+            SELECT SUM(
+                CASE WHEN tp.price_per_k_token IS NOT NULL
+                     THEN (ut.token_count::BIGINT * tp.price_per_k_token / 1000)::BIGINT
+                END
+            ) AS cost_micro_cents
+            FROM usage_tokens ut
+            LEFT JOIN LATERAL (
+                SELECT price_per_k_token
+                FROM token_prices
+                WHERE type_id = ut.type_id
+                  AND (model_id = le.model_id OR model_id IS NULL)
+                  AND (provider_id = le.provider_id OR provider_id IS NULL)
+                  AND valid_from <= le.timestamp_request
+                ORDER BY (model_id = le.model_id) DESC NULLS LAST,
+                         (provider_id = le.provider_id) DESC NULLS LAST,
+                         valid_from DESC
+                LIMIT 1
+            ) tp ON true
+            WHERE ut.log_entry_id = le.id
+        ) c ON true
+        WHERE le.team_id = :teamId
+          AND le.privacy_level = 'FULL'
+          AND le.timestamp_request BETWEEN :startTs AND :endTs
+          AND (CAST(:userId AS INTEGER) IS NULL OR le.user_id = CAST(:userId AS INTEGER))
+        ORDER BY le.timestamp_request DESC, le.id DESC
+        LIMIT :limitN
+        """, nativeQuery = true)
+    List<LogExportProjection> findFullTracesForExport(
+        @Param("teamId") int teamId,
+        @Param("startTs") Timestamp startTs,
+        @Param("endTs") Timestamp endTs,
+        @Param("userId") Integer userId,
+        @Param("limitN") int limitN);
+
     @Transactional(readOnly = true)
     @Query(value = """
         SELECT le.request_id AS requestId,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogExportProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogExportProjection.java
@@ -3,7 +3,12 @@ package de.tum.cit.aet.logos.logoswebservice.operations.repository;
 import java.time.Instant;
 
 /**
- * One consent-based (FULL) request trace for the team export (issue #667).
+ * One request trace of the team export (issue #667).
+ *
+ * Every row carries the lifecycle metadata; only the FULL-privacy rows
+ * (the ones the requester consented to) carry non-null content in the
+ * payload columns — a NULL is the answer "no content was stored", and the
+ * envelope makes that explicit.
  *
  * The payload columns are selected as text: the database handshakes JSONB as
  * a string, and the service turns them back into objects before they go out,
@@ -19,9 +24,7 @@ public interface LogExportProjection {
     Instant getTimeAtFirstToken();
     String getPrivacyLevel();
     String getModelName();
-    String getProviderName();
     String getProviderType();
-    Integer getPolicyId();
     String getEnvironment();
     Integer getApiKeyId();
     String getKeyName();
@@ -43,8 +46,6 @@ public interface LogExportProjection {
     Boolean getWasColdStart();
     Float getLoadDurationMs();
     Integer getAvailableVramMb();
-    Integer getAzureRateRemainingRequests();
-    Integer getAzureRateRemainingTokens();
     Long getPromptTokens();
     Long getCompletionTokens();
     Long getTotalTokens();

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogExportProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogExportProjection.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.repository;
+
+import java.time.Instant;
+
+/**
+ * One consent-based (FULL) request trace for the team export (issue #667).
+ *
+ * The payload columns are selected as text: the database handshakes JSONB as
+ * a string, and the service turns them back into objects before they go out,
+ * so a trace reads as structured data in the download rather than a string
+ * that happens to contain JSON.
+ */
+public interface LogExportProjection {
+    Integer getId();
+    String getRequestId();
+    Instant getTimestampRequest();
+    Instant getTimestampForwarding();
+    Instant getTimestampResponse();
+    Instant getTimeAtFirstToken();
+    String getPrivacyLevel();
+    String getModelName();
+    String getProviderName();
+    String getProviderType();
+    Integer getPolicyId();
+    String getEnvironment();
+    Integer getApiKeyId();
+    String getKeyName();
+    String getUsername();
+    String getFullName();
+    String getTeamName();
+    String getClientIp();
+    String getResultStatus();
+    String getErrorMessage();
+    String getPriority();
+    String getInitialPriority();
+    String getPriorityWhenScheduled();
+    Integer getQueueDepthAtEnqueue();
+    Integer getQueueDepthAtSchedule();
+    Integer getQueueDepthAtArrival();
+    Integer getTimeoutS();
+    Float getUtilizationAtArrival();
+    Float getQueueWaitMs();
+    Boolean getWasColdStart();
+    Float getLoadDurationMs();
+    Integer getAvailableVramMb();
+    Integer getAzureRateRemainingRequests();
+    Integer getAzureRateRemainingTokens();
+    Long getPromptTokens();
+    Long getCompletionTokens();
+    Long getTotalTokens();
+    Long getCostMicroCents();
+    String getClassificationStatistics();
+    String getInputPayload();
+    String getHeaders();
+    String getResponsePayload();
+}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
@@ -10,7 +10,9 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.LogLevel;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.Team;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.TeamRepository;
 import de.tum.cit.aet.logos.logoswebservice.operations.repository.LogEntryRepository;
 import de.tum.cit.aet.logos.logoswebservice.operations.repository.LogExportProjection;
@@ -60,15 +62,18 @@ public class TeamActivityService {
     private final LogEntryRepository logEntryRepository;
     private final RequestLogService requestLogService;
     private final TeamRepository teamRepository;
+    private final ApiKeyRepository apiKeyRepository;
     private final ObjectMapper objectMapper;
 
     public TeamActivityService(LogEntryRepository logEntryRepository,
                                RequestLogService requestLogService,
                                TeamRepository teamRepository,
+                               ApiKeyRepository apiKeyRepository,
                                ObjectMapper objectMapper) {
         this.logEntryRepository = logEntryRepository;
         this.requestLogService = requestLogService;
         this.teamRepository = teamRepository;
+        this.apiKeyRepository = apiKeyRepository;
         this.objectMapper = objectMapper;
     }
 
@@ -117,6 +122,10 @@ public class TeamActivityService {
         payload.put("team_id", teamId);
         payload.put("days", days);
         payload.put("since", since.toInstant().toString());
+        // Whether any key of the team is opted into FULL logging, so the view
+        // can say before an export is started that the download will hold no
+        // request or response content (issue #667).
+        payload.put("full_logging_enabled", hasFullLoggingKey(teamId));
         payload.put("live", live);
         payload.put("keys", keys);
         payload.put("total_tokens", totalTokens);
@@ -136,17 +145,20 @@ public class TeamActivityService {
     }
 
     /**
-     * The consent-based traces of one team: every request the orchestrator
-     * recorded at FULL privacy within the window, payloads included (issue
-     * #667). That is the whole point of the opt-in — the requester agreed to
-     * exactly this data being stored, and an administrator of the team is
-     * entitled to take it back out.
+     * The request traces of one team for the export (issue #667).
      *
-     * <p>The window and the narrowing rules are the ones of the activity view
-     * above, so an export and the list it was started from describe the same
-     * slice of traffic. Billing-only rows are not part of the result — the
-     * query does not even read their payloads, and there is no content to
-     * hand over for them anyway.
+     * <p>Every request of the window comes out — the same slice the activity
+     * list shows, so an export is never a mystery of which rows it skipped.
+     * The rows the requester consented to (recorded at FULL privacy) carry
+     * their request and response content; the billing-only rows come out
+     * with the content columns empty, because that is all the platform
+     * stored for them.
+     *
+     * <p>The envelope says how to read that: {@code full_logging_enabled}
+     * reports whether any key of the team is currently opted into FULL
+     * logging, and a {@code note} accompanies the file whenever not a single
+     * row of the export carries content — a download without an explanation
+     * reads as a bug.
      *
      * @param teamId         the team to export; the caller established access
      * @param requestedDays  window, clamped like {@link #getTeamActivity}
@@ -162,7 +174,7 @@ public class TeamActivityService {
         // One row beyond the cap, the same trick the feed uses for has_more:
         // the extra row is the answer to "was anything left behind", and it
         // is dropped before the file goes out.
-        List<LogExportProjection> fetched = logEntryRepository.findFullTracesForExport(
+        List<LogExportProjection> fetched = logEntryRepository.findTracesForExport(
             teamId, since, Timestamp.from(now), userId, EXPORT_MAX_ROWS + 1);
         boolean truncated = fetched.size() > EXPORT_MAX_ROWS;
         List<LogExportProjection> rows = truncated
@@ -170,6 +182,10 @@ public class TeamActivityService {
             : fetched;
 
         String teamName = teamRepository.findById(teamId).map(Team::getName).orElse(null);
+        boolean fullLoggingEnabled = hasFullLoggingKey(teamId);
+        long consentedCount = rows.stream()
+            .filter(p -> "FULL".equals(p.getPrivacyLevel()))
+            .count();
 
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("team_id", teamId);
@@ -177,9 +193,27 @@ public class TeamActivityService {
         result.put("days", days);
         result.put("since", since.toInstant().toString());
         result.put("count", rows.size());
+        result.put("full_logging_enabled", fullLoggingEnabled);
+        if (consentedCount == 0) {
+            // The rows are there but the content is not: name the reason in
+            // the file itself, because an administrator opening it later will
+            // not remember which keys were consented at export time.
+            result.put("note", fullLoggingEnabled
+                ? "No request with full logging in this window: request and response content is empty in every row of this export."
+                : "Full logging is not activated for this team: request and response content was never stored, so it is empty in every row of this export.");
+        }
         result.put("truncated", truncated);
         result.put("traces", rows.stream().map(this::toTrace).toList());
         return result;
+    }
+
+    /**
+     * Whether any active key of the team is opted into FULL logging — the
+     * only switch under which the orchestrator stores request and response
+     * content at all.
+     */
+    private boolean hasFullLoggingKey(int teamId) {
+        return apiKeyRepository.existsByTeamIdAndLogAndIsActive(teamId, LogLevel.FULL, true);
     }
 
     private Map<String, Object> toTrace(LogExportProjection p) {
@@ -191,9 +225,7 @@ public class TeamActivityService {
         m.put("time_at_first_token", ts(p.getTimeAtFirstToken()));
         m.put("privacy_level", p.getPrivacyLevel());
         m.put("model_name", p.getModelName());
-        m.put("provider_name", p.getProviderName());
         m.put("provider_type", p.getProviderType());
-        m.put("policy_id", p.getPolicyId());
         m.put("environment", p.getEnvironment());
         m.put("api_key_id", p.getApiKeyId());
         m.put("api_key_name", p.getKeyName());
@@ -215,8 +247,6 @@ public class TeamActivityService {
         m.put("was_cold_start", p.getWasColdStart());
         m.put("load_duration_ms", p.getLoadDurationMs());
         m.put("available_vram_mb", p.getAvailableVramMb());
-        m.put("azure_rate_remaining_requests", p.getAzureRateRemainingRequests());
-        m.put("azure_rate_remaining_tokens", p.getAzureRateRemainingTokens());
         m.put("prompt_tokens", p.getPromptTokens());
         m.put("completion_tokens", p.getCompletionTokens());
         m.put("total_tokens", p.getTotalTokens());
@@ -232,8 +262,8 @@ public class TeamActivityService {
      * Back to structured data for the download. The database returns JSONB as
      * text, and a trace whose payload is a string that merely contains JSON
      * is one layer harder to read than it should be. A column that is NULL
-     * stays NULL: billing-only rows never reached this method, but a FULL
-     * request whose response was never stored must still read as absent
+     * stays NULL: a billing-only request stored no content at all, and a
+     * FULL request whose response was never stored must read as absent
      * rather than as an empty object.
      */
     private Object json(String text) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
@@ -253,9 +253,28 @@ public class TeamActivityService {
         m.put("cost_microcents", p.getCostMicroCents());
         m.put("classification_statistics", json(p.getClassificationStatistics()));
         m.put("input_payload", json(p.getInputPayload()));
-        m.put("headers", json(p.getHeaders()));
+        m.put("headers", stripAuthorizationHeader(json(p.getHeaders())));
         m.put("response_payload", json(p.getResponsePayload()));
         return m;
+    }
+
+    /**
+     * The headers were stored the way the request carried them — which means
+     * the authorization header holds a working API key, in the clear. The
+     * export is the administrator's trace of the team's traffic, not a
+     * credential dump: a team owner reading this file must not be able to
+     * impersonate any of their members, so the key comes out on the way.
+     * The remaining headers (content-type, user-agent, …) stay.
+     */
+    private Object stripAuthorizationHeader(Object headers) {
+        if (!(headers instanceof Map<?, ?> stored)) return headers;
+        Map<String, Object> redacted = new LinkedHashMap<>();
+        stored.forEach((name, value) -> {
+            if (!"authorization".equalsIgnoreCase(String.valueOf(name))) {
+                redacted.put(String.valueOf(name), value);
+            }
+        });
+        return redacted;
     }
 
     /**

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
@@ -7,9 +7,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.Team;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.TeamRepository;
 import de.tum.cit.aet.logos.logoswebservice.operations.repository.LogEntryRepository;
+import de.tum.cit.aet.logos.logoswebservice.operations.repository.LogExportProjection;
 import de.tum.cit.aet.logos.logoswebservice.operations.repository.ScopeOptionProjection;
 import de.tum.cit.aet.logos.logoswebservice.operations.repository.TeamActivityProjections;
 
@@ -44,13 +48,28 @@ public class TeamActivityService {
     /** Rows of the request list per page. */
     private static final int REQUEST_PAGE_SIZE = 20;
 
+    /**
+     * Ceiling of one trace export. A consented team on a busy month can outrun
+     * a download that still fits in a browser tab; the export then keeps the
+     * newest slice and says so, instead of hanging on a multi-hundred-megabyte
+     * file. The caller narrows with a shorter window or the requester filter
+     * to get the rest.
+     */
+    private static final int EXPORT_MAX_ROWS = 10_000;
+
     private final LogEntryRepository logEntryRepository;
     private final RequestLogService requestLogService;
+    private final TeamRepository teamRepository;
+    private final ObjectMapper objectMapper;
 
     public TeamActivityService(LogEntryRepository logEntryRepository,
-                               RequestLogService requestLogService) {
+                               RequestLogService requestLogService,
+                               TeamRepository teamRepository,
+                               ObjectMapper objectMapper) {
         this.logEntryRepository = logEntryRepository;
         this.requestLogService = requestLogService;
+        this.teamRepository = teamRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -116,6 +135,119 @@ public class TeamActivityService {
         return payload;
     }
 
+    /**
+     * The consent-based traces of one team: every request the orchestrator
+     * recorded at FULL privacy within the window, payloads included (issue
+     * #667). That is the whole point of the opt-in — the requester agreed to
+     * exactly this data being stored, and an administrator of the team is
+     * entitled to take it back out.
+     *
+     * <p>The window and the narrowing rules are the ones of the activity view
+     * above, so an export and the list it was started from describe the same
+     * slice of traffic. Billing-only rows are not part of the result — the
+     * query does not even read their payloads, and there is no content to
+     * hand over for them anyway.
+     *
+     * @param teamId         the team to export; the caller established access
+     * @param requestedDays  window, clamped like {@link #getTeamActivity}
+     * @param userId         narrow to one requester, or {@code null} for all
+     * @return the export envelope: window metadata plus the {@code traces}
+     *         array the download is built from
+     */
+    public Map<String, Object> exportTeamTraces(int teamId, Integer requestedDays, Integer userId) {
+        int days = clampDays(requestedDays);
+        Instant now = Instant.now();
+        Timestamp since = Timestamp.from(now.minus(Duration.ofDays(days)));
+
+        // One row beyond the cap, the same trick the feed uses for has_more:
+        // the extra row is the answer to "was anything left behind", and it
+        // is dropped before the file goes out.
+        List<LogExportProjection> fetched = logEntryRepository.findFullTracesForExport(
+            teamId, since, Timestamp.from(now), userId, EXPORT_MAX_ROWS + 1);
+        boolean truncated = fetched.size() > EXPORT_MAX_ROWS;
+        List<LogExportProjection> rows = truncated
+            ? fetched.subList(0, EXPORT_MAX_ROWS)
+            : fetched;
+
+        String teamName = teamRepository.findById(teamId).map(Team::getName).orElse(null);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("team_id", teamId);
+        result.put("team_name", teamName);
+        result.put("days", days);
+        result.put("since", since.toInstant().toString());
+        result.put("count", rows.size());
+        result.put("truncated", truncated);
+        result.put("traces", rows.stream().map(this::toTrace).toList());
+        return result;
+    }
+
+    private Map<String, Object> toTrace(LogExportProjection p) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("request_id", p.getRequestId());
+        m.put("timestamp_request", ts(p.getTimestampRequest()));
+        m.put("timestamp_forwarding", ts(p.getTimestampForwarding()));
+        m.put("timestamp_response", ts(p.getTimestampResponse()));
+        m.put("time_at_first_token", ts(p.getTimeAtFirstToken()));
+        m.put("privacy_level", p.getPrivacyLevel());
+        m.put("model_name", p.getModelName());
+        m.put("provider_name", p.getProviderName());
+        m.put("provider_type", p.getProviderType());
+        m.put("policy_id", p.getPolicyId());
+        m.put("environment", p.getEnvironment());
+        m.put("api_key_id", p.getApiKeyId());
+        m.put("api_key_name", p.getKeyName());
+        m.put("username", p.getUsername());
+        m.put("full_name", p.getFullName());
+        m.put("team_name", p.getTeamName());
+        m.put("client_ip", p.getClientIp());
+        m.put("status", p.getResultStatus() != null ? p.getResultStatus() : "pending");
+        m.put("error_message", p.getErrorMessage());
+        m.put("priority", p.getPriority());
+        m.put("initial_priority", p.getInitialPriority());
+        m.put("priority_when_scheduled", p.getPriorityWhenScheduled());
+        m.put("queue_depth_at_enqueue", p.getQueueDepthAtEnqueue());
+        m.put("queue_depth_at_schedule", p.getQueueDepthAtSchedule());
+        m.put("queue_depth_at_arrival", p.getQueueDepthAtArrival());
+        m.put("timeout_s", p.getTimeoutS());
+        m.put("utilization_at_arrival", p.getUtilizationAtArrival());
+        m.put("queue_wait_ms", p.getQueueWaitMs());
+        m.put("was_cold_start", p.getWasColdStart());
+        m.put("load_duration_ms", p.getLoadDurationMs());
+        m.put("available_vram_mb", p.getAvailableVramMb());
+        m.put("azure_rate_remaining_requests", p.getAzureRateRemainingRequests());
+        m.put("azure_rate_remaining_tokens", p.getAzureRateRemainingTokens());
+        m.put("prompt_tokens", p.getPromptTokens());
+        m.put("completion_tokens", p.getCompletionTokens());
+        m.put("total_tokens", p.getTotalTokens());
+        m.put("cost_microcents", p.getCostMicroCents());
+        m.put("classification_statistics", json(p.getClassificationStatistics()));
+        m.put("input_payload", json(p.getInputPayload()));
+        m.put("headers", json(p.getHeaders()));
+        m.put("response_payload", json(p.getResponsePayload()));
+        return m;
+    }
+
+    /**
+     * Back to structured data for the download. The database returns JSONB as
+     * text, and a trace whose payload is a string that merely contains JSON
+     * is one layer harder to read than it should be. A column that is NULL
+     * stays NULL: billing-only rows never reached this method, but a FULL
+     * request whose response was never stored must still read as absent
+     * rather than as an empty object.
+     */
+    private Object json(String text) {
+        if (text == null || text.isBlank()) return null;
+        try {
+            return objectMapper.readValue(text, Object.class);
+        } catch (Exception e) {
+            // JSONB is valid JSON by construction; reaching this means the
+            // column stopped being what the schema says. Keep the raw text
+            // rather than dropping the trace's data.
+            return text;
+        }
+    }
+
     private static List<Map<String, Object>> toScopeOptions(List<ScopeOptionProjection> rows) {
         return rows.stream()
             .map(p -> {
@@ -144,5 +276,9 @@ public class TeamActivityService {
     private static int clampDays(Integer requested) {
         if (requested == null) return DEFAULT_DAYS;
         return Math.max(1, Math.min(MAX_DAYS, requested));
+    }
+
+    private static String ts(Instant t) {
+        return t != null ? t.toString() : null;
     }
 }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
@@ -29,8 +29,10 @@ import de.tum.cit.aet.logos.logoswebservice.TestJwt;
  * down what the export shows: every request of the window, with the content
  * columns filled only where the requester consented — an export must
  * describe the same slice of traffic the activity list does, not a silently
- * smaller one. The added key 3009 turns full logging on for 2001 (the shared
- * keys are all at the BILLING default), so the "activated" and the "not
+ * smaller one. 9003's stored headers additionally carry an authorization
+ * header with a working API key, which the export must strip on the way
+ * out. The added key 3009 turns full logging on for 2001 (the shared keys
+ * are all at the BILLING default), so the "activated" and the "not
  * activated" sides of the envelope hint are both covered by the seeded
  * teams: 2002 has no keys and no traffic at all.
  * User 1002 is an app admin owning 2001; team 2002 exists and they do not own
@@ -146,6 +148,21 @@ class TeamActivityExportControllerTest {
            .andExpect(jsonPath("$.traces[0].client_ip").value(nullValue()))
            .andExpect(jsonPath("$.traces[2].privacy_level").value("BILLING"))
            .andExpect(jsonPath("$.traces[2].input_payload").value(nullValue()));
+    }
+
+    @Test
+    void theAuthorizationHeaderNeverLeavesTheExport() throws Exception {
+        // The stored headers carry the request's API key in the clear
+        // (authorization: Bearer lg-…). An export that hands that back would
+        // let a team owner impersonate any of their members — the key is
+        // stripped on the way out, the remaining headers stay.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.traces[1].headers['authorization']").doesNotExist())
+           .andExpect(jsonPath("$.traces[1].headers['content-type']").value("application/json"));
     }
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,15 +20,21 @@ import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
 import de.tum.cit.aet.logos.logoswebservice.TestJwt;
 
 /**
- * The consent-based trace export (issue #667).
+ * The request trace export (issue #667).
  *
- * The export seed adds two rows to the shared operations seed, both in team
- * 2001 within the window: 9003 was recorded at FULL privacy and carries the
- * request and response payloads, 9004 is billing-only. Together with the
- * shared 9001 (also billing-only) they pin down the one rule that makes this
- * endpoint different from the activity view: only consented rows come back.
+ * The export seed adds two rows and one key to the shared operations seed.
+ * Both rows sit in team 2001 within the window: 9003 was recorded at FULL
+ * privacy and carries the request and response payloads, 9004 is
+ * billing-only. Together with the shared 9001 (also billing-only) they pin
+ * down what the export shows: every request of the window, with the content
+ * columns filled only where the requester consented — an export must
+ * describe the same slice of traffic the activity list does, not a silently
+ * smaller one. The added key 3009 turns full logging on for 2001 (the shared
+ * keys are all at the BILLING default), so the "activated" and the "not
+ * activated" sides of the envelope hint are both covered by the seeded
+ * teams: 2002 has no keys and no traffic at all.
  * User 1002 is an app admin owning 2001; team 2002 exists and they do not own
- * it, and it has no traffic at all.
+ * it.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -104,24 +112,61 @@ class TeamActivityExportControllerTest {
     // ── Content ──────────────────────────────────────────────────────────────
 
     @Test
-    void itCarriesTheFullRequestAndResponsePayloads() throws Exception {
-        // The point of the opt-in: what the requester agreed to be stored is
-        // what the download contains, structured rather than as a string that
-        // happens to hold JSON.
+    void itCarriesEveryRequestOfTheWindowNewestFirst() throws Exception {
+        // The export must describe the same slice of traffic the activity
+        // list shows: the two billing rows come back right next to the
+        // consented one, in the same newest-first order the feed reads.
         mvc.perform(post("/logosdb/teams/2001/activity/export")
                 .with(TestJwt.adminUser())
                 .contentType("application/json")
                 .content("{}"))
            .andExpect(status().isOk())
-           .andExpect(jsonPath("$.traces.length()").value(1))
-           .andExpect(jsonPath("$.traces[0].request_id").value("req-ccc-333"))
-           .andExpect(jsonPath("$.traces[0].privacy_level").value("FULL"))
-           .andExpect(jsonPath("$.traces[0].input_payload.model").value("gpt-4"))
-           .andExpect(jsonPath("$.traces[0].input_payload.messages[0].content").value("Hello, Logos"))
-           .andExpect(jsonPath("$.traces[0].response_payload.choices[0].message.content")
+           .andExpect(jsonPath("$.count").value(3))
+           .andExpect(jsonPath("$.truncated").value(false))
+           .andExpect(jsonPath("$.traces.length()").value(3))
+           .andExpect(jsonPath("$.traces[0].request_id").value("req-ddd-444"))
+           .andExpect(jsonPath("$.traces[1].request_id").value("req-ccc-333"))
+           .andExpect(jsonPath("$.traces[2].request_id").value("req-aaa-111"));
+    }
+
+    @Test
+    void billingRowsComeOutWithEmptyContent() throws Exception {
+        // Nothing was stored for a request the requester did not consent to,
+        // and the row says exactly that: present like every other request,
+        // the content columns simply empty.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.traces[0].privacy_level").value("BILLING"))
+           .andExpect(jsonPath("$.traces[0].input_payload").value(nullValue()))
+           .andExpect(jsonPath("$.traces[0].response_payload").value(nullValue()))
+           .andExpect(jsonPath("$.traces[0].headers").value(nullValue()))
+           .andExpect(jsonPath("$.traces[0].client_ip").value(nullValue()))
+           .andExpect(jsonPath("$.traces[2].privacy_level").value("BILLING"))
+           .andExpect(jsonPath("$.traces[2].input_payload").value(nullValue()));
+    }
+
+    @Test
+    void itCarriesTheFullRequestAndResponsePayloads() throws Exception {
+        // The point of the opt-in: what the requester agreed to be stored is
+        // what the download contains, structured rather than as a string that
+        // happens to hold JSON. The consented row sits between the two
+        // billing ones, newest first.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.traces[1].request_id").value("req-ccc-333"))
+           .andExpect(jsonPath("$.traces[1].privacy_level").value("FULL"))
+           .andExpect(jsonPath("$.traces[1].input_payload.model").value("gpt-4"))
+           .andExpect(jsonPath("$.traces[1].input_payload.messages[0].content").value("Hello, Logos"))
+           .andExpect(jsonPath("$.traces[1].response_payload.choices[0].message.content")
                 .value("Hi there!"))
-           .andExpect(jsonPath("$.traces[0].headers['content-type']").value("application/json"))
-           .andExpect(jsonPath("$.traces[0].client_ip").value("127.0.0.1"));
+           .andExpect(jsonPath("$.traces[1].headers['content-type']").value("application/json"))
+           .andExpect(jsonPath("$.traces[1].client_ip").value("127.0.0.1"));
     }
 
     @Test
@@ -131,33 +176,17 @@ class TeamActivityExportControllerTest {
                 .contentType("application/json")
                 .content("{}"))
            .andExpect(status().isOk())
-           .andExpect(jsonPath("$.traces[0].username").value("testuser"))
-           .andExpect(jsonPath("$.traces[0].full_name").value("Test User"))
-           .andExpect(jsonPath("$.traces[0].api_key_name").value("dev key"))
-           .andExpect(jsonPath("$.traces[0].model_name").value("gpt-4"))
-           .andExpect(jsonPath("$.traces[0].provider_name").value("openai-provider"))
-           .andExpect(jsonPath("$.traces[0].status").value("success"));
+           .andExpect(jsonPath("$.traces[1].username").value("testuser"))
+           .andExpect(jsonPath("$.traces[1].full_name").value("Test User"))
+           .andExpect(jsonPath("$.traces[1].api_key_name").value("dev key"))
+           .andExpect(jsonPath("$.traces[1].model_name").value("gpt-4"))
+           .andExpect(jsonPath("$.traces[1].status").value("success"));
     }
 
     @Test
-    void billingOnlyRequestsStayOutOfTheExport() throws Exception {
-        // 9004 (billing-only, same window) and the shared 9001 (billing-only
-        // default) both sit in team 2001. The count says the filter worked:
-        // the export holds the single consented row and nothing else.
-        mvc.perform(post("/logosdb/teams/2001/activity/export")
-                .with(TestJwt.adminUser())
-                .contentType("application/json")
-                .content("{}"))
-           .andExpect(status().isOk())
-           .andExpect(jsonPath("$.count").value(1))
-           .andExpect(jsonPath("$.truncated").value(false))
-           .andExpect(jsonPath("$.traces[0].request_id").value("req-ccc-333"));
-    }
-
-    @Test
-    void aTeamWithoutConsentedTrafficExportsAnEmptySet() throws Exception {
+    void aTeamWithoutTrafficExportsAnEmptySet() throws Exception {
         // No rows at all, but the file is still a well-formed empty set — the
-        // download must not fail just because the team never opted in.
+        // download must not fail just because the team never sent anything.
         mvc.perform(post("/logosdb/teams/2002/activity/export")
                 .with(TestJwt.logosAdmin())
                 .contentType("application/json")
@@ -175,17 +204,68 @@ class TeamActivityExportControllerTest {
                 .contentType("application/json")
                 .content("{\"user_id\": 1001}"))
            .andExpect(status().isOk())
-           .andExpect(jsonPath("$.count").value(1));
+           .andExpect(jsonPath("$.count").value(3));
 
-        // A requester who sent no consented traffic in the team narrows to
-        // nothing — the team scope still applies on top, like in the activity
-        // view, so this can only ever cut the set down further.
+        // A requester who sent no traffic in the team narrows to nothing —
+        // the team scope still applies on top, like in the activity view, so
+        // this can only ever cut the set down further.
         mvc.perform(post("/logosdb/teams/2001/activity/export")
                 .with(TestJwt.adminUser())
                 .contentType("application/json")
                 .content("{\"user_id\": 1003}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.count").value(0));
+    }
+
+    // ── The consent hint ─────────────────────────────────────────────────────
+
+    @Test
+    void theEnvelopeSaysWhetherFullLoggingIsActivated() throws Exception {
+        // 2001 has the added full key, so the download can say so — and with
+        // a consented row on board there is nothing to explain, so no note.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.full_logging_enabled").value(true))
+           .andExpect(jsonPath("$.note").doesNotExist());
+
+        // 2002 has no keys at all: the note must name the reason the content
+        // of the file is empty.
+        mvc.perform(post("/logosdb/teams/2002/activity/export")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.full_logging_enabled").value(false))
+           .andExpect(jsonPath("$.note").value(containsString("not activated")));
+    }
+
+    @Test
+    void theNoteExplainsConsentedTrafficWithoutAConsentSwitch() throws Exception {
+        // Full logging is on for 2001, but this requester never sent a
+        // consented request: the note has to say there was no full-logging
+        // traffic in the window, not that nobody consented.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{\"user_id\": 1003}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.full_logging_enabled").value(true))
+           .andExpect(jsonPath("$.note").value(containsString("No request with full logging")));
+    }
+
+    @Test
+    void theActivityViewCarriesTheSameFlag() throws Exception {
+        // The tab shows the hint before the export is even started, so the
+        // flag lives on the activity payload, not only on the envelope.
+        mvc.perform(post("/logosdb/teams/2001/activity")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.full_logging_enabled").value(true));
     }
 
     // ── Window ───────────────────────────────────────────────────────────────

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/TeamActivityExportControllerTest.java
@@ -1,0 +1,221 @@
+package de.tum.cit.aet.logos.logoswebservice.operations;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
+import de.tum.cit.aet.logos.logoswebservice.TestJwt;
+
+/**
+ * The consent-based trace export (issue #667).
+ *
+ * The export seed adds two rows to the shared operations seed, both in team
+ * 2001 within the window: 9003 was recorded at FULL privacy and carries the
+ * request and response payloads, 9004 is billing-only. Together with the
+ * shared 9001 (also billing-only) they pin down the one rule that makes this
+ * endpoint different from the activity view: only consented rows come back.
+ * User 1002 is an app admin owning 2001; team 2002 exists and they do not own
+ * it, and it has no traffic at all.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestContainersConfig.class)
+@TestPropertySource(properties = {
+    "spring.liquibase.enabled=true",
+    "spring.liquibase.change-log=classpath:liquibase/changelog/master.xml",
+    "logos.auth.roles.logos-admin=itg-admin",
+    "logos.auth.roles.app-admin=chair-member",
+    "logos.auth.sync-debounce-minutes=5"
+})
+@Sql(scripts = {"/sql/seed-identity.sql", "/sql/seed-configuration.sql", "/sql/seed-operations.sql",
+     "/sql/seed-operations-export.sql"},
+     executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"/sql/cleanup-operations-export.sql", "/sql/cleanup-operations.sql",
+     "/sql/cleanup-configuration.sql", "/sql/cleanup-identity.sql"},
+     executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class TeamActivityExportControllerTest {
+
+    @Autowired MockMvc mvc;
+    @MockitoBean JwtDecoder jwtDecoder;
+
+    // ── Access ───────────────────────────────────────────────────────────────
+
+    @Test
+    void anAppAdminExportsTheTracesOfTheirOwnTeam() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.team_id").value(2001));
+    }
+
+    @Test
+    void anAppAdminIsRefusedATeamTheyDoNotOwn() throws Exception {
+        // The export carries request content, which is the most sensitive
+        // thing the platform stores. The ownership gate is not negotiable.
+        mvc.perform(post("/logosdb/teams/2002/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void aLogosAdminExportsAnyTeam() throws Exception {
+        mvc.perform(post("/logosdb/teams/2002/activity/export")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.team_id").value(2002));
+    }
+
+    @Test
+    void aPlainDeveloperIsRefused() throws Exception {
+        // 1001 is a member of 2001, but reading the team's stored content is
+        // an admin job — the role gate applies like on the activity view.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.testUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void unauthenticatedIsRefused() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isUnauthorized());
+    }
+
+    // ── Content ──────────────────────────────────────────────────────────────
+
+    @Test
+    void itCarriesTheFullRequestAndResponsePayloads() throws Exception {
+        // The point of the opt-in: what the requester agreed to be stored is
+        // what the download contains, structured rather than as a string that
+        // happens to hold JSON.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.traces.length()").value(1))
+           .andExpect(jsonPath("$.traces[0].request_id").value("req-ccc-333"))
+           .andExpect(jsonPath("$.traces[0].privacy_level").value("FULL"))
+           .andExpect(jsonPath("$.traces[0].input_payload.model").value("gpt-4"))
+           .andExpect(jsonPath("$.traces[0].input_payload.messages[0].content").value("Hello, Logos"))
+           .andExpect(jsonPath("$.traces[0].response_payload.choices[0].message.content")
+                .value("Hi there!"))
+           .andExpect(jsonPath("$.traces[0].headers['content-type']").value("application/json"))
+           .andExpect(jsonPath("$.traces[0].client_ip").value("127.0.0.1"));
+    }
+
+    @Test
+    void itNamesWhoSentTheTraceAndWithWhichKey() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.traces[0].username").value("testuser"))
+           .andExpect(jsonPath("$.traces[0].full_name").value("Test User"))
+           .andExpect(jsonPath("$.traces[0].api_key_name").value("dev key"))
+           .andExpect(jsonPath("$.traces[0].model_name").value("gpt-4"))
+           .andExpect(jsonPath("$.traces[0].provider_name").value("openai-provider"))
+           .andExpect(jsonPath("$.traces[0].status").value("success"));
+    }
+
+    @Test
+    void billingOnlyRequestsStayOutOfTheExport() throws Exception {
+        // 9004 (billing-only, same window) and the shared 9001 (billing-only
+        // default) both sit in team 2001. The count says the filter worked:
+        // the export holds the single consented row and nothing else.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.count").value(1))
+           .andExpect(jsonPath("$.truncated").value(false))
+           .andExpect(jsonPath("$.traces[0].request_id").value("req-ccc-333"));
+    }
+
+    @Test
+    void aTeamWithoutConsentedTrafficExportsAnEmptySet() throws Exception {
+        // No rows at all, but the file is still a well-formed empty set — the
+        // download must not fail just because the team never opted in.
+        mvc.perform(post("/logosdb/teams/2002/activity/export")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.count").value(0))
+           .andExpect(jsonPath("$.truncated").value(false))
+           .andExpect(jsonPath("$.traces").isEmpty());
+    }
+
+    @Test
+    void theUserFilterNarrowsTheExport() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{\"user_id\": 1001}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.count").value(1));
+
+        // A requester who sent no consented traffic in the team narrows to
+        // nothing — the team scope still applies on top, like in the activity
+        // view, so this can only ever cut the set down further.
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{\"user_id\": 1003}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.count").value(0));
+    }
+
+    // ── Window ───────────────────────────────────────────────────────────────
+
+    @Test
+    void theWindowIsClampedJustLikeTheActivityView() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{\"days\": 100000}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.days").value(90));
+
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{\"days\": 0}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.days").value(1));
+    }
+
+    @Test
+    void theExportNamesTheTeamAndItsWindow() throws Exception {
+        mvc.perform(post("/logosdb/teams/2001/activity/export")
+                .with(TestJwt.adminUser())
+                .contentType("application/json")
+                .content("{}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.team_name").value("test-team"))
+           .andExpect(jsonPath("$.days").value(7))
+           .andExpect(jsonPath("$.since").isNotEmpty());
+    }
+}

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-operations-export.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-operations-export.sql
@@ -1,0 +1,1 @@
+DELETE FROM log_entry WHERE id IN (9003, 9004);

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-operations-export.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-operations-export.sql
@@ -1,1 +1,2 @@
+DELETE FROM api_keys WHERE id = 3009;
 DELETE FROM log_entry WHERE id IN (9003, 9004);

--- a/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
@@ -1,0 +1,27 @@
+-- Export-only fixtures (issue #667), kept in their own file so the shared
+-- operations seed stays untouched for the other test classes.
+
+-- Consent-based (FULL) trace: the requester opted into full logging, so the
+-- request and response data was stored and belongs in the export.
+INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
+                       timestamp_request, timestamp_forwarding, timestamp_response,
+                       privacy_level, client_ip, input_payload, headers, response_payload,
+                       was_cold_start, queue_depth_at_enqueue, user_id, team_id, environment)
+VALUES
+  (9003, 'req-ccc-333', 3001, 5001, 6001, 'success',
+   NOW() - INTERVAL '6 minutes', NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes',
+   'FULL', '127.0.0.1',
+   '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello, Logos"}]}'::jsonb,
+   '{"content-type": "application/json"}'::jsonb,
+   '{"choices": [{"message": {"role": "assistant", "content": "Hi there!"}}]}'::jsonb,
+   false, 1, 1001, 2001, NULL);
+
+-- Billing-only row in the same team and window: no content was stored for it,
+-- so it must stay out of the export.
+INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
+                       timestamp_request, timestamp_forwarding, timestamp_response,
+                       privacy_level, user_id, team_id)
+VALUES
+  (9004, 'req-ddd-444', 3001, 5001, 6001, 'success',
+   NOW() - INTERVAL '3 minutes', NOW() - INTERVAL '2 minutes', NOW() - INTERVAL '1 minute',
+   'BILLING', 1001, 2001);

--- a/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
@@ -17,7 +17,7 @@ VALUES
    false, 1, 1001, 2001, NULL);
 
 -- Billing-only row in the same team and window: no content was stored for it,
--- so it must stay out of the export.
+-- but it is still part of the export — with the content columns empty.
 INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
                        timestamp_request, timestamp_forwarding, timestamp_response,
                        privacy_level, user_id, team_id)
@@ -25,3 +25,9 @@ VALUES
   (9004, 'req-ddd-444', 3001, 5001, 6001, 'success',
    NOW() - INTERVAL '3 minutes', NOW() - INTERVAL '2 minutes', NOW() - INTERVAL '1 minute',
    'BILLING', 1001, 2001);
+
+-- A second key of team 2001, opted into full logging: the shared seed keys
+-- are all at the BILLING default, and the view needs one team where
+-- full_logging_enabled is true.
+INSERT INTO api_keys (id, key_value, name, key_type, user_id, team_id, is_active, log)
+VALUES (3009, 'full-key-9', 'full key', 'developer', 1001, 2001, true, 'FULL');

--- a/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-operations-export.sql
@@ -2,7 +2,9 @@
 -- operations seed stays untouched for the other test classes.
 
 -- Consent-based (FULL) trace: the requester opted into full logging, so the
--- request and response data was stored and belongs in the export.
+-- request and response data was stored and belongs in the export. The stored
+-- headers are the request's headers, which means the authorization header
+-- holds a working API key — exactly what the export must not hand back.
 INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
                        timestamp_request, timestamp_forwarding, timestamp_response,
                        privacy_level, client_ip, input_payload, headers, response_payload,
@@ -12,7 +14,7 @@ VALUES
    NOW() - INTERVAL '6 minutes', NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes',
    'FULL', '127.0.0.1',
    '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello, Logos"}]}'::jsonb,
-   '{"content-type": "application/json"}'::jsonb,
+   '{"content-type": "application/json", "authorization": "Bearer lg-9c4e5f6a7b8c9d0e1f2a3b4c5d6e7f80"}'::jsonb,
    '{"choices": [{"message": {"role": "assistant", "content": "Hi there!"}}]}'::jsonb,
    false, 1, 1001, 2001, NULL);
 


### PR DESCRIPTION
Fixes #667

## Summary

App admins can now export the request traces of their teams from the web UI. "Consent-based logging" in Logos is the per-API-key opt-in to **FULL** privacy logging (the BILLING/FULL toggle in My Workspace / API key editor): only for those requests does the orchestrator store the actual request and response content. This PR adds an endpoint that hands the team's requests back to its administrators, and an export control (JSON or CSV) in the team detail **Activity** tab.

The export carries the **same slice of traffic the Activity list shows** — every request of the selected period and requester. The consented (FULL-privacy) rows come with their stored request/response content; the billing-only rows keep the same columns with the content fields empty, because that is all the platform stored for them. So the export never silently skips rows: a team without full logging gets its full request history, plus a hint (in the tab and in the file) explaining why the content columns are empty.

## Changes

### logos-webservice
- `operations/controller/TeamActivityController.java` — new `POST /logosdb/teams/{teamId}/activity/export`. Same gate and rules as the activity view it extends: `logos_admin` may export any team, `app_admin` only a team they own (403 otherwise), `app_developer` is refused (403), unauthenticated 401. The team id comes from the path, so the scope cannot be widened through the body; `days` (clamped 1..90) and `user_id` (narrowing only) work exactly like on `.../activity`.
- `operations/repository/LogEntryRepository.java` — new `findTracesForExport`: selects every `log_entry` row of the team inside the window, joining the same token/cost lateral subqueries the request feed uses so exported numbers can never disagree with the feed; newest first, `LIMIT`-capped. Internal-only columns are not selected at all (`provider_name`, `policy_id`, the two `azure_rate_remaining_*`).
- `operations/repository/LogExportProjection.java` — projection for the query (payload JSONB columns selected as text).
- `operations/service/TeamActivityService.java` — new `exportTeamTraces`: builds the export envelope (`team_id`, `team_name`, `days`, `since`, `count`, `full_logging_enabled`, `truncated`, `traces`), parses the JSONB payload strings back into structured objects, and caps one export at 10,000 rows (newest slice, `truncated: true` when more existed). Whenever no row of the export carries content, a `note` in the envelope explains why — worded for "full logging not activated" and "activated, but no such request in this window". The activity payload additionally gains `full_logging_enabled`, so the tab can show the hint before the download is started. **Redaction:** the stored headers are the request's own headers, so `authorization` carries a working API key in the clear — `exportTeamTraces` strips it (case-insensitively) before anything goes out; a team owner must not be able to download functional keys of their members. The remaining headers stay.
- `identity/repository/ApiKeyRepository.java` — `existsByTeamIdAndLogAndIsActive` (does any active key of the team sit on FULL logging).

### logos-ui
- `features/team-detail/tabs/activity/activity-tab.html/.ts/.scss` — format select (JSON/CSV) + download button in the Requests toolbar; follows the selected period and requester filter. A quiet hint under the toolbar appears while no key of the team has full logging activated. The JSON file is the server envelope as-is; the CSV is cut client-side from the same envelope (the same Blob/anchor download pattern the import-credentials CSV uses), one row per trace, structured fields embedded as compact JSON with proper quoting/escaping (`TRACE_CSV_COLUMNS`, `tracesToCsv`, `traceCsvCell`).
- `features/team-detail/tabs/activity/activity-tab.service.ts` — `getTraceExport`.
- `features/team-detail/tabs/activity/activity-tab.models.ts` — `TraceExport` / `TraceExportItem` types.

No schema change: the consent flag (`api_keys.log` → `log_entry.privacy_level`) and the payload columns already exist; the orchestrator already writes them for consented keys. No new Traefik route needed (`/api/logosdb/*` is already routed to the webservice).

## New Endpoint

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/api/logosdb/teams/{teamId}/activity/export` | `logos_admin` (any team) / `app_admin` (owned team) | Export the team's requests of the window; the consented (FULL) rows include request/response content |

Body (all optional): `{ "days": 1..90 (default 7), "user_id": <narrow to one requester> }`

## Testing

- `TeamActivityExportControllerTest` (17 tests, Testcontainers Postgres + real Liquibase schema): access matrix (app_admin own team OK / foreign team 403 / logos_admin any team / developer 403 / anonymous 401), every request of the window comes out newest first, billing rows present with null content columns, FULL row's payloads and headers come back structured, the authorization header is stripped from the exported headers while the remaining headers stay, empty team exports a well-formed empty set, requester narrowing, window clamping, envelope metadata, the `full_logging_enabled` flag on both export and activity payloads, and both `note` wordings. Uses dedicated `seed-operations-export.sql` / `cleanup-operations-export.sql` (the FULL row's headers carry a `Bearer lg-…` key the test asserts never comes back) so the shared fixtures of the other operations tests are untouched.
- `activity-tab.spec.ts` additions (Vitest, same setup as the existing specs): CSV cell escaping (commas, quotes, newlines, structured values as compact JSON), row/header shape, the export hint (shown only while no key has full logging), and the component's export flow (server call args, downloaded filename/content-type/content, format validation, error reporting).
- Run locally:
  - `cd logos/logos-webservice && mvn -B test` → **267 tests, 0 failures**
  - `cd logos/logos-ui && npm test` → **63 tests, 0 failures**; `npm run build` succeeds (the initial-bundle budget warning is pre-existing — identical on clean main)

## Merge note

Merged `origin/main` into the branch (PR #804/#809 landed in the same Activity-tab area between branch creation and review): the activity-tab spec add/add conflict is resolved by keeping the main-side suite and appending the new export describes; component, template, models and service merged without semantic overlap. All suites re-run green on the merged tree. (The repo-wide "Pull Request" docs workflow reports `startup_failure` for this branch and for other open PRs alike — pre-existing, unrelated to this change.)
