### PR TITLE
`Logos`: Make calibration the single source of truth for tensor_parallel_size

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5888,14 +5888,15 @@ class CapacityPlanner:
         Only infers TP > 1 when the model clearly won't fit on a single GPU.
         Returns None if inference is not possible or TP=1 is sufficient.
 
-        Calibrated profiles are never inferred: their tensor_parallel_size is
+        Calibrated profiles are the exception: their tensor_parallel_size is
         the single source of truth (the calibrator probed this hardware and
-        the profile's residency/KV data were measured under that TP). The
-        callers already apply profile.tensor_parallel_size when it is > 1, so
-        this only matters for a calibrated TP=1 — inferring off the calibrated
-        base_residency (the full awake footprint, often most of a GPU) would
-        escalate it to a higher TP and overwrite the calibrated verdict with
-        data measured at a different parallelism (issue #616).
+        the profile's residency/KV data were measured under that TP), so it
+        is returned as-is — even TP=1, which all callers treat as "no
+        escalation" via their ``> 1`` checks. This matters for a calibrated
+        TP=1: inferring off the calibrated base_residency (the full awake
+        footprint, often most of a GPU) would escalate it to a higher TP and
+        overwrite the calibrated verdict with data measured at a different
+        parallelism (issue #616).
         """
         import math
 

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5887,8 +5887,20 @@ class CapacityPlanner:
 
         Only infers TP > 1 when the model clearly won't fit on a single GPU.
         Returns None if inference is not possible or TP=1 is sufficient.
+
+        Calibrated profiles are never inferred: their tensor_parallel_size is
+        the single source of truth (the calibrator probed this hardware and
+        the profile's residency/KV data were measured under that TP). The
+        callers already apply profile.tensor_parallel_size when it is > 1, so
+        this only matters for a calibrated TP=1 — inferring off the calibrated
+        base_residency (the full awake footprint, often most of a GPU) would
+        escalate it to a higher TP and overwrite the calibrated verdict with
+        data measured at a different parallelism (issue #616).
         """
         import math
+
+        if profile.residency_source == "calibrated" and profile.tensor_parallel_size is not None:
+            return int(profile.tensor_parallel_size)
 
         base_mb = profile.estimate_base_residency_mb()
         if base_mb is None or base_mb <= 0:

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibrated_tp_source_of_truth.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibrated_tp_source_of_truth.py
@@ -1,0 +1,100 @@
+"""The calibrated tensor_parallel_size is the single source of truth (issue #616).
+
+The size-vs-VRAM inference reads ``base_residency_mb`` against one GPU's 85%
+threshold. For a calibrated profile that value is the FULL awake footprint
+(weights + KV), often most of a GPU, so the inference escalates a calibrated
+TP=1 to a higher TP — and the worker then re-persists that escalated TP over
+the calibrated profile, leaving a split-brain (TP=1 KV data under a TP=2
+tensor_parallel_size). The planner must never re-infer TP for a calibrated
+profile; the calibrator's verdict wins.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from logos.capacity.capacity_planner import CapacityPlanner
+from logos.sdi.models import ModelProfile
+
+
+def _planner() -> CapacityPlanner:
+    return CapacityPlanner.__new__(CapacityPlanner)
+
+
+class _FakeRegistry:
+    def __init__(self, device_count: int) -> None:
+        self._devices = [{"index": i} for i in range(device_count)]
+
+    def peek_runtime_snapshot(self, provider_id: int) -> dict:
+        return {"runtime": {"devices": {"devices": self._devices}}}
+
+
+# 2 x 50 GB GPU node, as in the issue's Phi-4-reasoning setup.
+def _capacity() -> SimpleNamespace:
+    return SimpleNamespace(total_vram_mb=100_000.0)
+
+
+def _calibrated_profile(tp: int) -> ModelProfile:
+    # Full-footprint base residency (weights + KV) — large enough that the
+    # size heuristic would escalate to tp=2 on this node.
+    return ModelProfile(
+        model_name="ms/Phi-4-reasoning",
+        engine="vllm",
+        tensor_parallel_size=tp,
+        residency_source="calibrated",
+        base_residency_mb=46_000.0,
+        kv_cache_to_max_model_len_pairs=[{"kv_mb": 2048.0, "max_model_len": 5232}],
+    )
+
+
+def test_infer_never_escalates_a_calibrated_tp1() -> None:
+    """A calibrated TP=1 is proven by a real probe — no re-inference."""
+    planner = _planner()
+    assert planner._infer_tensor_parallel(_calibrated_profile(tp=1), _capacity(), 1) == 1
+
+
+def test_infer_returns_the_calibrated_tp() -> None:
+    planner = _planner()
+    assert planner._infer_tensor_parallel(_calibrated_profile(tp=2), _capacity(), 1) == 2
+
+
+def test_infer_still_infers_for_uncalibrated_profiles() -> None:
+    """The guard only suppresses inference for calibrated profiles."""
+    planner = _planner()
+    planner._registry = _FakeRegistry(device_count=2)  # noqa: SLF001
+    profile = ModelProfile(
+        model_name="big-model/70B",
+        engine="vllm",
+        base_residency_mb=46_000.0,
+    )
+    assert planner._infer_tensor_parallel(profile, _capacity(), 1) == 2
+
+
+def test_load_params_keep_a_calibrated_tp1_on_one_gpu() -> None:
+    """The lane request must not carry an inferred TP for a calibrated TP=1.
+
+    This is the upstream half of issue #616: the orchestrator sent tp=2 for
+    Phi-4-reasoning because it re-inferred off the full-footprint base
+    residency, and the worker then persisted tp=2 over the calibrated profile.
+    """
+    planner = _planner()
+    planner._registry = _FakeRegistry(device_count=2)  # noqa: SLF001
+    planner._estimate_available_for_kv_mb = lambda p, c, pid, tp: 4000.0
+    params = planner._build_load_params(
+        "ms/Phi-4-reasoning", "lane-1", _calibrated_profile(tp=1), capacity=_capacity(), provider_id=1
+    )
+    cfg = params.get("vllm_config") or {}
+    assert cfg.get("tensor_parallel_size") is None  # tp stays 1
+    # The calibrated KV pair is still what the lane gets.
+    assert cfg.get("max_model_len") == 5232
+
+
+def test_load_params_send_a_calibrated_tp2() -> None:
+    """A calibrated TP>1 keeps being sent as before."""
+    planner = _planner()
+    planner._estimate_available_for_kv_mb = lambda p, c, pid, tp: 4000.0
+    params = planner._build_load_params(
+        "ms/Phi-4-reasoning", "lane-1", _calibrated_profile(tp=2), capacity=_capacity(), provider_id=1
+    )
+    cfg = params.get("vllm_config") or {}
+    assert cfg.get("tensor_parallel_size") == 2

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1339,7 +1339,16 @@ class LaneManager:
         """Validate and optionally escalate tensor_parallel_size for vLLM lanes.
 
         Policy:
-        - TP=1 is the safe default when the model fits on one GPU.
+        - A calibrated profile's tensor_parallel_size is the single source of
+          truth — the profile's residency and KV data were measured under that
+          TP, so the lane must run at it. It wins over whatever TP the
+          incoming config carries, and even a calibrated TP=1 suppresses the
+          size heuristic below: a calibrated base_residency is the full awake
+          footprint (weights + KV, often most of a GPU), which the heuristic
+          misreads as "does not fit one GPU" and escalates to a higher TP,
+          silently overwriting the calibrated verdict with a split-brain
+          profile (see issue #616).
+        - Otherwise: TP=1 is the safe default when the model fits on one GPU.
         - If TP is explicitly set > 1, respect the operator's choice.
         - If TP is at default (1) and the model **provably** does not fit on
           a single GPU (based on model profile vs actual per-GPU VRAM), auto-
@@ -1351,6 +1360,38 @@ class LaneManager:
             return lane_config
         vc = lane_config.vllm_config
         gpu_count = self._gpu_device_count()
+
+        # Calibrated profile: the calibrator did a real probe and recorded the
+        # TP the model actually loaded at — use it as-is (capped at the
+        # available GPU count), overriding the incoming TP.
+        if self._model_profiles is not None:
+            profile = self._model_profiles.get_profile(lane_config.model)
+            if (
+                profile is not None
+                and profile.residency_source == "calibrated"
+                and profile.tensor_parallel_size is not None
+                and profile.tensor_parallel_size > 0
+            ):
+                needed_tp = min(int(profile.tensor_parallel_size), gpu_count)
+                if needed_tp < 1:
+                    # No GPU detected — nothing to cap to; leave the incoming
+                    # config alone (vLLM cannot start without a GPU anyway).
+                    return lane_config
+                if needed_tp != vc.tensor_parallel_size:
+                    new_vc = vc.model_copy(update={"tensor_parallel_size": needed_tp})
+                    new_config = lane_config.model_copy(update={"vllm_config": new_vc})
+                    logger.info(
+                        "\033[36mAuto-TP\033[0m lane '%s' model=%s: "
+                        "using calibrated tensor_parallel_size=%d (capped at %d GPU(s) available), "
+                        "incoming was %d",
+                        lane_config.model,
+                        lane_config.model,
+                        needed_tp,
+                        gpu_count,
+                        vc.tensor_parallel_size,
+                    )
+                    return new_config
+                return lane_config
 
         # Explicit TP > 1: respect the operator's choice, just validate
         if vc.tensor_parallel_size > 1:
@@ -1383,9 +1424,9 @@ class LaneManager:
         if profile is None:
             return lane_config
 
-        # Prefer the calibrated tp when present — the calibrator did a real
-        # probe (bin-search up to max GPUs) and recorded the minimum tp that
-        # actually loaded the model. That's a stronger signal than the
+        # Prefer the profile's known tp when present (calibrated profiles are
+        # handled above; this is a tp the runtime recorded for a measured
+        # profile) — a real load at that tp is a stronger signal than the
         # base_residency / per-GPU-VRAM ratio below, which is an estimate
         # that can pick a tp vLLM rejects (e.g. tp=3 fails the attention-
         # head divisibility check on many architectures, where the
@@ -2589,10 +2630,19 @@ class LaneManager:
                 tensor_parallel_size=tensor_parallel_size,
                 kv_cache_sent_mb=kv_cache_sent_mb,
             )
+            # A GMU min recorded at a different TP than the calibrated one
+            # could let a later calibrated-TP lane start below its real
+            # minimum and OOM — same conflict record_loaded_vram guards
+            # against above.
+            _profile = self._model_profiles.get_profile(model)
+            _tp_conflicts = _profile is not None and ModelProfileRegistry._calibrated_tp_conflicts(
+                _profile, tensor_parallel_size
+            )
             if (
                 status.vllm
                 and observed_gpu_memory_utilization is not None
                 and previous_state not in {"loaded", "running", "sleeping"}
+                and not _tp_conflicts
             ):
                 self._model_profiles.record_successful_load_util(
                     model,

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -313,6 +313,26 @@ class ModelProfileRegistry:
                 )
         self._load_persisted()
 
+    @staticmethod
+    def _calibrated_tp_conflicts(profile: ModelProfileRecord, tensor_parallel_size: int | None) -> bool:
+        """True when a runtime lane ran at a TP the calibrated profile did not record.
+
+        A calibrated profile's tensor_parallel_size is the single source of
+        truth: its base_residency, KV envelope, and max_model_len pairs were
+        all measured under that TP. A lane that ran at a different TP
+        (re-inferred at spawn time, a stale value from upstream) produces
+        measurements that describe a different configuration — recording
+        them, or letting the runtime TP overwrite the calibrated one, would
+        leave a split-brain profile (see issue #616).
+        """
+        return (
+            tensor_parallel_size is not None
+            and tensor_parallel_size > 0
+            and profile.residency_source == "calibrated"
+            and profile.tensor_parallel_size is not None
+            and profile.tensor_parallel_size != tensor_parallel_size
+        )
+
     def _update_metadata(
         self,
         profile: ModelProfileRecord,
@@ -537,12 +557,26 @@ class ModelProfileRegistry:
 
         Without kv_cache_sent_mb, only loaded_vram_mb is updated.
         base_residency_mb is never touched if it already has a calibrated/override value.
+        A lane that ran at a TP different from the calibrated profile's TP
+        records nothing: the calibrated TP is authoritative, and the
+        measurement would describe a different configuration.
         """
         if effective_vram_mb <= 0:
             return
 
         with self._lock:
             profile = self._profiles.setdefault(model_name, ModelProfileRecord())
+            if self._calibrated_tp_conflicts(profile, tensor_parallel_size):
+                logger.warning(
+                    "Model profile [%s] %s — discarding loaded-VRAM measurement: "
+                    "lane ran at tensor_parallel_size=%d but the calibrated profile says %d. "
+                    "The calibrated TP is the source of truth; the profile is left untouched.",
+                    (profile.residency_source or "unknown").upper(),
+                    model_name,
+                    tensor_parallel_size,
+                    profile.tensor_parallel_size,
+                )
+                return
             tp_changed = self._update_metadata(
                 profile,
                 engine=engine,
@@ -622,12 +656,29 @@ class ModelProfileRegistry:
         observed_gpu_memory_utilization: float | None = None,
         tensor_parallel_size: int | None = None,
     ) -> None:
-        """Called after successful sleep with the lane's measured residual VRAM."""
+        """Called after successful sleep with the lane's measured residual VRAM.
+
+        Like record_loaded_vram, a lane that ran at a TP different from the
+        calibrated profile's TP records nothing — the calibrated TP is
+        authoritative and the measurement would describe a different
+        configuration.
+        """
         if residual_vram_mb < 0:
             return
 
         with self._lock:
             profile = self._profiles.setdefault(model_name, ModelProfileRecord())
+            if self._calibrated_tp_conflicts(profile, tensor_parallel_size):
+                logger.warning(
+                    "Model profile [%s] %s — discarding sleeping-VRAM measurement: "
+                    "lane ran at tensor_parallel_size=%d but the calibrated profile says %d. "
+                    "The calibrated TP is the source of truth; the profile is left untouched.",
+                    (profile.residency_source or "unknown").upper(),
+                    model_name,
+                    tensor_parallel_size,
+                    profile.tensor_parallel_size,
+                )
+                return
             tp_changed = self._update_metadata(
                 profile,
                 engine=engine,

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -556,13 +556,18 @@ def test_auto_tp_caps_calibrated_tp_at_gpu_count() -> None:
     assert result.vllm_config.tensor_parallel_size == 4
 
 
-def test_auto_tp_calibrated_tp1_falls_through_to_heuristic() -> None:
-    """Calibrated tp=1 means the model fit on one GPU during calibration — no escalation."""
+def test_auto_tp_non_calibrated_tp1_falls_through_to_heuristic() -> None:
+    """A tp known only from runtime (no calibration) still defers to the heuristic.
+
+    The calibrated-TP guard must not block escalation for profiles that were
+    never calibrated: here the recorded tp=1 is the vLLM default, and the
+    large base residency still escalates.
+    """
     from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
 
     profiles = ModelProfileRegistry()
-    profiles._profiles["small/8B"] = ModelProfileRecord(
-        base_residency_mb=10_000.0,
+    profiles._profiles["big-model/70B"] = ModelProfileRecord(
+        base_residency_mb=42_000.0,
         engine="vllm",
         tensor_parallel_size=1,
     )
@@ -575,12 +580,108 @@ def test_auto_tp_calibrated_tp1_falls_through_to_heuristic() -> None:
         model_profiles=profiles,
     )
     lane = LaneConfig(
-        model="small/8B",
+        model="big-model/70B",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1),
+    )
+    result = manager._auto_tensor_parallel(lane)
+    assert result.vllm_config.tensor_parallel_size >= 2
+
+
+def test_auto_tp_calibrated_tp1_authoritative_despite_full_footprint_base() -> None:
+    """Issue #616: a calibrated tp=1 must not be escalated by the size heuristic.
+
+    The calibrated base_residency is the FULL awake footprint (weights + KV),
+    which on a 2-GPU Ada node is most of a single card — the heuristic would
+    misread that as "does not fit one GPU" and escalate to tp=2. But the
+    calibrator probed this hardware and proved the model loads fine at tp=1,
+    so the lane must stay at tp=1.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["ms/Phi-4-reasoning"] = ModelProfileRecord(
+        base_residency_mb=46_000.0,  # full footprint vs ~50 GB per GPU
+        engine="vllm",
+        tensor_parallel_size=1,
+        residency_source="calibrated",
+    )
+    manager = LaneManager(
+        OllamaConfig(),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        gpu_device_count=lambda: 2,
+        per_gpu_vram_mb=lambda: 50_000.0,
+        model_profiles=profiles,
+    )
+    lane = LaneConfig(
+        model="ms/Phi-4-reasoning",
         vllm=True,
         vllm_config=VllmConfig(tensor_parallel_size=1),
     )
     result = manager._auto_tensor_parallel(lane)
     assert result.vllm_config.tensor_parallel_size == 1
+
+
+def test_auto_tp_calibrated_tp1_overrides_incoming_tp() -> None:
+    """Issue #616: the calibrated TP wins over a stale/re-inferred TP from upstream.
+
+    The orchestrator's size-vs-VRAM inference sent tp=2 for a model the
+    calibrator decided fits at tp=1 — the worker must not serve it at tp=2
+    (and thus re-persist tp=2 over the calibrated profile).
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["ms/Phi-4-reasoning"] = ModelProfileRecord(
+        base_residency_mb=46_000.0,
+        engine="vllm",
+        tensor_parallel_size=1,
+        residency_source="calibrated",
+    )
+    manager = LaneManager(
+        OllamaConfig(),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        gpu_device_count=lambda: 2,
+        per_gpu_vram_mb=lambda: 50_000.0,
+        model_profiles=profiles,
+    )
+    lane = LaneConfig(
+        model="ms/Phi-4-reasoning",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=2),
+    )
+    result = manager._auto_tensor_parallel(lane)
+    assert result.vllm_config.tensor_parallel_size == 1
+
+
+def test_auto_tp_calibrated_tp2_applies_over_incoming_tp1() -> None:
+    """A calibrated tp>1 is applied even when the incoming config says tp=1."""
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["big-model/70B"] = ModelProfileRecord(
+        base_residency_mb=42_000.0,
+        engine="vllm",
+        tensor_parallel_size=2,
+        residency_source="calibrated",
+    )
+    manager = LaneManager(
+        OllamaConfig(),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        gpu_device_count=lambda: 4,
+        per_gpu_vram_mb=lambda: 24_000.0,
+        model_profiles=profiles,
+    )
+    lane = LaneConfig(
+        model="big-model/70B",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1),
+    )
+    result = manager._auto_tensor_parallel(lane)
+    assert result.vllm_config.tensor_parallel_size == 2
 
 
 def test_auto_tp_keeps_tp1_without_gpu_info() -> None:

--- a/logos/logos-workernode/tests/test_model_profiles.py
+++ b/logos/logos-workernode/tests/test_model_profiles.py
@@ -302,6 +302,88 @@ def test_calibrated_profile_not_overwritten_by_subsequent_load(tmp_path):
     assert profile.residency_source == "calibrated"
 
 
+def _write_calibrated_profile(tmp_path, tp: int) -> ModelProfileRegistry:
+    """Registry holding a calibrated profile with TP-dependent KV data."""
+    import yaml
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    profiles_path = state_dir / "model_profiles.yml"
+    calibrated_data = {
+        "model_profiles": {
+            "org/model": {
+                "loaded_vram_mb": 7000.0,
+                "sleeping_residual_mb": 4500.0,
+                "disk_size_bytes": None,
+                "base_residency_mb": 5000.0,
+                "kv_budget_mb": 2048.0,
+                "engine": "vllm",
+                "tensor_parallel_size": tp,
+                "residency_source": "calibrated",
+                "measurement_count": 1,
+                "last_measured_epoch": time.time(),
+                "observed_gpu_memory_utilization": None,
+                "min_gpu_memory_utilization_to_load": None,
+                "kv_per_token_bytes": None,
+                "max_context_length": None,
+                "kv_cache_to_max_model_len_pairs": [{"kv_mb": 2048.0, "max_model_len": 5232}],
+            }
+        }
+    }
+    profiles_path.write_text(yaml.safe_dump(calibrated_data))
+    return ModelProfileRegistry(state_dir=state_dir)
+
+
+def test_calibrated_tp_not_clobbered_by_mismatched_lane(tmp_path):
+    """A serving lane that ran at a TP different from the calibrated TP must
+    not overwrite the profile (issue #616): the calibrated TP is the single
+    source of truth, and the lane's measurements describe a different
+    configuration. The whole profile — tp, residency, KV data — stays intact.
+    """
+    registry = _write_calibrated_profile(tmp_path, tp=1)
+    registry.record_loaded_vram(
+        "org/model",
+        9000.0,
+        engine="vllm",
+        tensor_parallel_size=2,
+        kv_cache_sent_mb=2048.0,
+    )
+
+    profile = registry.get_profile("org/model")
+    assert profile.tensor_parallel_size == 1
+    assert profile.base_residency_mb == 5000.0
+    assert profile.residency_source == "calibrated"
+    assert profile.loaded_vram_mb == 7000.0  # untouched, not EMA-blended
+    assert profile.kv_cache_to_max_model_len_pairs == [{"kv_mb": 2048.0, "max_model_len": 5232}]
+    assert profile.measurement_count == 1  # the mismatched measurement was discarded
+
+
+def test_calibrated_tp_not_clobbered_by_mismatched_sleep(tmp_path):
+    """Same guard on the sleep path: a mismatched-TP residual records nothing."""
+    registry = _write_calibrated_profile(tmp_path, tp=1)
+    registry.record_sleeping_vram("org/model", 300.0, engine="vllm", tensor_parallel_size=2)
+
+    profile = registry.get_profile("org/model")
+    assert profile.tensor_parallel_size == 1
+    assert profile.sleeping_residual_mb == 4500.0  # untouched
+    assert profile.residency_source == "calibrated"
+
+
+def test_calibrated_profile_matching_tp_records_measurements(tmp_path):
+    """A lane that runs at the calibrated TP records as usual — the guard only
+    fires on a TP mismatch."""
+    registry = _write_calibrated_profile(tmp_path, tp=1)
+    registry.record_loaded_vram("org/model", 7200.0, engine="vllm", tensor_parallel_size=1, kv_cache_sent_mb=2048.0)
+
+    profile = registry.get_profile("org/model")
+    assert profile.tensor_parallel_size == 1
+    # EMA-blended with the calibrated 7000: 0.3 * 7200 + 0.7 * 7000 = 7060
+    assert profile.loaded_vram_mb == pytest.approx(7060.0)
+    assert profile.base_residency_mb == 5000.0  # calibrated value stays pinned
+    assert profile.residency_source == "calibrated"
+    assert profile.measurement_count == 2
+
+
 def test_persist_no_state_dir():
     """No state dir → persist is a no-op."""
     registry = ModelProfileRegistry(state_dir=None)


### PR DESCRIPTION
## What changed

The calibrated `tensor_parallel_size` (and the residency/KV data measured under it) is now the single source of truth. Serving/warmup lane spawns no longer re-infer TP from the calibrated profile's `base_residency_mb` and re-persist an inconsistent TP over the calibrated profile.

**Root cause.** Two independent size-vs-VRAM inferences read `base_residency_mb` against one GPU's 85% threshold. For a calibrated profile that value is the *full* awake footprint (weights + KV, often most of a GPU), so a model the calibrator proved fits at TP=1 was escalated to TP=2 — once in the orchestrator (`CapacityPlanner._infer_tensor_parallel`, which feeds lane requests, placement gates, the feasibility check, and eviction cost) and once in the worker (`LaneManager._auto_tensor_parallel`). The lane then ran at the escalated TP, and the worker's profile record path (`record_loaded_vram` / `record_sleeping_vram` → `_update_metadata`) re-persisted that TP over the calibrated one in `model_profiles.yml` and (via the runtime snapshot) the orchestrator `model_profiles` DB — while the calibrated TP=1 KV/context fields stayed in place. Result: a split-brain profile, reproducible only by hand-editing the worker YAML *and* the DB, both of which were clobbered again while the worker ran.

**The fix** (three small, targeted changes):
- **Worker `_auto_tensor_parallel`** — a calibrated profile's TP is authoritative (even TP=1) and wins over whatever TP the incoming config carries; the size heuristic only applies when the model was never calibrated.
- **Worker profile record path** — a lane that ran at a TP different from the calibrated one records nothing (loaded/sleeping VRAM and the GMU minimum). The calibrated profile is left fully intact instead of being partially overwritten, so `model_profiles.yml` and the DB snapshot the worker reports can no longer drift apart from it.
- **Orchestrator `_infer_tensor_parallel`** — never re-infers TP for a calibrated profile, so every TP consumer keeps the calibrated verdict.

No migration or manual edits are needed: the worker YAML and orchestrator DB converge to the calibrated values on their own, and a model that fits on one GPU is no longer pinned to TP=2.

## Verification

No deployment is available here, so this was verified by unit tests and linters:
- **New worker tests** (`test_lane_manager.py`, `test_model_profiles.py`): a calibrated TP=1 is *not* escalated despite a full-footprint base residency; it overrides a stale incoming TP=2; a mismatched-TP lane/sleep records nothing and leaves tp, residency, source, and KV pairs untouched; a matching-TP lane still records as usual; a never-calibrated profile still escalates (guard doesn't over-block).
- **New orchestrator tests** (`test_calibrated_tp_source_of_truth.py`): `_infer_tensor_parallel` never escalates a calibrated TP=1, returns the calibrated TP, and still infers for uncalibrated profiles; `_build_load_params` keeps a calibrated TP=1 on one GPU (no `tensor_parallel_size` sent) while still sending a calibrated TP=2.
- **Full suites:** worker `pytest tests/` → 515 passed, 2 skipped; orchestrator `pytest tests/unit` → 949 passed, 1 xfailed (pre-existing known gap).
- **Linters:** black, isort, flake8, and autoflake (per `logos/.pre-commit-config.yaml`) are clean on all changed files.

Fixes #616