### PR TITLE
`Logos`: Return cached token counts for local models

### DIFF
--- a/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
@@ -197,6 +197,128 @@ async def test_streaming_response_logs_usage_when_sse_events_are_split(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_streaming_local_response_logs_cached_token_details(monkeypatch):
+    # vLLM lanes report usage.prompt_tokens_details.cached_tokens (the worker
+    # starts them with --enable-prompt-tokens-details); the orchestrator must
+    # relay it to the application and log it the same way as the cloud
+    # provider's cached count (#813).
+    dummy_db = _make_dummy_db()
+    monkeypatch.setattr(main, "DBManager", dummy_db)
+    monkeypatch.setattr(
+        main,
+        "_context_resolver",
+        SimpleNamespace(prepare_headers_and_payload=lambda context, payload: ({}, payload)),
+        raising=False,
+    )
+
+    async def fake_send_stream_command(**kwargs):  # noqa: ARG001
+        chunks = [
+            b'data: {"id":"chunk-1","choices":[{"delta":{"content":"hi"}}]}\n\n',
+            b'data: {"id":"chunk-1","choices":[],"usage":{"prompt_tokens":10,'
+            b'"completion_tokens":4,"total_tokens":14,'
+            b'"prompt_tokens_details":{"cached_tokens":6}}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        for chunk in chunks:
+            yield chunk
+
+    monkeypatch.setattr(
+        main,
+        "_logosnode_registry",
+        SimpleNamespace(send_stream_command=fake_send_stream_command),
+        raising=False,
+    )
+
+    pipeline, _, _ = _make_pipeline()
+    monkeypatch.setattr(main, "_pipeline", pipeline, raising=False)
+
+    response = await main._streaming_response(
+        SimpleNamespace(provider_type="logosnode", lane_id="lane-1"),
+        {"messages": [{"role": "user", "content": "hi"}]},
+        43,
+        12,
+        27,
+        -1,
+        {"policy": "ok"},
+        {
+            "request_id": "req-cached",
+            "provider_type": "logosnode",
+            "queue_depth_at_arrival": 0,
+            "utilization_at_arrival": 1,
+            "is_cold_start": False,
+        },
+    )
+    body = await _read_stream_response(response)
+
+    # The client sees the provider's usage verbatim, details included.
+    assert '"prompt_tokens_details":{"cached_tokens":6}' in body
+    assert dummy_db.payload_calls[0]["usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 4,
+        "total_tokens": 14,
+        "prompt_cached_tokens": 6,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_local_response_keeps_cached_token_details(monkeypatch):
+    # The lane's usage.prompt_tokens_details must reach the application in
+    # the response and land in the request log as prompt_cached_tokens,
+    # mirroring the cloud path (#813).
+    dummy_db = _make_dummy_db()
+    monkeypatch.setattr(main, "DBManager", dummy_db)
+    monkeypatch.setattr(
+        main,
+        "_context_resolver",
+        SimpleNamespace(prepare_headers_and_payload=lambda context, payload: ({}, payload)),
+        raising=False,
+    )
+
+    async def send_command(**kwargs):  # noqa: ARG001
+        return {
+            "status_code": 200,
+            "body": {
+                "id": "cmpl-1",
+                "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 4,
+                    "total_tokens": 14,
+                    "prompt_tokens_details": {"cached_tokens": 6},
+                },
+            },
+            "headers": {"content-type": "application/json"},
+        }
+
+    monkeypatch.setattr(
+        main,
+        "_logosnode_registry",
+        SimpleNamespace(send_command=send_command),
+        raising=False,
+    )
+    pipeline, _, _ = _make_pipeline()
+    monkeypatch.setattr(main, "_pipeline", pipeline, raising=False)
+
+    response = await main._sync_response(
+        SimpleNamespace(provider_type="logosnode", lane_id="lane-a", model_name="local-model"),
+        {"model": "local-model", "messages": [{"role": "user", "content": "hi"}]},
+        44,
+        12,
+        27,
+        -1,
+        {"classified": True},
+        scheduling_stats={
+            "request_id": "req-sync-cached",
+            "provider_type": "logosnode",
+        },
+    )
+
+    content = json.loads(response.body)
+    assert content["usage"]["prompt_tokens_details"]["cached_tokens"] == 6
+    assert dummy_db.payload_calls[0]["usage"]["prompt_cached_tokens"] == 6
+
+
+@pytest.mark.asyncio
 async def test_cloud_streaming_response_returns_eur_cost_in_terminal_usage(monkeypatch):
     dummy_db = _make_dummy_db(cost_micro_cents=375)
     monkeypatch.setattr(main, "DBManager", dummy_db)

--- a/logos/logos-workernode/config.example.yml
+++ b/logos/logos-workernode/config.example.yml
@@ -386,6 +386,8 @@ engines:
 #     quantization: str          — "awq" | "gptq" | "fp8" | etc.
 #     enforce_eager: bool        — disable CUDA graph capture.
 #     enable_prefix_caching: bool
+#     enable_prompt_tokens_details: bool — report usage.prompt_tokens_details
+#                                          (cached_tokens); on by default.
 #     disable_custom_all_reduce: bool
 #     disable_nccl_p2p: bool
 #     attention_backend: str

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -112,6 +112,17 @@ class VllmConfig(BaseModel):
         "Empty = auto-detect (TRITON_ATTN on pre-Ampere, FlashInfer on Ampere+).",
     )
     enable_prefix_caching: bool = True
+    enable_prompt_tokens_details: bool = Field(
+        default=True,
+        description=(
+            "Make vLLM report usage.prompt_tokens_details (cached_tokens) on "
+            "every completion. Passes --enable-prompt-tokens-details to vLLM, "
+            "which is off by default there. On by default so consumers see the "
+            "prefix-cache hit share of local requests in usage, the same "
+            "meta-information cloud providers report natively. Set to false to "
+            "suppress the field."
+        ),
+    )
     disable_custom_all_reduce: bool = False
     enable_sleep_mode: bool = False
     server_dev_mode: bool = False

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -1450,6 +1450,13 @@ class VllmProcessHandle:
             cmd.extend(["--attention-config.backend", attn_backend])
         if vc.enable_prefix_caching:
             cmd.append("--enable-prefix-caching")
+        # vLLM only reports usage.prompt_tokens_details (cached_tokens) when
+        # this server flag is set — its default is off, so without it local
+        # lanes omit the prefix-cache hit count that cloud providers include
+        # in usage natively, and consumers can't optimise cached-token usage
+        # per request (#813).
+        if vc.enable_prompt_tokens_details:
+            cmd.append("--enable-prompt-tokens-details")
         if vc.disable_custom_all_reduce:
             cmd.append("--disable-custom-all-reduce")
         if vc.enable_sleep_mode:

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -59,7 +59,9 @@ def test_build_cmd_includes_prompt_tokens_details_by_default(monkeypatch) -> Non
     # Logos lanes must enable it so consumers see the prefix-cache hit share
     # of local requests the same way they do for cloud providers (#813).
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
-    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+    # Return a list, like the real _resolve_vllm_binary does: _build_cmd
+    # splats the prefix, so a string would expand into a broken command.
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: ["/tmp/vllm"])
 
     lane = LaneConfig(
         model="google/gemma-4-26B-A4B-it",
@@ -67,12 +69,14 @@ def test_build_cmd_includes_prompt_tokens_details_by_default(monkeypatch) -> Non
         vllm_config=VllmConfig(),
     )
     cmd = handle._build_cmd(lane)
+    assert cmd[0] == "/tmp/vllm" and cmd[1] == "serve"
     assert cmd.count("--enable-prompt-tokens-details") == 1
 
 
 def test_build_cmd_omits_prompt_tokens_details_when_disabled(monkeypatch) -> None:
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
-    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+    # List, not string — see the default test above for why.
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: ["/tmp/vllm"])
 
     lane = LaneConfig(
         model="google/gemma-4-26B-A4B-it",
@@ -80,6 +84,7 @@ def test_build_cmd_omits_prompt_tokens_details_when_disabled(monkeypatch) -> Non
         vllm_config=VllmConfig(enable_prompt_tokens_details=False),
     )
     cmd = handle._build_cmd(lane)
+    assert cmd[0] == "/tmp/vllm" and cmd[1] == "serve"
     assert "--enable-prompt-tokens-details" not in cmd
 
 

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -54,6 +54,35 @@ def test_build_cmd_does_not_duplicate_enforce_eager(monkeypatch) -> None:
     assert cmd.count("--enforce-eager") == 1
 
 
+def test_build_cmd_includes_prompt_tokens_details_by_default(monkeypatch) -> None:
+    # vLLM keeps usage.prompt_tokens_details (cached_tokens) off by default;
+    # Logos lanes must enable it so consumers see the prefix-cache hit share
+    # of local requests the same way they do for cloud providers (#813).
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+
+    lane = LaneConfig(
+        model="google/gemma-4-26B-A4B-it",
+        vllm=True,
+        vllm_config=VllmConfig(),
+    )
+    cmd = handle._build_cmd(lane)
+    assert cmd.count("--enable-prompt-tokens-details") == 1
+
+
+def test_build_cmd_omits_prompt_tokens_details_when_disabled(monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")
+
+    lane = LaneConfig(
+        model="google/gemma-4-26B-A4B-it",
+        vllm=True,
+        vllm_config=VllmConfig(enable_prompt_tokens_details=False),
+    )
+    cmd = handle._build_cmd(lane)
+    assert "--enable-prompt-tokens-details" not in cmd
+
+
 def test_build_cmd_includes_stability_and_sleep_flags(monkeypatch) -> None:
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
     monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: "/tmp/vllm")


### PR DESCRIPTION
## Fixes #813

## Summary

Applications already receive cached-token meta-information for cloud models (the provider returns `usage.prompt_tokens_details.cached_tokens`, and Logos relays it and stores it as `prompt_cached_tokens`). Local (vLLM) lanes did not — because **vLLM only emits `prompt_tokens_details` when the server flag `--enable-prompt-tokens-details` is set, and its default is off**. I confirmed this directly in the vLLM v0.28.0 source (the version the worker pins): `chat_completion/serving.py` builds `usage.prompt_tokens_details` via `_make_prompt_tokens_details(self.enable_prompt_tokens_details, ...)`, which returns `None` unless the flag is on (for both the non-streaming response and the final streaming usage chunk).

The Logos layer itself was already provider-agnostic and needed no source change:
- **Return/expose:** the worker relays the lane response verbatim (sync body / SSE bytes), and the orchestrator returns it to the application unchanged (cloud-only cost enrichment only *adds* fields). So once vLLM emits the field, applications see `usage.prompt_tokens_details.cached_tokens` for local models exactly as they do for cloud ones.
- **Collect/store:** `extract_token_usage` already flattens `prompt_tokens_details.cached_tokens` (and the Responses-API `input_tokens_details.cached_tokens`) into `prompt_cached_tokens`, which `set_response_payload` persists to `usage_tokens` — the same row cloud cached counts use. The `prefix_hit=` completion-log line already reads it.

So the missing link was the worker not enabling the vLLM flag. This PR makes every vLLM lane start with it.

## Changes

- `logos/logos-workernode/logos_worker_node/models.py`: new `VllmConfig.enable_prompt_tokens_details: bool = True` (documented; mirrors the existing `enable_prefix_caching` toggle, overridable per lane).
- `logos/logos-workernode/logos_worker_node/vllm_process.py`: `_build_cmd` appends `--enable-prompt-tokens-details` when enabled, right next to the existing `--enable-prefix-caching` handling.
- `logos/logos-workernode/config.example.yml`: document the new `vllm_config` field.
- `logos/logos-workernode/tests/test_vllm_process.py`: two tests — the flag is emitted by default and omitted when disabled.
- `logos/logos-orchestrator/tests/unit/main/test_request_logging.py`: two tests pinning the local-provider behavior end-to-end — a `logosnode` sync/streaming response carrying `usage.prompt_tokens_details.cached_tokens` reaches the application verbatim and is logged as `prompt_cached_tokens` (mirroring the cloud path).

## Testing

Verified against the pinned vLLM (v0.28.0) source that the flag is the gate for `prompt_tokens_details.cached_tokens` on both sync and streaming usage.

Ran the suites the same way CI does (uv venv on Python 3.13 with the master `logos` package + `pytest-timeout`):
- Worker-node suite (`pytest --timeout=30`, ignoring the three CI-excluded files): **334 passed, 2 skipped** (includes the 2 new worker tests).
- Orchestrator unit suite (`pytest tests/unit`): **946 passed, 1 xfailed** (includes the 2 new request-logging tests; the xfail is the pre-existing `test_best_first_scenarios` known-gap).
- Lint: `pre-commit run --config logos/.pre-commit-config.yaml --all-files` — all hooks pass (black, isort, autoflake, flake8, hygiene).

A full deployment (docker compose + vLLM worker + GPU) is not available in this environment, so the end-to-end relay was verified by unit tests that exercise the real `_sync_response`/`_streaming_response` paths with a mocked `logosnode` registry, plus direct reading of the vLLM v0.28.0 source for the flag behavior.

## Database Changes

None — `prompt_cached_tokens` is already a first-class `token_types`/`usage_tokens` entry used by the cloud path; no schema change is required.