### PR TITLE
`Logos`: Display token counts on the K/M/B/T scale

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -72,16 +72,16 @@ describe('messageIn', () => {
 /**
  * The context window a lane row shows.
  *
- * Abbreviated on the shared K/M/B/T token scale (issue #816), because the row
- * is a dense line of stats read to spot the roomy lane — the exact token
- * count is never what is being asked.
+ * Abbreviated on the shared K/M/B/T token scale, because the row is a dense
+ * line of stats read to spot the roomy lane — the exact token count is never
+ * what is being asked.
  */
 describe('formatContextWindow', () => {
   it('abbreviates on the token scale', () => {
-    expect(formatContextWindow(262144)).toBe('262.144 K');
-    expect(formatContextWindow(111200)).toBe('111.200 K');
-    expect(formatContextWindow(40960)).toBe('40.960 K');
-    expect(formatContextWindow(1000)).toBe('1.000 K');
+    expect(formatContextWindow(262144)).toBe('262.1 K');
+    expect(formatContextWindow(111200)).toBe('111.2 K');
+    expect(formatContextWindow(40960)).toBe('40.9 K');
+    expect(formatContextWindow(1000)).toBe('1 K');
   });
 
   it('leaves small windows alone', () => {

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -72,15 +72,16 @@ describe('messageIn', () => {
 /**
  * The context window a lane row shows.
  *
- * Rounded thousands, because the row is a dense line of stats read to spot the
- * roomy lane — the exact token count is never what is being asked.
+ * Abbreviated on the shared K/M/B/T token scale (issue #816), because the row
+ * is a dense line of stats read to spot the roomy lane — the exact token
+ * count is never what is being asked.
  */
 describe('formatContextWindow', () => {
-  it('abbreviates thousands', () => {
-    expect(formatContextWindow(262144)).toBe('262k');
-    expect(formatContextWindow(111200)).toBe('111k');
-    expect(formatContextWindow(40960)).toBe('41k');
-    expect(formatContextWindow(1000)).toBe('1k');
+  it('abbreviates on the token scale', () => {
+    expect(formatContextWindow(262144)).toBe('262.144 K');
+    expect(formatContextWindow(111200)).toBe('111.200 K');
+    expect(formatContextWindow(40960)).toBe('40.960 K');
+    expect(formatContextWindow(1000)).toBe('1.000 K');
   });
 
   it('leaves small windows alone', () => {

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -76,7 +76,7 @@ export interface LaneRow {
   kvColor: string | null;
   ttftColor: string | null;
   ttftLabel: string | null;
-  /** Served context window, abbreviated — "111.200 K". Null when unreported. */
+  /** Served context window, abbreviated — "111.2 K". Null when unreported. */
   contextLabel: string | null;
   /** "2 / 11 (min. 8)" — see runningLabel(); null when the line is hidden. */
   runningLabel: string | null;
@@ -86,12 +86,12 @@ export interface LaneRow {
 
 /**
  * Context window as a lane row shows it: abbreviated on the shared K/M/B/T
- * token scale (issue #816).
+ * token scale.
  *
  * These sit in a dense row of stats where the exact token count is never the
  * point — an operator reads them to see which lane is the roomy one, and
- * "262,144" costs three times the width to say the same thing as
- * "262.144 K". Below 1,000 there is nothing to abbreviate.
+ * "262,144" costs more width to say the same thing as "262.1 K". Below 1,000
+ * there is nothing to abbreviate.
  */
 export function formatContextWindow(tokens: number | null | undefined): string | null {
   if (typeof tokens !== 'number' || !Number.isFinite(tokens) || tokens <= 0) return null;

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -10,6 +10,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { StatisticsService, ProviderModel } from '../../services/statistics.service';
 import { getLaneStateColor } from '../../statistics.constants';
+import { formatTokenCount } from '../../statistics.utils';
 import { LaneSignalData, VramProviderMeta } from '../../statistics.models';
 import { EmptyState } from '../empty-state/empty-state';
 
@@ -75,7 +76,7 @@ export interface LaneRow {
   kvColor: string | null;
   ttftColor: string | null;
   ttftLabel: string | null;
-  /** Served context window, abbreviated — "111k". Null when unreported. */
+  /** Served context window, abbreviated — "111.200 K". Null when unreported. */
   contextLabel: string | null;
   /** "2 / 11 (min. 8)" — see runningLabel(); null when the line is hidden. */
   runningLabel: string | null;
@@ -84,16 +85,17 @@ export interface LaneRow {
 }
 
 /**
- * Context window as a lane row shows it: thousands, rounded, no decimals.
+ * Context window as a lane row shows it: abbreviated on the shared K/M/B/T
+ * token scale (issue #816).
  *
  * These sit in a dense row of stats where the exact token count is never the
  * point — an operator reads them to see which lane is the roomy one, and
- * "262,144" costs three times the width to say the same thing as "262k". Below
- * 1,000 there is nothing to abbreviate.
+ * "262,144" costs three times the width to say the same thing as
+ * "262.144 K". Below 1,000 there is nothing to abbreviate.
  */
 export function formatContextWindow(tokens: number | null | undefined): string | null {
   if (typeof tokens !== 'number' || !Number.isFinite(tokens) || tokens <= 0) return null;
-  return tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : String(tokens);
+  return formatTokenCount(tokens);
 }
 
 /** Which manual sleep/wake action a lane row offers, if any. */

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -24,6 +24,7 @@ import {
   chooseDynamicTargetBuckets,
   extractProviderVramMb,
   formatRangeLabel,
+  formatTokenCount as formatTokenCountValue,
   BYTES_PER_GIB,
   BYTES_PER_MIB,
   toGb,
@@ -673,11 +674,9 @@ export class Statistics implements OnInit, OnDestroy {
   readonly totalTokens = computed(() => this.stats()?.totals.totalTokens ?? 0);
   readonly cloudCostMicroCents = computed(() => this.stats()?.totals.cloudCostMicroCents ?? 0);
 
-  /** Format a token count for the KPI card (1.2M / 340k / 12). */
+  /** Format a token count for the KPI card on the K/M/B/T scale (issue #816). */
   formatTokenCount(v: number): string {
-    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-    if (v >= 1_000) return `${(v / 1_000).toFixed(0)}k`;
-    return String(Math.round(v));
+    return formatTokenCountValue(v);
   }
 
   /** Format cloud cost in microcents as USD (the unit litellm prices in). */

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -674,7 +674,7 @@ export class Statistics implements OnInit, OnDestroy {
   readonly totalTokens = computed(() => this.stats()?.totals.totalTokens ?? 0);
   readonly cloudCostMicroCents = computed(() => this.stats()?.totals.cloudCostMicroCents ?? 0);
 
-  /** Format a token count for the KPI card on the K/M/B/T scale (issue #816). */
+  /** Format a token count for the KPI card on the K/M/B/T scale. */
   formatTokenCount(v: number): string {
     return formatTokenCountValue(v);
   }

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -1,0 +1,48 @@
+import { formatTokenCount } from './statistics.utils';
+
+/**
+ * The scale token counts are displayed on (issue #816).
+ *
+ * A count that outgrows a unit steps up to the next magnitude — the 2470.7M
+ * the issue was filed against is 2.470 B, not 2.470,7 M — the unit is always
+ * the highest applicable one, and a space separates the value from the unit.
+ */
+describe('formatTokenCount', () => {
+  it('keeps counts below the scale plain', () => {
+    expect(formatTokenCount(0)).toBe('0');
+    expect(formatTokenCount(1)).toBe('1');
+    expect(formatTokenCount(512)).toBe('512');
+    expect(formatTokenCount(999)).toBe('999');
+  });
+
+  it('steps up to K at 1.000 and nowhere before', () => {
+    expect(formatTokenCount(1_000)).toBe('1.000 K');
+    expect(formatTokenCount(1_500)).toBe('1.500 K');
+    expect(formatTokenCount(999_999)).toBe('999.999 K');
+  });
+
+  it('steps up at every boundary of the scale', () => {
+    expect(formatTokenCount(1_000_000)).toBe('1.000 M');
+    expect(formatTokenCount(1_000_000_000)).toBe('1.000 B');
+    expect(formatTokenCount(1_000_000_000_000)).toBe('1.000 T');
+  });
+
+  it('always uses the highest applicable magnitude', () => {
+    // 2470.7M exceeds the million range, so it reads in billions — with the
+    // space before the unit and the dot as decimal separator.
+    expect(formatTokenCount(2_470_700_000)).toBe('2.470 B');
+    expect(formatTokenCount(1_234_567)).toBe('1.234 M');
+    expect(formatTokenCount(2_500_000_000)).toBe('2.500 B');
+  });
+
+  it('truncates the value rather than rounding it up', () => {
+    // 2.4707 B shows the digits the count has — 2.470 — not the rounded 2.471.
+    expect(formatTokenCount(2_470_700_000)).toBe('2.470 B');
+    expect(formatTokenCount(1_999_999_999)).toBe('1.999 B');
+  });
+
+  it('stays on T once the scale is exhausted', () => {
+    expect(formatTokenCount(2_000_000_000_000)).toBe('2.000 T');
+    expect(formatTokenCount(15_000_000_000_000)).toBe('15.000 T');
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -1,48 +1,59 @@
 import { formatTokenCount } from './statistics.utils';
 
 /**
- * The scale token counts are displayed on (issue #816).
+ * The scale token counts are displayed on.
  *
  * A count that outgrows a unit steps up to the next magnitude — the 2470.7M
- * the issue was filed against is 2.470 B, not 2.470,7 M — the unit is always
- * the highest applicable one, and a space separates the value from the unit.
+ * the statistics page used to show is 2.4 B — the unit is always the highest
+ * applicable one, and a space separates the value from the unit.
  */
 describe('formatTokenCount', () => {
-  it('keeps counts below the scale plain', () => {
+  it('reads "0" for input that is not a positive finite number', () => {
     expect(formatTokenCount(0)).toBe('0');
+    expect(formatTokenCount(-5)).toBe('0');
+    expect(formatTokenCount(Number.NaN)).toBe('0');
+    expect(formatTokenCount(Number.POSITIVE_INFINITY)).toBe('0');
+    expect(formatTokenCount(null)).toBe('0');
+    expect(formatTokenCount(undefined)).toBe('0');
+  });
+
+  it('keeps counts below the scale plain', () => {
     expect(formatTokenCount(1)).toBe('1');
     expect(formatTokenCount(512)).toBe('512');
     expect(formatTokenCount(999)).toBe('999');
   });
 
   it('steps up to K at 1.000 and nowhere before', () => {
-    expect(formatTokenCount(1_000)).toBe('1.000 K');
-    expect(formatTokenCount(1_500)).toBe('1.500 K');
-    expect(formatTokenCount(999_999)).toBe('999.999 K');
+    expect(formatTokenCount(1_000)).toBe('1 K');
+    expect(formatTokenCount(1_500)).toBe('1.5 K');
+    expect(formatTokenCount(999_999)).toBe('999.9 K');
   });
 
   it('steps up at every boundary of the scale', () => {
-    expect(formatTokenCount(1_000_000)).toBe('1.000 M');
-    expect(formatTokenCount(1_000_000_000)).toBe('1.000 B');
-    expect(formatTokenCount(1_000_000_000_000)).toBe('1.000 T');
+    expect(formatTokenCount(1_000_000)).toBe('1 M');
+    expect(formatTokenCount(1_000_000_000)).toBe('1 B');
+    expect(formatTokenCount(1_000_000_000_000)).toBe('1 T');
   });
 
   it('always uses the highest applicable magnitude', () => {
     // 2470.7M exceeds the million range, so it reads in billions — with the
     // space before the unit and the dot as decimal separator.
-    expect(formatTokenCount(2_470_700_000)).toBe('2.470 B');
-    expect(formatTokenCount(1_234_567)).toBe('1.234 M');
-    expect(formatTokenCount(2_500_000_000)).toBe('2.500 B');
+    expect(formatTokenCount(2_470_700_000)).toBe('2.4 B');
+    expect(formatTokenCount(1_234_567)).toBe('1.2 M');
+    expect(formatTokenCount(2_500_000_000)).toBe('2.5 B');
   });
 
-  it('truncates the value rather than rounding it up', () => {
-    // 2.4707 B shows the digits the count has — 2.470 — not the rounded 2.471.
-    expect(formatTokenCount(2_470_700_000)).toBe('2.470 B');
-    expect(formatTokenCount(1_999_999_999)).toBe('1.999 B');
+  it('truncates to one decimal and drops it when it is zero', () => {
+    // 2.4707 B shows the digit the count has — 2.4 — not the rounded 2.5, and
+    // an exact value carries no trailing ".0".
+    expect(formatTokenCount(2_470_700_000)).toBe('2.4 B');
+    expect(formatTokenCount(1_999_999_999)).toBe('1.9 B');
+    expect(formatTokenCount(262_144)).toBe('262.1 K');
+    expect(formatTokenCount(40_960)).toBe('40.9 K');
   });
 
   it('stays on T once the scale is exhausted', () => {
-    expect(formatTokenCount(2_000_000_000_000)).toBe('2.000 T');
-    expect(formatTokenCount(15_000_000_000_000)).toBe('15.000 T');
+    expect(formatTokenCount(2_000_000_000_000)).toBe('2 T');
+    expect(formatTokenCount(15_000_000_000_000)).toBe('15 T');
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -42,7 +42,7 @@ export function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
-// ── Token count scale (issue #816) ───────────────────────────────────────────
+// ── Token count scale ─────────────────────────────────────────────────────────
 
 /**
  * The scale a token count is displayed on: the unit steps up the moment the
@@ -50,27 +50,35 @@ export function formatElapsed(seconds: number): string {
  * T at 1.000.000.000.000.
  */
 const TOKEN_COUNT_UNITS: ReadonlyArray<{ value: number; label: string }> = [
-  { value: 1_000_000_000_000, label: 'T' },
-  { value: 1_000_000_000, label: 'B' },
-  { value: 1_000_000, label: 'M' },
   { value: 1_000, label: 'K' },
+  { value: 1_000_000, label: 'M' },
+  { value: 1_000_000_000, label: 'B' },
+  { value: 1_000_000_000_000, label: 'T' },
 ];
 
 /**
- * A token count on the K/M/B/T scale (issue #816): always the highest
- * applicable magnitude, a space between the value and the unit, and the
- * value's decimal notation kept — the 2470.7M the issue was filed against
- * reads "2.470 B", not "2.470,7 M". Counts below 1.000 stay plain.
+ * A token count on the K/M/B/T scale: always the highest applicable
+ * magnitude, a space between the value and the unit, and the value's decimal
+ * notation kept — the 2470.7M the statistics page used to show reads "2.4 B".
+ * Counts below 1.000 stay plain; input that is not a positive finite number
+ * reads "0".
  *
- * The value is truncated to three decimals rather than rounded, so the
- * digits shown are the digits the count actually has (2.4707 B reads 2.470,
- * not 2.471).
+ * The value is truncated to one decimal, dropped when it is zero. One digit
+ * after the dot keeps the dot unambiguous — a thousands group is three
+ * digits, never one — and it keeps the abbreviation shorter than the number
+ * it replaces (262.1 K instead of 262,144).
  */
-export function formatTokenCount(count: number): string {
+export function formatTokenCount(count: number | null | undefined): string {
+  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) return '0';
   if (count < 1_000) return String(Math.round(count));
-  const unit = TOKEN_COUNT_UNITS.find((u) => count >= u.value) ?? TOKEN_COUNT_UNITS[0];
-  const thousandths = Math.floor(count / (unit.value / 1000));
-  return `${(thousandths / 1000).toFixed(3)} ${unit.label}`;
+  // The early return guarantees count >= 1.000, so K always matches and the
+  // walk from K up ends on the highest unit the count reaches.
+  const unit = TOKEN_COUNT_UNITS.reduce(
+    (highest, u) => (count >= u.value ? u : highest),
+    TOKEN_COUNT_UNITS[0],
+  );
+  const tenths = Math.floor(count / (unit.value / 10));
+  return `${(tenths / 10).toFixed(1).replace(/\.0$/, '')} ${unit.label}`;
 }
 
 // ── X-axis labels (shared by request-volume and VRAM charts) ─────────────────

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -42,6 +42,37 @@ export function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
+// ── Token count scale (issue #816) ───────────────────────────────────────────
+
+/**
+ * The scale a token count is displayed on: the unit steps up the moment the
+ * value leaves its range — K at 1.000, M at 1.000.000, B at 1.000.000.000,
+ * T at 1.000.000.000.000.
+ */
+const TOKEN_COUNT_UNITS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 1_000_000_000_000, label: 'T' },
+  { value: 1_000_000_000, label: 'B' },
+  { value: 1_000_000, label: 'M' },
+  { value: 1_000, label: 'K' },
+];
+
+/**
+ * A token count on the K/M/B/T scale (issue #816): always the highest
+ * applicable magnitude, a space between the value and the unit, and the
+ * value's decimal notation kept — the 2470.7M the issue was filed against
+ * reads "2.470 B", not "2.470,7 M". Counts below 1.000 stay plain.
+ *
+ * The value is truncated to three decimals rather than rounded, so the
+ * digits shown are the digits the count actually has (2.4707 B reads 2.470,
+ * not 2.471).
+ */
+export function formatTokenCount(count: number): string {
+  if (count < 1_000) return String(Math.round(count));
+  const unit = TOKEN_COUNT_UNITS.find((u) => count >= u.value) ?? TOKEN_COUNT_UNITS[0];
+  const thousandths = Math.floor(count / (unit.value / 1000));
+  return `${(thousandths / 1000).toFixed(3)} ${unit.label}`;
+}
+
 // ── X-axis labels (shared by request-volume and VRAM charts) ─────────────────
 
 export interface TimeAxisLabel {

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -109,10 +109,11 @@ describe('ActivityTabComponent', () => {
 
     it('abbreviates the totals that run past it', () => {
       // A busy team clears nine figures over a quarter; the tile holds a
-      // figure plus a suffix, not ten digits.
-      expect(component.formatTokens(1_500)).toBe('1.5k');
-      expect(component.formatTokens(1_234_567)).toBe('1.2M');
-      expect(component.formatTokens(2_500_000_000)).toBe('2.5B');
+      // figure plus a suffix, not ten digits. The scale, the space and the
+      // decimal notation are the shared token-count rules (issue #816).
+      expect(component.formatTokens(1_500)).toBe('1.500 K');
+      expect(component.formatTokens(1_234_567)).toBe('1.234 M');
+      expect(component.formatTokens(2_500_000_000)).toBe('2.500 B');
     });
   });
 

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.spec.ts
@@ -97,10 +97,13 @@ describe('ActivityTabComponent', () => {
   describe('formatTokens', () => {
     it('shows nothing for a team that used nothing', () => {
       // The payload says zero and the server also sends null for a key whose
-      // requests recorded no usage — both must read as "0", never blank.
+      // requests recorded no usage — both must read as "0", never blank. The
+      // same goes for a NaN the server should never send but the tile must
+      // not render.
       expect(component.formatTokens(0)).toBe('0');
       expect(component.formatTokens(null)).toBe('0');
       expect(component.formatTokens(undefined)).toBe('0');
+      expect(component.formatTokens(Number.NaN)).toBe('0');
     });
 
     it('keeps exact counts while they fit on one screen', () => {
@@ -110,10 +113,10 @@ describe('ActivityTabComponent', () => {
     it('abbreviates the totals that run past it', () => {
       // A busy team clears nine figures over a quarter; the tile holds a
       // figure plus a suffix, not ten digits. The scale, the space and the
-      // decimal notation are the shared token-count rules (issue #816).
-      expect(component.formatTokens(1_500)).toBe('1.500 K');
-      expect(component.formatTokens(1_234_567)).toBe('1.234 M');
-      expect(component.formatTokens(2_500_000_000)).toBe('2.500 B');
+      // decimal notation are the shared token-count rules.
+      expect(component.formatTokens(1_500)).toBe('1.5 K');
+      expect(component.formatTokens(1_234_567)).toBe('1.2 M');
+      expect(component.formatTokens(2_500_000_000)).toBe('2.5 B');
     });
   });
 

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
@@ -13,7 +13,7 @@ import { CommonModule } from '@angular/common';
 
 import { AppSelectOption, SelectComponent } from '../../../../shared/components/select/select';
 import { RequestItem } from '../../../statistics/statistics.models';
-import { deriveStage, formatTimeAgo } from '../../../statistics/statistics.utils';
+import { deriveStage, formatTimeAgo, formatTokenCount } from '../../../statistics/statistics.utils';
 import { TeamActivityService } from './activity-tab.service';
 import { RequestCursor, TeamActivityPayload } from './activity-tab.models';
 
@@ -190,10 +190,7 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
   /** Token totals run to nine figures; the exact digit is never the question. */
   formatTokens(value: number | null | undefined): string {
     if (typeof value !== 'number' || value <= 0) return '0';
-    if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
-    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-    return String(value);
+    return formatTokenCount(value);
   }
 
   keyLabel(keyName: string, environment: string | null): string {

--- a/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
+++ b/logos/logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts
@@ -189,7 +189,6 @@ export class ActivityTabComponent implements OnChanges, OnDestroy {
 
   /** Token totals run to nine figures; the exact digit is never the question. */
   formatTokens(value: number | null | undefined): string {
-    if (typeof value !== 'number' || value <= 0) return '0';
     return formatTokenCount(value);
   }
 


### PR DESCRIPTION
Fixes #816

## What changed

Token counts were formatted with ad-hoc per-site rules: the statistics KPI card capped at millions (`2470.7M`), the team activity tab capped at billions, and the lane health panel only ever showed `k` (a one-million-token context window would have read `1000k`). All three now share one scale.

- `logos-ui/src/app/features/statistics/statistics.utils.ts`: new `formatTokenCount()` — the single source of truth for the issue's scale: K = 1.000, M = 1.000.000, B = 1.000.000.000, T = 1.000.000.000.000. The unit always steps up to the highest applicable magnitude, a space separates the value from the unit, and the dot stays the decimal separator. The value is truncated to one decimal, dropped when zero, so the 2470.7M the KPI card used to show reads `2.4 B`, `1000` reads `1 K`, and `262144` reads `262.1 K`. One digit after the dot keeps the dot unambiguous (a thousands group is three digits, never one) and keeps the abbreviation shorter than the number it replaces. Counts below 1.000 stay plain; input that is not a positive finite number (null, undefined, NaN, ≤ 0) reads `0`, so every caller inherits the guard.
- `logos-ui/src/app/features/statistics/statistics.ts`: the KPI card's `formatTokenCount` now delegates to the shared util.
- `logos-ui/src/app/features/team-detail/tabs/activity/activity-tab.ts`: `formatTokens` delegates to the shared util, including the null/NaN guard.
- `logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts`: `formatContextWindow` keeps its own guard (its "nothing" is `null`, not `0`) and delegates the numeric path to the shared util (a context window is a token count, so it follows the same scale).

Per review, this deliberately deviates from the issue's literal `2.470 B` example in favour of `2.4 B`: three fixed decimals is what makes the dot read like a thousands separator (`1.000 K` = a million in German notation). The unit-stepping rule the issue asks for is unchanged.

No server-side change: the orchestrator and webservice return raw numbers, all formatting happens in the UI.

## Verification

- `statistics.utils.spec.ts` pins the scale end to end: non-finite/null/undefined/≤ 0 → `0`, below 1K stays plain, `1000 → "1 K"`, every K/M/B/T boundary (`"1 M"`, `"1 B"`, `"1 T"`), the issue's example (`2_470_700_000 → "2.4 B"`), one-decimal truncation (`1_999_999_999 → "1.9 B"`, `262_144 → "262.1 K"`), and staying on T above the scale top.
- Updated the existing `formatTokens` assertions in `activity-tab.spec.ts` (including a new `NaN → "0"` case) and `formatContextWindow` assertions in `lane-health-panel.spec.ts`.
- `ng test --watch=false`: 5 spec files, 64 tests, all passing.
- `npm run build` (the job CI runs for logos-ui): passes; the only warnings are pre-existing SCSS budget warnings in files this PR does not touch.