### PR TITLE
`Logos`: Fix queued request provider display and live push signature

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
@@ -75,7 +75,7 @@
               <span class="rr-card__age">{{ timeAgoOf(item) }}</span>
             </div>
             <div class="rr-card__bottom-row">
-              <span class="rr-card__provider">{{ item.provider_name }}</span>
+              <span class="rr-card__provider">{{ providerLabelOf(item) }}</span>
               <span
                 class="rr-badge"
                 [class.rr-badge--cloud]="item.is_cloud"

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
@@ -1,0 +1,64 @@
+import { providerLabel } from '../../statistics.utils';
+
+/**
+ * The provider label of a request row.
+ *
+ * The log row carries a provider from the moment it is enqueued — the
+ * deployment the request was made for, not the one that will serve it. While
+ * the request is still queued at the orchestrator nothing has been forwarded
+ * anywhere, so naming a provider would show a decision that has not been made
+ * yet, and a row whose provider changes at the end must be able to grow into
+ * the real one rather than keeping the early guess.
+ */
+describe('providerLabel', () => {
+  it('says none while the request is still queued, even though a provider is on the row', () => {
+    // The enqueue-time write already recorded the deployment the request was
+    // made for — the very figure the row must not show before forwarding.
+    expect(
+      providerLabel({
+        provider_name: 'gpu-01',
+        scheduled_ts: null,
+        request_complete_ts: null,
+      }),
+    ).toBe('none');
+  });
+
+  it('shows the provider once the request has been forwarded', () => {
+    expect(
+      providerLabel({
+        provider_name: 'gpu-02',
+        scheduled_ts: '2026-08-28T10:15:30Z',
+        request_complete_ts: null,
+      }),
+    ).toBe('gpu-02');
+  });
+
+  it('shows the provider of a settled row', () => {
+    expect(
+      providerLabel({
+        provider_name: 'azure-openai',
+        scheduled_ts: '2026-08-28T10:15:30Z',
+        request_complete_ts: '2026-08-28T10:15:42Z',
+      }),
+    ).toBe('azure-openai');
+  });
+
+  it('falls back to none for a settled row without a provider of its own', () => {
+    // A request that failed before anything was scheduled has a terminal
+    // state but never a forwarding — its row has no provider to name.
+    expect(
+      providerLabel({
+        provider_name: null,
+        scheduled_ts: null,
+        request_complete_ts: '2026-08-28T10:15:42Z',
+      }),
+    ).toBe('none');
+    expect(
+      providerLabel({
+        provider_name: '',
+        scheduled_ts: '2026-08-28T10:15:30Z',
+        request_complete_ts: null,
+      }),
+    ).toBe('none');
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
@@ -23,6 +23,7 @@ import {
   getRequestBorderColor,
   formatTimeAgo,
   formatElapsed,
+  providerLabel,
   RequestStage,
 } from '../../statistics.utils';
 
@@ -284,6 +285,11 @@ export class RecentRequests implements OnChanges, OnDestroy {
 
   stageOf(item: RequestItem): RequestStage {
     return deriveStage(item);
+  }
+
+  /** 'none' while the request is still queued — see `providerLabel`. */
+  providerLabelOf(item: RequestItem): string {
+    return providerLabel(item);
   }
 
   borderColorOf(item: RequestItem): string {

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -24,6 +24,28 @@ export function getRequestBorderColor(stage: RequestStage, status: string): stri
   }
 }
 
+/**
+ * The provider label a request row shows.
+ *
+ * The log row already carries a provider while the request is still queued at
+ * the orchestrator: it is the deployment the request was made for, written at
+ * enqueue time, not the one that will serve it — scheduling can pick a
+ * different model or provider entirely. Naming it while the request has not
+ * been forwarded anywhere reads as a decision that has not been made, so a
+ * queued row says 'none' and the real provider appears only once the request
+ * was handed off (or the row settled).
+ */
+export function providerLabel(
+  item: {
+    provider_name: string | null;
+    scheduled_ts: string | null;
+    request_complete_ts: string | null;
+  },
+): string {
+  if (deriveStage(item) === 'queued') return 'none';
+  return item.provider_name || 'none';
+}
+
 export function formatTimeAgo(ts: string | null, nowMs: number): string {
   if (!ts) return '';
   const diffS = Math.max(0, (nowMs - new Date(ts).getTime()) / 1000);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -501,13 +501,26 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     // Content-only signature: the live window slide advances the range on
     // every delta, which must not force a push — user-driven range changes
     // are already pushed explicitly (force=true) in handleSetTimelineRange.
+    //
+    // Every field the row renders has to be in here: the push is skipped
+    // whenever the signature repeats, so a change to a field that is left out
+    // never reaches the page. The provider in particular moves after the first
+    // push — the row carries the deployment the request was made for from
+    // enqueue time, and the provider that actually serves it is only written
+    // once the request is scheduled (and can be re-resolved once the execution
+    // context lands). Without it in the signature, a re-routed request kept
+    // showing its queued-time provider while the badge next to it moved on.
     @SuppressWarnings("unchecked")
-    private String requestsSig(Map<String, Object> payload) {
+    static String requestsSig(Map<String, Object> payload) {
         var reqs = (java.util.List<Map<String, Object>>) payload.getOrDefault("requests", java.util.List.of());
         StringBuilder sb = new StringBuilder();
         for (var r : reqs) {
             sb.append(r.getOrDefault("request_id", "")).append(':')
               .append(r.getOrDefault("status", "")).append(':')
+              .append(r.getOrDefault("provider_name", "")).append(':')
+              // Rendered as the Cloud/Local badge, so the same rule as the
+              // name applies: a change to it must not be deduplicated away.
+              .append(r.getOrDefault("is_cloud", "")).append(':')
               .append(r.getOrDefault("scheduled_ts", "")).append(':')
               .append(r.getOrDefault("request_complete_ts", "")).append(':')
               // Usage and cost grow while a request streams, without any of the

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -504,12 +504,13 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     //
     // Every field the row renders has to be in here: the push is skipped
     // whenever the signature repeats, so a change to a field that is left out
-    // never reaches the page. The provider in particular moves after the first
-    // push — the row carries the deployment the request was made for from
-    // enqueue time, and the provider that actually serves it is only written
-    // once the request is scheduled (and can be re-resolved once the execution
-    // context lands). Without it in the signature, a re-routed request kept
-    // showing its queued-time provider while the badge next to it moved on.
+    // never reaches the page. The provider and the model in particular move
+    // after the first push — the row carries the deployment the request was
+    // made for from enqueue time, and the pair that actually serves it is
+    // only written once the request is scheduled (and both are re-resolved
+    // together once the execution context lands). Without them in the
+    // signature, a re-routed request kept showing its queued-time provider
+    // while the badge next to it moved on.
     @SuppressWarnings("unchecked")
     static String requestsSig(Map<String, Object> payload) {
         var reqs = (java.util.List<Map<String, Object>>) payload.getOrDefault("requests", java.util.List.of());
@@ -518,6 +519,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             sb.append(r.getOrDefault("request_id", "")).append(':')
               .append(r.getOrDefault("status", "")).append(':')
               .append(r.getOrDefault("provider_name", "")).append(':')
+              // Re-resolved in the same statement as the provider once the
+              // execution context lands, so a re-routed request changes its
+              // model without any timestamp moving — leaving it out pins the
+              // row to the model the request was enqueued for.
+              .append(r.getOrDefault("model_name", "")).append(':')
               // Rendered as the Cloud/Local badge, so the same rule as the
               // name applies: a change to it must not be deduplicated away.
               .append(r.getOrDefault("is_cloud", "")).append(':')

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerSigTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerSigTest.java
@@ -1,0 +1,113 @@
+package de.tum.cit.aet.logos.logoswebservice.websocket;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The content signature that decides whether the request feed of a session is
+ * re-pushed.
+ *
+ * The push runs every two seconds and is skipped whenever the signature
+ * repeats, so every field the feed renders has to be part of the signature —
+ * a change to a field that is left out never reaches the page and the row
+ * keeps showing the state of the last push.
+ */
+class StatsV2WebSocketHandlerSigTest {
+
+    /** A row the way {@code RequestLogService} hands it out: absent values are null. */
+    private static Map<String, Object> row(String requestId, String provider, String scheduledTs) {
+        Map<String, Object> r = new LinkedHashMap<>();
+        r.put("request_id", requestId);
+        r.put("status", "pending");
+        r.put("provider_name", provider);
+        r.put("is_cloud", false);
+        r.put("scheduled_ts", scheduledTs);
+        r.put("request_complete_ts", null);
+        r.put("prompt_tokens", null);
+        r.put("completion_tokens", null);
+        r.put("total_tokens", null);
+        r.put("cost_microcents", null);
+        return r;
+    }
+
+    private static Map<String, Object> page(Map<String, Object>... rows) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("requests", List.of(rows));
+        return payload;
+    }
+
+    @Test
+    void identicalPagesHaveIdenticalSignatures() {
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))))
+            .isEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))));
+    }
+
+    @Test
+    void aProviderChangeAloneChangesTheSignature() {
+        // The row carries the deployment the request was made for from enqueue
+        // time; the provider that actually serves it is only written once the
+        // request is scheduled. When that is the only thing that moved, the
+        // page must still be pushed — otherwise the row keeps the provider it
+        // showed while queued.
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-02", null))))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))));
+    }
+
+    @Test
+    void gainingAProviderFromNoneChangesTheSignature() {
+        // A freshly enqueued row has no provider yet; the enqueue-time write
+        // fills it in moments later. That is a change too, not a repeat.
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", null, null))));
+    }
+
+    @Test
+    void aCloudLocalFlipAloneChangesTheSignature() {
+        // The Cloud/Local badge is derived from the provider's type, so a
+        // re-route between a local and a cloud provider must be visible to the
+        // signature even though the name field is unchanged.
+        Map<String, Object> local = row("r-1", "upstream", null);
+        Map<String, Object> cloud = row("r-1", "upstream", null);
+        cloud.put("is_cloud", true);
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(cloud)))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(local)));
+    }
+
+    @Test
+    void aScheduledTimestampChangeStillChangesTheSignature() {
+        // Regression: the queued-to-running transition must keep being
+        // detected once the provider fields joined the signature.
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", "2026-08-28T10:15:30Z"))))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))));
+    }
+
+    @Test
+    void aCompletionStillChangesTheSignature() {
+        Map<String, Object> completed = row("r-1", "gpu-01", "2026-08-28T10:15:30Z");
+        completed.put("status", "success");
+        completed.put("request_complete_ts", "2026-08-28T10:15:42Z");
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(completed)))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", "2026-08-28T10:15:30Z"))));
+    }
+
+    @Test
+    void aGrowingTokenCountStillChangesTheSignature() {
+        // Regression: usage of a streaming request moves without any status or
+        // timestamp changing — the token and cost line must keep moving.
+        Map<String, Object> grown = row("r-1", "gpu-01", "2026-08-28T10:15:30Z");
+        grown.put("completion_tokens", 42);
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(grown)))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", "2026-08-28T10:15:30Z"))));
+    }
+
+    @Test
+    void anEmptyPageSignsStable() {
+        assertThat(StatsV2WebSocketHandler.requestsSig(page()))
+            .isEqualTo(StatsV2WebSocketHandler.requestsSig(page()));
+    }
+}

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerSigTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerSigTest.java
@@ -25,6 +25,7 @@ class StatsV2WebSocketHandlerSigTest {
         r.put("request_id", requestId);
         r.put("status", "pending");
         r.put("provider_name", provider);
+        r.put("model_name", "model-a");
         r.put("is_cloud", false);
         r.put("scheduled_ts", scheduledTs);
         r.put("request_complete_ts", null);
@@ -64,6 +65,19 @@ class StatsV2WebSocketHandlerSigTest {
         // fills it in moments later. That is a change too, not a repeat.
         assertThat(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))))
             .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", null, null))));
+    }
+
+    @Test
+    void aModelChangeAloneChangesTheSignature() {
+        // Scheduling re-resolves the model together with the provider, so a
+        // re-routed request changes its model while every timestamp on the row
+        // stays put. Without the model in the signature the push is skipped and
+        // the row keeps naming the model the request was enqueued for.
+        Map<String, Object> rerouted = row("r-1", "gpu-01", null);
+        rerouted.put("model_name", "model-b");
+
+        assertThat(StatsV2WebSocketHandler.requestsSig(page(rerouted)))
+            .isNotEqualTo(StatsV2WebSocketHandler.requestsSig(page(row("r-1", "gpu-01", null))));
     }
 
     @Test


### PR DESCRIPTION
Fixes #821 with two changes. (1) The recent-requests view now renders none as the provider for rows still queued, because the row carried an early enqueue-time provider that obscured the forwarding change. (2) The websocket requests push signature now includes provider fields so provider-only changes trigger a re-push. Added pure function providerLabel and template helper. Unit tests (61 UI; 8 signature; 264 webservice) and UI build all pass. Verification: queued rows show none; forwarding updates rows to actual provider and triggers push. Fixes #821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recent request cards now display the correct provider label.
  * Queued requests show “none” until a provider is assigned.
  * Missing provider information consistently falls back to “none”.
  * Statistics updates now refresh when provider, model, hosting type, timing, completion, or token details change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->