### PR TITLE
`Logos`: Monitor MTP/prefix-cache hit rates and token/context usage in Prometheus

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -713,6 +713,7 @@ class CapacityPlanner:
 
             provider_ids.sort(key=_provider_pressure, reverse=True)
         self._log_cluster_summary(provider_ids)
+        self._refresh_engine_cache_metrics(provider_ids)
 
         # Cross-provider best-first ranking: pre-score every (provider,
         # model) candidate so the cheapest worker for each model wins,
@@ -824,6 +825,51 @@ class CapacityPlanner:
                 )
 
         prom.CAPACITY_PLANNER_CYCLE_DURATION_SECONDS.observe(time.time() - cycle_start)
+
+    def _refresh_engine_cache_metrics(self, provider_ids: List[int]) -> None:
+        """Publish per-(provider, model) prefix-cache and MTP-acceptance rates.
+
+        Feeds the ``logos_prefix_cache_hit_rate`` / ``logos_mtp_acceptance_rate``
+        gauges from the workers' lane backend metrics. Aggregation mirrors the
+        live-statistics payload: the prefix hit rate is the plain mean across
+        the model's lanes, while the MTP acceptance rate is token-weighted
+        (sum of accepted / sum of draft tokens), because an unweighted mean of
+        per-lane rates misstates the model rate when lanes see different
+        draft volumes. Pairs with no lanes this cycle are retired by the
+        publish helper.
+        """
+        entries: list[tuple[str, str, float | None, float | None]] = []
+        for pid in provider_ids:
+            snap = self._registry.peek_runtime_snapshot(pid) if self._registry else None
+            if snap is None:
+                continue
+            provider_name = self._facade.get_provider_name(pid) or str(pid)
+            runtime = snap.get("runtime") or {}
+            lanes = runtime.get("lanes")
+            per_model: dict[str, dict[str, float]] = {}
+            for lane in lanes if isinstance(lanes, list) else []:
+                if not isinstance(lane, dict):
+                    continue
+                model = str(lane.get("model") or "").strip()
+                if not model:
+                    continue
+                backend_metrics = lane.get("backend_metrics") if isinstance(lane.get("backend_metrics"), dict) else {}
+                agg = per_model.setdefault(
+                    model, {"prefix_sum": 0.0, "prefix_count": 0.0, "mtp_draft": 0.0, "mtp_accepted": 0.0}
+                )
+                prefix_rate = lane_metric_float(backend_metrics.get("prefix_cache_hit_rate"))
+                if prefix_rate is not None:
+                    agg["prefix_sum"] += prefix_rate
+                    agg["prefix_count"] += 1
+                mtp_draft = lane_metric_float(backend_metrics.get("mtp_draft_tokens_total")) or 0.0
+                mtp_accepted = lane_metric_float(backend_metrics.get("mtp_accepted_tokens_total")) or 0.0
+                agg["mtp_draft"] += mtp_draft
+                agg["mtp_accepted"] += mtp_accepted
+            for model, agg in per_model.items():
+                prefix_rate = agg["prefix_sum"] / agg["prefix_count"] if agg["prefix_count"] > 0 else None
+                mtp_rate = agg["mtp_accepted"] / agg["mtp_draft"] if agg["mtp_draft"] > 0 else None
+                entries.append((model, provider_name, prefix_rate, mtp_rate))
+        prom.update_engine_cache_metrics(entries)
 
     def _log_cluster_summary(self, provider_ids: List[int]) -> None:
         """Print a colored cluster overview for the current planner cycle."""

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -3109,6 +3109,7 @@ async def _streaming_response(
                         result_status="error" if error_message else "success",
                         error_message=error_message,
                         cold_start=scheduling_stats.get("is_cold_start"),
+                        usage_tokens=usage_tokens,
                     )
                 _log_request_completion(
                     model_id=model_id,
@@ -3274,6 +3275,7 @@ async def _streaming_response(
                     result_status="error" if failed else "success",
                     error_message=error_message,
                     cold_start=scheduling_stats.get("is_cold_start"),
+                    usage_tokens=usage_tokens,
                 )
             _log_request_completion(
                 model_id=model_id,
@@ -3492,6 +3494,7 @@ async def _sync_response(
                     error_message if timed_out else (exec_result.error if not exec_result.success else None)
                 ),
                 cold_start=scheduling_stats.get("is_cold_start"),
+                usage_tokens=usage_tokens,
             )
 
         if rl_key:

--- a/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
@@ -3,6 +3,8 @@
 Defines all custom metrics and exposes a WSGI app for the /metrics endpoint.
 """
 
+from typing import Any
+
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, Histogram, generate_latest
 
 registry = CollectorRegistry()
@@ -271,13 +273,37 @@ REQUEST_CONTEXT_TOKENS = Histogram(
 _PUBLISHED_ENGINE_METRIC_KEYS: set[tuple[str, str]] = set()
 
 
+def _remove_label_silently(metric: Any, model: str, provider: str) -> None:
+    """Remove a (model, provider) label set, tolerating a never-published gauge.
+
+    ``prometheus_client``'s ``remove()`` raises ``KeyError`` for a label set
+    that was never created, and a pair can legitimately be missing one side:
+    a model without speculative decoding never publishes an MTP acceptance
+    rate (no ``MTP_ACCEPTANCE_RATE`` child exists for it), and a lane that
+    reports no prefix data never publishes a prefix rate. Retiring such a pair
+    must not raise — a raised error here would abort the planner cycle before
+    it does any capacity planning.
+    """
+    try:
+        # `remove()` lives on the parent metric and takes positional label
+        # values; a child obtained from .labels() has no working remove of its own.
+        metric.remove(model, provider)
+    except KeyError:
+        pass
+
+
 def update_engine_cache_metrics(entries: list[tuple[str, str, float | None, float | None]]) -> None:
     """Publish per-(model, provider) engine rates and retire stale label sets.
 
     Each entry is ``(model, provider, prefix_cache_hit_rate, mtp_acceptance_rate)``;
     a ``None`` rate is simply not published for that metric (the previous value
     stays until the pair disappears). Label sets that were published before but
-    are missing from *entries* are removed from both gauges.
+    are missing from *entries* are removed from the gauges that hold them.
+
+    The tracked-key state is refreshed in a ``finally`` so that a failure
+    during retirement can never leave it frozen — a stale diff set would
+    re-raise on every subsequent call and keep the caller (the planner cycle)
+    dead.
     """
     current: set[tuple[str, str]] = set()
     for model, provider, prefix_rate, mtp_rate in entries:
@@ -286,13 +312,13 @@ def update_engine_cache_metrics(entries: list[tuple[str, str, float | None, floa
             PREFIX_CACHE_HIT_RATE.labels(model=model, provider=provider).set(prefix_rate)
         if mtp_rate is not None:
             MTP_ACCEPTANCE_RATE.labels(model=model, provider=provider).set(mtp_rate)
-    # `remove()` lives on the parent metric and takes positional label values;
-    # a child obtained from .labels() has no working remove of its own.
-    for model, provider in _PUBLISHED_ENGINE_METRIC_KEYS - current:
-        PREFIX_CACHE_HIT_RATE.remove(model, provider)
-        MTP_ACCEPTANCE_RATE.remove(model, provider)
-    _PUBLISHED_ENGINE_METRIC_KEYS.clear()
-    _PUBLISHED_ENGINE_METRIC_KEYS.update(current)
+    try:
+        for model, provider in _PUBLISHED_ENGINE_METRIC_KEYS - current:
+            _remove_label_silently(PREFIX_CACHE_HIT_RATE, model, provider)
+            _remove_label_silently(MTP_ACCEPTANCE_RATE, model, provider)
+    finally:
+        _PUBLISHED_ENGINE_METRIC_KEYS.clear()
+        _PUBLISHED_ENGINE_METRIC_KEYS.update(current)
 
 
 # ---------------------------------------------------------------------------

--- a/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
@@ -210,6 +210,92 @@ WORKER_VRAM_FREE_MB = Gauge(
 )
 
 # ---------------------------------------------------------------------------
+# Engine telemetry (per provider/model pair)
+# ---------------------------------------------------------------------------
+
+PREFIX_CACHE_HIT_RATE = Gauge(
+    "logos_prefix_cache_hit_rate",
+    "vLLM prefix-cache hit rate per provider/model pair (0..1, cumulative since lane start)",
+    ["model", "provider"],
+    registry=registry,
+)
+
+MTP_ACCEPTANCE_RATE = Gauge(
+    "logos_mtp_acceptance_rate",
+    "MTP/speculative-decoding draft-token acceptance rate per provider/model pair (0..1, "
+    "cumulative since lane start); absent for models running without speculative decoding",
+    ["model", "provider"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Token usage (per request, cloud and local providers alike)
+# ---------------------------------------------------------------------------
+
+PROMPT_TOKENS_TOTAL = Counter(
+    "logos_prompt_tokens_total",
+    "Input (prompt) tokens processed per model/provider pair, all request outcomes",
+    ["model", "provider"],
+    registry=registry,
+)
+
+GENERATION_TOKENS_TOTAL = Counter(
+    "logos_generation_tokens_total",
+    "Output (generation) tokens produced per model/provider pair, all request outcomes",
+    ["model", "provider"],
+    registry=registry,
+)
+
+CACHED_PROMPT_TOKENS_TOTAL = Counter(
+    "logos_cached_prompt_tokens_total",
+    "Prompt tokens served from the prefix cache per model/provider pair; rate = "
+    "this counter / logos_prompt_tokens_total in Grafana",
+    ["model", "provider"],
+    registry=registry,
+)
+
+REQUEST_CONTEXT_TOKENS = Histogram(
+    "logos_request_context_tokens",
+    "Context window used by a completed request (prompt + generation tokens), per model",
+    ["model"],
+    # Top out at 512k: calibrated lanes run at up to 262144 tokens, and a
+    # generation can push the used window past the prompt length. Anything
+    # beyond the highest bucket would clamp every high percentile to the
+    # boundary, the same failure mode documented on REQUEST_DURATION_SECONDS.
+    buckets=(256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288),
+    registry=registry,
+)
+
+# Label sets published by update_engine_cache_metrics(), so pairs whose lanes
+# are gone can be removed instead of keeping their last value forever.
+_PUBLISHED_ENGINE_METRIC_KEYS: set[tuple[str, str]] = set()
+
+
+def update_engine_cache_metrics(entries: list[tuple[str, str, float | None, float | None]]) -> None:
+    """Publish per-(model, provider) engine rates and retire stale label sets.
+
+    Each entry is ``(model, provider, prefix_cache_hit_rate, mtp_acceptance_rate)``;
+    a ``None`` rate is simply not published for that metric (the previous value
+    stays until the pair disappears). Label sets that were published before but
+    are missing from *entries* are removed from both gauges.
+    """
+    current: set[tuple[str, str]] = set()
+    for model, provider, prefix_rate, mtp_rate in entries:
+        current.add((model, provider))
+        if prefix_rate is not None:
+            PREFIX_CACHE_HIT_RATE.labels(model=model, provider=provider).set(prefix_rate)
+        if mtp_rate is not None:
+            MTP_ACCEPTANCE_RATE.labels(model=model, provider=provider).set(mtp_rate)
+    # `remove()` lives on the parent metric and takes positional label values;
+    # a child obtained from .labels() has no working remove of its own.
+    for model, provider in _PUBLISHED_ENGINE_METRIC_KEYS - current:
+        PREFIX_CACHE_HIT_RATE.remove(model, provider)
+        MTP_ACCEPTANCE_RATE.remove(model, provider)
+    _PUBLISHED_ENGINE_METRIC_KEYS.clear()
+    _PUBLISHED_ENGINE_METRIC_KEYS.update(current)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -259,7 +259,7 @@ class MonitoringRecorder:
         if context_tokens > 0:
             # How much of the model's context window the request used — the
             # signal for whether a deployment can be downsized or needs a
-            # bigger window (issue #819).
+            # bigger window.
             prom.REQUEST_CONTEXT_TOKENS.labels(model=model).observe(context_tokens)
 
     def discard(self, request_id: str, result_status: ResultStatus | str) -> None:

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -79,6 +79,17 @@ def _sweep_stale_requests(now: float) -> None:
         )
 
 
+def _nonneg_int(value: Any) -> Optional[int]:
+    """A non-negative int token count, or None when the value is unusable.
+
+    ``bool`` is an ``int`` subclass but never a token count, so it is
+    excluded explicitly (same rule as ``extract_token_usage``).
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 def _resolve_label_names(model_id: Optional[int], provider_id: Optional[int]) -> tuple[str, str]:
     """Resolve the model/provider label values for completion metrics.
 
@@ -180,6 +191,7 @@ class MonitoringRecorder:
         request_id: str,
         result_status: ResultStatus | str,
         cold_start: Optional[bool] = None,
+        usage_tokens: Optional[Dict[str, int]] = None,
     ) -> str:
         """Close out a request's metrics and return the status string.
 
@@ -187,6 +199,13 @@ class MonitoringRecorder:
         reached ``record_enqueue`` (a classification failure completes before
         it is ever enqueued), contributes no duration observation and cannot
         move the in-flight gauge.
+
+        ``usage_tokens`` is the ``extract_token_usage`` dict of a completed
+        request (``prompt_tokens`` / ``completion_tokens`` /
+        ``prompt_cached_tokens``). Token counters count what the provider
+        actually processed, so they are observed for every outcome — a
+        timeout that streamed most of the generation still consumed those
+        tokens.
         """
         status_value = result_status.value if isinstance(result_status, ResultStatus) else str(result_status)
 
@@ -213,7 +232,35 @@ class MonitoringRecorder:
 
         if cold_start:
             prom.COLD_STARTS_TOTAL.labels(model=model, provider=provider).inc()
+        if usage_tokens:
+            self._observe_token_usage(model, provider, usage_tokens)
         return status_value
+
+    @staticmethod
+    def _observe_token_usage(model: str, provider: str, usage_tokens: Dict[str, int]) -> None:
+        """Feed the token counters and the per-model context-window histogram.
+
+        ``extract_token_usage`` already stores ints only, but the recorder
+        must not break a request over a malformed dict, so each value is
+        coerced defensively and skipped when absent.
+        """
+        prompt_tokens = _nonneg_int(usage_tokens.get("prompt_tokens"))
+        completion_tokens = _nonneg_int(usage_tokens.get("completion_tokens"))
+        cached_tokens = _nonneg_int(usage_tokens.get("prompt_cached_tokens"))
+
+        if prompt_tokens is not None:
+            prom.PROMPT_TOKENS_TOTAL.labels(model=model, provider=provider).inc(prompt_tokens)
+        if completion_tokens is not None:
+            prom.GENERATION_TOKENS_TOTAL.labels(model=model, provider=provider).inc(completion_tokens)
+        if cached_tokens is not None:
+            prom.CACHED_PROMPT_TOKENS_TOTAL.labels(model=model, provider=provider).inc(cached_tokens)
+
+        context_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+        if context_tokens > 0:
+            # How much of the model's context window the request used — the
+            # signal for whether a deployment can be downsized or needs a
+            # bigger window (issue #819).
+            prom.REQUEST_CONTEXT_TOKENS.labels(model=model).observe(context_tokens)
 
     def discard(self, request_id: str, result_status: ResultStatus | str) -> None:
         """Finalise a request whose terminal state was persisted elsewhere.
@@ -232,8 +279,9 @@ class MonitoringRecorder:
         result_status: ResultStatus | str,
         cold_start: Optional[bool] = None,
         error_message: Optional[str] = None,
+        usage_tokens: Optional[Dict[str, int]] = None,
     ) -> None:
-        status_value = self._settle(request_id, result_status, cold_start)
+        status_value = self._settle(request_id, result_status, cold_start, usage_tokens)
 
         payload = {
             "request_complete_ts": datetime.datetime.now(datetime.timezone.utc),

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -506,13 +506,19 @@ class RequestPipeline:
         result_status: str,
         error_message: Optional[str] = None,
         cold_start: Optional[bool] = None,
+        usage_tokens: Optional[Dict[str, int]] = None,
     ):
-        """Record request completion."""
+        """Record request completion.
+
+        ``usage_tokens`` (the ``extract_token_usage`` dict) feeds the token
+        counters and the per-model context-window histogram when present.
+        """
         self._monitoring.record_complete(
             request_id=request_id,
             result_status=result_status,
             error_message=error_message,
             cold_start=cold_start,
+            usage_tokens=usage_tokens,
         )
 
     def discard_request(self, request_id: str, result_status: str) -> None:

--- a/logos/logos-orchestrator/tests/unit/capacity/test_engine_cache_metrics.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_engine_cache_metrics.py
@@ -1,0 +1,129 @@
+"""Tests for the planner's per-(provider, model) engine-cache metric refresh (issue 819).
+
+The planner aggregates the workers' lane backend metrics into
+``(model, provider, prefix_cache_hit_rate, mtp_acceptance_rate)`` entries and
+hands them to ``prom.update_engine_cache_metrics``. The publish function is
+replaced with a recorder so these tests only cover the aggregation.
+"""
+
+import pytest
+
+from logos import CapacityPlanner
+from logos.monitoring import prometheus_metrics as prom
+
+
+def _lane(model, *, prefix=None, draft=None, accepted=None):
+    backend_metrics = {}
+    if prefix is not None:
+        backend_metrics["prefix_cache_hit_rate"] = prefix
+    if draft is not None:
+        backend_metrics["mtp_draft_tokens_total"] = draft
+    if accepted is not None:
+        backend_metrics["mtp_accepted_tokens_total"] = accepted
+    return {"model": model, "backend_metrics": backend_metrics}
+
+
+def _snapshot(lanes):
+    return {"runtime": {"lanes": lanes}}
+
+
+def _make_planner(provider_lanes, provider_names):
+    class _Registry:
+        def peek_runtime_snapshot(self, pid):
+            return provider_lanes.get(pid)
+
+    class _Facade:
+        def get_provider_name(self, pid):
+            return provider_names.get(pid, str(pid))
+
+    return CapacityPlanner(
+        logosnode_facade=_Facade(),
+        logosnode_registry=_Registry(),
+        demand_tracker=None,
+    )
+
+
+def _run_refresh(monkeypatch, planner, provider_ids):
+    calls = []
+    monkeypatch.setattr(prom, "update_engine_cache_metrics", lambda entries: calls.append(entries))
+    planner._refresh_engine_cache_metrics(provider_ids)
+    return calls[0] if calls else []
+
+
+def test_aggregates_prefix_mean_and_token_weighted_mtp_per_pair(monkeypatch):
+    planner = _make_planner(
+        {
+            1: _snapshot(
+                [
+                    _lane("model-a", prefix=0.6, draft=100, accepted=60),
+                    _lane("model-a", prefix=0.8, draft=300, accepted=90),
+                ]
+            ),
+            2: _snapshot([_lane("model-a", prefix=0.4)]),
+        },
+        {1: "node-a", 2: "node-b"},
+    )
+
+    entries = _run_refresh(monkeypatch, planner, [1, 2])
+
+    # Same model on two providers: two independent (model, provider) pairs.
+    by_pair = {(model, provider): (prefix, mtp) for model, provider, prefix, mtp in entries}
+    assert set(by_pair) == {("model-a", "node-a"), ("model-a", "node-b")}
+
+    prefix, mtp = by_pair[("model-a", "node-a")]
+    # Prefix: plain mean of the per-lane rates (0.6 + 0.8) / 2.
+    assert prefix == pytest.approx(0.7)
+    # MTP: token-weighted across lanes — (60 + 90) / (100 + 300), NOT the
+    # unweighted mean of the per-lane rates ((0.6 + 0.3) / 2 = 0.45).
+    assert mtp == pytest.approx(150 / 400)
+
+    prefix, mtp = by_pair[("model-a", "node-b")]
+    assert prefix == pytest.approx(0.4)
+    # No speculative decoding on this lane: rate absent, not zero.
+    assert mtp is None
+
+
+def test_lane_without_any_metrics_yields_pair_with_none_rates(monkeypatch):
+    """An ollama lane (or a failed vLLM scrape) still claims its pair."""
+    planner = _make_planner(
+        {1: _snapshot([_lane("model-b")])},
+        {1: "node-a"},
+    )
+
+    entries = _run_refresh(monkeypatch, planner, [1])
+
+    assert entries == [("model-b", "node-a", None, None)]
+
+
+def test_offline_provider_contributes_no_entries(monkeypatch):
+    planner = _make_planner(
+        {1: _snapshot([_lane("model-a", prefix=0.5, draft=10, accepted=5)]), 2: None},
+        {1: "node-a", 2: "node-b"},
+    )
+
+    entries = _run_refresh(monkeypatch, planner, [1, 2])
+
+    assert entries == [("model-a", "node-a", 0.5, 0.5)]
+
+
+def test_unnamed_provider_falls_back_to_id(monkeypatch):
+    planner = _make_planner(
+        {7: _snapshot([_lane("model-a", prefix=0.25)])},
+        {},
+    )
+
+    entries = _run_refresh(monkeypatch, planner, [7])
+
+    assert entries == [("model-a", "7", 0.25, None)]
+
+
+def test_prefix_average_ignores_lanes_without_a_rate(monkeypatch):
+    """A lane whose scrape dropped the rate must not skew the model mean."""
+    planner = _make_planner(
+        {1: _snapshot([_lane("model-a", prefix=0.8), _lane("model-a")])},
+        {1: "node-a"},
+    )
+
+    entries = _run_refresh(monkeypatch, planner, [1])
+
+    assert entries == [("model-a", "node-a", 0.8, None)]

--- a/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_request_logging.py
@@ -191,6 +191,11 @@ async def test_streaming_response_logs_usage_when_sse_events_are_split(monkeypat
             "result_status": "success",
             "error_message": None,
             "cold_start": False,
+            "usage_tokens": {
+                "prompt_tokens": 3,
+                "completion_tokens": 5,
+                "total_tokens": 8,
+            },
         }
     ]
     assert release_calls == [(27, 12, "logosnode", "req-stream")]
@@ -474,6 +479,8 @@ async def test_http_streaming_terminal_error_is_recorded(monkeypatch, terminal_e
             "result_status": "error",
             "error_message": terminal_error,
             "cold_start": False,
+            # The stream carried no usage chunk, so nothing was extracted.
+            "usage_tokens": {},
         }
     ]
     assert completion_logs[0]["status"] == "error"
@@ -671,6 +678,8 @@ async def test_sync_response_error_skips_ttft_and_records_error(monkeypatch):
             "result_status": "error",
             "error_message": "bad request",
             "cold_start": False,
+            # An error body carries no usage, so nothing was extracted.
+            "usage_tokens": {},
         }
     ]
     assert release_calls == [(10, 1, "cloud", "req-sync-error")]
@@ -738,6 +747,11 @@ async def test_sync_response_async_job_success_logs_usage(monkeypatch):
             "result_status": "success",
             "error_message": None,
             "cold_start": True,
+            "usage_tokens": {
+                "prompt_tokens": 11,
+                "completion_tokens": 13,
+                "total_tokens": 24,
+            },
         }
     ]
     assert release_calls == [(10, 1, "cloud", "req-job")]

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_engine_cache_metrics.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_engine_cache_metrics.py
@@ -6,13 +6,18 @@ fakes so the assertions are deterministic regardless of whether a stubbed
 ``prometheus_client`` is installed by the capacity test modules.
 """
 
+import pytest
+
 from logos.monitoring import prometheus_metrics as prom
 
 
 class _FakeLabeledGauge:
-    """Mirrors the real prometheus_client API: values are set through
+    """Mirrors the real prometheus_client API strictly: values are set through
     ``.labels(**kwargs)`` children, while ``remove(*labelvalues)`` lives on
-    the parent metric."""
+    the parent metric and raises ``KeyError`` for a label set that was never
+    created (the real library does ``del self._metrics[labelvalues]``). A
+    lenient ``pop(key, None)`` here would mask retire-path bugs that kill the
+    capacity planner in production."""
 
     _labelnames = ("model", "provider")
 
@@ -26,7 +31,7 @@ class _FakeLabeledGauge:
     def remove(self, *labelvalues):
         key = tuple(zip(self._labelnames, labelvalues))
         self.removed.append(key)
-        self.values.pop(key, None)
+        del self.values[key]
 
 
 class _FakeLabeledChild:
@@ -111,3 +116,89 @@ def test_empty_entries_retire_all_published_pairs(monkeypatch):
     assert fake_mtp.values == {}
     assert fake_prefix.removed == [_key("model-a", "node-1")]
     assert fake_mtp.removed == [_key("model-a", "node-1")]
+
+
+# ---------------------------------------------------------------------------
+# Retire path with a missing series (the planner-killing KeyError)
+# ---------------------------------------------------------------------------
+
+
+def test_retiring_pair_without_mtp_series_does_not_raise(monkeypatch):
+    """A model without speculative decoding never published an MTP child, so
+    its MTP remove raises KeyError in the real library. Retiring the pair must
+    still succeed — an escape here kills the capacity planner cycle and the
+    tracked-key state freezes, re-raising on every cycle afterwards."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics([("qwen", "w1", 0.5, None)])
+    prom.update_engine_cache_metrics([])
+
+    assert fake_prefix.values == {}
+    assert fake_mtp.values == {}
+    assert fake_prefix.removed == [_key("qwen", "w1")]
+    # The MTP remove was attempted and its KeyError swallowed by production
+    # code, not masked by a lenient fake.
+    assert fake_mtp.removed == [_key("qwen", "w1")]
+
+
+def test_retiring_pair_without_prefix_series_does_not_raise(monkeypatch):
+    """Symmetric case: a lane that reported no prefix data has no prefix child."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics([("qwen", "w1", None, 0.4)])
+    prom.update_engine_cache_metrics([])
+
+    assert fake_prefix.values == {}
+    assert fake_mtp.values == {}
+    assert fake_prefix.removed == [_key("qwen", "w1")]
+    assert fake_mtp.removed == [_key("qwen", "w1")]
+
+
+def test_retiring_pair_never_published_either_series_does_not_raise(monkeypatch):
+    """A pair seen only with two None rates (scrape failure) has no child on
+    either gauge."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics([("qwen", "w1", None, None)])
+    prom.update_engine_cache_metrics([])
+
+    assert fake_prefix.values == {}
+    assert fake_mtp.values == {}
+    assert fake_prefix.removed == [_key("qwen", "w1")]
+    assert fake_mtp.removed == [_key("qwen", "w1")]
+
+
+def test_tracked_state_refreshes_even_when_retirement_raises(monkeypatch):
+    """A failure during retirement must not freeze the tracked-key state: a
+    stale diff set would re-raise on every subsequent call and keep the
+    planner cycle dead. The ``finally`` refresh guarantees the next call sees
+    the up-to-date set of live pairs."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics(
+        [
+            ("model-a", "node-1", 0.5, 0.3),
+            ("model-b", "node-1", 0.2, 0.1),
+        ]
+    )
+
+    real_mtp_remove = fake_mtp.remove
+
+    def _explode(*labelvalues):
+        raise RuntimeError("boom")
+
+    fake_mtp.remove = _explode
+    with pytest.raises(RuntimeError, match="boom"):
+        prom.update_engine_cache_metrics([("model-a", "node-1", 0.6, 0.4)])
+
+    # Round 3 must diff against {model-a} only — model-b was dropped from the
+    # tracked state despite round 2's failure. With a frozen state, model-b's
+    # MTP remove would be attempted again here.
+    fake_mtp.remove = real_mtp_remove
+    prom.update_engine_cache_metrics([])
+
+    assert fake_prefix.removed == [
+        _key("model-b", "node-1"),  # round 2, before the failure
+        _key("model-a", "node-1"),  # round 3
+    ]
+    assert fake_mtp.removed == [_key("model-a", "node-1")]  # round 3 only

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_engine_cache_metrics.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_engine_cache_metrics.py
@@ -1,0 +1,113 @@
+"""Tests for the per-(model, provider) engine-cache gauges (issue 819).
+
+``update_engine_cache_metrics`` publishes the prefix-cache hit rate and the
+MTP acceptance rate to Prometheus. The gauges are replaced with recording
+fakes so the assertions are deterministic regardless of whether a stubbed
+``prometheus_client`` is installed by the capacity test modules.
+"""
+
+from logos.monitoring import prometheus_metrics as prom
+
+
+class _FakeLabeledGauge:
+    """Mirrors the real prometheus_client API: values are set through
+    ``.labels(**kwargs)`` children, while ``remove(*labelvalues)`` lives on
+    the parent metric."""
+
+    _labelnames = ("model", "provider")
+
+    def __init__(self):
+        self.values: dict[tuple[tuple[str, str], ...], float] = {}
+        self.removed: list[tuple[tuple[str, str], ...]] = []
+
+    def labels(self, **kwargs):
+        return _FakeLabeledChild(self, tuple(sorted(kwargs.items())))
+
+    def remove(self, *labelvalues):
+        key = tuple(zip(self._labelnames, labelvalues))
+        self.removed.append(key)
+        self.values.pop(key, None)
+
+
+class _FakeLabeledChild:
+    def __init__(self, parent: _FakeLabeledGauge, key: tuple[tuple[str, str], ...]):
+        self._parent = parent
+        self._key = key
+
+    def set(self, value):
+        self._parent.values[self._key] = value
+
+
+def _key(model: str, provider: str) -> tuple[tuple[str, str], ...]:
+    return (("model", model), ("provider", provider))
+
+
+def _patch_prom(monkeypatch):
+    fake_prefix = _FakeLabeledGauge()
+    fake_mtp = _FakeLabeledGauge()
+    monkeypatch.setattr(prom, "PREFIX_CACHE_HIT_RATE", fake_prefix)
+    monkeypatch.setattr(prom, "MTP_ACCEPTANCE_RATE", fake_mtp)
+    monkeypatch.setattr(prom, "_PUBLISHED_ENGINE_METRIC_KEYS", set())
+    return fake_prefix, fake_mtp
+
+
+def test_publishes_rates_for_each_pair(monkeypatch):
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics(
+        [
+            ("model-a", "node-1", 0.5, 0.3),
+            ("model-b", "node-1", None, 0.8),
+        ]
+    )
+
+    assert fake_prefix.values == {_key("model-a", "node-1"): 0.5}
+    assert fake_mtp.values == {
+        _key("model-a", "node-1"): 0.3,
+        _key("model-b", "node-1"): 0.8,
+    }
+    assert fake_prefix.removed == []
+    assert fake_mtp.removed == []
+
+
+def test_none_rate_keeps_previous_value(monkeypatch):
+    """A scrape failure (None rate) must not zero out or retire the pair."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics([("model-a", "node-1", 0.5, 0.3)])
+    prom.update_engine_cache_metrics([("model-a", "node-1", None, None)])
+
+    assert fake_prefix.values == {_key("model-a", "node-1"): 0.5}
+    assert fake_mtp.values == {_key("model-a", "node-1"): 0.3}
+    assert fake_prefix.removed == []
+    assert fake_mtp.removed == []
+
+
+def test_stale_pairs_are_removed(monkeypatch):
+    """Pairs whose lanes are gone lose their label sets on the next publish."""
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics(
+        [
+            ("model-a", "node-1", 0.5, 0.3),
+            ("model-b", "node-1", 0.2, None),
+        ]
+    )
+    prom.update_engine_cache_metrics([("model-a", "node-1", 0.6, 0.4)])
+
+    assert fake_prefix.values == {_key("model-a", "node-1"): 0.6}
+    assert fake_mtp.values == {_key("model-a", "node-1"): 0.4}
+    assert fake_prefix.removed == [_key("model-b", "node-1")]
+    assert fake_mtp.removed == [_key("model-b", "node-1")]
+
+
+def test_empty_entries_retire_all_published_pairs(monkeypatch):
+    fake_prefix, fake_mtp = _patch_prom(monkeypatch)
+
+    prom.update_engine_cache_metrics([("model-a", "node-1", 0.5, 0.3)])
+    prom.update_engine_cache_metrics([])
+
+    assert fake_prefix.values == {}
+    assert fake_mtp.values == {}
+    assert fake_prefix.removed == [_key("model-a", "node-1")]
+    assert fake_mtp.removed == [_key("model-a", "node-1")]

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
@@ -41,6 +41,7 @@ def _make_recording_metric(name):
             self.label_calls = []
             self.observations = []
             self.inc_calls = 0
+            self.inc_values = []
             self.dec_calls = 0
             self.set_values = []
 
@@ -51,8 +52,9 @@ def _make_recording_metric(name):
         def observe(self, value):
             self.observations.append(value)
 
-        def inc(self):
+        def inc(self, value=1):
             self.inc_calls += 1
+            self.inc_values.append(value)
 
         def dec(self):
             self.dec_calls += 1
@@ -83,6 +85,10 @@ def _patch_prom(monkeypatch):
         REQUEST_DURATION_SECONDS=_make_recording_metric("logos_request_duration_seconds"),
         COLD_STARTS_TOTAL=_make_recording_metric("logos_cold_starts_total"),
         QUEUE_DEPTH=_make_recording_metric("logos_queue_depth"),
+        PROMPT_TOKENS_TOTAL=_make_recording_metric("logos_prompt_tokens_total"),
+        GENERATION_TOKENS_TOTAL=_make_recording_metric("logos_generation_tokens_total"),
+        CACHED_PROMPT_TOKENS_TOTAL=_make_recording_metric("logos_cached_prompt_tokens_total"),
+        REQUEST_CONTEXT_TOKENS=_make_recording_metric("logos_request_context_tokens"),
     )
     monkeypatch.setattr(recorder_module, "prom", fake)
     return fake
@@ -241,3 +247,95 @@ def test_complete_without_enqueue_records_no_duration(monkeypatch):
 
     assert fake.REQUEST_DURATION_SECONDS.label_calls == []
     assert fake.REQUEST_DURATION_SECONDS.observations == []
+
+
+# ---------------------------------------------------------------------------
+# Token usage metrics (issue 819)
+# ---------------------------------------------------------------------------
+
+
+def _settle_with_usage(monkeypatch, result_status, usage_tokens):
+    recorder, _ = _make_recorder(monkeypatch, {27: "Qwen/Qwen3-8B"}, {12: "local-node"})
+    fake = _patch_prom(monkeypatch)
+
+    recorder.record_enqueue(
+        request_id="req-819-tokens",
+        model_id=27,
+        provider_id=12,
+        initial_priority="normal",
+        queue_depth=0,
+    )
+    recorder.record_scheduled(
+        request_id="req-819-tokens",
+        model_id=27,
+        provider_id=12,
+        priority_when_scheduled="normal",
+        queue_depth_at_schedule=0,
+    )
+    recorder.record_complete(
+        request_id="req-819-tokens",
+        result_status=result_status,
+        usage_tokens=usage_tokens,
+    )
+    return fake
+
+
+def test_record_complete_observes_token_counters_and_context_histogram(monkeypatch):
+    fake = _settle_with_usage(
+        monkeypatch,
+        "success",
+        {"prompt_tokens": 100, "completion_tokens": 40, "prompt_cached_tokens": 60},
+    )
+
+    # Counters are per model/provider pair…
+    for metric, expected in (
+        (fake.PROMPT_TOKENS_TOTAL, 100),
+        (fake.GENERATION_TOKENS_TOTAL, 40),
+        (fake.CACHED_PROMPT_TOKENS_TOTAL, 60),
+    ):
+        assert metric.label_calls == [{"model": "Qwen/Qwen3-8B", "provider": "local-node"}]
+        assert metric.inc_values == [expected]
+
+    # …the context-window histogram is per model only (issue 819: "not given
+    # model/provider pair") and covers prompt + generation tokens.
+    assert fake.REQUEST_CONTEXT_TOKENS.label_calls == [{"model": "Qwen/Qwen3-8B"}]
+    assert fake.REQUEST_CONTEXT_TOKENS.observations == [140]
+
+
+def test_timeout_with_usage_still_counts_tokens(monkeypatch):
+    """Tokens the provider processed count toward every outcome, not just success."""
+    fake = _settle_with_usage(monkeypatch, "timeout", {"prompt_tokens": 50})
+
+    assert fake.PROMPT_TOKENS_TOTAL.inc_values == [50]
+    # No completion/cached figures reported: those counters stay untouched.
+    assert fake.GENERATION_TOKENS_TOTAL.label_calls == []
+    assert fake.CACHED_PROMPT_TOKENS_TOTAL.label_calls == []
+    assert fake.REQUEST_CONTEXT_TOKENS.observations == [50]
+
+
+def test_record_complete_without_usage_observes_no_tokens(monkeypatch):
+    fake = _settle_with_usage(monkeypatch, "success", None)
+
+    for metric in (
+        fake.PROMPT_TOKENS_TOTAL,
+        fake.GENERATION_TOKENS_TOTAL,
+        fake.CACHED_PROMPT_TOKENS_TOTAL,
+        fake.REQUEST_CONTEXT_TOKENS,
+    ):
+        assert metric.label_calls == []
+        assert metric.observations == []
+        assert metric.inc_values == []
+
+
+def test_malformed_usage_tokens_are_skipped_not_fatal(monkeypatch):
+    """The recorder must never break a request over a malformed usage dict."""
+    fake = _settle_with_usage(
+        monkeypatch,
+        "success",
+        {"prompt_tokens": "100", "completion_tokens": True, "prompt_cached_tokens": -5},
+    )
+
+    assert fake.PROMPT_TOKENS_TOTAL.label_calls == []
+    assert fake.GENERATION_TOKENS_TOTAL.label_calls == []
+    assert fake.CACHED_PROMPT_TOKENS_TOTAL.label_calls == []
+    assert fake.REQUEST_CONTEXT_TOKENS.observations == []


### PR DESCRIPTION
## Closes #819

## Summary

Issue #819 asks for MTP acceptance rate and prefix-cache hit rate in monitoring, per provider/model pair. The statistics page and the per-lane terminal logs already render both rates (since #751), but the **Prometheus `/metrics` endpoint — the monitoring surface — exposed neither**, and it also had no token or context-window figures. The two follow-up comments on the issue extend the ask to token counts (cloud/local, cached/input/output, global and per provider/model pair, to derive rates in Grafana) and to the used context-window size per model over time (to decide whether a deployment can be downsized or needs a bigger window).

This PR adds all of that to the orchestrator's Prometheus registry. No worker change is needed: the vLLM workers already scrape and report `prefix_cache_hit_rate`, `mtp_acceptance_rate`, and the cumulative MTP draft/accepted token counters in every lane's `backend_metrics` payload, and the request-level token usage is already available at the orchestrator's completion path.

## New metrics

| Metric | Type | Labels | Source |
|--------|------|--------|--------|
| `logos_prefix_cache_hit_rate` | Gauge | `model`, `provider` | Mean of the model's lanes' vLLM prefix-cache hit rate (0..1, cumulative since lane start) |
| `logos_mtp_acceptance_rate` | Gauge | `model`, `provider` | Token-weighted MTP draft acceptance (Σ accepted / Σ draft tokens); absent when the model runs without speculative decoding |
| `logos_prompt_tokens_total` | Counter | `model`, `provider` | Input tokens per completed request, all outcomes, cloud + local |
| `logos_generation_tokens_total` | Counter | `model`, `provider` | Output tokens per completed request |
| `logos_cached_prompt_tokens_total` | Counter | `model`, `provider` | Prompt tokens served from the prefix cache → hit rate = this / `logos_prompt_tokens_total` in Grafana |
| `logos_request_context_tokens` | Histogram | `model` | Context window used by a request (prompt + generation tokens); per model on purpose (see issue comment) |

## Changes

- `logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py`: defines the six metrics and `update_engine_cache_metrics()`, which publishes the per-(model, provider) rates and removes label sets whose lanes are gone (a retired model must not keep its last gauge value in Grafana forever).
- `logos/logos-orchestrator/src/logos/capacity/capacity_planner.py`: new `_refresh_engine_cache_metrics()` runs each planner cycle right after the existing worker-gauge update. It aggregates the workers' lane backend metrics per (provider, model) with the same semantics as the live-statistics payload: plain mean for the prefix hit rate, token-weighted for MTP (an unweighted mean of per-lane rates misstates the model rate when lanes see different draft volumes).
- `logos/logos-orchestrator/src/logos/monitoring/recorder.py`: `_settle()` now takes the `extract_token_usage` dict and feeds the three token counters plus the context-window histogram. Token counts are observed for every outcome (a timeout that streamed most of the generation still consumed those tokens), and each value is coerced defensively so a malformed usage dict can never break a request.
- `logos/logos-orchestrator/src/logos/pipeline/pipeline.py` + `src/logos/main.py`: `record_completion()` passes the `usage_tokens` already computed at the three completion sites (logosnode stream, HTTP stream, sync) through to the recorder. Failure paths without usage are unchanged.

## Testing

- New unit tests:
  - `tests/unit/monitoring/test_engine_cache_metrics.py`: publish/retire semantics of `update_engine_cache_metrics()` (per-pair rates, None keeps the previous value, stale pairs removed from both gauges).
  - `tests/unit/capacity/test_engine_cache_metrics.py`: planner aggregation (mean vs token-weighted MTP, per-(model, provider) pairs across two providers, offline provider, unnamed provider, lanes without metrics).
  - `tests/unit/monitoring/test_recorder.py`: token counters + context histogram labelled per model/provider, timeout still counts, no usage → no observations, malformed usage skipped.
- `tests/unit/main/test_request_logging.py`: the `record_completion` assertions now expect the `usage_tokens` kwarg flowing through (the intended new behaviour at the three completion sites).
- A smoke script rendered the real `/metrics` output: all six series appear with correct label sets, the no-MTP model has no MTP series, and a retired pair's gauge series is gone after the next publish round.

Full orchestrator unit suite: **957 passed, 1 xfailed** (pre-existing). `black`, `isort`, `autoflake`, `flake8` (pinned versions, `logos/.flake8`) clean on all touched files.

One API subtlety worth noting: `prometheus_client`'s `remove()` lives on the *parent* metric and takes positional label values — a child from `.labels()` has no working remove. The publish helper uses the parent form, and the test fake mirrors that API so it guards against regressing to the child form.