### PR TITLE
`Logos`: Track every request in the live view from arrival and stream its token counts in real time

### DIFF
--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -21,7 +21,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from grpclocal import model_pb2_grpc
@@ -32,7 +32,7 @@ from logos.capacity.capacity_planner import CapacityPlanner
 from logos.capacity.demand_tracker import DemandTracker
 from logos.classification.classification_balancer import Balancer
 from logos.classification.classification_manager import ClassificationManager
-from logos.context_budget import required_context_tokens
+from logos.context_budget import estimate_prompt_tokens, required_context_tokens
 from logos.dbutils.dbmanager import DBManager
 from logos.dbutils.dbmodules import JobStatus
 from logos.dbutils.dbrequest import *
@@ -1101,7 +1101,7 @@ _MESSAGES_EVENT_TYPES = frozenset({"message_start", "message_delta", "message_st
 
 
 class _LiveStreamRegistry:
-    """Token counts of the streams running right now, keyed by request id.
+    """Token counts of the requests running right now, keyed by request id.
 
     A finished request's usage is in the database; one still running is
     nowhere, and "nowhere" is what the statistics page showed for the whole
@@ -1109,31 +1109,66 @@ class _LiveStreamRegistry:
     and on the orchestrator, because that is the only process that sees the
     chunks go past.
 
-    Bounded by construction: an entry exists only while its request is
-    streaming and is dropped in the same ``finally`` that logs the completion.
+    Bounded by construction: an entry exists only while its request is in
+    flight and is dropped in the same ``finally`` that logs the completion.
     """
 
     def __init__(self, now: Any = time.time) -> None:
         self._streams: dict[str, dict[str, Any]] = {}
         self._lock = threading.Lock()
+        # Bumped on every mutation so a subscriber (the SSE stream) can tell
+        # that something moved without diffing the whole table.
+        self._version = 0
         # Injected rather than read off the module so a test can drive the clock
         # without patching time.time for everything else running in-process.
         self._now = now
 
-    def start(self, request_id: Optional[str], model_name: Optional[str]) -> None:
+    @property
+    def version(self) -> int:
+        with self._lock:
+            return self._version
+
+    def start(
+        self,
+        request_id: Optional[str],
+        model_name: Optional[str] = None,
+        prompt_tokens: int = 0,
+        prompt_estimated: bool = False,
+    ) -> None:
+        """Register a request as in-flight; non-destructive for known ids.
+
+        A request is tracked from the moment it arrives, long before its
+        response starts streaming: while it queues, the only figure available
+        is the prompt estimate the context routing already computes. When the
+        streamer later calls this with the model name, the entry must keep its
+        counters and start time rather than resetting them — the numbers on
+        the page would jump backwards.
+        """
         if not request_id:
             return
         with self._lock:
-            self._streams[request_id] = {
-                "model_name": model_name,
-                "started_at": self._now(),
-                # Set on the first delta, not here: the wait for a lane to warm
-                # up is not generation, and averaging over it would report a
-                # rate no one is seeing.
-                "first_token_at": None,
-                "prompt_tokens": 0,
-                "completion_tokens": 0,
-            }
+            entry = self._streams.get(request_id)
+            if entry is None:
+                self._streams[request_id] = {
+                    "model_name": model_name,
+                    "started_at": self._now(),
+                    # Set on the first delta, not here: the wait for a lane to warm
+                    # up is not generation, and averaging over it would report a
+                    # rate no one is seeing.
+                    "first_token_at": None,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": 0,
+                    # True until the upstream states the real prompt size; the
+                    # page shows such a figure as an estimate, not a fact.
+                    "prompt_estimated": prompt_estimated and prompt_tokens > 0,
+                }
+            else:
+                if model_name:
+                    entry["model_name"] = model_name
+                if prompt_tokens > 0 and entry["prompt_tokens"] == 0:
+                    entry["prompt_tokens"] = prompt_tokens
+                    entry["prompt_estimated"] = prompt_estimated
+            self._version += 1
 
     def update(self, request_id: Optional[str], tokens: Dict[str, int]) -> None:
         if not request_id:
@@ -1145,17 +1180,24 @@ class _LiveStreamRegistry:
             completion = tokens.get("completion_tokens", 0)
             if completion > 0 and entry["first_token_at"] is None:
                 entry["first_token_at"] = self._now()
-            entry["prompt_tokens"] = tokens.get("prompt_tokens", 0)
+            prompt = tokens.get("prompt_tokens", 0)
+            if prompt > 0:
+                # The upstream has stated the prompt size; the estimate it
+                # stood in for is no longer an estimate.
+                entry["prompt_tokens"] = prompt
+                entry["prompt_estimated"] = False
             entry["completion_tokens"] = completion
+            self._version += 1
 
     def finish(self, request_id: Optional[str]) -> None:
         if not request_id:
             return
         with self._lock:
-            self._streams.pop(request_id, None)
+            if self._streams.pop(request_id, None) is not None:
+                self._version += 1
 
     def snapshot(self) -> list[dict[str, Any]]:
-        """Every running stream, with the rate it is generating at."""
+        """Every running request, with the rate it is generating at."""
         now = self._now()
         out: list[dict[str, Any]] = []
         with self._lock:
@@ -1169,6 +1211,7 @@ class _LiveStreamRegistry:
                     "request_id": request_id,
                     "model_name": entry["model_name"],
                     "prompt_tokens": entry["prompt_tokens"],
+                    "prompt_estimated": entry["prompt_estimated"],
                     "completion_tokens": completion,
                     # Measured from the first token, so it is the generation
                     # rate rather than an average dragged down by queueing.
@@ -1208,6 +1251,10 @@ class _StreamingLogAccumulator:
     # earlier — see _consume_messages_event.
     messages_usage: Optional[Dict[str, Any]] = None
     _saw_messages_events: bool = False
+    # True once message_delta's usage has arrived — the only event whose
+    # output_tokens is settled. message_start's is a one-token placeholder
+    # that must not stand in for the running count; see streamed_tokens.
+    _messages_final_usage: bool = False
     # Text deltas seen so far. The exact completion count only arrives with the
     # terminal usage event, which is no help to anyone watching the request run
     # — so the delta count stands in for it until then. See streamed_tokens.
@@ -1253,9 +1300,15 @@ class _StreamingLogAccumulator:
         """
         usage = self.usage()
         prompt = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
-        completion = usage.get("completion_tokens") or usage.get("output_tokens") or 0
         if not isinstance(prompt, int):
             prompt = 0
+        # A Messages stream's message_start already carries an
+        # ``output_tokens`` figure — but it is a one-token placeholder, not a
+        # count, and trusting it pins the live figure at 1 for the whole
+        # generation. Until message_delta settles it, the deltas are the count.
+        if self._saw_messages_events and not self._messages_final_usage:
+            return {"prompt_tokens": prompt, "completion_tokens": self.delta_count}
+        completion = usage.get("completion_tokens") or usage.get("output_tokens") or 0
         if not isinstance(completion, int) or completion <= 0:
             completion = self.delta_count
         return {"prompt_tokens": prompt, "completion_tokens": completion}
@@ -1398,6 +1451,8 @@ class _StreamingLogAccumulator:
         if not isinstance(usage, dict):
             return
 
+        if event_type == "message_delta":
+            self._messages_final_usage = True
         merged = dict(self.messages_usage or {})
         merged.update(usage)
         # Anthropic omits a total — it is the sum, so it says it once. Logos
@@ -2010,6 +2065,20 @@ async def internal_model_context_windows(request: Request):
     }
 
 
+def _require_internal_secret(request: Request) -> None:
+    """Authenticate an /internal/* call: the shared secret, no user context."""
+    if not _INTERNAL_SECRET:
+        raise HTTPException(status_code=403, detail="Internal endpoint disabled")
+    auth_header = request.headers.get("authorization", "")
+    token = (
+        auth_header.removeprefix("Bearer ").strip()
+        if auth_header.lower().startswith("bearer ")
+        else auth_header.strip()
+    )
+    if not hmac.compare_digest(token, _INTERNAL_SECRET):
+        raise HTTPException(status_code=401, detail="Invalid or missing internal secret")
+
+
 @app.get("/internal/live_streams", tags=["admin"])
 async def internal_live_streams(request: Request):
     """Token counts of the requests streaming right now, for the statistics page.
@@ -2022,17 +2091,47 @@ async def internal_live_streams(request: Request):
     Cheap by construction: a dict of the in-flight requests, no database work,
     and the webservice already polls on the cadence it pushes the feed at.
     """
-    if not _INTERNAL_SECRET:
-        raise HTTPException(status_code=403, detail="Internal endpoint disabled")
-    auth_header = request.headers.get("authorization", "")
-    token = (
-        auth_header.removeprefix("Bearer ").strip()
-        if auth_header.lower().startswith("bearer ")
-        else auth_header.strip()
-    )
-    if not hmac.compare_digest(token, _INTERNAL_SECRET):
-        raise HTTPException(status_code=401, detail="Invalid or missing internal secret")
+    _require_internal_secret(request)
     return {"streams": _live_streams.snapshot()}
+
+
+# How often the live-stream SSE connection checks for a changed snapshot. The
+# push is event-driven in effect — a token delta bumps the registry's version
+# and the very next check sends it — but the check itself is a short poll so
+# the endpoint stays a plain generator instead of event plumbing.
+_LIVE_STREAMS_SSE_TICK_S = 0.2
+
+
+@app.get("/internal/live_streams/stream", tags=["admin"])
+async def internal_live_streams_stream(request: Request):
+    """The live view as an SSE stream: the current snapshot, then one event
+    per change.
+
+    The statistics page's token counts used to move at the webservice's poll
+    interval; this lets the webservice forward a change the moment it happens
+    and push it to its websocket clients in real time. The payload is the
+    same shape as ``/internal/live_streams`` so both clients parse one way.
+    """
+    _require_internal_secret(request)
+
+    async def events():
+        version = -1
+        while True:
+            current = _live_streams.version
+            if current != version:
+                version = current
+                yield f"data: {json.dumps({'streams': _live_streams.snapshot()})}\n\n"
+            else:
+                # A comment line: keeps idle (but healthy) connections from
+                # being reaped by anything in the middle.
+                yield ": ping\n\n"
+            await asyncio.sleep(_LIVE_STREAMS_SSE_TICK_S)
+
+    return StreamingResponse(
+        events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @app.get("/internal/calibration_probe_logs", tags=["admin"])
@@ -4214,10 +4313,16 @@ async def route_and_execute(
         else:
             raise HTTPException(status_code=404, detail="No models available for this API key.")
 
+    # Jobs reach this point without going through handle_sync_request, so they
+    # publish their live view here. start() is non-destructive, so a request
+    # that already arrived on the sync path keeps the entry it has.
+    _live_streams.start(request_id, prompt_tokens=estimate_prompt_tokens(body), prompt_estimated=True)
+
+    response = None
     try:
         # PROXY mode (body["model"] specified → direct forwarding)
         if body.get("model"):
-            return await _execute_proxy_mode(
+            response = await _execute_proxy_mode(
                 body=body,
                 headers=headers,
                 auth=auth,
@@ -4227,18 +4332,19 @@ async def route_and_execute(
                 request_id=request_id,
                 request_path=path,
             )
-
-        # RESOURCE mode (no body["model"] → classification + scheduling)
-        return await _execute_resource_mode(
-            deployments=deployments,
-            body=body,
-            headers=headers,
-            auth=auth,
-            log_id=log_id,
-            is_async_job=is_async_job,
-            request_id=request_id,
-            request_path=path,
-        )
+        else:
+            # RESOURCE mode (no body["model"] → classification + scheduling)
+            response = await _execute_resource_mode(
+                deployments=deployments,
+                body=body,
+                headers=headers,
+                auth=auth,
+                log_id=log_id,
+                is_async_job=is_async_job,
+                request_id=request_id,
+                request_path=path,
+            )
+        return response
     except HTTPException as exc:
         _record_log_failure(log_id, request_id, str(exc.detail), result_status="error")
         if is_async_job:
@@ -4247,6 +4353,11 @@ async def route_and_execute(
     except Exception as exc:
         _record_log_failure(log_id, request_id, str(exc), result_status="error")
         raise
+    finally:
+        # Same hand-off as handle_sync_request: a stream keeps its entry until
+        # the streamer ends it, everything else ends here.
+        if not isinstance(response, StreamingResponse):
+            _live_streams.finish(request_id)
 
 
 _CLIENT_DISCONNECT_POLL_SECONDS = 1.0
@@ -4434,51 +4545,66 @@ async def handle_sync_request(path: str, request: Request):
     headers, auth, body, client_ip, log_id = await auth_parse_log(request, use_profile_auth=True)
     request_id = secrets.token_urlsafe(16)
 
+    # Publish the request to the live view from the moment it is known, so the
+    # statistics feed shows its (estimated) prompt size while it waits for a
+    # deployment or a reconnecting worker instead of sitting as a blank row.
+    _live_streams.start(request_id, prompt_tokens=estimate_prompt_tokens(body), prompt_estimated=True)
+
+    response = None
     try:
-        with DBManager() as db:
-            if log_id:
-                db.update_log_entry_metrics(
-                    log_id=log_id,
-                    request_id=request_id,
-                    timeout_s=body.get("timeout_s"),
-                )
-            raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
-        deployments = await _filter_logosnode_deployments(raw_deployments, payload=body)
-    except PermissionError as e:
-        _record_log_failure(log_id, request_id, str(e), result_status="error")
-        raise HTTPException(status_code=401, detail=str(e))
-    except ValueError as e:
-        _record_log_failure(log_id, request_id, str(e), result_status="error")
-        raise HTTPException(status_code=400, detail=str(e))
+        try:
+            with DBManager() as db:
+                if log_id:
+                    db.update_log_entry_metrics(
+                        log_id=log_id,
+                        request_id=request_id,
+                        timeout_s=body.get("timeout_s"),
+                    )
+                raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
+            deployments = await _filter_logosnode_deployments(raw_deployments, payload=body)
+        except PermissionError as e:
+            _record_log_failure(log_id, request_id, str(e), result_status="error")
+            raise HTTPException(status_code=401, detail=str(e))
+        except ValueError as e:
+            _record_log_failure(log_id, request_id, str(e), result_status="error")
+            raise HTTPException(status_code=400, detail=str(e))
 
-    if not deployments and raw_deployments:
-        # The key is granted models that no worker serves right now — either
-        # the orchestrator just (re)started and the workers are still
-        # (re)attaching, or a worker dropped a moment ago (reboot) and its
-        # models are unroutable until it comes back. Give the missing
-        # workers a chance to (re)connect instead of failing instantly; the
-        # window stays in effect even though other workers may already have
-        # re-attached.
-        deployments = await _wait_for_worker_connect(
-            raw_deployments, payload=body, request=request, client_timeout_s=_client_timeout_s(body)
+        if not deployments and raw_deployments:
+            # The key is granted models that no worker serves right now — either
+            # the orchestrator just (re)started and the workers are still
+            # (re)attaching, or a worker dropped a moment ago (reboot) and its
+            # models are unroutable until it comes back. Give the missing
+            # workers a chance to (re)connect instead of failing instantly; the
+            # window stays in effect even though other workers may already have
+            # re-attached.
+            deployments = await _wait_for_worker_connect(
+                raw_deployments, payload=body, request=request, client_timeout_s=_client_timeout_s(body)
+            )
+
+        if not deployments:
+            requested_model = body.get("model", "unknown")
+            msg = f"No available model deployments for model '{requested_model}' for this key"
+            _record_log_failure(log_id, request_id, msg, result_status="error")
+            raise HTTPException(status_code=404, detail=msg)
+
+        execute_kwargs = dict(
+            deployments=deployments,
+            body=body,
+            headers=headers,
+            auth=auth,
+            path=path,
+            log_id=log_id,
+            request_id=request_id,
         )
-
-    if not deployments:
-        requested_model = body.get("model", "unknown")
-        msg = f"No available model deployments for model '{requested_model}' for this key"
-        _record_log_failure(log_id, request_id, msg, result_status="error")
-        raise HTTPException(status_code=404, detail=msg)
-
-    execute_kwargs = dict(
-        deployments=deployments,
-        body=body,
-        headers=headers,
-        auth=auth,
-        path=path,
-        log_id=log_id,
-        request_id=request_id,
-    )
-    return await _execute_cancelling_on_disconnect(request, **execute_kwargs)
+        response = await _execute_cancelling_on_disconnect(request, **execute_kwargs)
+        return response
+    finally:
+        # A streaming response hands the live entry to its generator: the
+        # streamer drops it when the stream ends. Every other outcome — sync
+        # response, an error raise, the client walking away — ends the request
+        # here.
+        if not isinstance(response, StreamingResponse):
+            _live_streams.finish(request_id)
 
 
 async def auth_parse_log(request: Request, use_profile_auth: bool = False):
@@ -4718,48 +4844,58 @@ async def execute_proxy_job(
 
     request_id = secrets.token_urlsafe(16)
 
-    # Get available models for this API key
+    # Same early publication as the sync path: the moment the job has a
+    # request id, its (estimated) prompt is on the feed instead of the row
+    # sitting blank through the worker wait below.
+    _live_streams.start(request_id, prompt_tokens=estimate_prompt_tokens(json_data), prompt_estimated=True)
     try:
-        with DBManager() as db:
-            if log_id:
-                db.update_log_entry_metrics(
-                    log_id=log_id,
-                    request_id=request_id,
-                    timeout_s=json_data.get("timeout_s"),
-                )
-            raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
-        deployments = await _filter_logosnode_deployments(raw_deployments, payload=json_data)
-    except PermissionError as e:
-        _record_log_failure(log_id, request_id, str(e), result_status="error")
-        _, err_body = coerce_upstream_error(401, {"error": str(e)})
-        return {"status_code": 401, "data": err_body}
-    except ValueError as e:
-        _record_log_failure(log_id, request_id, str(e), result_status="error")
-        _, err_body = coerce_upstream_error(400, {"error": str(e)})
-        return {"status_code": 400, "data": err_body}
+        # Get available models for this API key
+        try:
+            with DBManager() as db:
+                if log_id:
+                    db.update_log_entry_metrics(
+                        log_id=log_id,
+                        request_id=request_id,
+                        timeout_s=json_data.get("timeout_s"),
+                    )
+                raw_deployments, allowed_models = request_setup(headers, auth.api_key_id, db=db)
+            deployments = await _filter_logosnode_deployments(raw_deployments, payload=json_data)
+        except PermissionError as e:
+            _record_log_failure(log_id, request_id, str(e), result_status="error")
+            _, err_body = coerce_upstream_error(401, {"error": str(e)})
+            return {"status_code": 401, "data": err_body}
+        except ValueError as e:
+            _record_log_failure(log_id, request_id, str(e), result_status="error")
+            _, err_body = coerce_upstream_error(400, {"error": str(e)})
+            return {"status_code": 400, "data": err_body}
 
-    # Same windows as the sync path: a job submitted while no worker is
-    # connected (startup or a worker reboot) must not fail before the
-    # workers re-attach.
-    if not deployments and raw_deployments:
-        deployments = await _wait_for_worker_connect(
-            raw_deployments, payload=json_data, client_timeout_s=_client_timeout_s(json_data)
+        # Same windows as the sync path: a job submitted while no worker is
+        # connected (startup or a worker reboot) must not fail before the
+        # workers re-attach.
+        if not deployments and raw_deployments:
+            deployments = await _wait_for_worker_connect(
+                raw_deployments, payload=json_data, client_timeout_s=_client_timeout_s(json_data)
+            )
+
+        # Force non-streaming for jobs without adding unsupported multipart fields.
+        json_data = force_non_streaming_payload(json_data)
+
+        # Route and execute request
+        return await route_and_execute(
+            deployments=deployments,
+            body=json_data,
+            headers=headers,
+            auth=auth,
+            path=path,
+            log_id=log_id,
+            is_async_job=True,
+            request_id=request_id,
         )
-
-    # Force non-streaming for jobs without adding unsupported multipart fields.
-    json_data = force_non_streaming_payload(json_data)
-
-    # Route and execute request
-    return await route_and_execute(
-        deployments=deployments,
-        body=json_data,
-        headers=headers,
-        auth=auth,
-        path=path,
-        log_id=log_id,
-        is_async_job=True,
-        request_id=request_id,
-    )
+    finally:
+        # A job never streams, so nothing here hands the entry on: every way
+        # out — error dict above, route_and_execute's own finally, an
+        # unexpected raise — ends the entry here at the latest.
+        _live_streams.finish(request_id)
 
 
 # ============================================================================

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_live_streams_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_live_streams_endpoint.py
@@ -1,0 +1,112 @@
+"""The /internal/live_streams endpoints: the token counts of the requests
+running right now, pulled by the Spring webservice.
+
+The statistics page shows a request row only once the webservice merges this
+view into its feed, so the view here and the shape of the SSE stream that
+pushes it are what the page ultimately renders.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import logos as main_mod
+from logos.main import _LiveStreamRegistry
+
+
+def _make_request(authorization: str = "") -> MagicMock:
+    request = MagicMock()
+    request.headers.get = lambda key, default="": authorization if key == "authorization" else default
+    return request
+
+
+@pytest.fixture
+def live_registry(monkeypatch):
+    registry = _LiveStreamRegistry()
+    monkeypatch.setattr(main_mod, "_live_streams", registry)
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_the_snapshot_requires_the_internal_secret(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_live_streams(_make_request("Bearer anything"))
+    assert exc_info.value.status_code == 403
+
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_live_streams(_make_request("Bearer wrong-secret"))
+    assert exc_info.value.status_code == 401
+
+    result = await main_mod.internal_live_streams(_make_request("Bearer correct-secret"))
+    assert result == {"streams": []}
+
+
+@pytest.mark.asyncio
+async def test_the_snapshot_serves_the_running_requests(live_registry, monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    live_registry.start("req-1", "qwen-27b", prompt_tokens=1200, prompt_estimated=True)
+    live_registry.update("req-1", {"prompt_tokens": 1187, "completion_tokens": 42})
+
+    result = await main_mod.internal_live_streams(_make_request("Bearer correct-secret"))
+
+    (row,) = result["streams"]
+    assert row["request_id"] == "req-1"
+    assert row["prompt_tokens"] == 1187
+    assert row["prompt_estimated"] is False
+    assert row["completion_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_the_stream_requires_the_internal_secret(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_live_streams_stream(_make_request("Bearer anything"))
+    assert exc_info.value.status_code == 403
+
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await main_mod.internal_live_streams_stream(_make_request("Bearer wrong-secret"))
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_the_stream_pushes_the_snapshot_then_every_change(live_registry, monkeypatch):
+    """The point of the SSE variant over polling: a change is on the wire on
+    the very next tick, and an idle connection only ever hears a ping."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+    monkeypatch.setattr(main_mod, "_LIVE_STREAMS_SSE_TICK_S", 0.01)
+    live_registry.start("req-1", "qwen-27b")
+
+    response = await main_mod.internal_live_streams_stream(_make_request("Bearer correct-secret"))
+    assert response.media_type == "text/event-stream"
+    iterator = response.body_iterator
+    try:
+        first = await iterator.__anext__()
+        assert first.startswith("data: ")
+        payload = json.loads(first.removeprefix("data: ").strip())
+        assert [row["request_id"] for row in payload["streams"]] == ["req-1"]
+
+        live_registry.update("req-1", {"prompt_tokens": 7, "completion_tokens": 3})
+        second = await iterator.__anext__()
+        assert second.startswith("data: ")
+        payload = json.loads(second.removeprefix("data: ").strip())
+        assert payload["streams"][0]["completion_tokens"] == 3
+
+        # Nothing moved since: a comment line, not a re-send.
+        third = await iterator.__anext__()
+        assert third == ": ping\n\n"
+
+        live_registry.finish("req-1")
+        fourth = await iterator.__anext__()
+        payload = json.loads(fourth.removeprefix("data: ").strip())
+        assert payload["streams"] == []
+    finally:
+        aclose = getattr(iterator, "aclose", None)
+        if aclose is not None:
+            await aclose()

--- a/logos/logos-orchestrator/tests/unit/main/test_live_streams.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_live_streams.py
@@ -55,6 +55,23 @@ def test_the_settled_count_replaces_the_estimate():
     assert acc.streamed_tokens() == {"prompt_tokens": 14, "completion_tokens": 3}
 
 
+def test_the_messages_start_placeholder_does_not_pin_the_count():
+    """Anthropic's message_start reports ``output_tokens: 1`` before a single
+    token exists. Trusting it would show "1 tok" for the whole request and a
+    rate of zero; until message_delta settles the figure, the deltas count."""
+    acc = _StreamingLogAccumulator()
+    _feed(acc, {"type": "message_start", "message": {"usage": {"input_tokens": 14, "output_tokens": 1}}})
+
+    assert acc.streamed_tokens() == {"prompt_tokens": 14, "completion_tokens": 0}
+
+    _feed(acc, {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "one"}})
+    _feed(acc, {"type": "content_block_delta", "delta": {"type": "text_delta", "text": " two"}})
+    assert acc.streamed_tokens()["completion_tokens"] == 2
+
+    _feed(acc, {"type": "message_delta", "delta": {}, "usage": {"input_tokens": 14, "output_tokens": 5}})
+    assert acc.streamed_tokens() == {"prompt_tokens": 14, "completion_tokens": 5}
+
+
 def test_it_counts_chat_completions_deltas_too():
     acc = _StreamingLogAccumulator()
     _feed(
@@ -162,3 +179,80 @@ def test_several_requests_are_tracked_independently():
 
     assert by_id["req-1"]["completion_tokens"] == 10
     assert by_id["req-2"]["completion_tokens"] == 20
+
+
+# ── Tracked from arrival ─────────────────────────────────────────────────────
+
+
+def test_a_request_is_tracked_from_arrival_with_an_estimated_prompt():
+    """While the request still queues, the only figure available is the prompt
+    estimate the context routing already computes — and the page must be able
+    to tell it is an estimate."""
+    reg = _LiveStreamRegistry()
+    reg.start("req-1", prompt_tokens=1200, prompt_estimated=True)
+
+    (row,) = reg.snapshot()
+
+    assert row["prompt_tokens"] == 1200
+    assert row["prompt_estimated"] is True
+    assert row["completion_tokens"] == 0
+    assert row["tokens_per_second"] is None
+
+
+def test_the_real_prompt_replaces_the_estimate():
+    """The moment the upstream states the prompt size, the number stops being
+    an estimate — even if it happens to come out the same."""
+    reg = _LiveStreamRegistry()
+    reg.start("req-1", prompt_tokens=1200, prompt_estimated=True)
+    reg.update("req-1", {"prompt_tokens": 1200, "completion_tokens": 10})
+
+    row = reg.snapshot()[0]
+
+    assert row["prompt_tokens"] == 1200
+    assert row["prompt_estimated"] is False
+
+
+def test_starting_an_already_tracked_request_keeps_its_counters():
+    """The streamer starts the entry again when the response begins. The
+    arrival-time entry must not be reset — the numbers on the page would jump
+    backwards and the elapsed time would lose its queueing part."""
+    clock = {"now": 1000.0}
+    reg = _LiveStreamRegistry(now=lambda: clock["now"])
+    reg.start("req-1", prompt_tokens=1200, prompt_estimated=True)
+    clock["now"] += 30.0
+    reg.update("req-1", {"prompt_tokens": 1200, "completion_tokens": 50})
+
+    reg.start("req-1", "Qwen/Qwen3.8-27B")  # the streamer's start
+
+    (row,) = reg.snapshot()
+
+    assert row["model_name"] == "Qwen/Qwen3.8-27B"
+    assert row["prompt_tokens"] == 1200
+    assert row["completion_tokens"] == 50
+    assert row["elapsed_seconds"] == 30.0
+
+
+def test_a_late_start_fills_in_a_missing_prompt():
+    reg = _LiveStreamRegistry()
+    reg.start("req-1", "m")  # nothing to estimate yet
+    reg.start("req-1", "m", prompt_tokens=900, prompt_estimated=True)
+
+    (row,) = reg.snapshot()
+
+    assert row["prompt_tokens"] == 900
+    assert row["prompt_estimated"] is True
+
+
+def test_the_version_moves_with_the_view():
+    """The SSE stream keys off this: a change the subscriber can see must be a
+    change the version reflects, and a no-op must not be."""
+    reg = _LiveStreamRegistry()
+    before = reg.version
+    reg.start("req-1")
+    assert reg.version == before + 1
+    reg.update("req-1", {"prompt_tokens": 1, "completion_tokens": 1})
+    assert reg.version == before + 2
+    reg.finish("req-1")
+    assert reg.version == before + 3
+    reg.finish("req-1")  # already gone
+    assert reg.version == before + 3

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
@@ -1,4 +1,5 @@
 import { providerLabel } from '../../statistics.utils';
+import { chaseStep, tokenLabel } from './recent-requests';
 
 /**
  * The provider label of a request row.
@@ -60,5 +61,63 @@ describe('providerLabel', () => {
         request_complete_ts: null,
       }),
     ).toBe('none');
+  });
+});
+
+/**
+ * The count-up behind the live token line.
+ *
+ * A push lands a new target; between pushes the figure on screen moves part of
+ * the way there every frame, so a jump of nine tokens reads as motion instead
+ * of a teleport.
+ */
+describe('chaseStep', () => {
+  it('stays put when the target has not moved', () => {
+    expect(chaseStep(42, 42)).toBe(42);
+  });
+
+  it('closes 30% of the gap per frame, at least one token', () => {
+    expect(chaseStep(0, 10)).toBe(3);
+    expect(chaseStep(3, 10)).toBe(6);
+    expect(chaseStep(6, 10)).toBe(8);
+    expect(chaseStep(8, 10)).toBe(9);
+  });
+
+  it('reaches the target in the frame that would overshoot it', () => {
+    expect(chaseStep(9, 10)).toBe(10);
+    expect(chaseStep(0, 1)).toBe(1);
+  });
+
+  it('runs a long queue of growth out in a handful of frames', () => {
+    // 1200 tokens: the first frame already takes a third of the way.
+    let n = 0;
+    for (let i = 0; i < 50 && n < 1200; i++) n = chaseStep(n, 1200);
+    expect(n).toBe(1200);
+  });
+
+  it('snaps to a lower target instead of counting backwards', () => {
+    // The estimate the real prompt replaced: 1200 down to 1187. A backwards
+    // count-up would read as the number falling out of the air.
+    expect(chaseStep(1200, 1187)).toBe(1187);
+  });
+});
+
+describe('tokenLabel', () => {
+  const shown = { p: 1200, c: 42 };
+
+  it('shows nothing when neither figure is known', () => {
+    expect(tokenLabel(null, null, shown, false)).toBeNull();
+  });
+
+  it('shows the figures the row is displaying, padded with zero', () => {
+    expect(tokenLabel(1200, 42, shown, false)).toBe('↑1200 ↓42');
+    expect(tokenLabel(null, 42, { p: 0, c: 42 }, false)).toBe('↑0 ↓42');
+  });
+
+  it('marks a prompt the upstream has not stated yet', () => {
+    // The request still queues; 1200 is what the body looks like in tokens,
+    // not what a model counted. The tilde keeps the page honest about that.
+    expect(tokenLabel(1200, 0, { p: 1200, c: 0 }, true)).toBe('↑~1200 ↓0');
+    expect(tokenLabel(1200, 0, { p: 1200, c: 0 }, false)).toBe('↑1200 ↓0');
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
@@ -35,6 +35,35 @@ import {
  */
 const PAGE_SIZE = 10;
 
+/**
+ * One frame's worth of the way from a shown figure to the pushed one: 30% of
+ * the gap, at least one token. A target below the shown one is reached at
+ * once — that is the estimate the real prompt replaced, and counting backwards
+ * from a wrong number reads as the count falling out of the air.
+ */
+export function chaseStep(shown: number, target: number): number {
+  if (target <= shown) return target;
+  return Math.min(target, shown + Math.max(1, Math.ceil((target - shown) * 0.3)));
+}
+
+/**
+ * The token line as the page shows it: "↑prompt ↓completion", nothing when
+ * neither figure is known. The numbers are the ones on screen — mid-chase
+ * that trails the last pushed one — and a prompt the upstream has not stated
+ * yet (the request still queues) carries a tilde, because it is the estimate
+ * the context routing computed from the body, not a measured figure.
+ */
+export function tokenLabel(
+  prompt: number | null,
+  completion: number | null,
+  shown: { p: number; c: number },
+  promptEstimated: boolean,
+): string | null {
+  if (prompt == null && completion == null) return null;
+  const est = promptEstimated ? '~' : '';
+  return `↑${est}${shown.p} ↓${shown.c}`;
+}
+
 @Component({
   selector: 'app-stats-recent-requests',
   standalone: true,
@@ -79,6 +108,22 @@ export class RecentRequests implements OnChanges, OnDestroy {
   now = signal(Date.now());
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  // ── Count-up ───────────────────────────────────────────────────────────────
+
+  /**
+   * The token line does not jump between two pushes — the figure on screen
+   * chases the pushed one a little at a time, so a jump of nine tokens reads
+   * as motion. Keyed by request id; a request that leaves the live set leaves
+   * with its entry.
+   *
+   * The template reads this through `tokensLabelOf`, which is what makes a
+   * write from the (zoneless) interval tick render: the view tracks the
+   * signal, the signal does not care who writes it.
+   */
+  private readonly _shownTokens = signal<Record<string, { p: number; c: number }>>({});
+
+  private chaseId: ReturnType<typeof setInterval> | null = null;
 
   // Input mirror signals so the computed()s below actually react: a plain
   // @Input() is not a tracked producer, so reading it inside computed() would
@@ -174,10 +219,13 @@ export class RecentRequests implements OnChanges, OnDestroy {
     }
     // Re-schedule ticker whenever inputs change so cadence stays correct.
     this.scheduleTicker();
+    // A new push is where the chase gets new ground to cover.
+    if (changes['liveRequests']) this.startChase();
   }
 
   ngOnDestroy(): void {
     this.clearTicker();
+    this.clearChase();
   }
 
   private resetToFirstPage(): void {
@@ -281,6 +329,65 @@ export class RecentRequests implements OnChanges, OnDestroy {
     }
   }
 
+  /**
+   * One frame of the chase: every streaming row's shown figure moves part of
+   * the way to the pushed one. A new row starts at its first pushed figure —
+   * a request that is already mid-generation when the page opens should show
+   * its numbers at once, not count them up from zero — and only the growth
+   * after that is animated.
+   */
+  private chaseFrame(): void {
+    const targets = new Map<string, { p: number; c: number }>();
+    for (const it of this.displayItems()) {
+      if (!it.streaming) continue;
+      targets.set(it.request_id, { p: it.prompt_tokens ?? 0, c: it.completion_tokens ?? 0 });
+    }
+
+    const shown = { ...this._shownTokens() };
+    let dirty = false;
+    let catchingUp = false;
+    for (const [id, target] of targets) {
+      const current = shown[id];
+      if (current === undefined) {
+        shown[id] = target;
+        dirty = true;
+        continue;
+      }
+      const p = chaseStep(current.p, target.p);
+      const c = chaseStep(current.c, target.c);
+      if (p !== current.p || c !== current.c) {
+        shown[id] = { p, c };
+        dirty = true;
+      }
+      if (p < target.p || c < target.c) catchingUp = true;
+    }
+    for (const id of Object.keys(shown)) {
+      if (!targets.has(id)) {
+        delete shown[id];
+        dirty = true;
+      }
+    }
+    if (dirty) this._shownTokens.set(shown);
+
+    // Nothing is streaming anymore, or every figure has reached its target and
+    // the next push will start a new chase. Either way this timer is done.
+    if (targets.size === 0 || !catchingUp) this.clearChase();
+  }
+
+  private startChase(): void {
+    if (this.chaseId !== null) return;
+    // ~15 fps: enough that the count reads as continuous, cheap enough that
+    // re-running change detection on ten rows does not register.
+    this.chaseId = setInterval(() => this.chaseFrame(), 66);
+  }
+
+  private clearChase(): void {
+    if (this.chaseId !== null) {
+      clearInterval(this.chaseId);
+      this.chaseId = null;
+    }
+  }
+
   // ── Template helpers ─────────────────────────────────────────────────────
 
   stageOf(item: RequestItem): RequestStage {
@@ -317,12 +424,28 @@ export class RecentRequests implements OnChanges, OnDestroy {
     return formatUsd(item.cost_microcents);
   }
 
-  /** Token line "↑prompt ↓completion", only when token counts are known. */
+  /**
+   * The figures the row shows right now: for a running request the chase
+   * value that is still moving toward the last pushed one, for everything
+   * else the stored numbers.
+   *
+   * Reads the chase signal, which is what keeps this component re-rendering
+   * on the interval's ticks in a zoneless app.
+   */
+  private shownTokensOf(item: RequestItem): { p: number; c: number } {
+    const shown = this._shownTokens();
+    const target = { p: item.prompt_tokens ?? 0, c: item.completion_tokens ?? 0 };
+    if (item.streaming && shown[item.request_id]) return shown[item.request_id];
+    return target;
+  }
+
   tokensLabelOf(item: RequestItem): string | null {
-    const p = item.prompt_tokens;
-    const c = item.completion_tokens;
-    if (p == null && c == null) return null;
-    return `↑${p ?? 0} ↓${c ?? 0}`;
+    return tokenLabel(
+      item.prompt_tokens,
+      item.completion_tokens,
+      this.shownTokensOf(item),
+      item.prompt_estimated ?? false,
+    );
   }
 
   /**

--- a/logos/logos-ui/src/app/features/statistics/statistics.models.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.models.ts
@@ -307,6 +307,12 @@ export interface RequestItem {
    * orchestrator's running tally and moves until the request completes.
    */
   streaming?: boolean;
+  /**
+   * The prompt figure is the estimate the context routing computed from the
+   * body — the request has not reached a point where the upstream states the
+   * real size yet (it still queues). Shown as an estimate, not a fact.
+   */
+  prompt_estimated?: boolean;
 }
 
 /**

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorLiveStreamClient.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorLiveStreamClient.java
@@ -1,8 +1,15 @@
 package de.tum.cit.aet.logos.logoswebservice.orchestrator;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +20,12 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
 /**
  * Token counts of the requests streaming right now, from the orchestrator.
  *
@@ -21,19 +34,38 @@ import org.springframework.web.client.RestTemplate;
  * request feed showed a row with no numbers for the whole minute a long
  * generation takes, then filled it in at once when the request ended.
  *
- * Deliberately not cached: the point of these figures is that they move. The
- * call is a dict lookup on the far end with no database work behind it, and it
- * runs on the cadence the feed is already pushed at.
+ * The primary transport is the orchestrator's SSE stream: a token delta is on
+ * the wire a couple of hundred milliseconds after it happens, and every data
+ * line updates the cached snapshot and notifies the listener, which is what
+ * lets the websocket handler push its viewers without waiting for the next
+ * tick. The one-shot GET stays as the fallback: when the subscription is
+ * down — or the snapshot is stale, which is how a dead connection reveals
+ * itself — a pull fetches what a push did not deliver.
  */
 @Service
 public class OrchestratorLiveStreamClient {
 
     private static final Logger log = LoggerFactory.getLogger(OrchestratorLiveStreamClient.class);
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * A cached snapshot younger than this is served without a pull. Older than
+     * this and the SSE connection is presumed dead (the orchestrator pings it
+     * far more often), so the next read falls back to the one-shot GET.
+     */
+    private static final long STALE_AFTER_MS = 5_000;
+
+    private static final long RECONNECT_INITIAL_MS = 1_000;
+    private static final long RECONNECT_MAX_MS = 30_000;
+
     /**
      * One in-flight request.
      *
-     * @param promptTokens     exact — every API states the prompt size up front
+     * @param promptTokens     exact as soon as the stream opened, but an
+     *                         estimate while the request still queues: until
+     *                         the upstream states the prompt size, this is the
+     *                         figure context routing computed from the body
      * @param completionTokens the count so far. Approximate while the request
      *                         runs: the settled figure only arrives with the
      *                         terminal usage event, so until then the
@@ -43,11 +75,19 @@ public class OrchestratorLiveStreamClient {
      * @param tokensPerSecond  measured from the first token rather than from
      *                         arrival, so queueing does not drag it down. Null
      *                         until there is a span to divide by.
+     * @param promptEstimated  true while promptTokens is that estimate, so the
+     *                         page can show it as such.
      */
-    public record LiveStream(int promptTokens, int completionTokens, Double tokensPerSecond) {
+    public record LiveStream(int promptTokens, int completionTokens, Double tokensPerSecond, boolean promptEstimated) {
+    }
+
+    private record Snapshot(Map<String, LiveStream> streams, long receivedAtMs) {
     }
 
     private final RestTemplate restTemplate;
+    private final HttpClient http = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(3))
+        .build();
 
     @Value("${logos.orchestrator.url:}")
     private String orchestratorUrl;
@@ -55,8 +95,28 @@ public class OrchestratorLiveStreamClient {
     @Value("${logos.orchestrator.internal-secret:}")
     private String internalSecret;
 
+    /** The last snapshot the SSE stream delivered, no matter how old. */
+    private final AtomicReference<Snapshot> cached = new AtomicReference<>();
+    /** Called on the SSE thread whenever a new snapshot arrives. */
+    private final AtomicReference<Consumer<Map<String, LiveStream>>> onLiveUpdate = new AtomicReference<>();
+    private volatile Thread sseThread;
+
     public OrchestratorLiveStreamClient(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
+    }
+
+    @PostConstruct
+    void start() {
+        if (orchestratorUrl.isBlank() || internalSecret.isBlank()) return;
+        sseThread = new Thread(this::runSseLoop, "orchestrator-live-streams");
+        sseThread.setDaemon(true);
+        sseThread.start();
+    }
+
+    @PreDestroy
+    void stop() {
+        Thread thread = sseThread;
+        if (thread != null) thread.interrupt();
     }
 
     /**
@@ -64,11 +124,29 @@ public class OrchestratorLiveStreamClient {
      * unreachable or not configured — the feed then shows what the database
      * holds, which is what it did before any of this existed.
      */
-    @SuppressWarnings("unchecked")
     public Map<String, LiveStream> getLiveStreams() {
         if (orchestratorUrl.isBlank() || internalSecret.isBlank()) {
             return Map.of();
         }
+        Snapshot snapshot = cached.get();
+        if (snapshot != null && System.currentTimeMillis() - snapshot.receivedAtMs() < STALE_AFTER_MS) {
+            return snapshot.streams();
+        }
+        // Stale or never received: pull. The pull doubles as the liveness
+        // check for the push — a subscription whose last line is older than
+        // STALE_AFTER_MS has died silently, and this call is what notices.
+        return fetchLiveStreams();
+    }
+
+    /**
+     * Called by the websocket handler to push a fresh snapshot to its viewers
+     * the moment it arrives, instead of waiting for the next tick.
+     */
+    public void setOnLiveUpdate(Consumer<Map<String, LiveStream>> listener) {
+        onLiveUpdate.set(listener);
+    }
+
+    private Map<String, LiveStream> fetchLiveStreams() {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.set("Authorization", "Bearer " + internalSecret);
@@ -78,24 +156,101 @@ public class OrchestratorLiveStreamClient {
                 new HttpEntity<Void>(headers),
                 Map.class);
             Map<String, Object> body = response.getBody();
-            Object raw = body != null ? body.get("streams") : null;
-            if (!(raw instanceof List<?> rows)) {
-                return Map.of();
-            }
-            Map<String, LiveStream> streams = new LinkedHashMap<>();
-            for (Object row : rows) {
-                if (!(row instanceof Map<?, ?> fields)) continue;
-                if (!(fields.get("request_id") instanceof String requestId) || requestId.isBlank()) continue;
-                streams.put(requestId, new LiveStream(
-                    intOf(fields.get("prompt_tokens")),
-                    intOf(fields.get("completion_tokens")),
-                    fields.get("tokens_per_second") instanceof Number n ? n.doubleValue() : null));
+            Map<String, LiveStream> streams = parseStreams(body != null ? body.get("streams") : null);
+            if (!streams.isEmpty()) {
+                cached.set(new Snapshot(streams, System.currentTimeMillis()));
             }
             return streams;
         } catch (Exception e) {
             log.debug("Failed to fetch live streams from orchestrator: {}", e.getMessage());
             return Map.of();
         }
+    }
+
+    /**
+     * One lap around the SSE connection: block on its lines until it ends,
+     * then reconnect with a backoff that resets on a connection that lasted.
+     */
+    private void runSseLoop() {
+        long backoffMs = RECONNECT_INITIAL_MS;
+        while (!Thread.currentThread().isInterrupted()) {
+            long connectedAt = System.currentTimeMillis();
+            try {
+                HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(orchestratorUrl + "/internal/live_streams/stream"))
+                    .header("Authorization", "Bearer " + internalSecret)
+                    .header("Accept", "text/event-stream")
+                    .GET()
+                    .build();
+                HttpResponse<java.util.stream.Stream<String>> response =
+                    http.send(request, HttpResponse.BodyHandlers.ofLines());
+                if (response.statusCode() != 200) {
+                    throw new IllegalStateException("live stream endpoint returned " + response.statusCode());
+                }
+                try (var lines = response.body()) {
+                    var it = lines.iterator();
+                    while (it.hasNext()) {
+                        handleLine(it.next());
+                    }
+                }
+                backoffMs = RECONNECT_INITIAL_MS;  // ran down, not down
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception e) {
+                log.debug("Live stream connection ended: {}", e.getMessage());
+                // A connection that lasted a while just dropped (an orchestrator
+                // restart): reconnect promptly. Only repeated immediate
+                // failures earn the growing backoff.
+                if (System.currentTimeMillis() - connectedAt >= RECONNECT_MAX_MS) {
+                    backoffMs = RECONNECT_INITIAL_MS;
+                }
+            }
+            if (Thread.currentThread().isInterrupted()) return;
+            try {
+                Thread.sleep(backoffMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS);
+        }
+    }
+
+    /**
+     * One line of the SSE stream. A data line is a full snapshot (the same
+     * shape the GET serves); a comment line is the orchestrator's heartbeat —
+     * nothing changed, but the connection is alive, which is worth knowing.
+     */
+    public void handleLine(String line) {
+        if (line.startsWith("data: ")) {
+            try {
+                Map<String, Object> body = MAPPER.readValue(line.substring(6), new TypeReference<>() {});
+                Map<String, LiveStream> streams = parseStreams(body.get("streams"));
+                cached.set(new Snapshot(streams, System.currentTimeMillis()));
+                Consumer<Map<String, LiveStream>> listener = onLiveUpdate.get();
+                if (listener != null) listener.accept(streams);
+            } catch (Exception e) {
+                log.debug("Failed to parse live stream event: {}", e.getMessage());
+            }
+        } else if (line.startsWith(":")) {
+            cached.updateAndGet(s -> s == null ? null : new Snapshot(s.streams(), System.currentTimeMillis()));
+        }
+    }
+
+    private static Map<String, LiveStream> parseStreams(Object raw) {
+        if (!(raw instanceof List<?> rows)) return Map.of();
+        Map<String, LiveStream> streams = new LinkedHashMap<>();
+        for (Object row : rows) {
+            if (!(row instanceof Map<?, ?> fields)) continue;
+            if (!(fields.get("request_id") instanceof String requestId) || requestId.isBlank()) continue;
+            streams.put(requestId, new LiveStream(
+                intOf(fields.get("prompt_tokens")),
+                intOf(fields.get("completion_tokens")),
+                fields.get("tokens_per_second") instanceof Number n ? n.doubleValue() : null,
+                Boolean.TRUE.equals(fields.get("prompt_estimated"))));
+        }
+        return streams;
     }
 
     private static int intOf(Object value) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -129,6 +129,10 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         this.objectMapper = objectMapper;
         this.scheduler = Executors.newSingleThreadScheduledExecutor();
         this.scheduler.scheduleAtFixedRate(this::tick, 1, 1, TimeUnit.SECONDS);
+        // The orchestrator pushes a fresh live snapshot as it happens; forward
+        // it to the viewers without waiting for the next tick, which is what
+        // makes the token numbers move in real time instead of in steps.
+        liveStreamClient.setOnLiveUpdate(this::onLiveUpdate);
     }
 
     @Override
@@ -457,6 +461,38 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         }
     }
 
+    // How often a live update may cost a DB read and a push per session. The
+    // orchestrator emits one per token delta, so without a gate the feed would
+    // requery the database at the model's token rate; with it, the numbers
+    // still move several times a second, which is what "live" needs.
+    private static final long LIVE_PUSH_MIN_INTERVAL_MS = 250;
+    private volatile long lastLivePushAtMs = 0;
+
+    /**
+     * A fresh live snapshot arrived from the orchestrator.
+     *
+     * Runs on the client's SSE thread, not the tick thread, and fires once per
+     * token delta — so it coalesces to at most one push per interval, and the
+     * push itself is the usual change-detected one: a session whose page shows
+     * nothing that moved pays a database read and sends nothing.
+     */
+    private void onLiveUpdate(Map<String, OrchestratorLiveStreamClient.LiveStream> streams) {
+        if (streams.isEmpty()) return;  // nothing running; the tick settles the feed
+        long now = System.currentTimeMillis();
+        if (now - lastLivePushAtMs < LIVE_PUSH_MIN_INTERVAL_MS) return;
+        lastLivePushAtMs = now;
+        for (Map.Entry<String, WebSocketSession> entry : sessions.entrySet()) {
+            WebSocketSession session = entry.getValue();
+            SessionState state = states.get(entry.getKey());
+            if (state == null || !state.initialized || !session.isOpen()) continue;
+            try {
+                pushRequests(session, state, false);
+            } catch (Exception e) {
+                log.warn("[ws/stats/v2] live requests push error for session {}: {}", entry.getKey(), e.getMessage());
+            }
+        }
+    }
+
     /**
      * Fill in the token counts of the requests that are still streaming.
      *
@@ -492,6 +528,10 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             request.put("completion_tokens", stream.completionTokens());
             request.put("total_tokens", stream.promptTokens() + stream.completionTokens());
             request.put("tokens_per_second", stream.tokensPerSecond());
+            // While the request still queues, the prompt figure is the
+            // estimate computed from the body, not something the upstream
+            // stated — the page shows it as such instead of as fact.
+            request.put("prompt_estimated", stream.promptEstimated());
             // Says outright that these are the in-flight figures, so the page can
             // present them as moving rather than final.
             request.put("streaming", true);
@@ -533,6 +573,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
               // fields above changing — leaving them out of the signature pins
               // the token and cost line of a running request to its first push.
               .append(r.getOrDefault("prompt_tokens", "")).append(':')
+              .append(r.getOrDefault("prompt_estimated", "")).append(':')
               .append(r.getOrDefault("completion_tokens", "")).append(':')
               .append(r.getOrDefault("total_tokens", "")).append(':')
               .append(r.getOrDefault("cost_microcents", "")).append(',');

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorLiveStreamClientTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorLiveStreamClientTest.java
@@ -1,0 +1,133 @@
+package de.tum.cit.aet.logos.logoswebservice.orchestrator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Plain unit tests for the client; the SSE loop itself is exercised line by
+ * line, which is all the handler tests downstream need as well.
+ */
+class OrchestratorLiveStreamClientTest {
+
+    private RestTemplate restTemplate;
+    private OrchestratorLiveStreamClient client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        client = new OrchestratorLiveStreamClient(restTemplate);
+        ReflectionTestUtils.setField(client, "orchestratorUrl", "http://orchestrator");
+        ReflectionTestUtils.setField(client, "internalSecret", "secret");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubPull(Map<String, Object> body) {
+        when(restTemplate.exchange(
+            eq("http://orchestrator/internal/live_streams"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(Map.class)))
+            .thenReturn(ResponseEntity.ok(body));
+    }
+
+    @Test
+    void unconfigured_returnsEmptyWithoutCalling() {
+        ReflectionTestUtils.setField(client, "orchestratorUrl", "");
+
+        assertThat(client.getLiveStreams()).isEmpty();
+
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void pull_maps_every_field_of_a_row() {
+        stubPull(Map.of("streams", List.of(Map.of(
+            "request_id", "req-1",
+            "prompt_tokens", 1200,
+            "prompt_estimated", true,
+            "completion_tokens", 42,
+            "tokens_per_second", 21.0))));
+
+        Map<String, OrchestratorLiveStreamClient.LiveStream> streams = client.getLiveStreams();
+
+        assertThat(streams).containsOnlyKeys("req-1");
+        assertThat(streams.get("req-1"))
+            .isEqualTo(new OrchestratorLiveStreamClient.LiveStream(1200, 42, 21.0, true));
+    }
+
+    @Test
+    void pull_failure_yields_empty() {
+        when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(Map.class)))
+            .thenThrow(new ResourceAccessException("down", new IOException("refused")));
+
+        assertThat(client.getLiveStreams()).isEmpty();
+    }
+
+    @Test
+    void a_data_line_updates_the_cache_and_notifies_the_listener() {
+        AtomicReference<Map<String, OrchestratorLiveStreamClient.LiveStream>> seen = new AtomicReference<>();
+        client.setOnLiveUpdate(seen::set);
+
+        client.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":1200,\"prompt_estimated\":true,\"completion_tokens\":7}]}");
+
+        // Served from the cache: a fresh snapshot costs no HTTP call.
+        Map<String, OrchestratorLiveStreamClient.LiveStream> cached = client.getLiveStreams();
+        assertThat(cached.get("req-1"))
+            .isEqualTo(new OrchestratorLiveStreamClient.LiveStream(1200, 7, null, true));
+        assertThat(seen.get()).isEqualTo(cached);
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void a_heartbeat_keeps_the_cache_fresh_and_stays_silent() {
+        AtomicInteger notifications = new AtomicInteger();
+        client.setOnLiveUpdate(streams -> notifications.incrementAndGet());
+
+        client.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":1,\"completion_tokens\":1}]}");
+        client.handleLine(": ping");
+
+        Map<String, OrchestratorLiveStreamClient.LiveStream> cached = client.getLiveStreams();
+        assertThat(cached).containsKey("req-1");
+        assertThat(notifications).hasValue(1);  // the ping changed nothing
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void a_malformed_data_line_is_ignored() {
+        stubPull(Map.of("streams", List.of()));
+
+        client.handleLine("data: not-json");
+
+        // No cache entry was born from it, so the read pulls.
+        assertThat(client.getLiveStreams()).isEmpty();
+    }
+
+    @Test
+    void a_newer_snapshot_replaces_the_older_one() {
+        client.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":10,\"completion_tokens\":1}]}");
+        client.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":10,\"completion_tokens\":9}]}");
+
+        Map<String, OrchestratorLiveStreamClient.LiveStream> cached = client.getLiveStreams();
+        assertThat(cached.get("req-1").completionTokens()).isEqualTo(9);
+    }
+}

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -1,0 +1,151 @@
+package de.tum.cit.aet.logos.logoswebservice.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.cit.aet.logos.logoswebservice.operations.service.EnqueueEventService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogStatsService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.VramService;
+import de.tum.cit.aet.logos.logoswebservice.orchestrator.OrchestratorLiveStreamClient;
+
+/**
+ * The realtime half of the request feed: an SSE line from the orchestrator
+ * must reach an initialised viewer as a websocket push without waiting for
+ * the two-second tick. Plain unit test on purpose — no container, no network,
+ * the client's SSE loop is fed line by line.
+ */
+class StatsV2WebSocketHandlerLivePushTest {
+
+    private VramService vramService;
+    private RequestLogService requestLogService;
+    private RequestLogStatsService statsService;
+    private EnqueueEventService enqueueService;
+    private OrchestratorLiveStreamClient liveStreamClient;
+    private StatsV2WebSocketHandler handler;
+    private WebSocketSession session;
+
+    private static Map<String, Object> requestRow(String requestId) {
+        Map<String, Object> row = new HashMap<>();
+        row.put("request_id", requestId);
+        row.put("status", "pending");
+        return row;
+    }
+
+    /**
+     * The real service returns fresh collections per call; the stub must too,
+     * because the tick thread and the live-push thread both read the feed.
+     * The template is copied per call, so a merge on one push does not leak
+     * into the next.
+     */
+    @SuppressWarnings("unchecked")
+    private static void stubLatestRequests(RequestLogService service, Map<String, Object> template) {
+        when(service.getLatestRequests(any(), any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
+            .thenAnswer(inv -> Map.of("requests", List.of(new HashMap<>(template))));
+    }
+
+    @BeforeEach
+    void setUp() {
+        vramService = mock(VramService.class);
+        requestLogService = mock(RequestLogService.class);
+        statsService = mock(RequestLogStatsService.class);
+        enqueueService = mock(EnqueueEventService.class);
+        when(statsService.getRequestLogStats(any(), any(), anyInt(), any(), any()))
+            .thenReturn(Map.of("bucketSeconds", 60));
+        when(vramService.getVramStats(anyString(), anyInt()))
+            .thenReturn(Map.of("providers", List.of(), "last_snapshot_id", 0));
+        when(enqueueService.getInRange(any(), any(), anyInt(), any(), any()))
+            .thenReturn(Map.of("events", List.of()));
+
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        liveStreamClient = new OrchestratorLiveStreamClient(restTemplate);
+        ReflectionTestUtils.setField(liveStreamClient, "orchestratorUrl", "http://orchestrator");
+        ReflectionTestUtils.setField(liveStreamClient, "internalSecret", "secret");
+        // The fallback pull: no streams, so the cache only ever fills from the
+        // data lines the tests feed.
+        when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class)))
+            .thenReturn(ResponseEntity.ok(Map.of("streams", List.of())));
+
+        handler = new StatsV2WebSocketHandler(
+            vramService, requestLogService, statsService, enqueueService,
+            liveStreamClient, new ObjectMapper());
+        stubLatestRequests(requestLogService, requestRow("req-1"));
+
+        session = mock(WebSocketSession.class);
+        when(session.getId()).thenReturn("live-push-session");
+        when(session.isOpen()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        handler.shutdown();
+    }
+
+    private void connectAndInit() throws Exception {
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\"}"));
+        clearInvocations(session);
+    }
+
+    @Test
+    void a_live_update_reaches_the_viewer_as_a_requests_push() throws Exception {
+        connectAndInit();
+
+        liveStreamClient.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":1200,\"prompt_estimated\":true,\"completion_tokens\":42,\"tokens_per_second\":21.0}]}");
+
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        String json = captor.getValue().getPayload();
+
+        assertThat(json).contains("\"type\":\"requests\"");
+        assertThat(json).contains("\"prompt_tokens\":1200");
+        assertThat(json).contains("\"completion_tokens\":42");
+        assertThat(json).contains("\"tokens_per_second\":21.0");
+        assertThat(json).contains("\"prompt_estimated\":true");
+        assertThat(json).contains("\"streaming\":true");
+    }
+
+    @Test
+    void a_settled_row_keeps_its_database_usage() throws Exception {
+        connectAndInit();
+        Map<String, Object> row = requestRow("req-1");
+        row.put("total_tokens", 100L);
+        stubLatestRequests(requestLogService, row);
+        clearInvocations(session);
+
+        liveStreamClient.handleLine("data: {\"streams\":[{\"request_id\":\"req-1\",\"prompt_tokens\":1200,\"completion_tokens\":42}]}");
+
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        String json = captor.getValue().getPayload();
+
+        assertThat(json).contains("\"total_tokens\":100");
+        assertThat(json).doesNotContain("\"streaming\":true");
+    }
+}


### PR DESCRIPTION
## What changed

Follow-up to #780, addressing the three gaps from the issue comments: token rates invisible for streamed Messages API requests, token counts updating only in fixed-interval steps, and no counts visible while a request is still queued.

**Orchestrator** (`logos-orchestrator/src/logos/main.py`)
- **Messages API counting fix**: `message_start`'s `output_tokens` is a one-token placeholder, and trusting it pinned the live completion figure at `1` for the whole generation — so the rate computed to ~0 and the numbers looked frozen (this is the "claude-logos has no rates" report). Until `message_delta` settles the figure, the accumulated text deltas are the count.
- **Tracked from arrival**: a request is published to the live view the moment it has a `request_id` — sync path, job path, and the worker-reconnect wait in between — carrying the prompt estimate context routing already computes, flagged `prompt_estimated`. The flag clears the moment the upstream states the real prompt size. `start()` is non-destructive so the streamer's later registration keeps the counters and start time; every exit path (error raises, sync responses, job error dicts) ends the entry via `finally`, streaming responses hand ownership to their generator.
- **New SSE endpoint** `GET /internal/live_streams/stream`: the same snapshot as the existing one-shot GET, pushed once per registry change (version counter, 0.2 s check tick) with `: ping` heartbeats while idle. Same auth as its sibling.

**Webservice**
- `OrchestratorLiveStreamClient` now subscribes to the SSE stream on a daemon thread (reconnect with backoff, reset after a long-lived connection), keeps the latest snapshot in a cache, and notifies a listener per new snapshot. The one-shot GET remains the fallback: a snapshot older than 5 s is served by a pull, which is also how a silently dead subscription reveals itself. `LiveStream` gains `promptEstimated`.
- `StatsV2WebSocketHandler` registers as listener and pushes a fresh `requests` page to its viewers the moment a snapshot arrives — coalesced to at most one push per 250 ms (the orchestrator emits one per token delta), each push still change-detected by the existing signature, with the 2 s tick unchanged as backstop. The merge now passes `prompt_estimated` through, and the signature includes it so estimate→real flips are pushed.

**UI** (`logos-ui`, statistics page)
- The token line no longer jumps between pushes: the shown figure chases the pushed one at ~15 fps (30 % of the gap per frame, at least one token; a downward target — the estimate the real prompt replaced — is reached at once). The chase timer runs only while a streaming row is still catching up.
- An estimated prompt carries a tilde (`↑~1200 ↓0`) until the upstream states the real size; queued requests therefore show their prompt figure immediately instead of sitting blank.
- `RequestItem` gains `prompt_estimated`.

## Why

The issue asked for live token numbers "streamed in real time through websocket instead of fetched in fixed intervals", for all requests including per-request tok/s, and for counts to be visible from the moment a request is queued. Each gap above mapped to one of those: the placeholder made the rate invisible for exactly the streamed Messages API traffic, the 2 s poll + 2 s tick made the counts move in steps, and tracking only started when the stream started left queued requests blank.

## How it was verified

- Orchestrator: `uv run --python 3.13 pytest tests/unit/` — 954 passed. New tests: Messages placeholder regression, arrival tracking with estimate + flag clearing, non-destructive `start`, version counter, and the SSE endpoint (auth, snapshot shape, data-on-change / ping-when-idle, finish propagation).
- Webservice: `mvn test` — 260 passed, 0 failures (Docker/Testcontainers available). New tests: client parsing, cache/fallback behavior, SSE line handling (data, heartbeat, malformed), and the handler end-to-end — an SSE line fed through the real client reaches an initialised viewer as a `requests` push with merged counts, and settled rows keep their database usage.
- UI: `npx ng test --watch=false` — 55 passed. New tests for `chaseStep` (per-frame progression, overshoot clamp, downward snap) and `tokenLabel` (estimate tilde, null handling).
- Linters: pre-commit (black, isort, autoflake, flake8) clean on the Python changes; the Java and TypeScript changes compile through their builds.

A full deployment (docker compose + vLLM workers + Keycloak) was not available, so end-to-end behaviour is covered by the unit tests above plus code reading of the request lifecycles (sync, streaming, jobs, worker-wait, client disconnect) rather than a live run.

Fixes #780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live statistics now show in-progress requests and token counts as they update.
  * Request statistics refresh automatically through a live event stream.
  * Estimated prompt-token counts are clearly marked until confirmed values arrive.
  * Streaming token counts animate smoothly in the recent requests view.

* **Bug Fixes**
  * Improved token counting for streaming responses.
  * Statistics continue updating reliably when requests start or finish.

* **Tests**
  * Added coverage for live updates, authentication, estimates, animations, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->