### PR TITLE
`Logos`: Filter recent requests by state in the statistics dashboard

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
@@ -53,13 +53,7 @@
   @if (pending && onLivePage()) {
     <app-stats-skeleton variant="rows" />
   } @else if (displayItems().length === 0) {
-    <div class="rr-empty">
-      @if (filterActive()) {
-        No requests from this requester or team in the selected range.
-      } @else {
-        No requests in this time range.
-      }
-    </div>
+    <div class="rr-empty">{{ emptyMessage() }}</div>
   } @else {
     <div class="rr-list">
       @for (item of displayItems(); track trackById($index, item)) {

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.html
@@ -10,7 +10,7 @@
       @if (displayItems().length > 0) {
         <span class="rr-pager__count">
           <strong>{{ formatCount(firstRowNumber()) }}-{{ formatCount(lastRowNumber()) }}</strong>
-          of <strong>{{ formatCount(totalCount()) }}</strong>
+          of <strong>{{ totalInRangeLabel() }}</strong>
         </span>
       }
       <!-- Left of the buttons on purpose: the badge and the spinner appear

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.spec.ts
@@ -1,5 +1,9 @@
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { providerLabel } from '../../statistics.utils';
-import { chaseStep, tokenLabel } from './recent-requests';
+import { RequestItem } from '../../statistics.models';
+import { StatisticsService } from '../../services/statistics.service';
+import { chaseStep, tokenLabel, RecentRequests } from './recent-requests';
 
 /**
  * The provider label of a request row.
@@ -119,5 +123,75 @@ describe('tokenLabel', () => {
     // not what a model counted. The tilde keeps the page honest about that.
     expect(tokenLabel(1200, 0, { p: 1200, c: 0 }, true)).toBe('↑~1200 ↓0');
     expect(tokenLabel(1200, 0, { p: 1200, c: 0 }, false)).toBe('↑1200 ↓0');
+  });
+});
+
+/**
+ * The "of N" figure while a state-filtered feed waits for the first push of
+ * its own bucket total.
+ *
+ * The page passes `null` for totalInRange in that window: the KPI aggregate
+ * it would otherwise borrow describes the whole scope, not the bucket, so the
+ * header must have no figure at all rather than one for a different set.
+ */
+describe('totalCount for a filtered feed without a bucket total yet', () => {
+  const settledRow: RequestItem = {
+    request_id: 'req-feed-total',
+    model_name: 'model-a',
+    provider_name: 'gpu-01',
+    is_cloud: false,
+    status: 'success',
+    timestamp: '2026-08-29T10:00:00Z',
+    duration: 12,
+    cold_start: false,
+    enqueue_ts: '2026-08-29T10:00:00Z',
+    scheduled_ts: '2026-08-29T10:00:01Z',
+    request_complete_ts: '2026-08-29T10:00:13Z',
+    queue_seconds: 1,
+    total_seconds: 13,
+    initial_priority: 'normal',
+    priority_when_scheduled: 'normal',
+    queue_depth_at_enqueue: 0,
+    error_message: null,
+    team_name: 'Team 1',
+    username: 'operator',
+    full_name: 'The Operator',
+    prompt_tokens: 1200,
+    completion_tokens: 42,
+    total_tokens: 1242,
+    cost_microcents: 123,
+  };
+
+  let component: RecentRequests;
+
+  async function createComponent(totalInRange: number | null): Promise<RecentRequests> {
+    await TestBed.configureTestingModule({
+      imports: [RecentRequests],
+      providers: [{ provide: StatisticsService, useValue: {} }],
+    }).compileComponents();
+    const fixture: ComponentFixture<RecentRequests> = TestBed.createComponent(RecentRequests);
+    component = fixture.componentInstance;
+    component.totalInRange = totalInRange;
+    component.liveRequests = [settledRow];
+    component.ngOnChanges({
+      totalInRange: new SimpleChange(0, totalInRange, true),
+      liveRequests: new SimpleChange([], [settledRow], true),
+    });
+    fixture.detectChanges();
+    return component;
+  }
+
+  afterEach(() => {
+    // The toolbar runs its own ticker and the token line its own chase; drop
+    // both so no test keeps a timer alive past the one that started it.
+    component.ngOnDestroy();
+  });
+
+  it('has no figure at all, so the header can show "—" instead of a wrong one', async () => {
+    expect((await createComponent(null)).totalCount()).toBeNull();
+  });
+
+  it('shows the bucket total once the first push for it lands', async () => {
+    expect((await createComponent(7)).totalCount()).toBe(7);
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
@@ -73,6 +73,12 @@ export class RecentRequests implements OnChanges, OnDestroy {
    */
   @Input() filterUserId: number | null = null;
   @Input() filterTeamId: number | null = null;
+  /**
+   * The lifecycle bucket the feed is narrowed to (queued/running/error/
+   * finished), or null for all states. Like the user/team inputs it is owned
+   * by the page — the live push and every fetched page must agree on it.
+   */
+  @Input() filterStatus: string | null = null;
 
   /** Shared ticker: ms since epoch, updated by setInterval. */
   now = signal(Date.now());
@@ -86,11 +92,24 @@ export class RecentRequests implements OnChanges, OnDestroy {
   private readonly _totalInRange = signal(0);
   private readonly _filterUserId = signal<number | null>(null);
   private readonly _filterTeamId = signal<number | null>(null);
+  private readonly _filterStatus = signal<string | null>(null);
 
   /** Only for the empty state, which reads differently once a filter is on. */
   readonly filterActive = computed(
     () => this._filterUserId() !== null || this._filterTeamId() !== null,
   );
+
+  /**
+   * The empty state, worded for the filters that are on. A state filter alone
+   * names the state; a team/user scope keeps its own wording, with the state
+   * folded in when both are active.
+   */
+  readonly emptyMessage = computed(() => {
+    const state = this._filterStatus() ? `${this._filterStatus()} ` : '';
+    return this.filterActive()
+      ? `No ${state}requests from this requester or team in the selected range.`
+      : `No ${state}requests in this time range.`;
+  });
 
   // ── Paging ─────────────────────────────────────────────────────────────────
 
@@ -162,12 +181,14 @@ export class RecentRequests implements OnChanges, OnDestroy {
     if (changes['totalInRange']) this._totalInRange.set(this.totalInRange ?? 0);
     if (changes['filterUserId']) this._filterUserId.set(this.filterUserId);
     if (changes['filterTeamId']) this._filterTeamId.set(this.filterTeamId);
+    if (changes['filterStatus']) this._filterStatus.set(this.filterStatus);
     // A new range or a new scope invalidates every page cut out of the previous
     // one. No fetch follows: page 0 is the live feed either way, and the
     // websocket is already sending it for the new scope.
     const scopeChanged =
       (changes['filterUserId'] && !changes['filterUserId'].firstChange) ||
-      (changes['filterTeamId'] && !changes['filterTeamId'].firstChange);
+      (changes['filterTeamId'] && !changes['filterTeamId'].firstChange) ||
+      (changes['filterStatus'] && !changes['filterStatus'].firstChange);
     if ((changes['range'] && !changes['range'].firstChange) || scopeChanged) {
       this.resetToFirstPage();
     }
@@ -238,7 +259,7 @@ export class RecentRequests implements OnChanges, OnDestroy {
         range.startIso,
         range.endIso,
         PAGE_SIZE,
-        { userId: this._filterUserId(), teamId: this._filterTeamId() },
+        { userId: this._filterUserId(), teamId: this._filterTeamId(), status: this._filterStatus() },
         cursor,
       );
       const rows = page.requests ?? [];

--- a/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/recent-requests/recent-requests.ts
@@ -86,8 +86,12 @@ export class RecentRequests implements OnChanges, OnDestroy {
    * Same range, resolved per aggregate push, so it can trail the live rows by a
    * few — hence the floor in `totalCount()`. Only used while page 1 is showing
    * live rows; a fetched page brings its own count.
+   *
+   * `null` for a state-filtered live feed while its first pushed bucket total
+   * is still in flight: the page then has no figure for that set, and the
+   * header shows "—" rather than a number describing a different set.
    */
-  @Input() totalInRange = 0;
+  @Input() totalInRange: number | null = 0;
 
   /** The selected range as ISO strings — what the pages are cut out of. */
   @Input() range: { startIso: string; endIso: string } | null = null;
@@ -135,7 +139,7 @@ export class RecentRequests implements OnChanges, OnDestroy {
   // @Input() is not a tracked producer, so reading it inside computed() would
   // cache the very first value (an empty list) forever.
   private readonly _liveRequests = signal<RequestItem[]>([]);
-  private readonly _totalInRange = signal(0);
+  private readonly _totalInRange = signal<number | null>(0);
   private readonly _filterUserId = signal<number | null>(null);
   private readonly _filterTeamId = signal<number | null>(null);
   private readonly _filterStatus = signal<string | null>(null);
@@ -191,11 +195,24 @@ export class RecentRequests implements OnChanges, OnDestroy {
     this.onLivePage() ? this._liveRequests() : this._pageRows(),
   );
 
-  readonly totalCount = computed(() => {
+  readonly totalCount = computed<number | null>(() => {
     const known = this.onLivePage() ? this._totalInRange() : (this._pageTotal() ?? 0);
+    // A filtered live feed waiting for its first pushed total has no figure
+    // for the set it shows; the header renders that as "—".
+    if (known === null) return null;
     // Never promise fewer rows than are on screen: on the live page the
     // aggregate push the total comes from can be a beat behind the feed.
     return Math.max(known, this.firstRowNumber() + this.displayItems().length - 1);
+  });
+
+  /**
+   * The total as the header prints it. A filtered feed waiting for its first
+   * pushed bucket total has no figure for the set it shows, so the line reads
+   * "of —" there rather than a number describing a different set.
+   */
+  readonly totalInRangeLabel = computed(() => {
+    const total = this.totalCount();
+    return total === null ? '—' : this.formatCount(total);
   });
 
   /** 1-based number of the first row on this page, for the "11-20 of n" line. */
@@ -224,7 +241,7 @@ export class RecentRequests implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['liveRequests']) this._liveRequests.set(this.liveRequests ?? []);
-    if (changes['totalInRange']) this._totalInRange.set(this.totalInRange ?? 0);
+    if (changes['totalInRange']) this._totalInRange.set(this.totalInRange);
     if (changes['filterUserId']) this._filterUserId.set(this.filterUserId);
     if (changes['filterTeamId']) this._filterTeamId.set(this.filterTeamId);
     if (changes['filterStatus']) this._filterStatus.set(this.filterStatus);

--- a/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
+++ b/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
@@ -32,6 +32,8 @@ export interface LatestRequestsPage {
 export interface RequestFilter {
   userId: number | null;
   teamId: number | null;
+  /** One lifecycle bucket (queued/running/error/finished), or null for all. */
+  status: string | null;
 }
 
 /** One entry of a filter dropdown, with how much picking it would select. */
@@ -98,6 +100,7 @@ export class StatisticsService {
         limit,
         user_id: filter.userId,
         team_id: filter.teamId,
+        status: filter.status,
         cursor_ts: cursor?.ts ?? null,
         cursor_id: cursor?.request_id ?? null,
       }),

--- a/logos/logos-ui/src/app/features/statistics/services/stats-websocket.service.ts
+++ b/logos/logos-ui/src/app/features/statistics/services/stats-websocket.service.ts
@@ -64,6 +64,12 @@ export interface StatsWsConnectOptions {
   timeline: TimelineRequestConfig;
   timelineDeltas: boolean;
   scope?: StatsScope;
+  /**
+   * State bucket the request feed is narrowed to (queued/running/error/
+   * finished), or null for all states. Feed-only: it never touches the page
+   * scope, so the KPI cards and charts keep their full team/user totals.
+   */
+  feedStatus?: string | null;
   handlers: StatsWsHandlers;
 }
 
@@ -143,6 +149,24 @@ export class StatsWebsocketService {
           team_id: scope.teamId,
         })
       );
+    }
+  }
+
+  /**
+   * Narrow the request feed to one lifecycle bucket (queued, running, error,
+   * finished); null shows all states.
+   *
+   * Stored on the options as well as sent, so a reconnect re-applies it — the
+   * dropdown keeps showing the filter, and a socket that came back unfiltered
+   * would quietly widen the list under it. The server answers with a forced
+   * feed push only; the aggregates are untouched by a state filter.
+   */
+  setFeedStatus(status: string | null): void {
+    if (this.opts) {
+      this.opts = { ...this.opts, feedStatus: status };
+    }
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ action: 'set_feed_status', status }));
     }
   }
 
@@ -267,6 +291,7 @@ export class StatsWebsocketService {
           },
           user_id: current.scope?.userId ?? null,
           team_id: current.scope?.teamId ?? null,
+          status: current.feedStatus ?? null,
         })
       );
 

--- a/logos/logos-ui/src/app/features/statistics/statistics.html
+++ b/logos/logos-ui/src/app/features/statistics/statistics.html
@@ -371,13 +371,26 @@
       title="Recent requests"
       subtitle="Latest activity from the request log."
     >
+      <span panelRight>
+        <!-- State filter for this list only — it sits with the feed, not in the
+             page scope, because it must not narrow the KPI cards and charts. -->
+        <app-select
+          class="stats-feed-status"
+          [options]="feedStatusOptions()"
+          [value]="selectedFeedStatusValue()"
+          [compact]="true"
+          ariaLabel="Filter requests by state"
+          (valueChange)="setFeedStatusFilter($event)"
+        />
+      </span>
       <app-stats-recent-requests
         [liveRequests]="latestRequests()"
-        [totalInRange]="totalRequests()"
+        [totalInRange]="requestFeedTotal()"
         [range]="requestFeedRange()"
         [pending]="requestsPending()"
         [filterUserId]="filterUserId()"
         [filterTeamId]="filterTeamId()"
+        [filterStatus]="feedStatus()"
       />
     </app-stats-chart-panel>
 

--- a/logos/logos-ui/src/app/features/statistics/statistics.scss
+++ b/logos/logos-ui/src/app/features/statistics/statistics.scss
@@ -52,6 +52,13 @@
   max-width: 200px;
 }
 
+// The feed's state filter, in the recent-requests panel header. Its entries are
+// short, so a cap only guards against the title wrapping on a narrow panel.
+.stats-feed-status {
+  min-width: 0;
+  max-width: 160px;
+}
+
 .stats-scope__note {
   font-size: var(--font-size-xs);
   color: rgb(var(--color-typography-500));

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -214,6 +214,12 @@ export class Statistics implements OnInit, OnDestroy {
   setFeedStatusFilter(value: string | null): void {
     const next = normalizeFeedStatus(value);
     if (next === this.feedStatus()) return;
+    // The total the last push reported describes the previous bucket — or,
+    // when clearing, there was none — so it is wrong for this selection and
+    // is dropped until the first push for it lands. Without this the header
+    // keeps advertising the old bucket's count, indefinitely if the socket
+    // is down.
+    this.liveFeedTotal.set(null);
     this.feedStatus.set(next);
     // Only the feed changes, so only it is marked loading — the KPI cards and
     // charts keep their current (unaffected) numbers.
@@ -1103,12 +1109,16 @@ export class Statistics implements OnInit, OnDestroy {
       this.latestRequests.set(payload.requests);
       this.requestsPending.set(false);
     }
-    // A status-filtered feed carries its own total (the page's KPI total is only
-    // as narrow as the team/user scope, not the state bucket). An unfiltered
-    // push has no total, so the borrowed aggregate stays in force.
-    this.liveFeedTotal.set(
-      this.feedStatus() && typeof payload.total === 'number' ? payload.total : null,
-    );
+    // A status-filtered feed carries its own total (the page's KPI total is
+    // only as narrow as the team/user scope, not the state bucket). The
+    // server sends it only when the row set it counts has moved, so a push
+    // without a total keeps the last one: the count cannot have changed in
+    // between. Unfiltered pushes have no total, and switching the filter
+    // clears this signal, so the borrowed aggregate is never shown for a
+    // set it does not describe.
+    if (this.feedStatus() && typeof payload.total === 'number') {
+      this.liveFeedTotal.set(payload.total);
+    }
   }
 
   private handleVramWsInitV2(payload: VramV2Payload): void {

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -24,6 +24,9 @@ import {
   chooseDynamicTargetBuckets,
   extractProviderVramMb,
   formatRangeLabel,
+  normalizeFeedStatus,
+  resolveFeedTotal,
+  REQUEST_STATUS_FILTERS,
   BYTES_PER_GIB,
   BYTES_PER_MIB,
   toGb,
@@ -180,6 +183,42 @@ export class Statistics implements OnInit, OnDestroy {
     }
     return parts.join(' · ');
   });
+
+  // ── Request feed state filter ───────────────────────────────────────────────
+  // One lifecycle bucket the recent-requests list is narrowed to; null shows
+  // every state. Deliberately not part of the page scope: a state filter only
+  // makes sense for the list of individual requests, not for the KPI cards and
+  // charts above it, which must keep summarising the whole team/user selection.
+  readonly feedStatus = signal<string | null>(null);
+
+  readonly feedStatusOptions = computed<AppSelectOption[]>(() => [
+    { value: '', label: 'All states' },
+    ...REQUEST_STATUS_FILTERS.map((s) => ({ value: s, label: s[0].toUpperCase() + s.slice(1) })),
+  ]);
+
+  readonly selectedFeedStatusValue = computed(() => this.feedStatus() ?? '');
+
+  /**
+   * The feed's own total, reported by the live push while a state filter is on.
+   * The unfiltered page borrows the statistics aggregate instead, so this stays
+   * null then and `requestFeedTotal` falls back to that total.
+   */
+  readonly liveFeedTotal = signal<number | null>(null);
+
+  /** Total the feed header shows: the status-filtered count, else the KPI total. */
+  readonly requestFeedTotal = computed(() =>
+    resolveFeedTotal(this.feedStatus(), this.liveFeedTotal(), this.totalRequests()),
+  );
+
+  setFeedStatusFilter(value: string | null): void {
+    const next = normalizeFeedStatus(value);
+    if (next === this.feedStatus()) return;
+    this.feedStatus.set(next);
+    // Only the feed changes, so only it is marked loading — the KPI cards and
+    // charts keep their current (unaffected) numbers.
+    this.requestsPending.set(true);
+    this.statsWs.setFeedStatus(next);
+  }
 
   // ── Raw WS signals ────────────────────────────────────────────────────────────
   readonly stats = signal<RequestLogStats | null>(null);
@@ -836,6 +875,7 @@ export class Statistics implements OnInit, OnDestroy {
       // events of the initial load and then never moves again.
       timelineDeltas: true,
       scope: { userId: this.filterUserId(), teamId: this.filterTeamId() },
+      feedStatus: this.feedStatus(),
       handlers: {
         onVramInit: (p) => this.handleVramWsInitV2(p),
         onVramDelta: (p) => this.handleVramWsDeltaV2(p),
@@ -1059,11 +1099,17 @@ export class Statistics implements OnInit, OnDestroy {
 
   // ── WS handlers ───────────────────────────────────────────────────────────────
 
-  private handleRequestsWsData(payload: { requests?: RequestItem[] }): void {
+  private handleRequestsWsData(payload: { requests?: RequestItem[]; total?: number }): void {
     if (payload.requests) {
       this.latestRequests.set(payload.requests);
       this.requestsPending.set(false);
     }
+    // A status-filtered feed carries its own total (the page's KPI total is only
+    // as narrow as the team/user scope, not the state bucket). An unfiltered
+    // push has no total, so the borrowed aggregate stays in force.
+    this.liveFeedTotal.set(
+      this.feedStatus() && typeof payload.total === 'number' ? payload.total : null,
+    );
   }
 
   private handleVramWsInitV2(payload: VramV2Payload): void {

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -39,7 +39,7 @@ describe('normalizeFeedStatus', () => {
  * Unfiltered, the feed and the KPI card count the same set, so the feed borrows
  * the aggregate. Filtered, it must show the count of that bucket — the aggregate
  * is only as narrow as the team/user scope — using the live push's total and
- * falling back to the aggregate only while that push is still in flight.
+ * showing nothing at all while that push is still in flight.
  */
 describe('resolveFeedTotal', () => {
   it('shows the aggregate total when no state filter is on', () => {
@@ -53,9 +53,12 @@ describe('resolveFeedTotal', () => {
     expect(resolveFeedTotal('finished', 0, 4312)).toBe(0);
   });
 
-  it('falls back to the aggregate while the filtered push is in flight', () => {
-    // The filter is set but its first push has not landed yet.
-    expect(resolveFeedTotal('queued', null, 4312)).toBe(4312);
+  it('shows nothing while the filtered push is in flight', () => {
+    // The filter is set but its first push has not landed yet. The aggregate
+    // describes the whole scope, not the bucket, so the header would promise
+    // a set the filter has hidden — an absent total ("—") is the honest
+    // figure until the bucket's own count lands.
+    expect(resolveFeedTotal('queued', null, 4312)).toBeNull();
   });
 });
 

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -1,0 +1,59 @@
+import {
+  normalizeFeedStatus,
+  resolveFeedTotal,
+  REQUEST_STATUS_FILTERS,
+} from './statistics.utils';
+
+/**
+ * The dropdown's raw value becomes the bucket the feed is narrowed by.
+ *
+ * The empty selection is "all states", and a value that is not one of the four
+ * buckets is treated the same way: it widens back to the full feed rather than
+ * matching nothing, which is what an operator expects when a picker they did
+ * not fill in stops showing everything.
+ */
+describe('normalizeFeedStatus', () => {
+  it('turns the empty selection into "no filter"', () => {
+    expect(normalizeFeedStatus('')).toBeNull();
+    expect(normalizeFeedStatus(null)).toBeNull();
+  });
+
+  it('passes each lifecycle bucket through unchanged', () => {
+    for (const bucket of REQUEST_STATUS_FILTERS) {
+      expect(normalizeFeedStatus(bucket)).toBe(bucket);
+    }
+  });
+
+  it('widens an unknown value back to the full feed', () => {
+    // A stale or tampered value must not quietly match zero rows.
+    expect(normalizeFeedStatus('pending')).toBeNull();
+    expect(normalizeFeedStatus('ERROR')).toBeNull();
+    expect(normalizeFeedStatus('queued ')).toBeNull();
+  });
+});
+
+/**
+ * Which "of N" total the feed header shows.
+ *
+ * Unfiltered, the feed and the KPI card count the same set, so the feed borrows
+ * the aggregate. Filtered, it must show the count of that bucket — the aggregate
+ * is only as narrow as the team/user scope — using the live push's total and
+ * falling back to the aggregate only while that push is still in flight.
+ */
+describe('resolveFeedTotal', () => {
+  it('shows the aggregate total when no state filter is on', () => {
+    // Even if a push carried a stale total, an unfiltered feed ignores it.
+    expect(resolveFeedTotal(null, 3, 4312)).toBe(4312);
+    expect(resolveFeedTotal('', 3, 4312)).toBe(4312);
+  });
+
+  it('shows the bucket total the live push reports', () => {
+    expect(resolveFeedTotal('error', 7, 4312)).toBe(7);
+    expect(resolveFeedTotal('finished', 0, 4312)).toBe(0);
+  });
+
+  it('falls back to the aggregate while the filtered push is in flight', () => {
+    // The filter is set but its first push has not landed yet.
+    expect(resolveFeedTotal('queued', null, 4312)).toBe(4312);
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -42,6 +42,47 @@ export function formatElapsed(seconds: number): string {
   return `${m}m ${s}s`;
 }
 
+// ── Recent-requests state filter ──────────────────────────────────────────────
+
+/**
+ * The lifecycle buckets the request feed can be narrowed to, in the order the
+ * filter offers them. `queued` and `running` are the in-flight states; `error`
+ * and `finished` split the settled ones by outcome (a timeout counts as an
+ * error, matching how the row border colours timeouts as a failure).
+ */
+export const REQUEST_STATUS_FILTERS = ['queued', 'running', 'error', 'finished'] as const;
+
+export type RequestStatusFilter = (typeof REQUEST_STATUS_FILTERS)[number];
+
+/**
+ * Normalise the state-filter dropdown's value to the bucket the feed is
+ * narrowed by. The empty selection means "all states" (null); anything that is
+ * not one of the four buckets is treated the same, so a stale or tampered value
+ * widens back to the full feed instead of matching nothing.
+ */
+export function normalizeFeedStatus(value: string | null): string | null {
+  if (!value) return null;
+  return (REQUEST_STATUS_FILTERS as readonly string[]).includes(value) ? value : null;
+}
+
+/**
+ * The "of N" total the feed header shows.
+ *
+ * An unfiltered feed borrows the statistics aggregate (the page's KPI total),
+ * which it already matches. A status-filtered feed must show the count of that
+ * bucket instead — the aggregate is only as narrow as the team/user scope, not
+ * the state — so it uses the total the live push reports for the bucket, and
+ * falls back to the aggregate only while that push is still in flight.
+ */
+export function resolveFeedTotal(
+  status: string | null,
+  pushedTotal: number | null,
+  aggregateTotal: number,
+): number {
+  if (!status) return aggregateTotal;
+  return pushedTotal ?? aggregateTotal;
+}
+
 // ── X-axis labels (shared by request-volume and VRAM charts) ─────────────────
 
 export interface TimeAxisLabel {

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -93,16 +93,18 @@ export function normalizeFeedStatus(value: string | null): string | null {
  * An unfiltered feed borrows the statistics aggregate (the page's KPI total),
  * which it already matches. A status-filtered feed must show the count of that
  * bucket instead — the aggregate is only as narrow as the team/user scope, not
- * the state — so it uses the total the live push reports for the bucket, and
- * falls back to the aggregate only while that push is still in flight.
+ * the state — so it shows the total the live push reports for the bucket, and
+ * nothing while that push is still in flight: the borrowed aggregate
+ * describes a different set, and a wrong "of N" reads as worse than an
+ * absent one.
  */
 export function resolveFeedTotal(
   status: string | null,
   pushedTotal: number | null,
   aggregateTotal: number,
-): number {
+): number | null {
   if (!status) return aggregateTotal;
-  return pushedTotal ?? aggregateTotal;
+  return pushedTotal;
 }
 
 // ── Token count scale ─────────────────────────────────────────────────────────

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
@@ -46,9 +46,12 @@ public class RequestLogController {
         String end = body.get("end") instanceof String s ? s : null;
         Integer userId = body.get("user_id") instanceof Number n ? n.intValue() : null;
         Integer teamId = body.get("team_id") instanceof Number n ? n.intValue() : null;
-        // One of queued/running/error/finished; anything else (or nothing)
-        // matches no bucket, which is the same fail-closed answer an unknown
-        // user_id gives.
+        // The feed's state bucket; absent means all states. A supplied value
+        // that names none of the four buckets matches no rows — the same
+        // fail-closed answer an unknown user_id gives. Blank and non-string
+        // values collapse to the all-states sentinel on purpose, mirroring the
+        // client's normalizeFeedStatus: a picker that stopped showing
+        // everything reads as broken, so the feed widens instead.
         String status = body.get("status") instanceof String s && !s.isBlank() ? s : null;
         String cursorTs = body.get("cursor_ts") instanceof String s ? s : null;
         String cursorId = body.get("cursor_id") instanceof String s ? s : null;

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
@@ -46,12 +46,16 @@ public class RequestLogController {
         String end = body.get("end") instanceof String s ? s : null;
         Integer userId = body.get("user_id") instanceof Number n ? n.intValue() : null;
         Integer teamId = body.get("team_id") instanceof Number n ? n.intValue() : null;
+        // One of queued/running/error/finished; anything else (or nothing)
+        // matches no bucket, which is the same fail-closed answer an unknown
+        // user_id gives.
+        String status = body.get("status") instanceof String s && !s.isBlank() ? s : null;
         String cursorTs = body.get("cursor_ts") instanceof String s ? s : null;
         String cursorId = body.get("cursor_id") instanceof String s ? s : null;
         int limit = body.get("limit") instanceof Number n
             ? n.intValue() : RequestLogService.LATEST_REQUESTS_PAGE_SIZE;
         return ResponseEntity.ok(requestLogService.getLatestRequests(
-            start, end, userId, teamId, cursorTs, cursorId, limit, true));
+            start, end, userId, teamId, status, cursorTs, cursorId, limit, true));
     }
 
     @PostMapping("/request_logs")

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/RequestLogController.java
@@ -49,9 +49,13 @@ public class RequestLogController {
         // The feed's state bucket; absent means all states. A supplied value
         // that names none of the four buckets matches no rows — the same
         // fail-closed answer an unknown user_id gives. Blank and non-string
-        // values collapse to the all-states sentinel on purpose, mirroring the
-        // client's normalizeFeedStatus: a picker that stopped showing
-        // everything reads as broken, so the feed widens instead.
+        // values collapse to the all-states sentinel. The client's
+        // normalizeFeedStatus widens on *any* value outside the four buckets —
+        // including an unknown non-blank string this one keeps and fails
+        // closed on. The two sides deliberately differ: a picker that stops
+        // showing everything reads as broken, so the feed widens there, while
+        // a value aimed straight at this admin-only endpoint must not
+        // silently widen it to the whole platform.
         String status = body.get("status") instanceof String s && !s.isBlank() ? s : null;
         String cursorTs = body.get("cursor_ts") instanceof String s ? s : null;
         String cursorId = body.get("cursor_id") instanceof String s ? s : null;

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -349,6 +349,45 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
         @Param("limitN") int limitN);
 
     /**
+     * Whether anything the statistics aggregates summarise has moved, as a
+     * single aggregate over the same set {@link #findTotals} counts.
+     *
+     * The window predicate and the scope are deliberately identical to
+     * {@link #findTotals}: a movement signal that describes a different set
+     * than the aggregates would either refresh them for nothing or, worse,
+     * let them go stale. There is no status narrowing on purpose — the
+     * signal has to see every bucket, the ones a feed filter hides included.
+     *
+     * The last-event timestamp is the GREATEST of the three lifecycle
+     * columns, not just {@code timestamp_request}: each of them is stamped
+     * when it moves the aggregates (a forward moves the queue figures, a
+     * response moves the outcome, token and cost totals), and a completion
+     * of an older request would advance none of count or request timestamp
+     * and so be invisible — which is exactly the case of an operator
+     * watching one bucket while the rest of the traffic settles.
+     *
+     * One aggregate pass, no joins: this runs on the two-second push cadence
+     * for every session that has a feed filter on, where
+     * {@link #findTotals} itself runs at a tenth of that.
+     */
+    @Transactional(readOnly = true)
+    @Query(value = """
+        SELECT COUNT(*) AS rowCount,
+               GREATEST(MAX(le.timestamp_request),
+                        MAX(le.timestamp_forwarding),
+                        MAX(le.timestamp_response)) AS lastEventTs
+        FROM log_entry le
+        WHERE COALESCE(le.timestamp_forwarding, le.timestamp_request, le.timestamp_response) BETWEEN :start AND :end
+          AND (CAST(:userId AS INTEGER) IS NULL OR le.user_id = CAST(:userId AS INTEGER))
+          AND (CAST(:teamId AS INTEGER) IS NULL OR le.team_id = CAST(:teamId AS INTEGER))
+        """, nativeQuery = true)
+    ScopeMovementProjection findScopeMovement(
+        @Param("start") Timestamp start,
+        @Param("end") Timestamp end,
+        @Param("userId") Integer userId,
+        @Param("teamId") Integer teamId);
+
+    /**
      * How many requests the range holds under the active filter — the "of N" in
      * the feed's header. The predicate has to stay identical to
      * {@link #findLatestRequests} (minus the cursor) or the count describes a

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/LogEntryRepository.java
@@ -300,6 +300,24 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
           AND le.timestamp_request BETWEEN :startTs AND :endTs
           AND (CAST(:userId AS INTEGER) IS NULL OR le.user_id = CAST(:userId AS INTEGER))
           AND (CAST(:teamId AS INTEGER) IS NULL OR le.team_id = CAST(:teamId AS INTEGER))
+          -- One of the four lifecycle buckets the feed can be narrowed to:
+          -- queued (not yet scheduled), running (scheduled, not answered),
+          -- error (answered with a failure), finished (answered otherwise).
+          -- A null status leaves the feed unfiltered.
+          AND (CAST(:status AS TEXT) IS NULL
+               OR (CAST(:status AS TEXT) = 'queued'
+                   AND le.timestamp_forwarding IS NULL
+                   AND le.timestamp_response IS NULL)
+               OR (CAST(:status AS TEXT) = 'running'
+                   AND le.timestamp_forwarding IS NOT NULL
+                   AND le.timestamp_response IS NULL)
+               OR (CAST(:status AS TEXT) = 'error'
+                   AND le.timestamp_response IS NOT NULL
+                   AND (le.result_status = 'error' OR le.result_status = 'timeout'))
+               OR (CAST(:status AS TEXT) = 'finished'
+                   AND le.timestamp_response IS NOT NULL
+                   AND le.result_status IS DISTINCT FROM 'error'
+                   AND le.result_status IS DISTINCT FROM 'timeout'))
           -- Keyset cursor: everything strictly older than the last row handed
           -- out. Unlike OFFSET this neither re-walks the skipped rows nor slides
           -- when new requests arrive at the top while the operator pages.
@@ -325,6 +343,7 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
         @Param("endTs") Timestamp endTs,
         @Param("userId") Integer userId,
         @Param("teamId") Integer teamId,
+        @Param("status") String status,
         @Param("cursorTs") Timestamp cursorTs,
         @Param("cursorId") String cursorId,
         @Param("limitN") int limitN);
@@ -343,12 +362,29 @@ public interface LogEntryRepository extends JpaRepository<LogEntry, Integer> {
           AND le.timestamp_request BETWEEN :startTs AND :endTs
           AND (CAST(:userId AS INTEGER) IS NULL OR le.user_id = CAST(:userId AS INTEGER))
           AND (CAST(:teamId AS INTEGER) IS NULL OR le.team_id = CAST(:teamId AS INTEGER))
+          -- Identical to the predicate in {@link #findLatestRequests} (minus the
+          -- cursor): the count and the rows must describe the same set.
+          AND (CAST(:status AS TEXT) IS NULL
+               OR (CAST(:status AS TEXT) = 'queued'
+                   AND le.timestamp_forwarding IS NULL
+                   AND le.timestamp_response IS NULL)
+               OR (CAST(:status AS TEXT) = 'running'
+                   AND le.timestamp_forwarding IS NOT NULL
+                   AND le.timestamp_response IS NULL)
+               OR (CAST(:status AS TEXT) = 'error'
+                   AND le.timestamp_response IS NOT NULL
+                   AND (le.result_status = 'error' OR le.result_status = 'timeout'))
+               OR (CAST(:status AS TEXT) = 'finished'
+                   AND le.timestamp_response IS NOT NULL
+                   AND le.result_status IS DISTINCT FROM 'error'
+                   AND le.result_status IS DISTINCT FROM 'timeout'))
         """, nativeQuery = true)
     Long countRequestsInRange(
         @Param("startTs") Timestamp startTs,
         @Param("endTs") Timestamp endTs,
         @Param("userId") Integer userId,
-        @Param("teamId") Integer teamId);
+        @Param("teamId") Integer teamId,
+        @Param("status") String status);
 
     @Transactional(readOnly = true)
     @Query(value = """

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/ScopeMovementProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/repository/ScopeMovementProjection.java
@@ -1,0 +1,8 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.repository;
+
+import java.time.Instant;
+
+public interface ScopeMovementProjection {
+    Long getRowCount();
+    Instant getLastEventTs();
+}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
@@ -32,7 +32,7 @@ public class RequestLogService {
 
     /** Unfiltered newest page of the range, without a row count — the live push. */
     public Map<String, Object> getLatestRequests(String startDate, String endDate) {
-        return getLatestRequests(startDate, endDate, null, null, null, null,
+        return getLatestRequests(startDate, endDate, null, null, null, null, null,
                                  LATEST_REQUESTS_PAGE_SIZE, false);
     }
 
@@ -56,6 +56,9 @@ public class RequestLogService {
      *                  defaults to now
      * @param userId    restrict to this requester, or {@code null} for all
      * @param teamId    restrict to this team, or {@code null} for all
+     * @param status    restrict to one lifecycle bucket — {@code queued},
+     *                  {@code running}, {@code error} or {@code finished} — or
+     *                  {@code null} for all states
      * @param cursorTs  {@code timestamp_request} of the last row already seen;
      *                  {@code null} starts at the newest
      * @param cursorId  {@code request_id} of that row, breaking timestamp ties
@@ -63,6 +66,7 @@ public class RequestLogService {
      */
     public Map<String, Object> getLatestRequests(String startDate, String endDate,
                                                  Integer userId, Integer teamId,
+                                                 String status,
                                                  String cursorTs, String cursorId,
                                                  int limit, boolean withTotal) {
         ZonedDateTime endDt = parseInstantOrNow(endDate);
@@ -88,7 +92,7 @@ public class RequestLogService {
         // One row beyond the page: its presence is the has_more answer, and it is
         // dropped before the rows go out.
         List<Map<String, Object>> fetched = logEntryRepository
-            .findLatestRequests(startTs, endTs, userId, teamId, cursor, cursorRequestId, pageSize + 1)
+            .findLatestRequests(startTs, endTs, userId, teamId, status, cursor, cursorRequestId, pageSize + 1)
             .stream()
             .map(p -> {
                 Map<String, Object> m = new LinkedHashMap<>();
@@ -138,13 +142,39 @@ public class RequestLogService {
             result.put("next_cursor", null);
         }
         if (withTotal) {
-            Long total = logEntryRepository.countRequestsInRange(startTs, endTs, userId, teamId);
+            Long total = logEntryRepository.countRequestsInRange(startTs, endTs, userId, teamId, status);
             // The feed shows a window onto the range, so it has to say how big
             // the range is — "1-10 of 4,312" is the difference between a capped
             // list and a list the operator reads as complete.
             result.put("total", total != null ? total : 0L);
         }
         return result;
+    }
+
+    /**
+     * How many requests the range holds under the given filters — the "of N"
+     * figure for a request feed narrowed to one lifecycle bucket.
+     *
+     * The live push serves its newest page without a count (counting is a scan
+     * of the range, and the push runs every two seconds per open session), so
+     * it borrows the statistics aggregates for the total. That total is only as
+     * narrow as the user/team scope, not the feed's status filter — so a
+     * status-filtered live page counts itself, and only when it is filtered.
+     *
+     * @param status one of the feed's lifecycle buckets, or {@code null} for
+     *               no status narrowing
+     */
+    public long countFeedRows(String startDate, String endDate,
+                              Integer userId, Integer teamId, String status) {
+        ZonedDateTime endDt = parseInstantOrNow(endDate);
+        ZonedDateTime startDt = parseInstantOrNull(startDate);
+        if (startDt == null || startDt.isAfter(endDt)) {
+            startDt = endDt.minusDays(30);
+        }
+        Timestamp startTs = Timestamp.from(startDt.toInstant());
+        Timestamp endTs = Timestamp.from(endDt.toInstant());
+        Long total = logEntryRepository.countRequestsInRange(startTs, endTs, userId, teamId, status);
+        return total != null ? total : 0L;
     }
 
     private static ZonedDateTime parseInstantOrNow(String iso) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/RequestLogService.java
@@ -177,6 +177,38 @@ public class RequestLogService {
         return total != null ? total : 0L;
     }
 
+    /**
+     * A signature of everything the statistics aggregates summarise, for
+     * change detection only — "has anything moved in this scope since the
+     * last time we looked".
+     *
+     * The live request push hands out one page at a time, and a feed filter
+     * narrows that page to a single lifecycle bucket. A change-detection
+     * signature of that page then only describes the bucket, while the
+     * aggregates it drives still cover the whole user/team scope — so the
+     * caller keeps this, the scope-wide probe, for its dirty flag and uses
+     * the page only for the rows that go out. Count plus last lifecycle
+     * timestamp instead of a second full page fetch: one aggregate pass, no
+     * joins, no row materialisation, at a push cadence of two seconds per
+     * filtered session.
+     *
+     * @return a string that changes whenever the scope's row count or the
+     *         newest enqueue, scheduling or completion in it does
+     */
+    public String scopeMovementSig(String startDate, String endDate,
+                                   Integer userId, Integer teamId) {
+        ZonedDateTime endDt = parseInstantOrNow(endDate);
+        ZonedDateTime startDt = parseInstantOrNull(startDate);
+        if (startDt == null || startDt.isAfter(endDt)) {
+            startDt = endDt.minusDays(30);
+        }
+        Timestamp startTs = Timestamp.from(startDt.toInstant());
+        Timestamp endTs = Timestamp.from(endDt.toInstant());
+        var movement = logEntryRepository.findScopeMovement(startTs, endTs, userId, teamId);
+        if (movement == null) return "";
+        return movement.getRowCount() + ";" + movement.getLastEventTs();
+    }
+
     private static ZonedDateTime parseInstantOrNow(String iso) {
         ZonedDateTime parsed = parseInstantOrNull(iso);
         return parsed != null ? parsed : ZonedDateTime.now(ZoneOffset.UTC);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/TeamActivityService.java
@@ -92,7 +92,7 @@ public class TeamActivityService {
         // that follows within seconds of the first one.
         Map<String, Object> requests = requestLogService.getLatestRequests(
             since.toInstant().toString(), now.toString(),
-            userId, teamId, cursorTs, cursorId, REQUEST_PAGE_SIZE, true);
+            userId, teamId, null, cursorTs, cursorId, REQUEST_PAGE_SIZE, true);
 
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("team_id", teamId);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -242,7 +242,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         state.scopeTeamId = msg.get("team_id") instanceof Number n ? n.intValue() : null;
     }
 
-    /** The feed's state bucket, read from {@code init} and {@code set_feed_status}. */
+    /**
+     * The feed's state bucket, read from {@code init} and {@code set_feed_status}.
+     * Absent (or blank, or non-string — mirroring the client's normalisation)
+     * means all states; a value naming none of the buckets matches no rows.
+     */
     private static void applyFeedStatus(SessionState state, Map<String, Object> msg) {
         state.feedStatus = msg.get("status") instanceof String s && !s.isBlank() ? s : null;
     }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -68,6 +68,14 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         volatile Integer scopeUserId = null;
         volatile Integer scopeTeamId = null;
 
+        // One lifecycle bucket the request feed is narrowed to (queued, running,
+        // error, finished); null shows all states. Deliberately not part of the
+        // scope above: the scope is who the whole page looks at, and it narrows
+        // the aggregates and the volume chart too. A state filter only makes
+        // sense for the request feed, so it must not drag the KPI cards and
+        // charts into a slice of the log they are meant to summarise in full.
+        volatile String feedStatus = null;
+
         volatile String prevReqSig = "";
         volatile String prevVramMetaSig = "";
 
@@ -166,6 +174,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             case "set_vram_day" -> handleSetVramDay(session, state, msg);
             case "set_timeline_range" -> handleSetTimelineRange(session, state, msg);
             case "set_scope" -> handleSetScope(session, state, msg);
+            case "set_feed_status" -> handleSetFeedStatus(session, state, msg);
             case "ping" -> send(session, Map.of("type", "pong"));
         }
     }
@@ -185,6 +194,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         // the filter the page is showing instead of silently widening back to
         // the whole platform under an unchanged pair of dropdowns.
         applyScope(state, msg);
+        applyFeedStatus(state, msg);
 
         Map<String, Object> tl = msg.get("timeline") instanceof Map<?,?> m
             ? (Map<String, Object>) m : Map.of();
@@ -226,6 +236,24 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private static void applyScope(SessionState state, Map<String, Object> msg) {
         state.scopeUserId = msg.get("user_id") instanceof Number n ? n.intValue() : null;
         state.scopeTeamId = msg.get("team_id") instanceof Number n ? n.intValue() : null;
+    }
+
+    /** The feed's state bucket, read from {@code init} and {@code set_feed_status}. */
+    private static void applyFeedStatus(SessionState state, Map<String, Object> msg) {
+        state.feedStatus = msg.get("status") instanceof String s && !s.isBlank() ? s : null;
+    }
+
+    /**
+     * Narrow the request feed to one lifecycle bucket.
+     *
+     * Unlike {@link #handleSetScope} this re-pushes only the feed, not the
+     * aggregates: the KPI cards and the volume chart summarise the whole scope,
+     * and a state filter does not change what they describe. A forced feed push
+     * is enough — no delta turns the unfiltered rows into the filtered ones.
+     */
+    private void handleSetFeedStatus(WebSocketSession session, SessionState state, Map<String, Object> msg) {
+        applyFeedStatus(state, msg);
+        pushRequests(session, state, true);
     }
 
     private void handleSetVramDay(WebSocketSession session, SessionState state, Map<String, Object> msg) {
@@ -440,15 +468,26 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             String end = state.timelineLive ? Instant.now().toString() : state.timelineEnd;
             Map<String, Object> payload = requestLogService.getLatestRequests(
                 state.timelineStart, end, state.scopeUserId, state.scopeTeamId,
-                null, null, LATEST_REQUESTS_PUSH_SIZE, false);
+                state.feedStatus, null, null, LATEST_REQUESTS_PUSH_SIZE, false);
             mergeLiveStreams(payload);
             String sig = requestsSig(payload);
-            if (!sig.equals(state.prevReqSig)) {
+            boolean changed = !sig.equals(state.prevReqSig);
+            if (changed) {
                 // A request arrived, finished, or grew its usage — whatever the
                 // aggregates summarise has moved with it.
                 state.statsDirty = true;
             }
-            if (force || !sig.equals(state.prevReqSig)) {
+            if (force || changed) {
+                // A status-filtered feed counts itself: the total an unfiltered
+                // page borrows from the statistics aggregates is only as narrow
+                // as the user/team scope, not the state bucket, so the "of N"
+                // would promise rows the filter has hidden. Counting is a range
+                // scan, so it runs only when a push actually goes out.
+                if (state.feedStatus != null) {
+                    payload.put("total", requestLogService.countFeedRows(
+                        state.timelineStart, end, state.scopeUserId, state.scopeTeamId,
+                        state.feedStatus));
+                }
                 state.prevReqSig = sig;
                 send(session, Map.of("type", "requests", "payload", payload));
             }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -77,6 +77,17 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         volatile String feedStatus = null;
 
         volatile String prevReqSig = "";
+        // The request ids of the last pushed page — the row set, values
+        // excluded. Token counts grow without this moving, and the feed's
+        // own count cannot change with them, so a changed row set is the
+        // only moment the count is re-queried.
+        volatile String prevFeedIdsSig = "";
+        // The last scope-wide movement probe (see scopeMovementSig). Reset to
+        // empty wherever the aggregates are re-pushed in full (init, scope
+        // or range change), so the first probe under a fresh window is just
+        // a baseline and does not trigger a redundant stats push on top of
+        // the one timeline_init already sent.
+        volatile String prevScopeSig = "";
         volatile String prevVramMetaSig = "";
 
         // Traffic moved since the last aggregate push, so the totals the
@@ -212,6 +223,10 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                                  "payload", Map.of("error", "Invalid timeline range")));
             state.initDefaultTimeline();
         }
+        // The init push below re-sends the aggregates, so the scope-wide
+        // movement probe starts from a fresh baseline rather than reporting
+        // the reconnect as one more move.
+        state.prevScopeSig = "";
 
         pushTimelineInit(session, state);
         pushVramInit(session, state);
@@ -233,6 +248,8 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         // from it would skip everything the new scope should have seen.
         state.cursorTs = state.timelineEnd;
         state.cursorId = "";
+        // The init re-push below already carries the new scope's aggregates.
+        state.prevScopeSig = "";
         pushTimelineInit(session, state);
         pushRequests(session, state, true);
     }
@@ -244,8 +261,13 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
     /**
      * The feed's state bucket, read from {@code init} and {@code set_feed_status}.
-     * Absent (or blank, or non-string — mirroring the client's normalisation)
-     * means all states; a value naming none of the buckets matches no rows.
+     * Absent, blank, or non-string means all states; a value naming none of
+     * the buckets matches no rows. Unlike the client's normalizeFeedStatus,
+     * which widens on any value outside the four buckets, an unknown
+     * non-blank string is kept and fails closed here: a stale picker may
+     * widen, because a filter that shows nothing reads as broken, but a
+     * value sent straight to the server must not silently widen an
+     * admin-only feed to the whole platform.
      */
     private static void applyFeedStatus(SessionState state, Map<String, Object> msg) {
         state.feedStatus = msg.get("status") instanceof String s && !s.isBlank() ? s : null;
@@ -282,6 +304,8 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             send(session, Map.of("type", "timeline_init",
                                  "payload", Map.of("error", "Invalid timeline range")));
         } else {
+            // The init re-push below already carries the new range's aggregates.
+            state.prevScopeSig = "";
             pushTimelineInit(session, state);
             pushRequests(session, state, true);
         }
@@ -308,10 +332,13 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                 }
                 // Aggregates are the expensive push (findTotals alone scans the
                 // range twice more for tokens and cost), so they go out at a
-                // tenth of the request cadence and only when the request feed
-                // actually reported a change. Without this the page's counters
-                // never moved after load: stats only ever came with
-                // timeline_init, i.e. on connect and on a range change.
+                // tenth of the request cadence and only when something in
+                // their scope reported a change: the request feed itself, or —
+                // while a state filter narrows it to one bucket — the
+                // scope-wide movement probe pushRequests keeps for exactly
+                // this flag. Without this the page's counters never moved
+                // after load: stats only ever came with timeline_init, i.e. on
+                // connect and on a range change.
                 if (t % 10 == 0 && state.statsDirty) {
                     state.statsDirty = false;
                     pushStats(session, state);
@@ -479,10 +506,34 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                 state.feedStatus, null, null, LATEST_REQUESTS_PUSH_SIZE, false);
             mergeLiveStreams(payload);
             String sig = requestsSig(payload);
+            String idsSig = requestIdsSig(payload);
             boolean changed = !sig.equals(state.prevReqSig);
-            if (changed) {
-                // A request arrived, finished, or grew its usage — whatever the
-                // aggregates summarise has moved with it.
+            boolean rowsChanged = !idsSig.equals(state.prevFeedIdsSig);
+
+            // The aggregates summarise the whole user/team scope, and the page
+            // above only shows what its state filter lets through. So a
+            // filtered feed's signature changes when its bucket moves — and
+            // says nothing when the rest of the scope does. The scope-wide
+            // probe below answers that second question: one aggregate over
+            // the exact set the aggregates count, no row materialisation.
+            boolean scopeMoved = false;
+            if (state.feedStatus != null) {
+                String scopeSig = requestLogService.scopeMovementSig(
+                    state.timelineStart, end, state.scopeUserId, state.scopeTeamId);
+                if (scopeSig != null && !scopeSig.equals(state.prevScopeSig)) {
+                    // The first probe after a fresh baseline (init, scope or
+                    // range change re-pushed the aggregates moments ago) just
+                    // records the baseline; a move is a change on top of one.
+                    scopeMoved = !state.prevScopeSig.isEmpty();
+                    state.prevScopeSig = scopeSig;
+                }
+            }
+            if (changed || scopeMoved) {
+                // A request arrived, was scheduled, finished, or grew its
+                // usage — whatever the aggregates summarise has moved with
+                // it. With a state filter on, `changed` only sees that one
+                // bucket, so `scopeMoved` carries the signal for the rest of
+                // the scope the aggregates still cover.
                 state.statsDirty = true;
             }
             if (force || changed) {
@@ -490,13 +541,17 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                 // page borrows from the statistics aggregates is only as narrow
                 // as the user/team scope, not the state bucket, so the "of N"
                 // would promise rows the filter has hidden. Counting is a range
-                // scan, so it runs only when a push actually goes out.
-                if (state.feedStatus != null) {
+                // scan, so it runs only when the row set it counts can have
+                // moved: a forced push, or a page whose request ids changed.
+                // Token values grow without the ids or the count moving, so
+                // the figure the last push carried stays valid in between.
+                if (state.feedStatus != null && (force || rowsChanged)) {
                     payload.put("total", requestLogService.countFeedRows(
                         state.timelineStart, end, state.scopeUserId, state.scopeTeamId,
                         state.feedStatus));
                 }
                 state.prevReqSig = sig;
+                state.prevFeedIdsSig = idsSig;
                 send(session, Map.of("type", "requests", "payload", payload));
             }
         } catch (Exception e) {
@@ -621,6 +676,18 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
               .append(r.getOrDefault("total_tokens", "")).append(':')
               .append(r.getOrDefault("cost_microcents", "")).append(',');
         }
+        return sb.toString();
+    }
+
+    // The page's row set, values excluded: a changed row set is the only
+    // moment the feed's own count can have moved, so it gates the range scan
+    // that recounts it. Token and cost figures grow on a running request
+    // without a single id changing, and the count rides through that.
+    @SuppressWarnings("unchecked")
+    static String requestIdsSig(Map<String, Object> payload) {
+        var reqs = (java.util.List<Map<String, Object>>) payload.getOrDefault("requests", java.util.List.of());
+        StringBuilder sb = new StringBuilder();
+        for (var r : reqs) sb.append(r.getOrDefault("request_id", "")).append(',');
         return sb.toString();
     }
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/RequestLogControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -110,6 +111,74 @@ class RequestLogControllerTest {
                 .with(TestJwt.logosAdmin())
                 .contentType("application/json")
                 .content("{\"user_id\": 1002}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests").isEmpty())
+           .andExpect(jsonPath("$.total").value(0));
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = {"/sql/seed-operations-status.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void latestRequests_filtersByStatus() throws Exception {
+        // One seeded row per lifecycle bucket, merged over the shared seed (whose
+        // two "success" rows are themselves "finished"). Each bucket is the newest
+        // row of its kind, so it leads its filtered page.
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"queued\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests.length()").value(1))
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-state-queued"))
+           .andExpect(jsonPath("$.total").value(1))
+           .andExpect(jsonPath("$.has_more").value(false));
+
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"running\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests.length()").value(1))
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-state-running"))
+           .andExpect(jsonPath("$.total").value(1));
+
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"error\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests.length()").value(1))
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-state-error"))
+           .andExpect(jsonPath("$.total").value(1));
+
+        // "finished" is the settled-but-not-failed bucket: the seeded success row
+        // plus the shared seed's two success rows.
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"finished\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests.length()").value(3))
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-state-finished"))
+           .andExpect(jsonPath("$.total").value(3));
+
+        // The filters compose: team 2001 sits only on the shared req-aaa-111, so
+        // intersecting it with "finished" narrows to that one row.
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"finished\", \"team_id\": 2001}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.requests.length()").value(1))
+           .andExpect(jsonPath("$.requests[0].request_id").value("req-aaa-111"))
+           .andExpect(jsonPath("$.total").value(1));
+
+        // An unknown state matches no bucket — fail closed, like an unknown
+        // user_id, rather than quietly returning the unfiltered feed.
+        mvc.perform(post("/logosdb/latest_requests")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"status\": \"bogus\"}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.requests").isEmpty())
            .andExpect(jsonPath("$.total").value(0));

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerFeedStatusTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerFeedStatusTest.java
@@ -1,0 +1,231 @@
+package de.tum.cit.aet.logos.logoswebservice.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.cit.aet.logos.logoswebservice.operations.service.EnqueueEventService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogStatsService;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.VramService;
+import de.tum.cit.aet.logos.logoswebservice.orchestrator.OrchestratorLiveStreamClient;
+
+/**
+ * The bookkeeping around the feed's state filter.
+ *
+ * Two things the filter must not break: the aggregates' dirty signal has to
+ * stay scope-wide while the page is narrowed to one bucket, and the bucket's
+ * own count must not be re-scanned on every token delta. Plain unit test, the
+ * same way the live-push one is built — and the handler's background tick is
+ * stopped, because these tests drive {@code tick()} and {@code pushRequests}
+ * themselves and would otherwise race a second caller on the same session.
+ */
+class StatsV2WebSocketHandlerFeedStatusTest {
+
+    private VramService vramService;
+    private RequestLogService requestLogService;
+    private RequestLogStatsService statsService;
+    private EnqueueEventService enqueueService;
+    private StatsV2WebSocketHandler handler;
+    private WebSocketSession session;
+    private ObjectMapper objectMapper;
+    private final List<TextMessage> sent = new ArrayList<>();
+
+    /** The rows the service stub serves; the answer copies them per call. */
+    private List<Map<String, Object>> servedRows = List.of();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        objectMapper = new ObjectMapper();
+        vramService = mock(VramService.class);
+        requestLogService = mock(RequestLogService.class);
+        statsService = mock(RequestLogStatsService.class);
+        enqueueService = mock(EnqueueEventService.class);
+        when(statsService.getRequestLogStats(any(), any(), anyInt(), any(), any()))
+            .thenReturn(Map.of("bucketSeconds", 60));
+        when(vramService.getVramStats(anyString(), anyInt()))
+            .thenReturn(Map.of("providers", List.of(), "last_snapshot_id", 0));
+        when(enqueueService.getInRange(any(), any(), anyInt(), any(), any()))
+            .thenReturn(Map.of("events", List.of()));
+        when(enqueueService.getDeltas(any(), any(), any(), anyInt(), any(), any()))
+            .thenReturn(Map.of("events", List.of(), "cursor", Map.of("enqueue_ts", "", "request_id", "")));
+        // A fresh, mutable payload per call — the push writes "total" into it
+        // while a filter is on, and the real service returns a fresh map too.
+        when(requestLogService.getLatestRequests(
+                any(), any(), any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
+            .thenAnswer(inv -> {
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("requests", servedRows.stream().map(HashMap::new).toList());
+                payload.put("has_more", false);
+                payload.put("next_cursor", null);
+                return payload;
+            });
+
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        OrchestratorLiveStreamClient liveStreamClient = new OrchestratorLiveStreamClient(restTemplate);
+        ReflectionTestUtils.setField(liveStreamClient, "orchestratorUrl", "http://orchestrator");
+        ReflectionTestUtils.setField(liveStreamClient, "internalSecret", "secret");
+        // No streams: the live merge stays out of these tests.
+        when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class)))
+            .thenReturn(ResponseEntity.ok(Map.of("streams", List.of())));
+
+        handler = new StatsV2WebSocketHandler(
+            vramService, requestLogService, statsService, enqueueService,
+            liveStreamClient, objectMapper);
+        // The tests below drive the tick themselves; the scheduled one would
+        // advance the same session in between.
+        handler.shutdown();
+
+        session = mock(WebSocketSession.class);
+        when(session.getId()).thenReturn("feed-status-session");
+        when(session.isOpen()).thenReturn(true);
+        doAnswer((Answer<Void>) inv -> {
+            sent.add(inv.<TextMessage>getArgument(0));
+            return null;
+        }).when(session).sendMessage(any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        handler.shutdown();
+    }
+
+    private void connectAndInit() throws Exception {
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\"}"));
+        sent.clear();
+    }
+
+    private static Map<String, Object> row(String id, Object totalTokens) {
+        // The token figure exists only to move the page's signature between
+        // two pushes of the same row set.
+        Map<String, Object> r = new HashMap<>();
+        r.put("request_id", id);
+        r.put("status", "queued");
+        r.put("total_tokens", totalTokens);
+        return r;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void invokeTick() {
+        ReflectionTestUtils.invokeMethod(handler, "tick");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void invokePushRequests(boolean force) {
+        Map<String, Object> states = (Map<String, Object>) ReflectionTestUtils.getField(handler, "states");
+        ReflectionTestUtils.invokeMethod(handler, "pushRequests", session, states.get(session.getId()), force);
+    }
+
+    private List<String> pushedTypes() throws Exception {
+        List<String> types = new ArrayList<>();
+        for (TextMessage m : sent) {
+            JsonNode node = objectMapper.readTree(m.getPayload());
+            types.add(node.path("type").asText());
+        }
+        return types;
+    }
+
+    @Test
+    void a_filtered_session_refreshes_its_aggregates_when_out_of_bucket_traffic_moves() throws Exception {
+        servedRows = List.of(row("req-1", null));
+        connectAndInit();
+
+        // A stable scope: the probe repeats its fingerprint, and the feed
+        // counts its one queued row.
+        when(requestLogService.scopeMovementSig(any(), any(), any(), any()))
+            .thenReturn("6;2026-08-29T21:00:00Z");
+        when(requestLogService.countFeedRows(any(), any(), any(), any(), any())).thenReturn(1L);
+
+        handler.handleMessage(session, new TextMessage("{\"action\":\"set_feed_status\",\"status\":\"queued\"}"));
+        assertThat(pushedTypes()).containsExactly("requests");
+        sent.clear();
+
+        // The init push marked the feed changed, so the first aggregate gate
+        // after connect still delivers the opening aggregates. Let that drain
+        // so the assertions below see only what the filter's bookkeeping does.
+        ReflectionTestUtils.setField(handler, "globalTick", 10);
+        invokeTick();
+        assertThat(pushedTypes()).containsExactly("stats");
+        sent.clear();
+
+        // A tick that reaches the aggregate gate: nothing in scope moved, so
+        // nothing goes out.
+        ReflectionTestUtils.setField(handler, "globalTick", 20);
+        invokeTick();
+        assertThat(pushedTypes()).isEmpty();
+
+        // Out-of-bucket traffic moves — the scope's newest event advances
+        // while the queued page is untouched, so the feed's own signature
+        // stays put and only the probe reports it.
+        when(requestLogService.scopeMovementSig(any(), any(), any(), any()))
+            .thenReturn("6;2026-08-29T21:05:00Z");
+        ReflectionTestUtils.setField(handler, "globalTick", 30);
+        invokeTick();
+
+        // The aggregates go out for the whole scope; the page did not change,
+        // so no requests push rides along.
+        assertThat(pushedTypes()).containsExactly("stats");
+    }
+
+    @Test
+    void the_bucket_count_is_recounted_only_when_the_row_set_moves() throws Exception {
+        connectAndInit();
+
+        when(requestLogService.scopeMovementSig(any(), any(), any(), any()))
+            .thenReturn("1;2026-08-29T21:00:00Z");
+        when(requestLogService.countFeedRows(any(), any(), any(), any(), any())).thenReturn(1L);
+
+        servedRows = List.of(row("req-1", 100));
+        handler.handleMessage(session, new TextMessage("{\"action\":\"set_feed_status\",\"status\":\"queued\"}"));
+        // The forced push after a filter change counts the bucket.
+        verify(requestLogService, times(1)).countFeedRows(any(), any(), any(), any(), any());
+        clearInvocations(requestLogService);
+        sent.clear();
+
+        // Only the token count grows: the page changes, the row set does not,
+        // and the count cannot have moved with the tokens.
+        servedRows = List.of(row("req-1", 101));
+        invokePushRequests(false);
+        assertThat(pushedTypes()).containsExactly("requests");
+        verify(requestLogService, never()).countFeedRows(any(), any(), any(), any(), any());
+        sent.clear();
+
+        // A second queued row appears: the row set has moved, so the count is
+        // re-queried.
+        servedRows = List.of(row("req-1", 101), row("req-2", 40));
+        invokePushRequests(false);
+        assertThat(pushedTypes()).containsExactly("requests");
+        verify(requestLogService, times(1)).countFeedRows(any(), any(), any(), any(), any());
+    }
+}

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -66,7 +66,7 @@ class StatsV2WebSocketHandlerLivePushTest {
      */
     @SuppressWarnings("unchecked")
     private static void stubLatestRequests(RequestLogService service, Map<String, Object> template) {
-        when(service.getLatestRequests(any(), any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
+        when(service.getLatestRequests(any(), any(), any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
             .thenAnswer(inv -> Map.of("requests", List.of(new HashMap<>(template))));
     }
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerTest.java
@@ -1,5 +1,9 @@
 package de.tum.cit.aet.logos.logoswebservice.websocket;
 
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +13,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -32,6 +37,8 @@ class StatsV2WebSocketHandlerTest {
 
     @Autowired
     StatsV2WebSocketHandler handler;
+    @Autowired
+    ObjectMapper objectMapper;
     @MockitoBean JwtDecoder jwtDecoder;
 
     @Test
@@ -53,5 +60,65 @@ class StatsV2WebSocketHandlerTest {
         assertThat(captor.getValue().getPayload()).contains("\"type\":\"pong\"");
 
         handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = {"/sql/seed-operations-status.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void setFeedStatus_narrowsTheRequestPushAndReportsTheBucketTotal() throws Exception {
+        // One row per lifecycle bucket plus the shared seed's two finished rows.
+        WebSocketSession session = mock(WebSocketSession.class);
+        when(session.getId()).thenReturn("test-v2-feed-status-session");
+        when(session.isOpen()).thenReturn(true);
+
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\"}"));
+
+        // The unfiltered init push carries every row and no total — the page
+        // borrows the statistics aggregate for its "of N" figure.
+        List<TextMessage> sent = captureRequestsPushes(session);
+        JsonNode first = requestsPayload(sent);
+        assertThat(first.get("requests").size()).isEqualTo(6);
+        assertThat(first.has("total")).isFalse();
+
+        // Narrowing the feed re-pushes only the bucket and counts it: the
+        // aggregate the page borrows is only as narrow as the team/user scope,
+        // so a filtered feed must say how big its own bucket is.
+        handler.handleMessage(session, new TextMessage("{\"action\":\"set_feed_status\",\"status\":\"queued\"}"));
+        sent = captureRequestsPushes(session);
+        JsonNode queued = requestsPayload(sent);
+        assertThat(queued.get("requests").size()).isEqualTo(1);
+        assertThat(queued.get("requests").get(0).get("request_id").asText()).isEqualTo("req-state-queued");
+        assertThat(queued.get("total").asLong()).isEqualTo(1L);
+
+        handler.handleMessage(session, new TextMessage("{\"action\":\"set_feed_status\",\"status\":\"finished\"}"));
+        sent = captureRequestsPushes(session);
+        JsonNode finished = requestsPayload(sent);
+        assertThat(finished.get("requests").size()).isEqualTo(3);
+        assertThat(finished.get("total").asLong()).isEqualTo(3L);
+
+        // Clearing the filter goes back to the full feed and drops the total,
+        // handing the "of N" figure back to the statistics aggregate.
+        handler.handleMessage(session, new TextMessage("{\"action\":\"set_feed_status\",\"status\":null}"));
+        sent = captureRequestsPushes(session);
+        JsonNode cleared = requestsPayload(sent);
+        assertThat(cleared.get("requests").size()).isEqualTo(6);
+        assertThat(cleared.has("total")).isFalse();
+
+        handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+    }
+
+    /** Every requests push the session has been sent so far, in order. */
+    private List<TextMessage> captureRequestsPushes(WebSocketSession session) throws Exception {
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        return captor.getAllValues().stream()
+            .filter(m -> m.getPayload().contains("\"type\":\"requests\""))
+            .toList();
+    }
+
+    private JsonNode requestsPayload(List<TextMessage> pushes) throws Exception {
+        assertThat(pushes).as("a requests push was sent").isNotEmpty();
+        return objectMapper.readTree(pushes.get(pushes.size() - 1).getPayload()).get("payload");
     }
 }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerTest.java
@@ -4,11 +4,15 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -19,6 +23,7 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.RequestLogService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -39,6 +44,10 @@ class StatsV2WebSocketHandlerTest {
     StatsV2WebSocketHandler handler;
     @Autowired
     ObjectMapper objectMapper;
+    @Autowired
+    RequestLogService requestLogService;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
     @MockitoBean JwtDecoder jwtDecoder;
 
     @Test
@@ -106,6 +115,36 @@ class StatsV2WebSocketHandlerTest {
         assertThat(cleared.has("total")).isFalse();
 
         handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = {"/sql/seed-operations-status.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void scopeMovementSig_movesWhenAnOutOfBucketRowCompletes() {
+        // The shared seed's two rows plus one per lifecycle bucket, all within
+        // the last minute.
+        String start = Instant.now().minus(Duration.ofDays(1)).toString();
+        String end = Instant.now().toString();
+
+        String first = requestLogService.scopeMovementSig(start, end, null, null);
+        assertThat(first).startsWith("6;");
+        // A stable scope repeats its fingerprint.
+        assertThat(requestLogService.scopeMovementSig(start, end, null, null)).isEqualTo(first);
+
+        // A running request settles: no row is added and nothing is enqueued
+        // — the two things a newest-page signature would see — yet the scope's
+        // newest lifecycle event has moved. This is the case a state-filtered
+        // feed's own signature cannot report, so the aggregates' dirty signal
+        // must come from here.
+        jdbcTemplate.update(
+            "UPDATE log_entry SET result_status = 'error', timestamp_response = NOW() "
+            + "WHERE request_id = 'req-state-running'");
+
+        String after = requestLogService.scopeMovementSig(start, end, null, null);
+        // The row count is unchanged ...
+        assertThat(after).startsWith("6;");
+        // ... but the signal moved with the completion.
+        assertThat(after).isNotEqualTo(first);
     }
 
     /** Every requests push the session has been sent so far, in order. */

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-operations.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-operations.sql
@@ -1,4 +1,4 @@
 DELETE FROM token_prices WHERE id IN (92001);
 DELETE FROM token_types WHERE id IN (91001, 91002);
 DELETE FROM ollama_provider_snapshots WHERE id IN (4001, 4002, 4003, 4004);
-DELETE FROM log_entry WHERE id IN (9001, 9002);
+DELETE FROM log_entry WHERE id IN (9001, 9002, 9010, 9011, 9012, 9013);

--- a/logos/logos-webservice/src/test/resources/sql/seed-operations-status.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-operations-status.sql
@@ -1,0 +1,25 @@
+-- Lifecycle fixtures for the request feed's state filter, loaded by the status
+-- filter test only (method-level) so the shared seed keeps its two rows.
+-- One row per bucket:
+--   queued   -> enqueued, never scheduled          (req-state-queued)
+--   running  -> scheduled, not yet answered         (req-state-running)
+--   error    -> answered with a failure             (req-state-error)
+--   finished -> answered successfully               (req-state-finished)
+-- They are the newest rows in the range, so each bucket is non-empty whichever
+-- one the filter asks for. The ids keep clear of the shared seed (9001+).
+INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
+                       timestamp_request, timestamp_forwarding, timestamp_response,
+                       was_cold_start, queue_depth_at_enqueue, user_id, team_id, environment)
+VALUES
+  (9010, 'req-state-queued', 3001, 5001, 6001, NULL,
+   NOW() - INTERVAL '60 seconds', NULL, NULL,
+   false, 0, NULL, NULL, NULL),
+  (9011, 'req-state-running', 3001, 5001, 6001, NULL,
+   NOW() - INTERVAL '50 seconds', NOW() - INTERVAL '45 seconds', NULL,
+   false, 0, NULL, NULL, NULL),
+  (9012, 'req-state-error', 3001, 5001, 6001, 'error',
+   NOW() - INTERVAL '40 seconds', NOW() - INTERVAL '35 seconds', NOW() - INTERVAL '30 seconds',
+   false, 0, NULL, NULL, NULL),
+  (9013, 'req-state-finished', 3001, 5001, 6001, 'success',
+   NOW() - INTERVAL '20 seconds', NOW() - INTERVAL '15 seconds', NOW() - INTERVAL '10 seconds',
+   true, 0, NULL, NULL, NULL);


### PR DESCRIPTION
## What changed

The recent-requests feed on the statistics dashboard can now be narrowed to one lifecycle state — **queued**, **running**, **error**, **finished** — via a dropdown in the panel header (default: *All states*).

- **Webservice**
  - `POST /logosdb/latest_requests` accepts a `status` field; the bucket predicate is added to both `findLatestRequests` and `countRequestsInRange`, so paged rows and the reported `total` always describe the same set.
  - The stats v2 websocket gains a `set_feed_status` action. The state is deliberately *not* part of the page scope: it only narrows the request feed, while the KPI cards and the volume chart keep summarising the whole team/user selection. Like the scope, the state is carried on `init`, so a reconnect restores the filter instead of quietly widening the list.
  - A status-filtered feed counts itself: the forced feed push and the REST pages report the bucket's `total`, because the page's KPI aggregate is only as narrow as the team/user scope. An unfiltered feed carries no `total` and the page keeps borrowing the aggregate, exactly as before.
- **UI**
  - The dropdown lives in the recent-requests panel header (`panelRight` slot, next to the existing provider badge and the range badge) and sends `set_feed_status` over the websocket; the page stores the state so it survives reconnects and reaches every paged REST fetch, so page 0 and the history pages agree.
  - Only the feed is marked loading while the filter applies; the KPI cards and charts keep their numbers. The "of N" header figure switches from the KPI aggregate to the pushed bucket total, and the empty state names the active state.

The buckets are read off the same `timestamp_forwarding`/`timestamp_response`/`result_status` pair the team activity view already uses: *queued* = not yet forwarded, *running* = forwarded without a response yet, *error* = answered with a failure (timeouts included, matching the row border colouring), *finished* = answered otherwise. Every row falls into exactly one bucket. An unknown state value matches no bucket and fails closed — the same behaviour as an unknown `user_id` — rather than silently returning the unfiltered feed.

## Why

Issue #820 asks for filtering the recent requests by their states, so an operator can look at exactly the queue, the in-flight generations, the failures or the finished work without paging through everything.

## How it was verified

- **Webservice**: full `mvn test` suite — 258 tests, 0 failures — including new coverage:
  - `RequestLogControllerTest.latestRequests_filtersByStatus` exercises each bucket through the endpoint, the combination of `status` with `team_id`, and the fail-closed unknown-state case (seed rows added via `seed-operations-status.sql`, merged over the shared seed, cleaned up by the existing cleanup script).
  - `StatsV2WebSocketHandlerTest.setFeedStatus_narrowsTheRequestPushAndReportsTheBucketTotal` drives the handler through `init` → `set_feed_status` (queued, finished, cleared) and asserts the pushed rows and the bucket total at each step.
- **UI**: `ng test` (63 tests, incl. a new spec for the pure `normalizeFeedStatus` / `resolveFeedTotal` helpers) and the production `ng build` both pass; the only build warnings are pre-existing bundle-budget warnings in files this PR does not touch.
- Read-through of the websocket lifecycle (init/reconnect, scope change, range change, clearing the filter) to confirm the feed, its total and the KPI aggregates stay consistent; a full deployment is not available in this environment.

Fixes #820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added status filtering to the Recent Requests panel for queued, running, error, and finished requests.
  * Filtered results and totals update across live updates and pagination.
  * Empty-state messages now reflect the selected status filter.
  * Token usage displays now show prompt estimates and animate streaming updates.
  * Status filtering does not affect statistics, charts, or other page-wide metrics.

* **Bug Fixes**
  * Improved consistency between displayed request results and their totals when filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->