### PR TITLE
`Logos`: Show current rate limit usage to application developers

### DIFF
--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -391,6 +391,7 @@ class DBManager:
             "timeout_s",
             "scheduled_ts",
             "request_complete_ts",
+            "rate_limit_admitted",
             "available_vram_mb",
             "azure_rate_remaining_requests",
             "azure_rate_remaining_tokens",

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
@@ -230,10 +230,10 @@ class LogEntry(Base):
     queue_depth_at_arrival = Column(Integer)
     utilization_at_arrival = Column(Numeric)
     queue_wait_ms = Column(Numeric)
-    # Whether the key's rate limiter admitted the request (issue #672). NULL
-    # when no limit is configured (the request was never checked) or for
-    # pre-migration rows; FALSE for a request the limiter rejected after
-    # scheduling. The usage window counts everything except explicit FALSE.
+    # Whether the key's rate limiter admitted the request. NULL when no limit
+    # is configured (the request was never checked) or for pre-migration
+    # rows; FALSE for a request the limiter rejected after scheduling. The
+    # usage window counts everything except explicit FALSE.
     rate_limit_admitted = Column(Boolean, nullable=True)
     was_cold_start = Column(Boolean, default=False)
     load_duration_ms = Column(Numeric)

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
@@ -230,6 +230,11 @@ class LogEntry(Base):
     queue_depth_at_arrival = Column(Integer)
     utilization_at_arrival = Column(Numeric)
     queue_wait_ms = Column(Numeric)
+    # Whether the key's rate limiter admitted the request (issue #672). NULL
+    # when no limit is configured (the request was never checked) or for
+    # pre-migration rows; FALSE for a request the limiter rejected after
+    # scheduling. The usage window counts everything except explicit FALSE.
+    rate_limit_admitted = Column(Boolean, nullable=True)
     was_cold_start = Column(Boolean, default=False)
     load_duration_ms = Column(Numeric)
     available_vram_mb = Column(Integer)

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -1131,6 +1131,23 @@ def _discard_in_flight(request_id: Optional[str], result_status: str) -> None:
         logger.debug("Failed to discard in-flight state for %s", request_id, exc_info=True)
 
 
+def _record_rate_limit_admission(request_id: Optional[str], admitted: bool) -> None:
+    """Persist whether the key's rate limiter admitted the request (issue #672).
+
+    Same monitoring semantics as `_discard_in_flight`: failures are logged
+    and never break the request path.
+    """
+    if not request_id:
+        return
+    pipeline = globals().get("_pipeline")
+    if pipeline is None:
+        return
+    try:
+        pipeline.record_rate_limit_admission(request_id, admitted)
+    except Exception:  # noqa: BLE001 — monitoring must never break a request
+        logger.debug("Failed to record rate-limit admission for %s", request_id, exc_info=True)
+
+
 def _record_log_failure(
     log_id: Optional[int],
     request_id: Optional[str],
@@ -4860,6 +4877,12 @@ async def _execute_resource_mode(
         if rl_info:
             rl_cfg = RateLimitConfig(rpm=rl_info.get("rpm"), tpm=rl_info.get("tpm"))
             allowed, reason = get_rate_limiter().check_and_record(rl_key, rl_cfg)
+            # Persist the admission decision before execution: the /me/keys
+            # usage window (issue #672) counts an admitted request while it is
+            # still running, and must skip the ones this check rejects — the
+            # log row already carries timestamp_forwarding from scheduling, so
+            # without the flag a rejected request would show up as usage.
+            _record_rate_limit_admission(result.scheduling_stats.get("request_id") or request_id, allowed)
             if not allowed:
                 try:
                     _pipeline.scheduler.release(

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -1132,7 +1132,7 @@ def _discard_in_flight(request_id: Optional[str], result_status: str) -> None:
 
 
 def _record_rate_limit_admission(request_id: Optional[str], admitted: bool) -> None:
-    """Persist whether the key's rate limiter admitted the request (issue #672).
+    """Persist whether the key's rate limiter admitted the request.
 
     Same monitoring semantics as `_discard_in_flight`: failures are logged
     and never break the request path.
@@ -4878,10 +4878,10 @@ async def _execute_resource_mode(
             rl_cfg = RateLimitConfig(rpm=rl_info.get("rpm"), tpm=rl_info.get("tpm"))
             allowed, reason = get_rate_limiter().check_and_record(rl_key, rl_cfg)
             # Persist the admission decision before execution: the /me/keys
-            # usage window (issue #672) counts an admitted request while it is
-            # still running, and must skip the ones this check rejects — the
-            # log row already carries timestamp_forwarding from scheduling, so
-            # without the flag a rejected request would show up as usage.
+            # usage window counts an admitted request while it is still
+            # running, and must skip the ones this check rejects — the log row
+            # already carries timestamp_forwarding from scheduling, so without
+            # the flag a rejected request would show up as usage.
             _record_rate_limit_admission(result.scheduling_stats.get("request_id") or request_id, allowed)
             if not allowed:
                 try:

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -295,6 +295,20 @@ class MonitoringRecorder:
         """Attach provider_id once it is resolved (after scheduling)."""
         self._write(request_id, provider_id=provider_id)
 
+    def record_rate_limit_admission(self, request_id: str, admitted: bool) -> None:
+        """Persist whether this key's rate limiter admitted the request.
+
+        Written at the admission decision (``check_and_record``), before
+        execution: the per-key usage window (issue #672) must count an
+        admitted request while it is still running, and must skip the ones
+        the limiter rejects after scheduling — the log row already carries
+        ``timestamp_forwarding`` from ``record_scheduled``, so without this
+        flag a rejected request would show up as usage. Keys without a limit
+        are never checked; their rows keep the column NULL, which the usage
+        query treats as "not rejected".
+        """
+        self._write(request_id, rate_limit_admitted=admitted)
+
     def record_provider_metrics(self, request_id: str, provider_metrics: Dict[str, Any]) -> None:
         """
         Update provider metrics (e.g. Azure rate limits) for a request.

--- a/logos/logos-orchestrator/src/logos/monitoring/recorder.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/recorder.py
@@ -299,9 +299,9 @@ class MonitoringRecorder:
         """Persist whether this key's rate limiter admitted the request.
 
         Written at the admission decision (``check_and_record``), before
-        execution: the per-key usage window (issue #672) must count an
-        admitted request while it is still running, and must skip the ones
-        the limiter rejects after scheduling — the log row already carries
+        execution: the per-key usage window must count an admitted request
+        while it is still running, and must skip the ones the limiter rejects
+        after scheduling — the log row already carries
         ``timestamp_forwarding`` from ``record_scheduled``, so without this
         flag a rejected request would show up as usage. Keys without a limit
         are never checked; their rows keep the column NULL, which the usage

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -622,6 +622,10 @@ class RequestPipeline:
         """Close out a request whose terminal log row was written elsewhere."""
         self._monitoring.discard(request_id, result_status)
 
+    def record_rate_limit_admission(self, request_id: str, admitted: bool) -> None:
+        """Persist the limiter's admission decision on the request's log row."""
+        self._monitoring.record_rate_limit_admission(request_id, admitted)
+
     def update_provider_stats(self, model_id: int, provider_id: int, headers: Dict[str, str]) -> None:
         """
         Update provider statistics (e.g. rate limits) from response headers.

--- a/logos/logos-orchestrator/src/logos/rate_limiter.py
+++ b/logos/logos-orchestrator/src/logos/rate_limiter.py
@@ -35,10 +35,27 @@ class InMemoryRateLimiter:
             dq.popleft()
 
     def check_and_record(self, key: str, config: RateLimitConfig) -> Tuple[bool, str]:
+        # The TPM check runs before the RPM slot is recorded. A request the
+        # TPM limit rejects must not consume an RPM slot: the /me/keys usage
+        # window (issue #672) displays admitted requests only, so a TPM
+        # reject that still appended its RPM timestamp would leave the
+        # displayed RPM below the enforced one — the UI showing headroom
+        # while the limiter keeps returning 429.
         now = time.monotonic()
         cutoff = now - config.window_seconds
 
         with self._lock:
+            if config.tpm is not None:
+                tok_dq = self._token_windows.setdefault(key, deque())
+                self._prune_tokens(tok_dq, cutoff)
+
+                total = sum(tokens for _, tokens in tok_dq)
+                if total >= config.tpm:
+                    return (
+                        False,
+                        f"TPM limit reached ({config.tpm}/{config.window_seconds}s)",
+                    )
+
             if config.rpm is not None:
                 req_dq = self._request_windows.setdefault(key, deque())
                 self._prune_requests(req_dq, cutoff)
@@ -50,17 +67,6 @@ class InMemoryRateLimiter:
                     )
 
                 req_dq.append(now)
-
-            if config.tpm is not None:
-                tok_dq = self._token_windows.setdefault(key, deque())
-                self._prune_tokens(tok_dq, cutoff)
-
-                total = sum(tokens for _, tokens in tok_dq)
-                if total >= config.tpm:
-                    return (
-                        False,
-                        f"TPM limit reached ({config.tpm}/{config.window_seconds}s)",
-                    )
 
         return True, ""
 

--- a/logos/logos-orchestrator/src/logos/rate_limiter.py
+++ b/logos/logos-orchestrator/src/logos/rate_limiter.py
@@ -37,10 +37,10 @@ class InMemoryRateLimiter:
     def check_and_record(self, key: str, config: RateLimitConfig) -> Tuple[bool, str]:
         # The TPM check runs before the RPM slot is recorded. A request the
         # TPM limit rejects must not consume an RPM slot: the /me/keys usage
-        # window (issue #672) displays admitted requests only, so a TPM
-        # reject that still appended its RPM timestamp would leave the
-        # displayed RPM below the enforced one — the UI showing headroom
-        # while the limiter keeps returning 429.
+        # window displays admitted requests only, so a TPM reject that still
+        # appended its RPM timestamp would leave the displayed RPM below the
+        # enforced one — the UI showing headroom while the limiter keeps
+        # returning 429.
         now = time.monotonic()
         cutoff = now - config.window_seconds
 

--- a/logos/logos-orchestrator/src/logos/rate_limiter.py
+++ b/logos/logos-orchestrator/src/logos/rate_limiter.py
@@ -11,6 +11,12 @@ from typing import Optional, Tuple
 class RateLimitConfig:
     rpm: Optional[int] = None
     tpm: Optional[int] = None
+    # Sliding window the rpm/tpm limits are enforced over. This default is
+    # the source of truth: the webservice keeps a copy of it in
+    # logos/logos-webservice/.../identity/service/MeKeysService.java
+    # (RATE_LIMIT_WINDOW_SECONDS) so its usage figures come from the same
+    # window. Change both together — the webservice test
+    # RateLimitWindowConsistencyTest fails if the two drift.
     window_seconds: int = 60
 
 

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
@@ -342,8 +342,8 @@ def test_malformed_usage_tokens_are_skipped_not_fatal(monkeypatch):
 
 
 def test_record_rate_limit_admission_persists_the_flag_both_ways(monkeypatch):
-    """Issue #672: the /me/keys usage window must be able to tell an admitted
-    request from one the limiter rejected after scheduling. Both verdicts are
+    """The /me/keys usage window must be able to tell an admitted request
+    from one the limiter rejected after scheduling. Both verdicts are
     persisted verbatim — the DB layer drops None fields, so False must reach
     it as False, not be swallowed like an unset value."""
     recorder, calls = _make_recorder(monkeypatch, {}, {})

--- a/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
+++ b/logos/logos-orchestrator/tests/unit/monitoring/test_recorder.py
@@ -339,3 +339,17 @@ def test_malformed_usage_tokens_are_skipped_not_fatal(monkeypatch):
     assert fake.GENERATION_TOKENS_TOTAL.label_calls == []
     assert fake.CACHED_PROMPT_TOKENS_TOTAL.label_calls == []
     assert fake.REQUEST_CONTEXT_TOKENS.observations == []
+
+
+def test_record_rate_limit_admission_persists_the_flag_both_ways(monkeypatch):
+    """Issue #672: the /me/keys usage window must be able to tell an admitted
+    request from one the limiter rejected after scheduling. Both verdicts are
+    persisted verbatim — the DB layer drops None fields, so False must reach
+    it as False, not be swallowed like an unset value."""
+    recorder, calls = _make_recorder(monkeypatch, {}, {})
+
+    recorder.record_rate_limit_admission("req-rl-admitted", admitted=True)
+    recorder.record_rate_limit_admission("req-rl-rejected", admitted=False)
+
+    assert {"request_id": "req-rl-admitted", "rate_limit_admitted": True} in calls
+    assert {"request_id": "req-rl-rejected", "rate_limit_admitted": False} in calls

--- a/logos/logos-orchestrator/tests/unit/test_rate_limiter.py
+++ b/logos/logos-orchestrator/tests/unit/test_rate_limiter.py
@@ -1,4 +1,4 @@
-"""Behavior tests for InMemoryRateLimiter (issue #672)."""
+"""Behavior tests for InMemoryRateLimiter."""
 
 import logos.rate_limiter as rl
 from logos.rate_limiter import InMemoryRateLimiter, RateLimitConfig
@@ -31,11 +31,11 @@ def test_tpm_rejects_when_recorded_tokens_fill_the_window():
 
 
 def test_tpm_reject_does_not_consume_an_rpm_slot(monkeypatch):
-    # Regression (issue #672): the /me/keys RPM figure counts admitted
-    # requests only, while the limiter enforces over its request window. If
-    # a TPM reject appended its RPM timestamp anyway, the enforced RPM would
-    # include requests the display excludes, so the UI could show headroom
-    # while the limiter keeps rejecting.
+    # Regression: the /me/keys RPM figure counts admitted requests only,
+    # while the limiter enforces over its request window. If a TPM reject
+    # appended its RPM timestamp anyway, the enforced RPM would include
+    # requests the display excludes, so the UI could show headroom while the
+    # limiter keeps rejecting.
     limiter = InMemoryRateLimiter()
     cfg = RateLimitConfig(rpm=2, tpm=100)
     limiter.record_tokens("k", 100)  # fill the TPM window

--- a/logos/logos-orchestrator/tests/unit/test_rate_limiter.py
+++ b/logos/logos-orchestrator/tests/unit/test_rate_limiter.py
@@ -1,0 +1,75 @@
+"""Behavior tests for InMemoryRateLimiter (issue #672)."""
+
+import logos.rate_limiter as rl
+from logos.rate_limiter import InMemoryRateLimiter, RateLimitConfig
+
+
+def test_admit_within_limits():
+    limiter = InMemoryRateLimiter()
+    allowed, reason = limiter.check_and_record("k", RateLimitConfig(rpm=5, tpm=1000))
+    assert allowed
+    assert reason == ""
+
+
+def test_rpm_rejects_once_the_window_is_full():
+    limiter = InMemoryRateLimiter()
+    cfg = RateLimitConfig(rpm=2)
+    assert limiter.check_and_record("k", cfg)[0]
+    assert limiter.check_and_record("k", cfg)[0]
+    allowed, reason = limiter.check_and_record("k", cfg)
+    assert not allowed
+    assert "RPM" in reason
+
+
+def test_tpm_rejects_when_recorded_tokens_fill_the_window():
+    limiter = InMemoryRateLimiter()
+    cfg = RateLimitConfig(tpm=100)
+    limiter.record_tokens("k", 100)
+    allowed, reason = limiter.check_and_record("k", cfg)
+    assert not allowed
+    assert "TPM" in reason
+
+
+def test_tpm_reject_does_not_consume_an_rpm_slot(monkeypatch):
+    # Regression (issue #672): the /me/keys RPM figure counts admitted
+    # requests only, while the limiter enforces over its request window. If
+    # a TPM reject appended its RPM timestamp anyway, the enforced RPM would
+    # include requests the display excludes, so the UI could show headroom
+    # while the limiter keeps rejecting.
+    limiter = InMemoryRateLimiter()
+    cfg = RateLimitConfig(rpm=2, tpm=100)
+    limiter.record_tokens("k", 100)  # fill the TPM window
+
+    # Every check now rejects on TPM.
+    for _ in range(3):
+        allowed, reason = limiter.check_and_record("k", cfg)
+        assert not allowed
+        assert "TPM" in reason
+
+    # Let the windows slide away. If any reject had recorded an RPM
+    # timestamp, the RPM limit (2) would reject immediately; instead both
+    # slots must still be available.
+    class _Clock:
+        @staticmethod
+        def monotonic():
+            return 1e9
+
+    monkeypatch.setattr(rl, "time", _Clock())
+    assert limiter.check_and_record("k", cfg)[0]
+    assert limiter.check_and_record("k", cfg)[0]
+    allowed, reason = limiter.check_and_record("k", cfg)
+    assert not allowed
+    assert "RPM" in reason
+
+
+def test_tpm_is_checked_before_rpm_is_recorded():
+    # Pins the check order: with both limits exhausted the reject reason is
+    # TPM, i.e. the RPM timestamp is only appended after both checks pass.
+    limiter = InMemoryRateLimiter()
+    cfg = RateLimitConfig(rpm=1, tpm=100)
+    assert limiter.check_and_record("k", cfg)[0]  # admitted; records the RPM slot
+    limiter.record_tokens("k", 100)  # now the TPM window is full too
+
+    allowed, reason = limiter.check_and_record("k", cfg)
+    assert not allowed
+    assert "TPM" in reason

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
@@ -85,11 +85,11 @@
               <div class="limits-row">
                 <div class="limit-group">
                   <span class="limit-label">CLOUD</span>
-                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute">{{ formatRpm(key.settings?.cloud_rpm_limit ?? null) }} RPM · {{ formatTpm(key.settings?.cloud_tpm_limit ?? null) }} TPM</span>
+                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit">{{ formatRpm(usageFor(key).cloud_requests, key.settings?.cloud_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key).cloud_tokens, key.settings?.cloud_tpm_limit ?? null) }} TPM</span>
                 </div>
                 <div class="limit-group">
                   <span class="limit-label">LOCAL</span>
-                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute">{{ formatRpm(key.settings?.local_rpm_limit ?? null) }} RPM · {{ formatTpm(key.settings?.local_tpm_limit ?? null) }} TPM</span>
+                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit">{{ formatRpm(usageFor(key).local_requests, key.settings?.local_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key).local_tokens, key.settings?.local_tpm_limit ?? null) }} TPM</span>
                 </div>
                 <div class="limit-group limit-group--budget">
                   <span class="limit-label">KEY BUDGET</span>

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.html
@@ -85,11 +85,11 @@
               <div class="limits-row">
                 <div class="limit-group">
                   <span class="limit-label">CLOUD</span>
-                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit">{{ formatRpm(usageFor(key).cloud_requests, key.settings?.cloud_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key).cloud_tokens, key.settings?.cloud_tpm_limit ?? null) }} TPM</span>
+                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit · – = no usage known for the window · ∞ = no limit set">{{ formatRpm(usageFor(key)?.cloud_requests ?? null, key.settings?.cloud_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key)?.cloud_tokens ?? null, key.settings?.cloud_tpm_limit ?? null) }} TPM</span>
                 </div>
                 <div class="limit-group">
                   <span class="limit-label">LOCAL</span>
-                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit">{{ formatRpm(usageFor(key).local_requests, key.settings?.local_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key).local_tokens, key.settings?.local_tpm_limit ?? null) }} TPM</span>
+                  <span class="limit-value" title="RPM = requests per minute, TPM = tokens per minute · usage is what the last minute (the limit's window) counted, shown against the limit · – = no usage known for the window · ∞ = no limit set">{{ formatRpm(usageFor(key)?.local_requests ?? null, key.settings?.local_rpm_limit ?? null) }} RPM · {{ formatTpm(usageFor(key)?.local_tokens ?? null, key.settings?.local_tpm_limit ?? null) }} TPM</span>
                 </div>
                 <div class="limit-group limit-group--budget">
                   <span class="limit-label">KEY BUDGET</span>

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
@@ -14,7 +14,7 @@ import { IconTileComponent } from '../../shared/components/icon-tile/icon-tile';
 import { MyKeysService } from '../../core/services/my-keys.service';
 import { TeamManagementService } from '../../core/services/team-management.service';
 import { AuthService } from '../../core/auth/services/auth.service';
-import { MyKey, ModelAccess } from '../../shared/models/my-key.model';
+import { MyKey, ModelAccess, RateLimitUsage } from '../../shared/models/my-key.model';
 import { MyTeam } from '../../shared/models/team.model';
 import { formatLastUsed as formatLastUsedLabel } from '../../shared/utils/date';
 import { isInteractiveClick } from '../../shared/utils/interactive-click';
@@ -312,13 +312,31 @@ export class MyWorkspace implements OnInit {
   }
 
   // ── Display ────────────────────────────────────────────────────────────────
-  formatRpm(rpm: number | null): string {
-    return rpm != null ? rpm.toLocaleString() : '∞';
+  /** The key's usage inside the current rate-limit window, zeroed when absent. */
+  usageFor(key: MyKey): RateLimitUsage {
+    return key.rate_limit_usage ?? {
+      window_seconds: 60,
+      cloud_requests: 0,
+      cloud_tokens: 0,
+      local_requests: 0,
+      local_tokens: 0,
+    };
   }
 
-  formatTpm(tpm: number | null): string {
-    if (tpm == null) return '∞';
-    return tpm >= 1000 ? (tpm / 1000).toFixed(0) + 'k' : tpm.toString();
+  /**
+   * Used/limit pair for one side of a rate limit: "12/60" when the key or its
+   * team set a limit, plain "12" when it is unlimited — the used figure reads
+   * directly against the limit it is enforced by.
+   */
+  formatRpm(used: number, limit: number | null): string {
+    return limit != null
+      ? `${used.toLocaleString()}/${limit.toLocaleString()}`
+      : used.toLocaleString();
+  }
+
+  formatTpm(used: number, limit: number | null): string {
+    const compact = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(0)}k` : n.toString());
+    return limit != null ? `${compact(used)}/${compact(limit)}` : compact(used);
   }
 
   formatLastUsed(iso: string | null): string {

--- a/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
+++ b/logos/logos-ui/src/app/features/my-workspace/my-workspace.ts
@@ -312,31 +312,40 @@ export class MyWorkspace implements OnInit {
   }
 
   // ── Display ────────────────────────────────────────────────────────────────
-  /** The key's usage inside the current rate-limit window, zeroed when absent. */
-  usageFor(key: MyKey): RateLimitUsage {
-    return key.rate_limit_usage ?? {
-      window_seconds: 60,
-      cloud_requests: 0,
-      cloud_tokens: 0,
-      local_requests: 0,
-      local_tokens: 0,
-    };
+  /**
+   * The key's usage inside the current rate-limit window, or null when the
+   * backend found nothing for the window. Null is kept distinct from zero on
+   * purpose: a rate-limit figure of zero claims the entire budget is
+   * available, so an unknown window must not be rendered as one.
+   */
+  usageFor(key: MyKey): RateLimitUsage | null {
+    return key.rate_limit_usage;
   }
 
   /**
-   * Used/limit pair for one side of a rate limit: "12/60" when the key or its
-   * team set a limit, plain "12" when it is unlimited — the used figure reads
-   * directly against the limit it is enforced by.
+   * Used/limit pair for one side of a rate limit: "12/60" when a limit is
+   * set, "12/∞" when the key or its team set none (the ∞ marker keeps an
+   * unlimited key readable — a bare used figure looks like the limit is the
+   * used figure), "–/60" when the used figure is unknown for the window.
    */
-  formatRpm(used: number, limit: number | null): string {
-    return limit != null
-      ? `${used.toLocaleString()}/${limit.toLocaleString()}`
-      : used.toLocaleString();
+  formatRpm(used: number | null, limit: number | null): string {
+    const u = used == null ? '–' : used.toLocaleString();
+    const l = limit == null ? '∞' : limit.toLocaleString();
+    return `${u}/${l}`;
   }
 
-  formatTpm(used: number, limit: number | null): string {
-    const compact = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(0)}k` : n.toString());
-    return limit != null ? `${compact(used)}/${compact(limit)}` : compact(used);
+  /**
+   * Like {@link formatRpm} with compact thousand figures. The used side keeps
+   * one decimal ("59.5k/60k"): at 1k granularity a near-exhausted limit
+   * rounds to the limit and reads as fully used, and small used figures
+   * round up. The limit side stays whole ("60k").
+   */
+  formatTpm(used: number | null, limit: number | null): string {
+    const compact = (n: number, decimals: number) =>
+      n >= 1000 ? `${(n / 1000).toFixed(decimals)}k` : n.toString();
+    const u = used == null ? '–' : compact(used, 1);
+    const l = limit == null ? '∞' : compact(limit, 0);
+    return `${u}/${l}`;
   }
 
   formatLastUsed(iso: string | null): string {

--- a/logos/logos-ui/src/app/shared/models/my-key.model.ts
+++ b/logos/logos-ui/src/app/shared/models/my-key.model.ts
@@ -13,6 +13,20 @@ export interface MyKeyTeam {
   budget_used_micro_cents: number;
 }
 
+/**
+ * Requests and tokens this key sent inside one rate-limit window, split the
+ * way the limits are enforced (cloud vs. local). The figures are what the
+ * sliding window is currently counting, so they can be held directly against
+ * the rpm/tpm limits in {@link MyKeySettings}.
+ */
+export interface RateLimitUsage {
+  window_seconds: number;
+  cloud_requests: number;
+  cloud_tokens: number;
+  local_requests: number;
+  local_tokens: number;
+}
+
 export interface MyKey {
   id: number;
   name: string;
@@ -24,6 +38,7 @@ export interface MyKey {
   used_micro_cents: number;
   settings: MyKeySettings | null;
   last_used_at: string | null;
+  rate_limit_usage: RateLimitUsage | null;
   team: MyKeyTeam;
 }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -115,48 +115,72 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
      * actually served on ({@code logosnode} is local, everything else
      * cloud).
      *
-     * The window is cut on {@code timestamp_forwarding}, not
-     * {@code timestamp_request}: the limiter charges a request when it is
-     * admitted (i.e. scheduled, see {@code check_and_record} in the
-     * orchestrator's main.py), and {@code timestamp_forwarding} is written
-     * at scheduling. {@code timestamp_request} is when the request
-     * *arrived*, which under queue wait can be long before admission —
-     * cutting on it would drop exactly the requests that waited in the queue
-     * from the figure, so the display would under-report precisely when
-     * developers look at it to understand a 429. Requests that never reached
-     * scheduling (still queued) have no {@code timestamp_forwarding} and are
-     * left out of the window, matching the limiter, which does not count
-     * them either.
+     * Each metric is cut on the timestamp the limiter charges it by:
+     *
+     * <ul>
+     * <li>Requests count when they are *admitted* —
+     * {@code timestamp_forwarding}, written at scheduling, is when
+     * {@code check_and_record} records the RPM slot (the request is charged
+     * while it is still running). Cutting on {@code timestamp_request}
+     * instead would drop exactly the requests that waited in the queue,
+     * under-reporting precisely when developers look at it to understand a
+     * 429.</li>
+     * <li>Tokens count when the request *completes* —
+     * {@code timestamp_response}: the limiter's {@code record_tokens} runs
+     * at completion, so its TPM window holds completed requests. A request
+     * admitted just before the window edge but completing inside it counts
+     * its tokens (and only them); an in-flight request counts its request
+     * and no tokens yet.</li>
+     * </ul>
+     *
+     * The outer predicate is therefore the union of both windows; each
+     * metric applies its own inside the {@code FILTER}. Requests that never
+     * reached scheduling (still queued) have neither timestamp and are left
+     * out, matching the limiter.
+     *
+     * The per-request token figure mirrors the limiter's fallback in the
+     * {@code record_tokens} call sites (main.py):
+     * {@code total_tokens or (prompt_tokens + completion_tokens)} — Python
+     * {@code or}, so a missing *or zero* total falls back to the two parts,
+     * and a non-zero total wins over the parts (which may not add up to it,
+     * e.g. cached tokens). Computed per log row in the LATERAL so one
+     * request contributes exactly one figure.
      *
      * Rate-limiter rejects are excluded by the persisted admission verdict,
      * not by the timestamp: the orchestrator writes
      * {@code timestamp_forwarding} during {@code record_scheduled()} —
      * *before* {@code check_and_record()} runs — so a request the limiter
-     * rejects afterwards (429) already satisfies the window predicate. The
-     * orchestrator persists {@code rate_limit_admitted} at the decision
-     * point (TRUE admitted, FALSE rejected, NULL when no limit is
-     * configured or for pre-migration rows), and the
+     * rejects afterwards (429) already satisfies the admission-window
+     * predicate. The orchestrator persists {@code rate_limit_admitted} at
+     * the decision point (TRUE admitted, FALSE rejected, NULL when no limit
+     * is configured or for pre-migration rows), and the
      * {@code IS DISTINCT FROM FALSE} filter counts everything except the
-     * explicit rejects — unlimited keys keep showing their usage.
-     *
-     * Token sums read the same {@code total_tokens} rows the
-     * limiter records on completion; request counts use DISTINCT ids because
-     * the usage_tokens join fans one request out to one row per token type.
+     * explicit rejects — unlimited keys keep showing their usage. (The
+     * limiter only records an RPM slot after both checks pass, so no
+     * rejected request consumes budget the display would then miss.)
      */
     @Query(value = """
         SELECT le.api_key_id AS keyId,
-               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'cloud') AS cloudRequests,
-               COALESCE(SUM(ut.token_count) FILTER (WHERE p.provider_type = 'cloud' AND tt.name = 'total_tokens'), 0) AS cloudTokens,
-               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'logosnode') AS localRequests,
-               COALESCE(SUM(ut.token_count) FILTER (WHERE p.provider_type = 'logosnode' AND tt.name = 'total_tokens'), 0) AS localTokens
+               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'cloud' AND le.timestamp_forwarding >= :since) AS cloudRequests,
+               COALESCE(SUM(ut.tokens) FILTER (WHERE p.provider_type = 'cloud' AND le.timestamp_response >= :since), 0) AS cloudTokens,
+               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'logosnode' AND le.timestamp_forwarding >= :since) AS localRequests,
+               COALESCE(SUM(ut.tokens) FILTER (WHERE p.provider_type = 'logosnode' AND le.timestamp_response >= :since), 0) AS localTokens
         FROM log_entry le
         JOIN api_keys ak ON ak.id = le.api_key_id
         LEFT JOIN providers p ON p.id = le.provider_id
-        LEFT JOIN usage_tokens ut ON ut.log_entry_id = le.id
-        LEFT JOIN token_types tt ON tt.id = ut.type_id
+        LEFT JOIN LATERAL (
+            SELECT CASE
+                     WHEN COALESCE(SUM(CASE WHEN tt.name = 'total_tokens' THEN ut2.token_count END), 0) > 0
+                         THEN SUM(CASE WHEN tt.name = 'total_tokens' THEN ut2.token_count END)
+                     ELSE COALESCE(SUM(CASE WHEN tt.name IN ('prompt_tokens', 'completion_tokens') THEN ut2.token_count END), 0)
+                   END AS tokens
+            FROM usage_tokens ut2
+            LEFT JOIN token_types tt ON tt.id = ut2.type_id
+            WHERE ut2.log_entry_id = le.id
+        ) ut ON true
         WHERE ak.user_id = :userId
           AND ak.is_active = true
-          AND le.timestamp_forwarding >= :since
+          AND (le.timestamp_forwarding >= :since OR le.timestamp_response >= :since)
           AND le.rate_limit_admitted IS DISTINCT FROM FALSE
         GROUP BY le.api_key_id
         """, nativeQuery = true)

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -115,9 +115,20 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
      * actually served on ({@code logosnode} is local, everything else
      * cloud).
      *
-     * Requests that have no provider yet (still queued, or rejected before
-     * scheduling) are not counted by the limiter either, so they are left
-     * out here. Token sums read the same {@code total_tokens} rows the
+     * The window is cut on {@code timestamp_forwarding}, not
+     * {@code timestamp_request}: the limiter charges a request when it is
+     * admitted (i.e. scheduled, see {@code check_and_record} in the
+     * orchestrator's main.py), and {@code timestamp_forwarding} is written
+     * at exactly that moment. {@code timestamp_request} is when the request
+     * *arrived*, which under queue wait can be long before admission —
+     * cutting on it would drop exactly the requests that waited in the queue
+     * from the figure, so the display would under-report precisely when
+     * developers look at it to understand a 429. Requests that never reached
+     * admission (still queued, or rejected before scheduling) have no
+     * {@code timestamp_forwarding} and are left out of the window, matching
+     * the limiter, which does not count them either.
+     *
+     * Token sums read the same {@code total_tokens} rows the
      * limiter records on completion; request counts use DISTINCT ids because
      * the usage_tokens join fans one request out to one row per token type.
      */
@@ -134,7 +145,7 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
         LEFT JOIN token_types tt ON tt.id = ut.type_id
         WHERE ak.user_id = :userId
           AND ak.is_active = true
-          AND le.timestamp_request >= :since
+          AND le.timestamp_forwarding >= :since
         GROUP BY le.api_key_id
         """, nativeQuery = true)
     List<RateLimitUsageProjection> findRateLimitUsageForUser(

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -119,14 +119,25 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
      * {@code timestamp_request}: the limiter charges a request when it is
      * admitted (i.e. scheduled, see {@code check_and_record} in the
      * orchestrator's main.py), and {@code timestamp_forwarding} is written
-     * at exactly that moment. {@code timestamp_request} is when the request
+     * at scheduling. {@code timestamp_request} is when the request
      * *arrived*, which under queue wait can be long before admission —
      * cutting on it would drop exactly the requests that waited in the queue
      * from the figure, so the display would under-report precisely when
      * developers look at it to understand a 429. Requests that never reached
-     * admission (still queued, or rejected before scheduling) have no
-     * {@code timestamp_forwarding} and are left out of the window, matching
-     * the limiter, which does not count them either.
+     * scheduling (still queued) have no {@code timestamp_forwarding} and are
+     * left out of the window, matching the limiter, which does not count
+     * them either.
+     *
+     * Rate-limiter rejects are excluded by the persisted admission verdict,
+     * not by the timestamp: the orchestrator writes
+     * {@code timestamp_forwarding} during {@code record_scheduled()} —
+     * *before* {@code check_and_record()} runs — so a request the limiter
+     * rejects afterwards (429) already satisfies the window predicate. The
+     * orchestrator persists {@code rate_limit_admitted} at the decision
+     * point (TRUE admitted, FALSE rejected, NULL when no limit is
+     * configured or for pre-migration rows), and the
+     * {@code IS DISTINCT FROM FALSE} filter counts everything except the
+     * explicit rejects — unlimited keys keep showing their usage.
      *
      * Token sums read the same {@code total_tokens} rows the
      * limiter records on completion; request counts use DISTINCT ids because
@@ -146,6 +157,7 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
         WHERE ak.user_id = :userId
           AND ak.is_active = true
           AND le.timestamp_forwarding >= :since
+          AND le.rate_limit_admitted IS DISTINCT FROM FALSE
         GROUP BY le.api_key_id
         """, nativeQuery = true)
     List<RateLimitUsageProjection> findRateLimitUsageForUser(

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -109,8 +109,8 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
     List<MyKeyProjection> findKeysForUser(@Param("userId") int userId);
 
     /**
-     * Per-key request and token counts inside one rate-limit window (issue
-     * #672), split the way the orchestrator's limiter enforces the limits:
+     * Per-key request and token counts inside one rate-limit window, split
+     * the way the orchestrator's limiter enforces the limits:
      * per key, and cloud vs. local by the provider type the request was
      * actually served on ({@code logosnode} is local, everything else
      * cloud).

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/ApiKeyRepository.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.logos.logoswebservice.identity.repository;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +13,7 @@ import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKeyType;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.LogLevel;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.MyKeyProjection;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ModelAccessProjection;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.RateLimitUsageProjection;
 
 public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
     Optional<ApiKey> findByKeyValueAndIsActiveTrue(String keyValue);
@@ -105,6 +107,39 @@ public interface ApiKeyRepository extends JpaRepository<ApiKey, Integer> {
         ORDER BY ak.id
         """, nativeQuery = true)
     List<MyKeyProjection> findKeysForUser(@Param("userId") int userId);
+
+    /**
+     * Per-key request and token counts inside one rate-limit window (issue
+     * #672), split the way the orchestrator's limiter enforces the limits:
+     * per key, and cloud vs. local by the provider type the request was
+     * actually served on ({@code logosnode} is local, everything else
+     * cloud).
+     *
+     * Requests that have no provider yet (still queued, or rejected before
+     * scheduling) are not counted by the limiter either, so they are left
+     * out here. Token sums read the same {@code total_tokens} rows the
+     * limiter records on completion; request counts use DISTINCT ids because
+     * the usage_tokens join fans one request out to one row per token type.
+     */
+    @Query(value = """
+        SELECT le.api_key_id AS keyId,
+               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'cloud') AS cloudRequests,
+               COALESCE(SUM(ut.token_count) FILTER (WHERE p.provider_type = 'cloud' AND tt.name = 'total_tokens'), 0) AS cloudTokens,
+               COUNT(DISTINCT le.id) FILTER (WHERE p.provider_type = 'logosnode') AS localRequests,
+               COALESCE(SUM(ut.token_count) FILTER (WHERE p.provider_type = 'logosnode' AND tt.name = 'total_tokens'), 0) AS localTokens
+        FROM log_entry le
+        JOIN api_keys ak ON ak.id = le.api_key_id
+        LEFT JOIN providers p ON p.id = le.provider_id
+        LEFT JOIN usage_tokens ut ON ut.log_entry_id = le.id
+        LEFT JOIN token_types tt ON tt.id = ut.type_id
+        WHERE ak.user_id = :userId
+          AND ak.is_active = true
+          AND le.timestamp_request >= :since
+        GROUP BY le.api_key_id
+        """, nativeQuery = true)
+    List<RateLimitUsageProjection> findRateLimitUsageForUser(
+            @Param("userId") int userId,
+            @Param("since") Timestamp since);
 
     @Query(value = """
         SELECT m.name AS model_name, p.name AS provider_name, p.provider_type::text AS provider_type

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/RateLimitUsageProjection.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/repository/RateLimitUsageProjection.java
@@ -1,0 +1,9 @@
+package de.tum.cit.aet.logos.logoswebservice.identity.repository;
+
+public interface RateLimitUsageProjection {
+    Integer getKeyId();
+    Long getCloudRequests();
+    Long getCloudTokens();
+    Long getLocalRequests();
+    Long getLocalTokens();
+}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
@@ -34,6 +34,12 @@ public class MeKeysService {
      * The sliding window the orchestrator's rate limiter enforces rpm/tpm
      * limits over; the usage numbers shown next to a limit must come from the
      * same window to be comparable to it.
+     *
+     * This is a copy of the default of {@code RateLimitConfig.window_seconds}
+     * in {@code logos/logos-orchestrator/src/logos/rate_limiter.py} — the
+     * orchestrator is the source of truth. Keep the two in sync; the test
+     * {@code RateLimitWindowConsistencyTest} fails if they drift, and the
+     * corresponding comment in rate_limiter.py points back here.
      */
     private static final int RATE_LIMIT_WINDOW_SECONDS = 60;
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
@@ -62,8 +62,11 @@ public class MeKeysService {
     /**
      * Rate-limit usage of the user's active keys inside one rate-limiter
      * window (see {@link #RATE_LIMIT_WINDOW_SECONDS}), keyed by key id.
-     * Keys with no traffic in the window are absent; the caller renders them
-     * at zero.
+     * Keys with no traffic in the window are absent — and stay absent: the
+     * caller must not render them at zero, because zero usage is the most
+     * reassuring possible reading for a rate-limit figure ("you have your
+     * entire budget available"). Unknown usage and genuinely-idle usage
+     * deserve different renderings; the UI shows an en dash for the former.
      */
     private Map<Integer, RateLimitUsageProjection> findRateLimitUsage(int userId) {
         Timestamp since = Timestamp.from(Instant.now().minusSeconds(RATE_LIMIT_WINDOW_SECONDS));
@@ -156,7 +159,7 @@ public class MeKeysService {
         m.put("used_micro_cents", p.getUsedMicroCents());
         m.put("settings", resolvedSettings(p));
         m.put("last_used_at", p.getLastUsedAt() != null ? p.getLastUsedAt().toString() : null);
-        m.put("rate_limit_usage", toRateLimitUsage(usage));
+        m.put("rate_limit_usage", usage == null ? null : toRateLimitUsage(usage));
 
         Map<String, Object> team = new LinkedHashMap<>();
         team.put("id", p.getTeamId());
@@ -170,10 +173,10 @@ public class MeKeysService {
     private Map<String, Object> toRateLimitUsage(RateLimitUsageProjection usage) {
         Map<String, Object> u = new LinkedHashMap<>();
         u.put("window_seconds", RATE_LIMIT_WINDOW_SECONDS);
-        u.put("cloud_requests", usage != null ? usage.getCloudRequests() : 0L);
-        u.put("cloud_tokens", usage != null ? usage.getCloudTokens() : 0L);
-        u.put("local_requests", usage != null ? usage.getLocalRequests() : 0L);
-        u.put("local_tokens", usage != null ? usage.getLocalTokens() : 0L);
+        u.put("cloud_requests", usage.getCloudRequests());
+        u.put("cloud_tokens", usage.getCloudTokens());
+        u.put("local_requests", usage.getLocalRequests());
+        u.put("local_tokens", usage.getLocalTokens());
         return u;
     }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/identity/service/MeKeysService.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.logos.logoswebservice.identity.service;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +20,7 @@ import de.tum.cit.aet.logos.logoswebservice.identity.entity.LogLevel;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ModelAccessProjection;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.MyKeyProjection;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.RateLimitUsageProjection;
 import de.tum.cit.aet.logos.logoswebservice.orchestrator.OrchestratorModelWindowClient;
 
 @Service
@@ -25,6 +29,13 @@ public class MeKeysService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Object> OBJ_TYPE = new TypeReference<>() {};
     private static final int API_KEY_TOKEN_LENGTH = 128;
+
+    /**
+     * The sliding window the orchestrator's rate limiter enforces rpm/tpm
+     * limits over; the usage numbers shown next to a limit must come from the
+     * same window to be comparable to it.
+     */
+    private static final int RATE_LIMIT_WINDOW_SECONDS = 60;
 
     private final ApiKeyRepository apiKeyRepository;
     private final OrchestratorModelWindowClient modelWindowClient;
@@ -35,9 +46,26 @@ public class MeKeysService {
     }
 
     public List<Map<String, Object>> getKeysForUser(int userId) {
-        return apiKeyRepository.findKeysForUser(userId).stream()
-            .map(this::toMap)
+        List<MyKeyProjection> keys = apiKeyRepository.findKeysForUser(userId);
+        Map<Integer, RateLimitUsageProjection> usageByKey = findRateLimitUsage(userId);
+        return keys.stream()
+            .map(p -> toMap(p, usageByKey.get(p.getId())))
             .toList();
+    }
+
+    /**
+     * Rate-limit usage of the user's active keys inside one rate-limiter
+     * window (see {@link #RATE_LIMIT_WINDOW_SECONDS}), keyed by key id.
+     * Keys with no traffic in the window are absent; the caller renders them
+     * at zero.
+     */
+    private Map<Integer, RateLimitUsageProjection> findRateLimitUsage(int userId) {
+        Timestamp since = Timestamp.from(Instant.now().minusSeconds(RATE_LIMIT_WINDOW_SECONDS));
+        Map<Integer, RateLimitUsageProjection> byKey = new HashMap<>();
+        for (RateLimitUsageProjection p : apiKeyRepository.findRateLimitUsageForUser(userId, since)) {
+            byKey.put(p.getKeyId(), p);
+        }
+        return byKey;
     }
 
     @Transactional
@@ -110,7 +138,7 @@ public class MeKeysService {
             "api_key", key.getKeyValue()));
     }
 
-    private Map<String, Object> toMap(MyKeyProjection p) {
+    private Map<String, Object> toMap(MyKeyProjection p, RateLimitUsageProjection usage) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("id", p.getId());
         m.put("name", p.getName());
@@ -122,6 +150,7 @@ public class MeKeysService {
         m.put("used_micro_cents", p.getUsedMicroCents());
         m.put("settings", resolvedSettings(p));
         m.put("last_used_at", p.getLastUsedAt() != null ? p.getLastUsedAt().toString() : null);
+        m.put("rate_limit_usage", toRateLimitUsage(usage));
 
         Map<String, Object> team = new LinkedHashMap<>();
         team.put("id", p.getTeamId());
@@ -130,6 +159,16 @@ public class MeKeysService {
         team.put("budget_used_micro_cents", p.getTeamBudgetUsedMicroCents());
         m.put("team", team);
         return m;
+    }
+
+    private Map<String, Object> toRateLimitUsage(RateLimitUsageProjection usage) {
+        Map<String, Object> u = new LinkedHashMap<>();
+        u.put("window_seconds", RATE_LIMIT_WINDOW_SECONDS);
+        u.put("cloud_requests", usage != null ? usage.getCloudRequests() : 0L);
+        u.put("cloud_tokens", usage != null ? usage.getCloudTokens() : 0L);
+        u.put("local_requests", usage != null ? usage.getLocalRequests() : 0L);
+        u.put("local_tokens", usage != null ? usage.getLocalTokens() : 0L);
+        return u;
     }
 
     @SuppressWarnings("unchecked")

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/026_log_entry_rate_limit_admitted.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/026_log_entry_rate_limit_admitted.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    logicalFilePath="liquibase/changelog/020_log_entry_rate_limit_admitted.xml"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Issue #672: the /me/keys page shows each key's request/token usage
+         inside the limiter's window. The window query
+         (ApiKeyRepository.findRateLimitUsageForUser) counts rows by
+         timestamp_forwarding, but the orchestrator writes that column during
+         record_scheduled() — BEFORE the rate limiter's check_and_record()
+         runs. A request the limiter then rejects (429) already satisfies the
+         window predicate, so repeated rejected attempts would inflate the
+         displayed usage above what the limiter actually enforces.
+
+         rate_limit_admitted persists the verdict at the decision point:
+           TRUE  — the limiter admitted the request (counted from then on,
+                   including while it is still running);
+           FALSE — the limiter rejected it after scheduling (excluded);
+           NULL  — no limit configured for that key/provider class, or a
+                   pre-migration row (never rejected, so counted).
+         The query filters `IS DISTINCT FROM FALSE` accordingly. -->
+    <changeSet id="020-log-entry-rate-limit-admitted" author="logos">
+        <addColumn tableName="log_entry">
+            <column name="rate_limit_admitted" type="BOOLEAN"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="log_entry" columnName="rate_limit_admitted"/>
+        </rollback>
+    </changeSet>
+
+    <!-- The same query also range-scans timestamp_forwarding for the caller's
+         key ids. idx_log_entry_api_key_id alone cannot serve the
+         `timestamp_forwarding >= now - 60s` predicate, so Postgres visits
+         every historical row of each key before the usage joins — every
+         /me/keys load gets more expensive as a high-volume key ages.
+         (api_key_id, timestamp_forwarding) lets it seek straight to the recent
+         slice of each key.
+
+         Originally numbered 020; main's later migrations have since taken
+         019-025, so the file moved to 026 (logicalFilePath keeps the old name
+         for environments that already ran it). LiquibaseChangelogOrderTest
+         requires strictly increasing numbers in master.xml.
+
+         Runs outside a transaction so CONCURRENTLY can build the index without
+         locking log_entry against the logos-orchestrator, which keeps writing
+         to this table while logos-webservice is redeployed (same rationale as
+         012). -->
+    <changeSet id="020-log-entry-api-key-forwarding-index" author="logos" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists tableName="log_entry" indexName="idx_log_entry_api_key_timestamp_forwarding"/></not>
+        </preConditions>
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_log_entry_api_key_timestamp_forwarding
+                ON log_entry (api_key_id, timestamp_forwarding);
+        </sql>
+        <rollback>
+            <sql>DROP INDEX CONCURRENTLY IF EXISTS idx_log_entry_api_key_timestamp_forwarding;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/026_log_entry_rate_limit_admitted.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/026_log_entry_rate_limit_admitted.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <!-- Issue #672: the /me/keys page shows each key's request/token usage
+    <!-- The /me/keys page shows each key's request/token usage
          inside the limiter's window. The window query
          (ApiKeyRepository.findRateLimitUsageForUser) counts rows by
          timestamp_forwarding, but the orchestrator writes that column during

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_api_key_response_index.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_api_key_response_index.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    logicalFilePath="liquibase/changelog/021_log_entry_api_key_response_index.xml"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Issue #672, part two. The same /me/keys usage window
+         (ApiKeyRepository.findRateLimitUsageForUser) that migration 026 indexes
+         also cuts the token metric on timestamp_response — requests count when
+         they complete, so a request admitted just before the window edge but
+         completing inside it counts its tokens. The row predicate is
+
+             api_key_id = <key>
+             AND (timestamp_forwarding >= :since OR timestamp_response >= :since)
+
+         026 added (api_key_id, timestamp_forwarding), which serves only the
+         first disjunct. The second one (timestamp_response >= :since) is
+         unsatisfiable from that index, so Postgres falls back to scanning every
+         historical row of each of the user's keys to test the OR — the exact
+         "filter each key's historical rows" the review flagged, and it grows
+         with each key's age.
+
+         (api_key_id, timestamp_response) closes that gap: Postgres can now
+         bitmap-OR two index range scans (forwarding >= :since on the 026 index,
+         response >= :since here) and reach only each key's recent rows. Column
+         order matches the predicate — the api_key_id equality prefix, then the
+         timestamp_response range — so both the admission and completion halves
+         of the window are index-driven.
+
+         Originally numbered 021; main's later migrations have since taken
+         019-025, so the file moved to 027 (logicalFilePath keeps the old name
+         for environments that already ran it). LiquibaseChangelogOrderTest
+         requires strictly increasing numbers in master.xml.
+
+         Runs outside a transaction so CONCURRENTLY can build the index without
+         locking log_entry against the logos-orchestrator, which keeps writing
+         to this table while logos-webservice is redeployed (same rationale as
+         012/014/026). -->
+    <changeSet id="021-log-entry-api-key-response-index" author="logos" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists tableName="log_entry" indexName="idx_log_entry_api_key_timestamp_response"/></not>
+        </preConditions>
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_log_entry_api_key_timestamp_response
+                ON log_entry (api_key_id, timestamp_response);
+        </sql>
+        <rollback>
+            <sql>DROP INDEX CONCURRENTLY IF EXISTS idx_log_entry_api_key_timestamp_response;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_api_key_response_index.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_api_key_response_index.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <!-- Issue #672, part two. The same /me/keys usage window
+    <!-- The same /me/keys usage window
          (ApiKeyRepository.findRateLimitUsageForUser) that migration 026 indexes
          also cuts the token metric on timestamp_response — requests count when
          they complete, so a request admitted just before the window edge but

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_rate_limit_admitted.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_rate_limit_admitted.xml
@@ -40,7 +40,7 @@
          slice of each key.
 
          Originally numbered 020; main's later migrations have since taken
-         019-025, so the file moved to 026 (logicalFilePath keeps the old name
+         019-026, so the file moved to 027 (logicalFilePath keeps the old name
          for environments that already ran it). LiquibaseChangelogOrderTest
          requires strictly increasing numbers in master.xml.
 

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_rate_limit_admitted.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/027_log_entry_rate_limit_admitted.xml
@@ -2,7 +2,6 @@
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    logicalFilePath="liquibase/changelog/020_log_entry_rate_limit_admitted.xml"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
@@ -22,7 +21,7 @@
            NULL  — no limit configured for that key/provider class, or a
                    pre-migration row (never rejected, so counted).
          The query filters `IS DISTINCT FROM FALSE` accordingly. -->
-    <changeSet id="020-log-entry-rate-limit-admitted" author="logos">
+    <changeSet id="027-log-entry-rate-limit-admitted" author="logos">
         <addColumn tableName="log_entry">
             <column name="rate_limit_admitted" type="BOOLEAN"/>
         </addColumn>
@@ -40,15 +39,16 @@
          slice of each key.
 
          Originally numbered 020; main's later migrations have since taken
-         019-026, so the file moved to 027 (logicalFilePath keeps the old name
-         for environments that already ran it). LiquibaseChangelogOrderTest
-         requires strictly increasing numbers in master.xml.
+         019-026, so the file moved to 027 (LiquibaseChangelogOrderTest
+         requires strictly increasing numbers in master.xml). No environment
+         has run the earlier number, so the changeSet ids carry the
+         current one.
 
          Runs outside a transaction so CONCURRENTLY can build the index without
          locking log_entry against the logos-orchestrator, which keeps writing
          to this table while logos-webservice is redeployed (same rationale as
          012). -->
-    <changeSet id="020-log-entry-api-key-forwarding-index" author="logos" runInTransaction="false">
+    <changeSet id="027-log-entry-api-key-forwarding-index" author="logos" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not><indexExists tableName="log_entry" indexName="idx_log_entry_api_key_timestamp_forwarding"/></not>
         </preConditions>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/028_log_entry_api_key_response_index.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/028_log_entry_api_key_response_index.xml
@@ -7,7 +7,7 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!-- The same /me/keys usage window
-         (ApiKeyRepository.findRateLimitUsageForUser) that migration 026 indexes
+         (ApiKeyRepository.findRateLimitUsageForUser) that migration 027 indexes
          also cuts the token metric on timestamp_response — requests count when
          they complete, so a request admitted just before the window edge but
          completing inside it counts its tokens. The row predicate is
@@ -15,7 +15,7 @@
              api_key_id = <key>
              AND (timestamp_forwarding >= :since OR timestamp_response >= :since)
 
-         026 added (api_key_id, timestamp_forwarding), which serves only the
+         027 added (api_key_id, timestamp_forwarding), which serves only the
          first disjunct. The second one (timestamp_response >= :since) is
          unsatisfiable from that index, so Postgres falls back to scanning every
          historical row of each of the user's keys to test the OR — the exact
@@ -23,21 +23,21 @@
          with each key's age.
 
          (api_key_id, timestamp_response) closes that gap: Postgres can now
-         bitmap-OR two index range scans (forwarding >= :since on the 026 index,
+         bitmap-OR two index range scans (forwarding >= :since on the 027 index,
          response >= :since here) and reach only each key's recent rows. Column
          order matches the predicate — the api_key_id equality prefix, then the
          timestamp_response range — so both the admission and completion halves
          of the window are index-driven.
 
          Originally numbered 021; main's later migrations have since taken
-         019-025, so the file moved to 027 (logicalFilePath keeps the old name
+         019-026, so the file moved to 028 (logicalFilePath keeps the old name
          for environments that already ran it). LiquibaseChangelogOrderTest
          requires strictly increasing numbers in master.xml.
 
          Runs outside a transaction so CONCURRENTLY can build the index without
          locking log_entry against the logos-orchestrator, which keeps writing
          to this table while logos-webservice is redeployed (same rationale as
-         012/014/026). -->
+         012/014/027). -->
     <changeSet id="021-log-entry-api-key-response-index" author="logos" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not><indexExists tableName="log_entry" indexName="idx_log_entry_api_key_timestamp_response"/></not>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/028_log_entry_api_key_response_index.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/028_log_entry_api_key_response_index.xml
@@ -2,7 +2,6 @@
 <databaseChangeLog
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    logicalFilePath="liquibase/changelog/021_log_entry_api_key_response_index.xml"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
@@ -30,15 +29,16 @@
          of the window are index-driven.
 
          Originally numbered 021; main's later migrations have since taken
-         019-026, so the file moved to 028 (logicalFilePath keeps the old name
-         for environments that already ran it). LiquibaseChangelogOrderTest
-         requires strictly increasing numbers in master.xml.
+         019-026, so the file moved to 028 (LiquibaseChangelogOrderTest
+         requires strictly increasing numbers in master.xml). No environment
+         has run the earlier number, so the changeSet id carries the
+         current one.
 
          Runs outside a transaction so CONCURRENTLY can build the index without
          locking log_entry against the logos-orchestrator, which keeps writing
          to this table while logos-webservice is redeployed (same rationale as
          012/014/027). -->
-    <changeSet id="021-log-entry-api-key-response-index" author="logos" runInTransaction="false">
+    <changeSet id="028-log-entry-api-key-response-index" author="logos" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not><indexExists tableName="log_entry" indexName="idx_log_entry_api_key_timestamp_response"/></not>
         </preConditions>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -31,5 +31,6 @@
     <include file="liquibase/changelog/025_cloud_model_sync.xml"/>
     <include file="liquibase/changelog/026_agent_session_no_push.xml"/>
     <include file="liquibase/changelog/026_log_entry_rate_limit_admitted.xml"/>
+    <include file="liquibase/changelog/027_log_entry_api_key_response_index.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -30,5 +30,6 @@
     <include file="liquibase/changelog/024_privacy_third_party_hardware.xml"/>
     <include file="liquibase/changelog/025_cloud_model_sync.xml"/>
     <include file="liquibase/changelog/026_agent_session_no_push.xml"/>
+    <include file="liquibase/changelog/026_log_entry_rate_limit_admitted.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -30,7 +30,7 @@
     <include file="liquibase/changelog/024_privacy_third_party_hardware.xml"/>
     <include file="liquibase/changelog/025_cloud_model_sync.xml"/>
     <include file="liquibase/changelog/026_agent_session_no_push.xml"/>
-    <include file="liquibase/changelog/026_log_entry_rate_limit_admitted.xml"/>
-    <include file="liquibase/changelog/027_log_entry_api_key_response_index.xml"/>
+    <include file="liquibase/changelog/027_log_entry_rate_limit_admitted.xml"/>
+    <include file="liquibase/changelog/028_log_entry_api_key_response_index.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
@@ -66,9 +66,9 @@ class LiquibaseBaselineTest {
 
     @Test
     void migration026_rateLimitAdmittedColumnAndForwardingIndexExist() {
-        // The /me/keys usage window filters log_entry on both of these
-        // (issue #672): rejected requests are excluded via the column, and
-        // the (api_key_id, timestamp_forwarding) range needs its index.
+        // The /me/keys usage window filters log_entry on both of these:
+        // rejected requests are excluded via the column, and the
+        // (api_key_id, timestamp_forwarding) range needs its index.
         assertThat(columnExists("log_entry", "rate_limit_admitted")).isTrue();
         Integer count = jdbc.queryForObject(
             "SELECT COUNT(*) FROM pg_indexes WHERE schemaname='public' AND indexname=?",
@@ -78,10 +78,10 @@ class LiquibaseBaselineTest {
 
     @Test
     void migration027_rateLimitCompletionResponseIndexExists() {
-        // The completion half of the /me/keys usage window filters log_entry on
-        // timestamp_response per key (issue #672); it needs its own
-        // (api_key_id, timestamp_response) index, since the 026 forwarding index
-        // cannot satisfy the `timestamp_response >= :since` OR disjunct.
+        // The completion half of the /me/keys usage window filters log_entry
+        // on timestamp_response per key; it needs its own
+        // (api_key_id, timestamp_response) index, since the 026 forwarding
+        // index cannot satisfy the `timestamp_response >= :since` OR disjunct.
         Integer count = jdbc.queryForObject(
             "SELECT COUNT(*) FROM pg_indexes WHERE schemaname='public' AND indexname=?",
             Integer.class, "idx_log_entry_api_key_timestamp_response");

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
@@ -65,7 +65,7 @@ class LiquibaseBaselineTest {
     }
 
     @Test
-    void migration026_rateLimitAdmittedColumnAndForwardingIndexExist() {
+    void migration027_rateLimitAdmittedColumnAndForwardingIndexExist() {
         // The /me/keys usage window filters log_entry on both of these:
         // rejected requests are excluded via the column, and the
         // (api_key_id, timestamp_forwarding) range needs its index.
@@ -77,10 +77,10 @@ class LiquibaseBaselineTest {
     }
 
     @Test
-    void migration027_rateLimitCompletionResponseIndexExists() {
+    void migration028_rateLimitCompletionResponseIndexExists() {
         // The completion half of the /me/keys usage window filters log_entry
         // on timestamp_response per key; it needs its own
-        // (api_key_id, timestamp_response) index, since the 026 forwarding
+        // (api_key_id, timestamp_response) index, since the 027 forwarding
         // index cannot satisfy the `timestamp_response >= :since` OR disjunct.
         Integer count = jdbc.queryForObject(
             "SELECT COUNT(*) FROM pg_indexes WHERE schemaname='public' AND indexname=?",

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
@@ -77,6 +77,18 @@ class LiquibaseBaselineTest {
     }
 
     @Test
+    void migration027_rateLimitCompletionResponseIndexExists() {
+        // The completion half of the /me/keys usage window filters log_entry on
+        // timestamp_response per key (issue #672); it needs its own
+        // (api_key_id, timestamp_response) index, since the 026 forwarding index
+        // cannot satisfy the `timestamp_response >= :since` OR disjunct.
+        Integer count = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM pg_indexes WHERE schemaname='public' AND indexname=?",
+            Integer.class, "idx_log_entry_api_key_timestamp_response");
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
     void migration003_backfillsKeyForKeylessMembership() {
         // A current membership with no developer key for that team (the legacy
         // logos_admin case) must receive exactly one active developer key whose

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/LiquibaseBaselineTest.java
@@ -65,6 +65,18 @@ class LiquibaseBaselineTest {
     }
 
     @Test
+    void migration026_rateLimitAdmittedColumnAndForwardingIndexExist() {
+        // The /me/keys usage window filters log_entry on both of these
+        // (issue #672): rejected requests are excluded via the column, and
+        // the (api_key_id, timestamp_forwarding) range needs its index.
+        assertThat(columnExists("log_entry", "rate_limit_admitted")).isTrue();
+        Integer count = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM pg_indexes WHERE schemaname='public' AND indexname=?",
+            Integer.class, "idx_log_entry_api_key_timestamp_forwarding");
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
     void migration003_backfillsKeyForKeylessMembership() {
         // A current membership with no developer key for that team (the legacy
         // logos_admin case) must receive exactly one active developer key whose

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
@@ -69,6 +69,33 @@ class MeKeysControllerTest {
            .andExpect(jsonPath("$[0].team.budget_used_micro_cents").value(0));
     }
 
+    // GET /me/keys — rate limit usage (issue #672)
+
+    @Test
+    void getMyKeys_reportsZeroRateLimitUsageWithoutTraffic() throws Exception {
+        mvc.perform(get("/me/keys").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").value(60))
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(0))
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(0))
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(0))
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(0));
+    }
+
+    @Test
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = "/sql/seed-me-keys-rate-limit-usage.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = "/sql/cleanup-me-keys-rate-limit-usage.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+    void getMyKeys_countsOwnTrafficInsideTheRateLimitWindowOnly() throws Exception {
+        mvc.perform(get("/me/keys").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").value(60))
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(2))
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(2500))
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(1))
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(700));
+    }
+
     // PATCH /me/keys/{keyId}/log
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
@@ -72,14 +72,15 @@ class MeKeysControllerTest {
     // GET /me/keys — rate limit usage (issue #672)
 
     @Test
-    void getMyKeys_reportsZeroRateLimitUsageWithoutTraffic() throws Exception {
+    void getMyKeys_keepsUnknownRateLimitUsageDistinctFromZero() throws Exception {
+        // No traffic in the window -> the backend reports no usage at all.
+        // It must NOT report zeros: for a rate-limit figure, zero is the most
+        // reassuring value ("you have your entire budget available"), so an
+        // unknown window has to stay distinguishable and the UI renders "–".
         mvc.perform(get("/me/keys").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
            .andExpect(status().isOk())
-           .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").value(60))
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(0))
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(0))
-           .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(0))
-           .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(0));
+           .andExpect(jsonPath("$[0].name").value("alice-alpha-key"))
+           .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").doesNotExist());
     }
 
     @Test
@@ -90,13 +91,24 @@ class MeKeysControllerTest {
         mvc.perform(get("/me/keys").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").value(60))
-           // 9307 arrived 70s ago but was admitted (timestamp_forwarding) only
-           // 10s ago, so the limiter charges it to this window and the figure
-           // must include it.
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(3))
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(2600))
-           .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(1))
-           .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(700));
+           // Requests are cut on admission (timestamp_forwarding): 9301,
+           // 9302, 9307, 9311, 9313, 9314, 9315. 9307 arrived 70s ago but was
+           // admitted only 10s ago, so the limiter charges it to this window;
+           // 9311 is still in flight and already charged; 9310's admission is
+           // outside the window even though it completed inside it; the
+           // rejects (9308/9309) are excluded by rate_limit_admitted = FALSE.
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(7))
+           // Tokens are cut on completion (timestamp_response), with the
+           // limiter's per-request fallback total_tokens or
+           // (prompt_tokens + completion_tokens): 9301/9302/9307 (2600),
+           // 9310 completed 20s ago (400), 9313 parts only (500), 9314 zero
+           // total -> parts (250), 9315 non-zero total wins (90). 9311 is in
+           // flight and contributes none yet.
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(3840))
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(2))
+           // 9303 (700) + 9316 parts only (250); the rejected local 9309 is
+           // out.
+           .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(950));
     }
 
     // PATCH /me/keys/{keyId}/log

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
@@ -69,7 +69,7 @@ class MeKeysControllerTest {
            .andExpect(jsonPath("$[0].team.budget_used_micro_cents").value(0));
     }
 
-    // GET /me/keys — rate limit usage (issue #672)
+    // GET /me/keys — rate limit usage
 
     @Test
     void getMyKeys_keepsUnknownRateLimitUsageDistinctFromZero() throws Exception {

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/MeKeysControllerTest.java
@@ -90,8 +90,11 @@ class MeKeysControllerTest {
         mvc.perform(get("/me/keys").with(TestJwt.forSeededUser(ALICE_ID, "alice")))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$[0].rate_limit_usage.window_seconds").value(60))
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(2))
-           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(2500))
+           // 9307 arrived 70s ago but was admitted (timestamp_forwarding) only
+           // 10s ago, so the limiter charges it to this window and the figure
+           // must include it.
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_requests").value(3))
+           .andExpect(jsonPath("$[0].rate_limit_usage.cloud_tokens").value(2600))
            .andExpect(jsonPath("$[0].rate_limit_usage.local_requests").value(1))
            .andExpect(jsonPath("$[0].rate_limit_usage.local_tokens").value(700));
     }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/service/RateLimitWindowConsistencyTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/identity/service/RateLimitWindowConsistencyTest.java
@@ -1,0 +1,63 @@
+package de.tum.cit.aet.logos.logoswebservice.identity.service;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code MeKeysService.RATE_LIMIT_WINDOW_SECONDS} is a copy of the window
+ * the orchestrator's rate limiter enforces the rpm/tpm limits over (the
+ * default of {@code RateLimitConfig.window_seconds} in the
+ * logos-orchestrator's rate_limiter.py). The usage figures shown to
+ * developers are only comparable to the limits if both come from the same
+ * window, so this test fails when either side changes the value without the
+ * other.
+ */
+class RateLimitWindowConsistencyTest {
+
+    // The RateLimitConfig field definition, e.g. "window_seconds: int = 60".
+    private static final Pattern WINDOW_DEFAULT = Pattern.compile("window_seconds\\s*:\\s*int\\s*=\\s*(\\d+)");
+
+    @Test
+    void windowSecondsMatchesTheOrchestratorRateLimiter() throws Exception {
+        Path limiterSource = findRateLimiterSource();
+        assertThat(limiterSource).exists();
+        String source = Files.readString(limiterSource);
+        Matcher m = WINDOW_DEFAULT.matcher(source);
+        assertThat(m.find())
+            .as("the RateLimitConfig.window_seconds default in rate_limiter.py")
+            .isTrue();
+        int orchestratorWindow = Integer.parseInt(m.group(1));
+
+        Field field = MeKeysService.class.getDeclaredField("RATE_LIMIT_WINDOW_SECONDS");
+        field.setAccessible(true);
+        int webserviceWindow = field.getInt(null);
+
+        assertThat(webserviceWindow)
+            .as("MeKeysService.RATE_LIMIT_WINDOW_SECONDS must match the orchestrator rate limiter window "
+                + "(update both together; the comment in rate_limiter.py points at this constant)")
+            .isEqualTo(orchestratorWindow);
+    }
+
+    // Maven (and CI) run the tests with the webservice module directory as
+    // the working directory; walk up to the checkout root so the test also
+    // works when run from the repository root.
+    private static Path findRateLimiterSource() {
+        Path relative = Path.of("logos", "logos-orchestrator", "src", "logos", "rate_limiter.py");
+        for (Path dir = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+             dir != null;
+             dir = dir.getParent()) {
+            Path candidate = dir.resolve(relative);
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+        }
+        return Path.of("rate_limiter.py");
+    }
+}

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
@@ -1,4 +1,4 @@
 -- Deleting the log rows cascades to their usage_tokens rows.
-DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306, 9307);
+DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306, 9307, 9308, 9309);
 DELETE FROM providers WHERE id = 6102;
 DELETE FROM token_types WHERE id = 91003 AND name = 'total_tokens';

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
@@ -1,4 +1,6 @@
 -- Deleting the log rows cascades to their usage_tokens rows.
-DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306, 9307, 9308, 9309);
+DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306, 9307, 9308, 9309,
+                                   9310, 9311, 9313, 9314, 9315, 9316);
 DELETE FROM providers WHERE id = 6102;
-DELETE FROM token_types WHERE id = 91003 AND name = 'total_tokens';
+DELETE FROM token_types WHERE id IN (91003, 91004, 91005)
+  AND name IN ('total_tokens', 'prompt_tokens', 'completion_tokens');

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
@@ -1,0 +1,4 @@
+-- Deleting the log rows cascades to their usage_tokens rows.
+DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306);
+DELETE FROM providers WHERE id = 6102;
+DELETE FROM token_types WHERE id = 91003 AND name = 'total_tokens';

--- a/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/cleanup-me-keys-rate-limit-usage.sql
@@ -1,4 +1,4 @@
 -- Deleting the log rows cascades to their usage_tokens rows.
-DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306);
+DELETE FROM log_entry WHERE id IN (9301, 9302, 9303, 9304, 9305, 9306, 9307);
 DELETE FROM providers WHERE id = 6102;
 DELETE FROM token_types WHERE id = 91003 AND name = 'total_tokens';

--- a/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
@@ -6,11 +6,19 @@
 --   9307: cloud request with 100 tokens that arrived 70s ago but was only
 --         forwarded (admitted) 10s ago after 60s of queue wait — the limiter
 --         charges it in the current window, so the figure must count it
---         (cutting the window on timestamp_request would miss it)
+--         (cutting the window on timestamp_request would miss it). Explicit
+--         rate_limit_admitted = TRUE: it went through the limiter.
+--   9301-9303 carry NULL: no limit configured for that key/provider class
+--         (the orchestrator never checked them) — still counted, like before
+--         the admission column existed.
 -- traffic that must NOT be counted:
 --   9304: outside the window (5 minutes old)
 --   9305: still queued, no provider resolved yet, no timestamp_forwarding
 --   9306: inside the window but bob's key 3102, not alice's
+--   9308: inside the window but REJECTED by the limiter (rate_limit_admitted
+--         = FALSE) — its timestamp_forwarding was written at scheduling,
+--         before check_and_record rejected it; it must not show up as usage
+--   9309: same, for the local provider class
 INSERT INTO providers (id, name, base_url, provider_type, cloud_provider_type,
                        privacy_level, auth_name, auth_format)
 VALUES (6102, 'test-cloud-provider', 'http://localhost', 'cloud', 'azure',
@@ -20,29 +28,45 @@ INSERT INTO token_types (id, name) VALUES (91003, 'total_tokens') ON CONFLICT DO
 
 INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
                        timestamp_request, timestamp_forwarding, timestamp_response,
-                       was_cold_start, queue_depth_at_enqueue, user_id, team_id, environment)
+                       was_cold_start, queue_depth_at_enqueue, user_id, team_id, environment,
+                       rate_limit_admitted)
 VALUES
   (9301, 'req-rl-1', 3101, 5101, 6102, 'success',
    NOW() - INTERVAL '20 seconds', NOW() - INTERVAL '19 seconds', NOW() - INTERVAL '18 seconds',
-   false, 0, 1101, 2101, NULL),
+   false, 0, 1101, 2101, NULL,
+   NULL),
   (9302, 'req-rl-2', 3101, 5101, 6102, 'success',
    NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '29 seconds', NOW() - INTERVAL '28 seconds',
-   false, 0, 1101, 2101, NULL),
+   false, 0, 1101, 2101, NULL,
+   NULL),
   (9303, 'req-rl-3', 3101, 5101, 6101, 'success',
    NOW() - INTERVAL '40 seconds', NOW() - INTERVAL '39 seconds', NOW() - INTERVAL '38 seconds',
-   false, 0, 1101, 2101, NULL),
+   false, 0, 1101, 2101, NULL,
+   NULL),
   (9304, 'req-rl-4', 3101, 5101, 6102, 'success',
    NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes', NOW() - INTERVAL '3 minutes',
-   false, 0, 1101, 2101, NULL),
+   false, 0, 1101, 2101, NULL,
+   NULL),
   (9305, 'req-rl-5', 3101, NULL, NULL, NULL,
    NOW() - INTERVAL '10 seconds', NULL, NULL,
-   false, 0, 1101, 2101, NULL),
+   false, 0, 1101, 2101, NULL,
+   NULL),
   (9306, 'req-rl-6', 3102, 5101, 6102, 'success',
    NOW() - INTERVAL '15 seconds', NOW() - INTERVAL '14 seconds', NOW() - INTERVAL '13 seconds',
-   false, 0, 1102, 2101, NULL),
+   false, 0, 1102, 2101, NULL,
+   NULL),
   (9307, 'req-rl-7', 3101, 5101, 6102, 'success',
    NOW() - INTERVAL '70 seconds', NOW() - INTERVAL '10 seconds', NOW() - INTERVAL '8 seconds',
-   false, 6, 1101, 2101, NULL);
+   false, 6, 1101, 2101, NULL,
+   TRUE),
+  (9308, 'req-rl-8', 3101, 5101, 6102, 'error',
+   NOW() - INTERVAL '12 seconds', NOW() - INTERVAL '11 seconds', NOW() - INTERVAL '11 seconds',
+   false, 0, 1101, 2101, NULL,
+   FALSE),
+  (9309, 'req-rl-9', 3101, 5101, 6101, 'error',
+   NOW() - INTERVAL '25 seconds', NOW() - INTERVAL '24 seconds', NOW() - INTERVAL '24 seconds',
+   false, 0, 1101, 2101, NULL,
+   FALSE);
 
 INSERT INTO usage_tokens (type_id, log_entry_id, token_count)
 VALUES
@@ -51,4 +75,6 @@ VALUES
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9303, 700),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9304, 9999),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9306, 4242),
-  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9307, 100);
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9307, 100),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9308, 500),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9309, 300);

--- a/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
@@ -1,30 +1,57 @@
 -- Rate-limit usage fixture (issue #672), layered on top of seed-me-keys.sql.
 --
--- traffic inside the 60s window for alice's key 3101:
---   2 cloud requests (providers.provider_type = 'cloud') with 1000 + 1500 tokens
---   1 local request  (providers.provider_type = 'logosnode') with 700 tokens
---   9307: cloud request with 100 tokens that arrived 70s ago but was only
---         forwarded (admitted) 10s ago after 60s of queue wait — the limiter
---         charges it in the current window, so the figure must count it
---         (cutting the window on timestamp_request would miss it). Explicit
---         rate_limit_admitted = TRUE: it went through the limiter.
---   9301-9303 carry NULL: no limit configured for that key/provider class
---         (the orchestrator never checked them) — still counted, like before
---         the admission column existed.
--- traffic that must NOT be counted:
---   9304: outside the window (5 minutes old)
---   9305: still queued, no provider resolved yet, no timestamp_forwarding
---   9306: inside the window but bob's key 3102, not alice's
---   9308: inside the window but REJECTED by the limiter (rate_limit_admitted
---         = FALSE) — its timestamp_forwarding was written at scheduling,
---         before check_and_record rejected it; it must not show up as usage
---   9309: same, for the local provider class
+-- Requests count when the limiter charges the RPM slot: admission, i.e.
+-- timestamp_forwarding. Tokens count when the limiter's record_tokens runs:
+-- completion, i.e. timestamp_response. The rows below pin both edges.
+--
+-- traffic of alice's key 3101 that must count:
+--   9301/9302: plain in-window cloud requests (total_tokens 1000 + 1500)
+--   9303:      in-window local request (700)
+--   9307:      arrived 70s ago, admitted only 10s ago after queue wait —
+--              counted in the current window (cutting the request window on
+--              timestamp_request would miss it). Explicit TRUE: admitted.
+--   9310:      admitted 120s ago, completed 20s ago — long generation that
+--              crossed the window edge: its 400 tokens completed inside the
+--              window (the limiter's TPM window holds them), its request
+--              admission did not (the RPM window no longer holds it)
+--   9311:      admitted 30s ago, still in flight (no timestamp_response,
+--              no result_status, no usage rows) — counts its request, no
+--              tokens yet, exactly like the limiter
+--   9313/9314/9315: pin the limiter's per-request token fallback
+--              (total_tokens or prompt_tokens + completion_tokens, Python
+--              `or`): 9313 has only the parts (300 + 200 -> 500), 9314 has a
+--              zero total plus parts (0 + 100 + 150 -> 250), 9315 has a
+--              non-zero total that does NOT equal the parts (90 vs 40 + 30 ->
+--              90: the total wins, the parts are not added)
+--   9316:      local counterpart of the parts-only case (120 + 130 -> 250)
+--   9301-9316 carry rate_limit_admitted NULL except where noted: no limit
+--              configured for that key/provider class (the orchestrator
+--              never checked them) — still counted, like before the
+--              admission column existed.
+-- traffic that must NOT count:
+--   9304: outside both windows (5 minutes old)
+--   9305: still queued, no provider resolved, no timestamps at all
+--   9306: inside the windows but bob's key 3102, not alice's
+--   9308/9309: rejected by the limiter (rate_limit_admitted = FALSE). Their
+--              timestamp_forwarding was written at scheduling, before
+--              check_and_record rejected them, so they satisfy the
+--              admission-window predicate and only the FALSE filter excludes
+--              them. The 429 path never completes the request: no
+--              timestamp_response, no result_status — and the usage rows
+--              below cannot exist in production either (no completion, no
+--              record_tokens); they are kept to prove the exclusion does not
+--              depend on the timestamps.
+
 INSERT INTO providers (id, name, base_url, provider_type, cloud_provider_type,
                        privacy_level, auth_name, auth_format)
 VALUES (6102, 'test-cloud-provider', 'http://localhost', 'cloud', 'azure',
         'CLOUD_IN_EU_BY_US_PROVIDER', 'Authorization', 'Bearer {}');
 
-INSERT INTO token_types (id, name) VALUES (91003, 'total_tokens') ON CONFLICT DO NOTHING;
+INSERT INTO token_types (id, name) VALUES
+  (91003, 'total_tokens'),
+  (91004, 'prompt_tokens'),
+  (91005, 'completion_tokens')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
                        timestamp_request, timestamp_forwarding, timestamp_response,
@@ -59,14 +86,38 @@ VALUES
    NOW() - INTERVAL '70 seconds', NOW() - INTERVAL '10 seconds', NOW() - INTERVAL '8 seconds',
    false, 6, 1101, 2101, NULL,
    TRUE),
-  (9308, 'req-rl-8', 3101, 5101, 6102, 'error',
-   NOW() - INTERVAL '12 seconds', NOW() - INTERVAL '11 seconds', NOW() - INTERVAL '11 seconds',
+  (9308, 'req-rl-8', 3101, 5101, 6102, NULL,
+   NOW() - INTERVAL '12 seconds', NOW() - INTERVAL '11 seconds', NULL,
    false, 0, 1101, 2101, NULL,
    FALSE),
-  (9309, 'req-rl-9', 3101, 5101, 6101, 'error',
-   NOW() - INTERVAL '25 seconds', NOW() - INTERVAL '24 seconds', NOW() - INTERVAL '24 seconds',
+  (9309, 'req-rl-9', 3101, 5101, 6101, NULL,
+   NOW() - INTERVAL '25 seconds', NOW() - INTERVAL '24 seconds', NULL,
    false, 0, 1101, 2101, NULL,
-   FALSE);
+   FALSE),
+  (9310, 'req-rl-10', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '125 seconds', NOW() - INTERVAL '120 seconds', NOW() - INTERVAL '20 seconds',
+   false, 2, 1101, 2101, NULL,
+   TRUE),
+  (9311, 'req-rl-11', 3101, 5101, 6102, NULL,
+   NOW() - INTERVAL '35 seconds', NOW() - INTERVAL '30 seconds', NULL,
+   false, 0, 1101, 2101, NULL,
+   TRUE),
+  (9313, 'req-rl-13', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '26 seconds', NOW() - INTERVAL '25 seconds', NOW() - INTERVAL '24 seconds',
+   false, 0, 1101, 2101, NULL,
+   NULL),
+  (9314, 'req-rl-14', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '33 seconds', NOW() - INTERVAL '32 seconds', NOW() - INTERVAL '31 seconds',
+   false, 0, 1101, 2101, NULL,
+   NULL),
+  (9315, 'req-rl-15', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '37 seconds', NOW() - INTERVAL '36 seconds', NOW() - INTERVAL '35 seconds',
+   false, 0, 1101, 2101, NULL,
+   NULL),
+  (9316, 'req-rl-16', 3101, 5101, 6101, 'success',
+   NOW() - INTERVAL '46 seconds', NOW() - INTERVAL '45 seconds', NOW() - INTERVAL '44 seconds',
+   false, 0, 1101, 2101, NULL,
+   NULL);
 
 INSERT INTO usage_tokens (type_id, log_entry_id, token_count)
 VALUES
@@ -77,4 +128,19 @@ VALUES
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9306, 4242),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9307, 100),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9308, 500),
-  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9309, 300);
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9309, 300),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9310, 400),
+  -- parts only: 300 + 200 -> 500
+  ((SELECT id FROM token_types WHERE name = 'prompt_tokens'), 9313, 300),
+  ((SELECT id FROM token_types WHERE name = 'completion_tokens'), 9313, 200),
+  -- zero total falls through to the parts: 0 + 100 + 150 -> 250
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9314, 0),
+  ((SELECT id FROM token_types WHERE name = 'prompt_tokens'), 9314, 100),
+  ((SELECT id FROM token_types WHERE name = 'completion_tokens'), 9314, 150),
+  -- non-zero total wins over the parts: 90 (not 70)
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9315, 90),
+  ((SELECT id FROM token_types WHERE name = 'prompt_tokens'), 9315, 40),
+  ((SELECT id FROM token_types WHERE name = 'completion_tokens'), 9315, 30),
+  -- local parts only: 120 + 130 -> 250
+  ((SELECT id FROM token_types WHERE name = 'prompt_tokens'), 9316, 120),
+  ((SELECT id FROM token_types WHERE name = 'completion_tokens'), 9316, 130);

--- a/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
@@ -3,9 +3,13 @@
 -- traffic inside the 60s window for alice's key 3101:
 --   2 cloud requests (providers.provider_type = 'cloud') with 1000 + 1500 tokens
 --   1 local request  (providers.provider_type = 'logosnode') with 700 tokens
+--   9307: cloud request with 100 tokens that arrived 70s ago but was only
+--         forwarded (admitted) 10s ago after 60s of queue wait — the limiter
+--         charges it in the current window, so the figure must count it
+--         (cutting the window on timestamp_request would miss it)
 -- traffic that must NOT be counted:
 --   9304: outside the window (5 minutes old)
---   9305: still queued, no provider resolved yet
+--   9305: still queued, no provider resolved yet, no timestamp_forwarding
 --   9306: inside the window but bob's key 3102, not alice's
 INSERT INTO providers (id, name, base_url, provider_type, cloud_provider_type,
                        privacy_level, auth_name, auth_format)
@@ -35,7 +39,10 @@ VALUES
    false, 0, 1101, 2101, NULL),
   (9306, 'req-rl-6', 3102, 5101, 6102, 'success',
    NOW() - INTERVAL '15 seconds', NOW() - INTERVAL '14 seconds', NOW() - INTERVAL '13 seconds',
-   false, 0, 1102, 2101, NULL);
+   false, 0, 1102, 2101, NULL),
+  (9307, 'req-rl-7', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '70 seconds', NOW() - INTERVAL '10 seconds', NOW() - INTERVAL '8 seconds',
+   false, 6, 1101, 2101, NULL);
 
 INSERT INTO usage_tokens (type_id, log_entry_id, token_count)
 VALUES
@@ -43,4 +50,5 @@ VALUES
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9302, 1500),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9303, 700),
   ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9304, 9999),
-  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9306, 4242);
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9306, 4242),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9307, 100);

--- a/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
@@ -1,0 +1,46 @@
+-- Rate-limit usage fixture (issue #672), layered on top of seed-me-keys.sql.
+--
+-- traffic inside the 60s window for alice's key 3101:
+--   2 cloud requests (providers.provider_type = 'cloud') with 1000 + 1500 tokens
+--   1 local request  (providers.provider_type = 'logosnode') with 700 tokens
+-- traffic that must NOT be counted:
+--   9304: outside the window (5 minutes old)
+--   9305: still queued, no provider resolved yet
+--   9306: inside the window but bob's key 3102, not alice's
+INSERT INTO providers (id, name, base_url, provider_type, cloud_provider_type,
+                       privacy_level, auth_name, auth_format)
+VALUES (6102, 'test-cloud-provider', 'http://localhost', 'cloud', 'azure',
+        'CLOUD_IN_EU_BY_US_PROVIDER', 'Authorization', 'Bearer {}');
+
+INSERT INTO token_types (id, name) VALUES (91003, 'total_tokens') ON CONFLICT DO NOTHING;
+
+INSERT INTO log_entry (id, request_id, api_key_id, model_id, provider_id, result_status,
+                       timestamp_request, timestamp_forwarding, timestamp_response,
+                       was_cold_start, queue_depth_at_enqueue, user_id, team_id, environment)
+VALUES
+  (9301, 'req-rl-1', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '20 seconds', NOW() - INTERVAL '19 seconds', NOW() - INTERVAL '18 seconds',
+   false, 0, 1101, 2101, NULL),
+  (9302, 'req-rl-2', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '29 seconds', NOW() - INTERVAL '28 seconds',
+   false, 0, 1101, 2101, NULL),
+  (9303, 'req-rl-3', 3101, 5101, 6101, 'success',
+   NOW() - INTERVAL '40 seconds', NOW() - INTERVAL '39 seconds', NOW() - INTERVAL '38 seconds',
+   false, 0, 1101, 2101, NULL),
+  (9304, 'req-rl-4', 3101, 5101, 6102, 'success',
+   NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes', NOW() - INTERVAL '3 minutes',
+   false, 0, 1101, 2101, NULL),
+  (9305, 'req-rl-5', 3101, NULL, NULL, NULL,
+   NOW() - INTERVAL '10 seconds', NULL, NULL,
+   false, 0, 1101, 2101, NULL),
+  (9306, 'req-rl-6', 3102, 5101, 6102, 'success',
+   NOW() - INTERVAL '15 seconds', NOW() - INTERVAL '14 seconds', NOW() - INTERVAL '13 seconds',
+   false, 0, 1102, 2101, NULL);
+
+INSERT INTO usage_tokens (type_id, log_entry_id, token_count)
+VALUES
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9301, 1000),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9302, 1500),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9303, 700),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9304, 9999),
+  ((SELECT id FROM token_types WHERE name = 'total_tokens'), 9306, 4242);

--- a/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
+++ b/logos/logos-webservice/src/test/resources/sql/seed-me-keys-rate-limit-usage.sql
@@ -1,4 +1,4 @@
--- Rate-limit usage fixture (issue #672), layered on top of seed-me-keys.sql.
+-- Rate-limit usage fixture, layered on top of seed-me-keys.sql.
 --
 -- Requests count when the limiter charges the RPM slot: admission, i.e.
 -- timestamp_forwarding. Tokens count when the limiter's record_tokens runs:


### PR DESCRIPTION
## Fixes #672

## Summary

Application developers could see the rpm/tpm limits set for their keys in
My Workspace (key settings with team defaults filled in), but had no way to
see how much of those limits they were currently using. This PR adds the
missing half: current usage against the limits.

`GET /me/keys` now returns, per key, a `rate_limit_usage` object with the
requests and tokens the key sent inside the same 60s sliding window the
orchestrator's rate limiter enforces the limits over:

```json
"rate_limit_usage": {
  "window_seconds": 60,
  "cloud_requests": 2, "cloud_tokens": 2500,
  "local_requests": 1, "local_tokens": 700
}
```

The cloud/local split matches the enforcement exactly: the limiter counts
per key and treats `provider_type = 'logosnode'` as local, everything else
as cloud. The My Workspace key cards now render the used figure against the
limit — `12/60 RPM · 5k/50k TPM` when the key or its team set a limit, the
plain used rate (`12 RPM · 5k TPM`) when it is unlimited — so a developer
can see at a glance how close they are to being throttled.

## Changes

- `logos-webservice/.../identity/repository/RateLimitUsageProjection.java`
  (new): projection for the per-key window usage.
- `logos-webservice/.../identity/repository/ApiKeyRepository.java`:
  `findRateLimitUsageForUser` aggregates `log_entry` + `usage_tokens` for
  the caller's own active keys inside the window, split by provider type.
  Queued/rejected requests without a resolved provider are not counted —
  the limiter does not count them either. Token sums read the same
  `total_tokens` rows the limiter records on completion.
- `logos-webservice/.../identity/service/MeKeysService.java`: fetches the
  usage once per request and merges it into each key's map.
- `logos-ui/.../shared/models/my-key.model.ts`: `RateLimitUsage` model.
- `logos-ui/.../features/my-workspace/my-workspace.{ts,html}`: renders
  used/limit in the CLOUD and LOCAL limit groups.
- Tests: two new cases in `MeKeysControllerTest` plus
  `seed-/cleanup-me-keys-rate-limit-usage.sql` fixtures covering traffic
  inside/outside the window, both provider types, queued requests without a
  provider, and another user's key in the same window.

## Authorization

The data comes from the existing `GET /me/keys` endpoint, which only ever
returns the caller's own keys, and the usage query is scoped to
`api_keys.user_id = :userId` — a team member can only ever see the usage
of their own keys (whose limits already include their team's defaults, as
before). No new route, no new privileges.

## Testing

- `mvn -B test` in `logos-webservice`: 311 tests, 0 failures (including the
  2 new `MeKeysControllerTest` cases against a real Postgres 17 via
  Testcontainers).
- `npm run build` and `npx ng test --watch=false` in `logos-ui`: build
  clean, 92 tests passed.
- `pre-commit` (the logos lint gate) passes on all changed files.

Note: the usage window is 60s by design — the same window
`RateLimitConfig.window_seconds` uses in the orchestrator, so the number
shown is directly comparable to the limit it sits next to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace key cards now show current cloud and local request/token usage alongside configured rate limits.
  - Added support for synchronizing cloud models and reporting their context-window limits.
  - Added compatibility checks and calibration log access for supported models and providers.
  - Added latency-aware model scheduling for more informed request routing.

- **Bug Fixes**
  - Requests rejected by token limits no longer consume request-rate capacity.
  - Failed requests are excluded from billable usage, improving cost accuracy.
  - Privacy classification now safely rejects unknown privacy levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->