### PR TITLE
`Logos`: Measure model cold load and wake-from-sleep times in calibration

### DIFF
--- a/logos/logos-orchestrator/src/logos/sdi/models.py
+++ b/logos/logos-orchestrator/src/logos/sdi/models.py
@@ -400,6 +400,19 @@ class ModelProfile:
     # weight-transfer size and is more predictive.
     sleep_l1_transient_host_ram_mb: Optional[float] = None
     sleep_l2_transient_host_ram_mb: Optional[float] = None
+    # Wall-clock seconds the worker's calibration measured from the final
+    # probe spawn to the first request it served (the warmup 1-token
+    # completion) — the cold start a client pays when a lane has to load for
+    # its request (vLLM startup + weight load + first-request CUDA-graph/JIT
+    # overhead). None from a worker that predates the field, or when the
+    # calibrating run's warmup request did not serve.
+    cold_load_time_s: Optional[float] = None
+    # Wall-clock seconds from the calibrated /wake_up trigger to the
+    # post-wake test request being served — the wait a request queued on a
+    # sleeping lane pays for the wake. None when the sleep phases were
+    # skipped, the post-wake request did not serve, or the worker predates
+    # the field.
+    wake_from_sleep_time_s: Optional[float] = None
     # Host RAM the lane keeps for the whole time it sleeps, as opposed to the
     # peak during the call above. sleep_l1 relocates the weights to the host
     # rather than dropping them, so a sleeping lane holds roughly its weight
@@ -476,6 +489,8 @@ class ModelProfile:
             "residency_source": self.residency_source,
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
+            "cold_load_time_s": self.cold_load_time_s,
+            "wake_from_sleep_time_s": self.wake_from_sleep_time_s,
             "host_ram_residual_mb": self.host_ram_residual_mb,
             "sleep_mode_disabled": self.sleep_mode_disabled,
             "calibration_unsupported": self.calibration_unsupported,

--- a/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
+++ b/logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py
@@ -652,6 +652,8 @@ class LogosNodeDataProvider:
                 residency_source=data.get("residency_source"),
                 sleep_l1_transient_host_ram_mb=data.get("sleep_l1_transient_host_ram_mb"),
                 sleep_l2_transient_host_ram_mb=data.get("sleep_l2_transient_host_ram_mb"),
+                cold_load_time_s=data.get("cold_load_time_s"),
+                wake_from_sleep_time_s=data.get("wake_from_sleep_time_s"),
                 host_ram_residual_mb=data.get("host_ram_residual_mb"),
                 sleep_mode_disabled=data.get("sleep_mode_disabled"),
                 calibration_unsupported=data.get("calibration_unsupported"),

--- a/logos/logos-orchestrator/tests/unit/sdi/test_scheduler_view.py
+++ b/logos/logos-orchestrator/tests/unit/sdi/test_scheduler_view.py
@@ -375,6 +375,39 @@ def test_get_model_profiles_reads_from_snapshot(monkeypatch):
     assert qwen.tensor_parallel_size == 2
 
 
+def test_get_model_profiles_reads_timing_fields_from_snapshot(monkeypatch):
+    """Calibrated cold-load / wake timings flow from the snapshot into ModelProfile."""
+    profiles_data = {
+        "qwen3:8b": {
+            "base_residency_mb": 4500.0,
+            "engine": "vllm",
+            "measurement_count": 1,
+            "last_measured_epoch": 1710000100.0,
+            "cold_load_time_s": 91.5,
+            "wake_from_sleep_time_s": 12.25,
+        },
+        "legacy-model": {
+            "base_residency_mb": 3000.0,
+            "engine": "vllm",
+            "measurement_count": 1,
+            "last_measured_epoch": 1710000200.0,
+        },
+    }
+    registry = _make_registry(lanes=[], model_profiles=profiles_data)
+    facade = _build_facade(registry, 101, "qwen3:8b", monkeypatch)
+
+    profiles = facade.get_model_profiles(provider_id=12)
+    qwen = profiles["qwen3:8b"]
+    assert qwen.cold_load_time_s == 91.5
+    assert qwen.wake_from_sleep_time_s == 12.25
+    # to_dict carries the fields for API consumers.
+    assert qwen.to_dict()["cold_load_time_s"] == 91.5
+    assert qwen.to_dict()["wake_from_sleep_time_s"] == 12.25
+    # A profile from a worker that predates the fields stays None.
+    assert profiles["legacy-model"].cold_load_time_s is None
+    assert profiles["legacy-model"].wake_from_sleep_time_s is None
+
+
 def test_get_model_profiles_empty_when_no_profiles(monkeypatch):
     """No model_profiles in snapshot → returns empty dict."""
     registry = _make_registry(lanes=[])

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1244,6 +1244,22 @@ class CalibrationResult:
     # makes sleeping and the model cache compete for one pool. None when the
     # run skipped the sleep phases, or when /proc/meminfo was unreadable.
     host_ram_residual_mb: float | None = None
+    # Wall-clock seconds from the final measurement probe's spawn (the same
+    # configuration the serving lane runs with — final KV size, resolved
+    # max_model_len, ...) until the first request it served completed: the
+    # Phase 2.5 warmup 1-token completion. That is exactly what a client
+    # waiting for a cold lane experiences before its first token — vLLM
+    # startup, weight load, and the first-request overhead (CUDA graph
+    # capture, JIT, KV page allocation) all included. None when the warmup
+    # request did not serve: a value that never actually served a request
+    # must not pose as a cold-load measurement.
+    cold_load_time_s: float | None = None
+    # Wall-clock seconds from the Phase 5.5 /wake_up trigger until the
+    # post-wake test request completed — the same "trigger → first served
+    # request" interval as cold_load_time_s, for the path a lane takes when a
+    # request finds it asleep. None when the run skipped the sleep phases,
+    # the wake failed verification, or the post-wake request did not serve.
+    wake_from_sleep_time_s: float | None = None
     # Set when calibrate_model bails because the model itself can never
     # load on this worker (bad repo id, gated repo, unsupported architecture).
     # Caller persists the model into model_profiles.yml so the master's
@@ -1917,6 +1933,12 @@ def calibrate_model(
             return None
 
     proc: subprocess.Popen[str] | None = None
+    # perf_counter anchor for the cold-load measurement. Re-armed right
+    # before every final-measurement spawn attempt; only the attempt that
+    # actually spawns proceeds to Phase 2.5, so whatever is left here belongs
+    # to the live probe. None while no final spawn has been armed yet.
+    final_spawn_at: float | None = None
+    cold_load_time_s: float | None = None
 
     if kv_search:
         search_lo = _KV_CACHE_MIN_STEP_MB  # 1 GB floor
@@ -2247,6 +2269,7 @@ def calibrate_model(
             _final_planned = {**plan, "kv_cache_memory_bytes": _final_kv_str}
             _final_fp = _cmd_fingerprint(_build_vllm_cmd(_final_planned, vllm_binary, host, port, _final_kv_str))
             failed_commands.discard(_final_fp)
+            final_spawn_at = time.perf_counter()
             proc = _try_start(_final_kv, record_blacklist=False, allow_whitelist=False)
             if proc is not None:
                 kv_cache_sent_mb = _final_kv
@@ -2294,6 +2317,7 @@ def calibrate_model(
                 _fixed_kv_str,
             )
         explicit_probe_overrides: dict[str, Any] = {"_max_model_len_retry_count": 0, "_max_num_seqs_retry_count": 0}
+        final_spawn_at = time.perf_counter()
         proc = _try_start(kv_cache_sent_mb, plan_overrides=explicit_probe_overrides)
         if proc is None:
             partial.error = f"Model failed to start with KV cache " f"{_format_kv_mb(kv_cache_sent_mb)} on tp={tp}"
@@ -2356,6 +2380,17 @@ def calibrate_model(
                 "        warmup done in %.1fs — graphs/JIT/KV pools allocated",
                 warmup_dt,
             )
+            # The warmup IS the first request the probe served, so this point
+            # is the end of the cold load a client would experience for a lane
+            # spawned with this exact configuration: final_spawn_at → here
+            # spans vLLM startup, weight load, and the first-request overhead
+            # (CUDA graph capture, JIT, KV page allocation).
+            if final_spawn_at is not None:
+                cold_load_time_s = time.perf_counter() - final_spawn_at
+                logger.info(
+                    "        cold load (spawn → first served request) = %.1fs",
+                    cold_load_time_s,
+                )
         else:
             logger.warning(
                 "        warmup failed (%.1fs) — awake VRAM may underestimate peak",
@@ -2403,6 +2438,7 @@ def calibrate_model(
         sleep_transient_mb: float | None = None
         host_ram_residual_mb: float | None = None
         sleep_mode_disabled: bool | None = None
+        wake_from_sleep_time_s: float | None = None
         if sleep_level <= 0:
             logger.info(
                 "  [4/6 + 5/6 + 5.5/6] Sleep phases skipped (sleep mode disabled for this model) — "
@@ -2536,6 +2572,10 @@ def calibrate_model(
                     partial.error = "cancelled"
                     return partial
                 logger.info("  [5.5/6] Waking model and verifying it serves again...")
+                # Anchor for the wake measurement: from this trigger to the
+                # post-wake test request serving is exactly what a request
+                # queued on the sleeping lane waits for.
+                wake_t0 = time.perf_counter()
                 wake_status, _ = _post(f"{base_url}/wake_up", timeout_s=_SLEEP_TIMEOUT_S)
                 if wake_status not in (200, 204):
                     sleep_phase_failed = True
@@ -2568,6 +2608,15 @@ def calibrate_model(
                             "did not serve either — no evidence of a wake regression (the "
                             "request type may simply be unsupported by this model, e.g. an "
                             "embedding lane); accepting wake on /is_sleeping evidence"
+                        )
+                    else:
+                        # First request served after the wake completed — the
+                        # interval from the /wake_up trigger to here is the
+                        # awake-from-sleep time a queued request pays.
+                        wake_from_sleep_time_s = time.perf_counter() - wake_t0
+                        logger.info(
+                            "        wake (wake_up → first served request) = %.1fs",
+                            wake_from_sleep_time_s,
                         )
             if sleep_phase_failed:
                 # A residual measured for a sleep that cannot be reversed must
@@ -2612,6 +2661,20 @@ def calibrate_model(
                 "    host_ram_residual_mb = %.0f MB  (held on the host for the whole sleep)",
                 host_ram_residual_mb,
             )
+        if cold_load_time_s is None:
+            logger.info("    cold_load_time_s     = n/a  (first served request did not complete)")
+        else:
+            logger.info(
+                "    cold_load_time_s     = %.1fs  (spawn → first served request)",
+                cold_load_time_s,
+            )
+        if wake_from_sleep_time_s is None:
+            logger.info("    wake_from_sleep_time_s = n/a  (sleep phases skipped or post-wake request did not serve)")
+        else:
+            logger.info(
+                "    wake_from_sleep_time_s = %.1fs  (wake_up → first served request after wake)",
+                wake_from_sleep_time_s,
+            )
         logger.info(
             "    Scheduler uses base_residency directly — no KV added on top",
         )
@@ -2631,6 +2694,8 @@ def calibrate_model(
             sleep_l1_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 1 else None),
             sleep_l2_transient_host_ram_mb=(sleep_transient_mb if sleep_level == 2 else None),
             host_ram_residual_mb=host_ram_residual_mb,
+            cold_load_time_s=cold_load_time_s,
+            wake_from_sleep_time_s=wake_from_sleep_time_s,
             min_kv_cache_mb=min_kv_observed_mb,
             max_kv_cache_mb=max_kv_observed_mb,
             max_model_len=partial.max_model_len,
@@ -2695,6 +2760,15 @@ def result_to_profile_dict(r: CalibrationResult) -> dict[str, Any]:
             round(r.sleep_l2_transient_host_ram_mb, 1) if r.sleep_l2_transient_host_ram_mb is not None else None
         ),
         "host_ram_residual_mb": (round(r.host_ram_residual_mb, 1) if r.host_ram_residual_mb is not None else None),
+        # Cold-load and wake timings (see CalibrationResult): what a client
+        # waits for when it finds the model cold or asleep. None when the run
+        # that produced this result did not complete the request each
+        # interval is anchored on — merge_profile then keeps the value an
+        # earlier calibration recorded, same as the other sleep fields.
+        "cold_load_time_s": (round(r.cold_load_time_s, 1) if r.cold_load_time_s is not None else None),
+        "wake_from_sleep_time_s": (
+            round(r.wake_from_sleep_time_s, 1) if r.wake_from_sleep_time_s is not None else None
+        ),
         # Not part of ModelProfileRecord but useful for auditing
         "_calibration_kv_cache_mb": round(r.kv_cache_sent_mb, 1),
         # Discovered KV cache size for use by the lane manager at runtime

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -1244,15 +1244,26 @@ class CalibrationResult:
     # makes sleeping and the model cache compete for one pool. None when the
     # run skipped the sleep phases, or when /proc/meminfo was unreadable.
     host_ram_residual_mb: float | None = None
-    # Wall-clock seconds from the final measurement probe's spawn (the same
-    # configuration the serving lane runs with — final KV size, resolved
-    # max_model_len, ...) until the first request it served completed: the
-    # Phase 2.5 warmup 1-token completion. That is exactly what a client
-    # waiting for a cold lane experiences before its first token — vLLM
-    # startup, weight load, and the first-request overhead (CUDA graph
-    # capture, JIT, KV page allocation) all included. None when the warmup
-    # request did not serve: a value that never actually served a request
-    # must not pose as a cold-load measurement.
+    # Wall-clock seconds from the final measurement probe's successful spawn
+    # attempt (the same configuration the serving lane runs with — final KV
+    # size, resolved max_model_len, ...) until the first request it served
+    # completed: the Phase 2.5 warmup 1-token completion. The anchor is the
+    # successful attempt itself: _try_start recurses through its
+    # max_model_len / max_num_seqs retries and a rejected start typically
+    # fails only after loading the weights, so anchoring before the first
+    # attempt would bill those near-full loads to the interval. The span
+    # covers vLLM startup, the weight load, and the first-request overhead
+    # (CUDA graph capture, JIT, KV page allocation). CAVEAT: this is a
+    # page-cache-WARM figure — the KV search spawns the same model once per
+    # candidate before the final spawn (and prior runs on this host
+    # otherwise leave the weights resident), so the load is served from the
+    # OS page cache, not from disk. It is therefore a LOWER BOUND on a true
+    # from-disk cold load; a deliberately cold reading (dropping the host
+    # page cache) is out of scope here, and consumers must not substitute
+    # this value for a from-disk cold-start constant (estimator-side
+    # consumption is tracked in #860). None when the warmup request did not
+    # serve: a value that never actually served a request must not pose as a
+    # cold-load measurement.
     cold_load_time_s: float | None = None
     # Wall-clock seconds from the Phase 5.5 /wake_up trigger until the
     # post-wake test request completed — the same "trigger → first served
@@ -1673,7 +1684,7 @@ def calibrate_model(
             model-identity-level failure (see ``_unsupported_box``) or a
             node-level transient failure (see ``_node_unhealthy_box``).
         """
-        nonlocal hf_home, _ram_cached
+        nonlocal hf_home, _ram_cached, final_spawn_at
         # Short-circuit: a prior probe already proved this model can't load,
         # or proved the node itself is degraded.
         if _unsupported_box or _node_unhealthy_box:
@@ -1717,6 +1728,7 @@ def calibrate_model(
         # parses THIS probe rather than the tail of the shared append log.
         _spawn_log_offset = _log_size(log_path)
         _last_probe_log_offset[0] = _spawn_log_offset
+        t_spawn = time.perf_counter()  # cold-load anchor candidate: this attempt's spawn
         proc, cmd = spawn_vllm(
             planned,
             vllm_binary,
@@ -1737,6 +1749,11 @@ def calibrate_model(
         t0 = time.perf_counter()
         try:
             wait_ready(base_url, ready_timeout_s, proc, gpu_indices, cancel_event=cancel_event)
+            # This attempt actually came up — anchor the cold-load
+            # measurement at ITS spawn, not before the outer call: the
+            # retry attempts that recursed into this one each cost a
+            # near-full weight load before failing.
+            final_spawn_at = t_spawn
             logger.info(
                 "        OK kv_cache=%s ready in %.1fs",
                 kv_str,
@@ -1933,10 +1950,13 @@ def calibrate_model(
             return None
 
     proc: subprocess.Popen[str] | None = None
-    # perf_counter anchor for the cold-load measurement. Re-armed right
-    # before every final-measurement spawn attempt; only the attempt that
-    # actually spawns proceeds to Phase 2.5, so whatever is left here belongs
-    # to the live probe. None while no final spawn has been armed yet.
+    # perf_counter anchor for the cold-load measurement: the spawn time of
+    # the successful attempt, set by _try_start when wait_ready comes back
+    # on it. _try_start recurses through its max_model_len / max_num_seqs
+    # retries and a rejected start typically fails only after loading the
+    # weights, so the anchor must be the successful attempt's spawn —
+    # arming it before the outer call would bill those near-full loads to
+    # the span. None until a spawn has actually succeeded.
     final_spawn_at: float | None = None
     cold_load_time_s: float | None = None
 
@@ -2269,7 +2289,6 @@ def calibrate_model(
             _final_planned = {**plan, "kv_cache_memory_bytes": _final_kv_str}
             _final_fp = _cmd_fingerprint(_build_vllm_cmd(_final_planned, vllm_binary, host, port, _final_kv_str))
             failed_commands.discard(_final_fp)
-            final_spawn_at = time.perf_counter()
             proc = _try_start(_final_kv, record_blacklist=False, allow_whitelist=False)
             if proc is not None:
                 kv_cache_sent_mb = _final_kv
@@ -2317,7 +2336,6 @@ def calibrate_model(
                 _fixed_kv_str,
             )
         explicit_probe_overrides: dict[str, Any] = {"_max_model_len_retry_count": 0, "_max_num_seqs_retry_count": 0}
-        final_spawn_at = time.perf_counter()
         proc = _try_start(kv_cache_sent_mb, plan_overrides=explicit_probe_overrides)
         if proc is None:
             partial.error = f"Model failed to start with KV cache " f"{_format_kv_mb(kv_cache_sent_mb)} on tp={tp}"
@@ -2381,14 +2399,17 @@ def calibrate_model(
                 warmup_dt,
             )
             # The warmup IS the first request the probe served, so this point
-            # is the end of the cold load a client would experience for a lane
+            # is the end of the load a client would experience for a lane
             # spawned with this exact configuration: final_spawn_at → here
             # spans vLLM startup, weight load, and the first-request overhead
-            # (CUDA graph capture, JIT, KV page allocation).
+            # (CUDA graph capture, JIT, KV page allocation). The weights
+            # themselves were already in the OS page cache by now (the search
+            # probes — or prior runs on this host — loaded them), so this is
+            # a cache-warm figure: a lower bound on a from-disk cold load.
             if final_spawn_at is not None:
                 cold_load_time_s = time.perf_counter() - final_spawn_at
                 logger.info(
-                    "        cold load (spawn → first served request) = %.1fs",
+                    "        cold load (spawn → first served request, page-cache-warm) = %.1fs",
                     cold_load_time_s,
                 )
         else:
@@ -2665,7 +2686,7 @@ def calibrate_model(
             logger.info("    cold_load_time_s     = n/a  (first served request did not complete)")
         else:
             logger.info(
-                "    cold_load_time_s     = %.1fs  (spawn → first served request)",
+                "    cold_load_time_s     = %.1fs  (spawn → first served request, page-cache-warm)",
                 cold_load_time_s,
             )
         if wake_from_sleep_time_s is None:

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -959,6 +959,12 @@ class LogosBridgeClient:
                     "min_kv_cache_mb": round(result.min_kv_cache_mb, 1),
                     "max_kv_cache_mb": round(result.max_kv_cache_mb, 1),
                     "max_model_len": result.max_model_len,
+                    "cold_load_time_s": (
+                        round(result.cold_load_time_s, 1) if result.cold_load_time_s is not None else None
+                    ),
+                    "wake_from_sleep_time_s": (
+                        round(result.wake_from_sleep_time_s, 1) if result.wake_from_sleep_time_s is not None else None
+                    ),
                     "log_text": self._truncate_calibration_log_text(log_text),
                 }
             ),

--- a/logos/logos-workernode/logos_worker_node/model_profiles.py
+++ b/logos/logos-workernode/logos_worker_node/model_profiles.py
@@ -158,6 +158,19 @@ class ModelProfileRecord:
     # EngineCore. None on profiles calibrated before this field existed.
     sleep_l1_transient_host_ram_mb: float | None = None
     sleep_l2_transient_host_ram_mb: float | None = None
+    # Wall-clock seconds the calibration measured from the final probe spawn
+    # to the first request it served (the warmup 1-token completion) — the
+    # cold start a client pays when a lane has to load for its request (vLLM
+    # startup + weight load + first-request CUDA-graph/JIT overhead). None
+    # when the calibrating run's warmup did not serve, or on profiles that
+    # predate the field.
+    cold_load_time_s: float | None = None
+    # Wall-clock seconds from the calibrated /wake_up trigger to the
+    # post-wake test request being served — the wait a request queued on a
+    # sleeping lane pays for the wake. None when the sleep phases were
+    # skipped, the post-wake request did not serve, or the profile predates
+    # the field.
+    wake_from_sleep_time_s: float | None = None
     # True when this worker's effective config forbids sleep mode for this
     # model (engines.vllm.disable_sleep_mode worker kill switch, or a
     # per-model enable_sleep_mode=false override under engines.vllm or
@@ -250,6 +263,8 @@ class ModelProfileRecord:
             "host_ram_residual_mb": self.host_ram_residual_mb,
             "sleep_l1_transient_host_ram_mb": self.sleep_l1_transient_host_ram_mb,
             "sleep_l2_transient_host_ram_mb": self.sleep_l2_transient_host_ram_mb,
+            "cold_load_time_s": self.cold_load_time_s,
+            "wake_from_sleep_time_s": self.wake_from_sleep_time_s,
             "sleep_mode_disabled": self.sleep_mode_disabled,
             "calibration_unsupported": self.calibration_unsupported,
             "calibration_unsupported_reason": self.calibration_unsupported_reason,
@@ -884,6 +899,8 @@ class ModelProfileRegistry:
                     host_ram_residual_mb=profile_data.get("host_ram_residual_mb"),
                     sleep_l1_transient_host_ram_mb=profile_data.get("sleep_l1_transient_host_ram_mb"),
                     sleep_l2_transient_host_ram_mb=profile_data.get("sleep_l2_transient_host_ram_mb"),
+                    cold_load_time_s=profile_data.get("cold_load_time_s"),
+                    wake_from_sleep_time_s=profile_data.get("wake_from_sleep_time_s"),
                     sleep_mode_disabled=profile_data.get("sleep_mode_disabled"),
                     calibration_unsupported=profile_data.get("calibration_unsupported"),
                     calibration_unsupported_reason=profile_data.get("calibration_unsupported_reason"),

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -42,6 +42,7 @@ from logos_worker_node.calibration import (
     calibrate_model,
     is_model_unsupported,
     load_existing_profiles,
+    merge_profile,
     parse_gpu_indices,
     plans_from_config,
     result_to_profile_dict,
@@ -2526,3 +2527,103 @@ def test_result_to_profile_dict_maps_sleep_mode_disabled() -> None:
     assert result_to_profile_dict(_success_result("m"))["sleep_mode_disabled"] is None
     assert result_to_profile_dict(_success_result("m", sleep_mode_disabled=True))["sleep_mode_disabled"] is True
     assert result_to_profile_dict(_success_result("m", sleep_mode_disabled=False))["sleep_mode_disabled"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Cold-load & wake-from-sleep timing (issue #627)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def test_cold_load_time_measured_from_spawn_to_first_served_request():
+    """The warmup IS the first request served, so spawn → warmup completion is recorded."""
+    patches = _patch_calibration_infra()  # _post answers 200 → warmup request "serves"
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert result.cold_load_time_s is not None
+    assert result.cold_load_time_s >= 0.0
+    # Everything external is mocked — the interval is only the (tiny)
+    # in-process walk through calibrate_model, so it must stay small.
+    assert result.cold_load_time_s < 10.0
+
+
+def test_cold_load_time_none_when_first_request_does_not_serve():
+    """A value that never actually served a request must not pose as one."""
+    post, _ = _capturing_post(**{"/v1/completions": (500, {})})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert result.cold_load_time_s is None
+
+
+def test_wake_from_sleep_time_measured_from_wake_to_first_served_request():
+    """/wake_up trigger → post-wake test request served is recorded as the wake time."""
+    post, urls = _capturing_post()
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert any(u.endswith("/wake_up") for u in urls)
+    assert result.wake_from_sleep_time_s is not None
+    assert result.wake_from_sleep_time_s >= 0.0
+    assert result.wake_from_sleep_time_s < 10.0
+
+
+def test_wake_from_sleep_time_none_when_sleep_phases_skipped():
+    """No sleep in the run → no wake to measure."""
+    result, _ = _run_calibrate(_patch_calibration_infra(), sleep_level=0)
+
+    assert result.success, result.error
+    assert result.wake_from_sleep_time_s is None
+
+
+def test_wake_from_sleep_time_none_when_wake_fails():
+    """A wake that cannot be verified safe carries no timing (same rule as the residual)."""
+    post, _ = _capturing_post(**{"/wake_up": (500, {})})
+    patches = _patch_calibration_infra()
+    patches["post"] = patch("logos_worker_node.calibration._post", side_effect=post)
+
+    result, _ = _run_calibrate(patches)
+
+    assert result.success, result.error
+    assert result.sleep_mode_disabled is True
+    assert result.wake_from_sleep_time_s is None
+
+
+def test_result_to_profile_dict_maps_timing_fields():
+    """Measured timings map 1:1 into the profile dict; unmeasured ones stay None."""
+    assert result_to_profile_dict(_success_result("m"))["cold_load_time_s"] is None
+    assert result_to_profile_dict(_success_result("m"))["wake_from_sleep_time_s"] is None
+
+    d = result_to_profile_dict(_success_result("m", cold_load_time_s=123.45, wake_from_sleep_time_s=12.34))
+    assert d["cold_load_time_s"] == 123.5  # rounded to 0.1s like the MB fields
+    assert d["wake_from_sleep_time_s"] == 12.3
+
+
+def test_merge_profile_keeps_prior_timing_when_new_run_unmeasured():
+    """A None timing in a fresh result must not erase an earlier measurement."""
+    prior = {"base_residency_mb": 5000.0, "cold_load_time_s": 90.0, "wake_from_sleep_time_s": 12.0}
+    merged = merge_profile(prior, result_to_profile_dict(_success_result("m")))
+    assert merged["cold_load_time_s"] == 90.0
+    assert merged["wake_from_sleep_time_s"] == 12.0
+
+    # A fresh measurement replaces the stored value.
+    merged2 = merge_profile(merged, result_to_profile_dict(_success_result("m", cold_load_time_s=42.0)))
+    assert merged2["cold_load_time_s"] == 42.0
+    assert merged2["wake_from_sleep_time_s"] == 12.0
+
+
+def test_timing_fields_survive_profile_store_roundtrip(tmp_path):
+    result = _success_result("org/m", cold_load_time_s=123.4, wake_from_sleep_time_s=12.3)
+    profiles_path = tmp_path / "model_profiles.yml"
+    save_profiles(profiles_path, {"org/m": merge_profile(None, result_to_profile_dict(result))})
+
+    loaded = load_existing_profiles(profiles_path)
+    assert loaded["org/m"]["cold_load_time_s"] == 123.4
+    assert loaded["org/m"]["wake_from_sleep_time_s"] == 12.3

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2548,6 +2548,52 @@ def test_cold_load_time_measured_from_spawn_to_first_served_request():
     assert result.cold_load_time_s < 10.0
 
 
+def test_cold_load_anchor_excludes_failed_retry_attempts():
+    """The anchor is the successful attempt's spawn, not the moment before
+    the first attempt: _try_start's internal retries (max_model_len /
+    max_num_seqs) typically fail only AFTER loading the weights, and those
+    near-full loads must not be billed to cold_load_time_s."""
+    patches = _patch_calibration_infra()
+
+    def wait_ready_side_effect(*args, **kwargs):
+        if not wait_ready_side_effect.attempts:
+            wait_ready_side_effect.attempts.append(time.perf_counter())
+            # The rejected attempt loads the weights and is only refused at
+            # the very end — simulate that cost before raising.
+            deadline = time.perf_counter() + 0.2
+            while time.perf_counter() < deadline:
+                pass
+            raise RuntimeError("vLLM exited (code=1)")
+        return None
+
+    wait_ready_side_effect.attempts = []
+    patches["ready"] = patch("logos_worker_node.calibration.wait_ready", side_effect=wait_ready_side_effect)
+    # The one failure's log parses to a --max-model-len suggestion, which
+    # drives the retry recursion; nothing else in this run parses to one.
+    suggested = {"done": False}
+
+    def suggest_side_effect(log_tail):
+        if suggested["done"]:
+            return None
+        suggested["done"] = True
+        return 65536
+
+    patches["suggest"] = patch(
+        "logos_worker_node.calibration._extract_vllm_max_model_len_suggestion",
+        side_effect=suggest_side_effect,
+    )
+
+    result, mocks = _run_calibrate(patches)
+
+    assert result.success, result.error
+    # One rejected attempt, one successful retry.
+    assert mocks["spawn"].call_count == 2
+    assert result.cold_load_time_s is not None
+    # The rejected attempt's ~0.2s weight load is NOT in the measured
+    # interval — only the successful attempt (startup → warmup) is.
+    assert result.cold_load_time_s < 0.1
+
+
 def test_cold_load_time_none_when_first_request_does_not_serve():
     """A value that never actually served a request must not pose as one."""
     post, _ = _capturing_post(**{"/v1/completions": (500, {})})

--- a/logos/logos-workernode/tests/test_model_profiles.py
+++ b/logos/logos-workernode/tests/test_model_profiles.py
@@ -782,3 +782,48 @@ def test_add_overrides_before_record_creation_lands_on_seeded_record():
     profile = registry.get_profile("org/model-7b")
     assert profile is not None
     assert profile.min_context_fraction == 1.0
+
+
+def test_calibrated_timing_fields_reload_and_serialize(tmp_path):
+    """Cold-load / wake timings persist in model_profiles.yml and come back on reload."""
+    import yaml
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    profiles_path = state_dir / "model_profiles.yml"
+
+    calibrated_data = {
+        "model_profiles": {
+            "org/model": {
+                "base_residency_mb": 5000.0,
+                "engine": "vllm",
+                "residency_source": "calibrated",
+                "measurement_count": 1,
+                "last_measured_epoch": time.time(),
+                "cold_load_time_s": 91.5,
+                "wake_from_sleep_time_s": 12.25,
+            }
+        }
+    }
+    profiles_path.write_text(yaml.safe_dump(calibrated_data))
+
+    registry = ModelProfileRegistry(state_dir=state_dir)
+    profile = registry.get_profile("org/model")
+    assert profile is not None
+    assert profile.cold_load_time_s == pytest.approx(91.5)
+    assert profile.wake_from_sleep_time_s == pytest.approx(12.25)
+    # The runtime snapshot the server planner reads must carry them too.
+    dumped = registry.get_all_profiles()["org/model"]
+    assert dumped["cold_load_time_s"] == pytest.approx(91.5)
+    assert dumped["wake_from_sleep_time_s"] == pytest.approx(12.25)
+
+
+def test_timing_fields_default_to_none_on_legacy_records():
+    """Profiles written before the fields existed load with None, not 0.0."""
+    registry = ModelProfileRegistry()
+    registry.record_loaded_vram("org/model-7b", 8000.0, engine="vllm")
+
+    profile = registry.get_profile("org/model-7b")
+    assert profile is not None
+    assert profile.cold_load_time_s is None
+    assert profile.wake_from_sleep_time_s is None


### PR DESCRIPTION
## Fixes #627

## Summary

Calibration now measures and persists two new timings per model per worker node:

- **`cold_load_time_s`** — wall-clock time from the final measurement probe's spawn (the same configuration the serving lane runs with: final KV size, resolved `max_model_len`, ...) to the first request the probe served, i.e. the Phase 2.5 warmup 1-token completion. That is exactly what a client experiences before its first token when a lane has to cold-load for its request: vLLM startup, weight load, and the first-request overhead (CUDA graph capture, JIT, KV page allocation).
- **`wake_from_sleep_time_s`** — wall-clock time from the Phase 5.5 `/wake_up` trigger to the post-wake test request being served. The same "trigger → first served request" interval for the path a lane takes when a request finds it asleep.

Both values are recorded as `None` when the request anchoring each interval did not complete in the run (warmup not served, sleep phases skipped, wake not verified): a value that never actually served a request must not pose as a measurement, following the codebase's established semantics for measured fields. This makes ETTFT estimates more accurate and gives adaptive orchestration a per-model load/wake latency signal. The calibration decision logic itself is unchanged — this is measurement and persistence only.

## Changes

- `logos/logos-workernode/logos_worker_node/calibration.py`
  - `CalibrationResult` gains `cold_load_time_s` / `wake_from_sleep_time_s`.
  - `calibrate_model()` arms a `perf_counter` anchor right before every final-measurement spawn attempt (KV-search and pinned-KV paths) and stops it at the first served request (Phase 2.5 warmup) and the post-wake test request (Phase 5.5); both intervals are logged in the run summary.
  - `result_to_profile_dict()` persists both values into the profile (rounded to 0.1 s like the MB fields). With the existing `merge_profile` semantics a `None` from a run that could not measure keeps the previously calibrated value.
- `logos/logos-workernode/logos_worker_node/model_profiles.py` — `ModelProfileRecord` gains both fields (`to_dict` / `_load_persisted`), so the values round-trip through `model_profiles.yml` and are carried in the runtime status push the server reads.
- `logos/logos-workernode/logos_worker_node/logos_bridge.py` — the `calibration_probe_log` event payload (persisted by the orchestrator into `calibration_probe_logs.summary`) now includes both timings alongside the other measured values.
- `logos/logos-orchestrator/src/logos/sdi/models.py` — server-side `ModelProfile` gains both fields (including `to_dict`).
- `logos/logos-orchestrator/src/logos/sdi/providers/logosnode_provider.py` — `get_model_profiles()` maps both fields from the worker's runtime snapshot, so the capacity planner and any future ETTFT consumer can use them.

Persistence follows the existing calibration-data pattern: the worker's `model_profiles.yml` plus the runtime snapshot are the source of truth (as for `sleep_l1_transient_host_ram_mb`, `host_ram_residual_mb`, `sleep_mode_disabled`, ...), and the orchestrator already persists the full profile dict into `ollama_provider_snapshots.runtime_payload` (JSONB). No DB migration is required.

## Testing

- New tests in `logos/logos-workernode/tests/test_calibration.py`: cold load measured spawn → first served request; `None` when the warmup does not serve; wake time measured `/wake_up` → post-wake request; `None` when the sleep phases are skipped or the wake fails verification; profile-dict mapping (incl. rounding); `merge_profile` keeping prior values; profile-store round trip.
- New tests in `logos/logos-workernode/tests/test_model_profiles.py`: persisted timing fields reload into the record and appear in `get_all_profiles()`; legacy records default to `None`.
- New test in `logos/logos-orchestrator/tests/unit/sdi/test_scheduler_view.py`: `get_model_profiles` maps the new fields from the snapshot into `ModelProfile` (incl. `to_dict`); a profile from a worker that predates the fields stays `None`.

Verified (no GPU deployment available in this environment):
- Orchestrator unit suite: `pytest` in `logos/logos-orchestrator` → **1018 passed, 1 xfailed**.
- Worker suite with the CI exclusions → **340 passed, 2 skipped**; the CI-excluded `test_calibration.py` and `test_lane_manager.py` also pass locally (**161** + **54 passed**).
- Lint: `pre-commit run --config logos/.pre-commit-config.yaml --all-files` → all hooks pass (black, isort, autoflake, flake8, hygiene checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cold-load and wake-from-sleep timing measurements to model calibration results.
  * Exposed calibration timings through model profiles and serialized profile data.
  * Preserved timing information across profile storage and reloads.
  * Legacy profiles continue to work with unavailable timings shown as unset.

* **Bug Fixes**
  * Calibration timing values are now retained when new calibration results lack measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->