### PR TITLE
`Logos`: Auto-detect and recover from poisoned vLLM torch.compile / AOT cache

### DIFF
--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -493,11 +493,27 @@ class VllmProcessHandle:
                     raise
                 purged = self._purge_compile_caches(lane_config.model)
                 if not purged:
-                    # This model's own per-lane cache dir holds nothing — its
-                    # artifacts live in the legacy shared location (or a
-                    # user-overridden --compilation-config we can't resolve),
-                    # so fall back to the worker-wide set for the retry.
-                    purged = self._purge_compile_caches()
+                    # The per-lane purge removed nothing, so the poisoned
+                    # artifact (if any) lives in the shared location. Widening
+                    # to the worker-wide set forces every other model on the
+                    # node to recompile, so it is only justified when the
+                    # traceback actually names a file under the compile cache
+                    # (the strong signal). A fingerprint-only match on an
+                    # empty per-lane dir is not: a brand-new lane has no cache
+                    # to be poisoned by, and the fingerprint is a heuristic,
+                    # so widening would risk wiping every model's cache on an
+                    # unrelated startup failure (a mistyped repo id, a gated
+                    # repo). Propagate instead.
+                    if self._logs_reference_compile_cache():
+                        purged = self._purge_compile_caches()
+                    else:
+                        logger.warning(
+                            "[%s] Cache poisoning detected (fingerprint=%s) but the traceback "
+                            "names no compile-cache file and this lane has no per-lane cache — "
+                            "not widening to the worker-wide cache; propagating",
+                            self.lane_id,
+                            fingerprint,
+                        )
                 purged_once = True
                 if not purged:
                     raise
@@ -640,12 +656,16 @@ class VllmProcessHandle:
 
     # Known cache-poisoning failure fingerprints, matched against the captured
     # startup logs. Each fingerprint is a tuple of fragments that must ALL
-    # appear in the recent log buffer; the pair is specific enough that no
-    # other startup failure matches it. They complement the stack-trace
-    # path-fragment detector above: a cached AOT artifact can also die deep
-    # inside torch/vllm library code, where no frame of the traceback points
-    # into the cache directory (the GLM-OCR incident: the artifact asserts
-    # in copy_misaligned_inputs on a stale input signature).
+    # appear in the recent log buffer; each is specific enough that an
+    # unrelated startup failure (a missing HF file, a bad module import) does
+    # not match it. Where a fragment is generic (FileNotFoundError,
+    # AssertionError), the tuple pairs it with a compile-cache path marker so
+    # the match only fires when the failure actually involves the cache. They
+    # complement the stack-trace path-fragment detector above: a cached AOT
+    # artifact can also die deep inside torch/vllm library code, where no
+    # frame of the traceback points into the cache directory (the GLM-OCR
+    # incident: the artifact asserts in copy_misaligned_inputs on a stale
+    # input signature).
     _CACHE_POISONING_FINGERPRINTS: ClassVar[tuple[tuple[str, tuple[str, ...]], ...]] = (
         # Stale AOT graph: a Python int arrives where the cached artifact
         # expects a torch.Tensor.
@@ -653,8 +673,12 @@ class VllmProcessHandle:
         # A cached AOT artifact raises on load/invocation.
         ("aot_artifact_assertion", ("CacheCompiledArtifact", "AssertionError")),
         # A previous startup was killed mid-AOT-write, leaving a truncated
-        # artifact the next startup cannot read.
-        ("inductor_artifact_missing", ("torch/_inductor", "FileNotFoundError")),
+        # artifact the next startup cannot read. The compile-cache path is
+        # required alongside FileNotFoundError so this only matches a file
+        # that is actually under the cache — not an unrelated missing-file
+        # error (a mistyped model id, a gated repo) that merely co-occurs
+        # with ordinary torch/_inductor compilation output in the same log.
+        ("inductor_artifact_missing", ("FileNotFoundError", "torch_compile_cache")),
         # Cache-key lookup hits an entry that no longer matches.
         ("compilation_cache_key_error", ("vllm/compilation/caching.py", "KeyError")),
     )
@@ -709,6 +733,21 @@ class VllmProcessHandle:
             )
         return removed
 
+    def _logs_reference_compile_cache(self) -> bool:
+        """True if the recent logs name a file under the torch.compile cache.
+
+        This is the strong signal of poisoning: the traceback actually reached
+        into a cached artifact, so whatever the originating exception is, the
+        artifact is implicated. Weaker than that is a fingerprint match (a
+        known error signature that may co-occur with an unrelated failure),
+        which ``has_poisoned_compile_cache`` accepts on its own but the
+        worker-wide purge must not be widened on (see ``spawn``).
+        """
+        if not self._recent_logs:
+            return False
+        log_blob = "\n".join(self._recent_logs)
+        return any(frag in log_blob for frag in self._POISONED_COMPILE_CACHE_PATH_FRAGMENTS)
+
     @property
     def has_poisoned_compile_cache(self) -> bool:
         """True if recent logs implicate the on-disk torch.compile cache.
@@ -723,8 +762,7 @@ class VllmProcessHandle:
         """
         if not self._recent_logs:
             return False
-        log_blob = "\n".join(self._recent_logs)
-        if any(frag in log_blob for frag in self._POISONED_COMPILE_CACHE_PATH_FRAGMENTS):
+        if self._logs_reference_compile_cache():
             return True
         return self._matched_cache_poisoning_fingerprint() is not None
 

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -26,6 +26,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 import urllib.parse
 from collections import deque
 from datetime import datetime
@@ -80,6 +81,27 @@ _SCRUBBED_ENV_VARS = (
 
 # Cache for _discover_pip_cuda_lib_dirs() — computed once per process.
 _pip_cuda_lib_dirs: list[str] | None = None
+
+# Wall-clock (time.monotonic) of the last reactive cache recovery per model.
+# Capped at one per (model, hour) so a model whose startup is broken for a
+# non-cache reason (which can still leave a cache path in its traceback)
+# cannot loop purge → retry → fail forever across lane-manager restarts.
+# Module-level because the lane manager recreates handles on restart.
+_last_reactive_cache_recovery: dict[str, float] = {}
+_CACHE_RECOVERY_COOLDOWN_S: float = 3600.0
+
+
+def _reactive_cache_recovery_allowed(model: str, now: float | None = None) -> bool:
+    """True when no reactive cache recovery for this model ran within the cooldown window."""
+    last = _last_reactive_cache_recovery.get(model)
+    if last is None:
+        return True
+    return ((now if now is not None else time.monotonic()) - last) >= _CACHE_RECOVERY_COOLDOWN_S
+
+
+def _note_reactive_cache_recovery(model: str, now: float | None = None) -> None:
+    """Record that a reactive cache recovery ran for this model now."""
+    _last_reactive_cache_recovery[model] = now if now is not None else time.monotonic()
 
 
 def _discover_pip_cuda_lib_dirs() -> list[str]:
@@ -395,13 +417,21 @@ class VllmProcessHandle:
     async def spawn(self, lane_config: LaneConfig) -> ProcessStatus:
         """Spawn the vLLM process for this lane.
 
-        Cache safety: before spawning, the on-disk torch.compile and inductor
-        caches are purged if the recorded (vLLM, torch) versions don't match
-        the venv's current versions — a version bump is the most common cause
-        of cache poisoning. If the spawn still fails with a stack trace
-        pointing inside the compile cache directory (e.g. an AOT-compiled
-        graph that was specialized on a stale shape profile), the caches are
-        purged again and the spawn is retried once.
+        Cache safety: before spawning, two pre-flight checks purge poisoned
+        on-disk torch.compile / inductor caches — the worker-wide version
+        stamp (a vLLM/torch bump is the most common poisoning cause) and the
+        per-lane ``cache_meta.json`` (vLLM + torch + CUDA versions, image
+        version, model and compilation-config hash recorded after the last
+        healthy start of this exact cache dir). If the spawn still fails with
+        a stack trace pointing inside the compile cache directory or a known
+        cache-poisoning error fingerprint (e.g. an AOT-compiled graph that
+        was specialized on a stale shape profile), the caches are purged
+        again and the spawn is retried once. Reactive recovery is capped at
+        one per (model, hour) so a genuinely broken model cannot loop
+        purge → retry → fail forever.
+
+        Every purge-and-retry event logs a greppable
+        ``[lane] cache_auto_recovered=true model=… fingerprint=…`` line.
 
         The same shape of recovery covers a sharded checkpoint the loader
         rejects: the cached conversion is discarded and the lane retried once
@@ -416,7 +446,12 @@ class VllmProcessHandle:
             )
             await self._kill_process()
 
-        self._purge_compile_caches_if_versions_changed()
+        purged = self._purge_compile_caches_if_versions_changed()
+        if purged:
+            self._log_cache_auto_recovered(lane_config.model, "version_stamp_mismatch", purged)
+        purged = self._purge_lane_cache_if_meta_changed(lane_config)
+        if purged:
+            self._log_cache_auto_recovered(lane_config.model, "cache_meta_mismatch", purged)
 
         purged_once = False
         unsharded_once = False
@@ -425,6 +460,7 @@ class VllmProcessHandle:
             try:
                 status = await self._spawn_once(lane_config)
                 self._write_compile_cache_stamp()
+                self._write_lane_cache_meta(lane_config)
                 return status
             except RuntimeError:
                 # Checked before the compile cache: a sharded-loader failure
@@ -445,15 +481,33 @@ class VllmProcessHandle:
                     continue
                 if purged_once or not self.has_poisoned_compile_cache:
                     raise
-                purged = self._purge_compile_caches()
+                fingerprint = self._matched_cache_poisoning_fingerprint() or "stack_trace_in_cache"
+                if not _reactive_cache_recovery_allowed(lane_config.model):
+                    logger.warning(
+                        "[%s] Cache poisoning detected (fingerprint=%s) but a recovery already "
+                        "ran for %s within the last hour — not purging again",
+                        self.lane_id,
+                        fingerprint,
+                        lane_config.model,
+                    )
+                    raise
+                purged = self._purge_compile_caches(lane_config.model)
+                if not purged:
+                    # This model's own per-lane cache dir holds nothing — its
+                    # artifacts live in the legacy shared location (or a
+                    # user-overridden --compilation-config we can't resolve),
+                    # so fall back to the worker-wide set for the retry.
+                    purged = self._purge_compile_caches()
                 purged_once = True
                 if not purged:
                     raise
+                _note_reactive_cache_recovery(lane_config.model)
                 logger.warning(
                     "[%s] vLLM startup failed inside the on-disk compile cache; " "purged %s and retrying once",
                     self.lane_id,
                     purged,
                 )
+                self._log_cache_auto_recovered(lane_config.model, fingerprint, purged)
 
     async def _spawn_once(self, lane_config: LaneConfig) -> ProcessStatus:
         """A single vLLM spawn attempt; raises on startup failure."""
@@ -567,16 +621,43 @@ class VllmProcessHandle:
         "/inductor_cache/",
     )
 
-    # Subdirectories under <cache_root>/.cache that are safe to wipe when a
-    # compile-cache poisoning is detected. FlashInfer JIT artifacts and the
-    # HuggingFace weights cache are intentionally excluded — they are not
-    # implicated in compile-cache poisoning and are expensive to rebuild.
-    _PURGEABLE_COMPILE_CACHE_SUBDIRS: ClassVar[tuple[str, ...]] = (
-        "vllm",
-        "torch_inductor",
-    )
+    # Subdirectories of a vLLM compile cache dir that hold torch.compile
+    # artifacts and are safe to wipe when a compile-cache poisoning is
+    # detected. rank_* holds the per-rank backbone cache and is matched by
+    # prefix because the rank indices are layout-dependent (rank_0_0,
+    # rank_0_1, …). Everything else — in particular modelinfos/ — is
+    # intentionally excluded, along with the FlashInfer JIT artifacts and
+    # the HuggingFace weights: none of it is implicated in compile-cache
+    # poisoning and it is expensive to rebuild.
+    _VLLM_COMPILE_ARTIFACT_SUBDIRS: ClassVar[tuple[str, ...]] = ("torch_compile_cache",)
+    _RANK_DIR_PREFIX: ClassVar[str] = "rank_"
 
     _COMPILE_CACHE_STAMP_FILENAME: ClassVar[str] = ".logos_compile_cache_stamp.json"
+
+    # Per-lane environment fingerprint written next to the lane's compile
+    # cache after a healthy start; validated before every subsequent start.
+    _CACHE_META_FILENAME: ClassVar[str] = "cache_meta.json"
+
+    # Known cache-poisoning failure fingerprints, matched against the captured
+    # startup logs. Each fingerprint is a tuple of fragments that must ALL
+    # appear in the recent log buffer; the pair is specific enough that no
+    # other startup failure matches it. They complement the stack-trace
+    # path-fragment detector above: a cached AOT artifact can also die deep
+    # inside torch/vllm library code, where no frame of the traceback points
+    # into the cache directory (the GLM-OCR incident: the artifact asserts
+    # in copy_misaligned_inputs on a stale input signature).
+    _CACHE_POISONING_FINGERPRINTS: ClassVar[tuple[tuple[str, tuple[str, ...]], ...]] = (
+        # Stale AOT graph: a Python int arrives where the cached artifact
+        # expects a torch.Tensor.
+        ("copy_misaligned_inputs", ("copy_misaligned_inputs", "Expected tensors only")),
+        # A cached AOT artifact raises on load/invocation.
+        ("aot_artifact_assertion", ("CacheCompiledArtifact", "AssertionError")),
+        # A previous startup was killed mid-AOT-write, leaving a truncated
+        # artifact the next startup cannot read.
+        ("inductor_artifact_missing", ("torch/_inductor", "FileNotFoundError")),
+        # Cache-key lookup hits an entry that no longer matches.
+        ("compilation_cache_key_error", ("vllm/compilation/caching.py", "KeyError")),
+    )
 
     # Log fragments that mean the pre-sharded checkpoint is the thing vLLM
     # could not load. Matched only while this lane is actually serving one, so
@@ -632,17 +713,34 @@ class VllmProcessHandle:
     def has_poisoned_compile_cache(self) -> bool:
         """True if recent logs implicate the on-disk torch.compile cache.
 
-        Triggered when a stack-trace line references a file under
-        ``VLLM_CACHE_ROOT`` or ``TORCHINDUCTOR_CACHE_DIR``. The originating
-        exception can be anything (``RuntimeError`` on a shape assert,
-        ``ImportError`` on a stale symbol, ``UnpicklingError`` on a stale
-        FX graph) — if execution is reaching into a cached compile artifact
-        and crashing there, the artifact is bad.
+        Triggered either when a stack-trace line references a file under
+        ``VLLM_CACHE_ROOT`` or ``TORCHINDUCTOR_CACHE_DIR`` (the originating
+        exception can be anything — if execution is reaching into a cached
+        compile artifact and crashing there, the artifact is bad), or when a
+        known cache-poisoning error fingerprint matches (a cached artifact
+        dying inside torch/vllm library code, where no frame of the
+        traceback names the cache directory).
         """
         if not self._recent_logs:
             return False
         log_blob = "\n".join(self._recent_logs)
-        return any(frag in log_blob for frag in self._POISONED_COMPILE_CACHE_PATH_FRAGMENTS)
+        if any(frag in log_blob for frag in self._POISONED_COMPILE_CACHE_PATH_FRAGMENTS):
+            return True
+        return self._matched_cache_poisoning_fingerprint() is not None
+
+    def _matched_cache_poisoning_fingerprint(self) -> str | None:
+        """Name of the first known cache-poisoning fingerprint in the recent logs.
+
+        Returns ``None`` when no fingerprint matches. The returned name is
+        the ``fingerprint=…`` value of the structured auto-recovery log line.
+        """
+        if not self._recent_logs:
+            return None
+        log_blob = "\n".join(self._recent_logs)
+        for name, fragments in self._CACHE_POISONING_FINGERPRINTS:
+            if all(frag in log_blob for frag in fragments):
+                return name
+        return None
 
     def _compile_cache_root(self) -> str | None:
         """Return ``<persistent_root>/.cache`` or ``None`` if unresolvable."""
@@ -655,24 +753,74 @@ class VllmProcessHandle:
             return None
         return os.path.join(cache_root_dir, ".cache")
 
-    def _purge_compile_caches(self) -> list[str]:
-        """Remove the torch.compile and inductor caches for this worker.
+    @classmethod
+    def _lane_artifact_paths(cls, lane_dir: str) -> list[str]:
+        """Existing compile-artifact subdirectories of one vLLM cache dir.
 
-        Returns the paths actually removed. HuggingFace weights and the
-        FlashInfer JIT cache are left in place — they are not implicated
-        in compile-cache poisoning and are expensive to rebuild. Paths
-        resolve to the persistent cache root which, in the standard
-        docker-compose deployment, is bind-mounted onto host storage
-        (e.g. ``/mnt/ceph``), so the wipe affects the host volume too.
+        Matches ``torch_compile_cache/`` and ``rank_*/`` only — ``modelinfos/``
+        and anything else in the dir survives a purge.
+        """
+        if not os.path.isdir(lane_dir):
+            return []
+        try:
+            entries = sorted(os.listdir(lane_dir))
+        except OSError:
+            return []
+        paths: list[str] = []
+        for entry in entries:
+            if entry in cls._VLLM_COMPILE_ARTIFACT_SUBDIRS or entry.startswith(cls._RANK_DIR_PREFIX):
+                path = os.path.join(lane_dir, entry)
+                if os.path.isdir(path):
+                    paths.append(path)
+        return paths
+
+    def _compile_artifact_paths(self, model: str | None) -> list[str]:
+        """Compile-artifact directories that would be removed on cache poisoning.
+
+        ``model=None`` returns the worker-wide set (top-level artifacts, every
+        per-lane dir, and the shared inductor cache) — used by the proactive
+        version-stamp check. ``model=<id>`` returns that lane's own per-lane
+        dir only, so a poisoned model does not force every other model on the
+        node to recompile. Never returns anything outside the compile
+        artifacts — in particular not ``modelinfos/``.
         """
         cache_root = self._compile_cache_root()
         if cache_root is None:
             return []
+        vllm_root = os.path.join(cache_root, "vllm")
+        if model is not None:
+            lanes = [os.path.join(vllm_root, "lanes", model.replace("/", "__"))]
+        else:
+            lanes = [vllm_root]
+            lanes_root = os.path.join(vllm_root, "lanes")
+            if os.path.isdir(lanes_root):
+                try:
+                    lanes += [os.path.join(lanes_root, entry) for entry in sorted(os.listdir(lanes_root))]
+                except OSError:
+                    pass
+        paths: list[str] = []
+        for lane_dir in lanes:
+            paths.extend(self._lane_artifact_paths(lane_dir))
+        if model is None:
+            inductor = os.path.join(cache_root, "torch_inductor")
+            if os.path.isdir(inductor):
+                paths.append(inductor)
+        return paths
+
+    def _purge_compile_caches(self, model: str | None = None) -> list[str]:
+        """Remove the torch.compile artifacts for this worker.
+
+        ``model=None`` purges the worker-wide set; ``model=<id>`` purges that
+        lane's per-lane dir only. Returns the paths actually removed.
+        ``modelinfos/``, HuggingFace weights, the FlashInfer JIT cache and
+        sharded checkpoints are left in place — they are not implicated in
+        compile-cache poisoning and are expensive to rebuild. Paths resolve
+        to the persistent cache root which, in the standard docker-compose
+        deployment, is bind-mounted onto host storage (e.g. ``/mnt/ceph``),
+        so the wipe affects the host volume too.
+        """
         removed: list[str] = []
-        for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS:
-            path = os.path.join(cache_root, sub)
-            if not os.path.isdir(path):
-                continue
+        for path in self._compile_artifact_paths(model):
             try:
                 shutil.rmtree(path)
                 removed.append(path)
@@ -705,9 +853,10 @@ class VllmProcessHandle:
             return None
         return os.path.join(cache_root, self._COMPILE_CACHE_STAMP_FILENAME)
 
-    def _read_compile_cache_stamp(self) -> dict[str, str] | None:
-        path = self._compile_cache_stamp_path()
-        if not path or not os.path.isfile(path):
+    @staticmethod
+    def _read_json_dict(path: str) -> dict[str, str] | None:
+        """Read a JSON object of string values, or ``None`` if missing/unreadable."""
+        if not os.path.isfile(path):
             return None
         import json as _json
 
@@ -715,16 +864,24 @@ class VllmProcessHandle:
             with open(path, encoding="utf-8") as fh:
                 data = _json.load(fh)
         except (OSError, ValueError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return {str(k): str(v) for k, v in data.items()}
+
+    def _read_compile_cache_stamp(self) -> dict[str, str] | None:
+        path = self._compile_cache_stamp_path()
+        if not path or not os.path.isfile(path):
+            return None
+        stamp = self._read_json_dict(path)
+        if stamp is None:
             logger.debug(
                 "[%s] Could not read compile cache stamp at %s",
                 self.lane_id,
                 path,
                 exc_info=True,
             )
-            return None
-        if not isinstance(data, dict):
-            return None
-        return {str(k): str(v) for k, v in data.items()}
+        return stamp
 
     def _write_compile_cache_stamp(self) -> None:
         """Record the current (vllm, torch) versions next to the compile cache."""
@@ -748,6 +905,133 @@ class VllmProcessHandle:
                 exc_info=True,
             )
 
+    # ------------------------------------------------------------------
+    # Per-lane compile cache meta (cache_meta.json)
+    # ------------------------------------------------------------------
+
+    def _lane_compile_cache_dir(self, lane_config: LaneConfig) -> str | None:
+        """The per-lane ``--compilation-config`` cache_dir for this lane.
+
+        ``None`` when the lane overrides the compilation config itself
+        (extra_args) — that directory is not one we manage and cannot be
+        resolved from here.
+        """
+        vc = lane_config.vllm_config
+        if vc is None or self._has_compilation_config_override(vc.extra_args or []):
+            return None
+        root = self._resolve_persistent_cache_root(self._global_config)
+        if not root:
+            return None
+        return os.path.join(root, ".cache", "vllm", "lanes", lane_config.model.replace("/", "__"))
+
+    def _current_cache_meta(self, lane_config: LaneConfig) -> dict[str, str]:
+        """Environment fingerprint to record in the lane's cache_meta.json.
+
+        Any field changing between two healthy starts (image upgrade, vLLM or
+        torch bump, CUDA bump, or a different compilation config) means the
+        cached AOT/inductor artifacts were produced for a different
+        environment and must be rebuilt before reuse. Unreadable fields are
+        omitted — the comparison then only sees fields we actually recorded.
+        """
+        lane_cache_dir = self._lane_compile_cache_dir(lane_config)
+        if lane_cache_dir is None:
+            return {}
+        meta: dict[str, str] = dict(self._current_compile_versions())
+        try:
+            import torch  # noqa: PLC0415
+
+            cuda = getattr(torch.version, "cuda", None)
+            if cuda:
+                meta["cuda"] = str(cuda)
+        except Exception:  # noqa: BLE001
+            pass
+        image = (os.environ.get("LOGOS_IMAGE_VERSION") or "").strip()
+        if image:
+            meta["image"] = image
+        meta["model"] = lane_config.model
+        import hashlib
+        import json as _json
+
+        meta["compilation_config"] = hashlib.sha256(
+            _json.dumps({"cache_dir": lane_cache_dir}, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        return meta
+
+    def _purge_lane_cache_if_meta_changed(self, lane_config: LaneConfig) -> list[str]:
+        """Pre-flight validation of this lane's cache_meta.json.
+
+        After the first healthy start we wrote ``cache_meta.json`` into the
+        lane's compile cache dir. Before every subsequent start we compare it
+        against the current environment; on any mismatch (or a cache without
+        a meta file, produced by a worker that predates this check) the
+        lane's ``torch_compile_cache/`` and ``rank_*/`` are wiped and vLLM
+        recompiles from scratch. Returns the paths actually removed.
+        """
+        lane_cache_dir = self._lane_compile_cache_dir(lane_config)
+        if lane_cache_dir is None:
+            return []
+        if not self._lane_artifact_paths(lane_cache_dir):
+            return []
+        current = self._current_cache_meta(lane_config)
+        if not current:
+            return []
+        meta_path = os.path.join(lane_cache_dir, self._CACHE_META_FILENAME)
+        stored = self._read_json_dict(meta_path)
+        if stored is not None:
+            mismatched = {k: (stored.get(k), current[k]) for k in current if stored.get(k) != current[k]}
+            if not mismatched:
+                return []
+            logger.warning(
+                "[%s] Compile cache meta mismatch for %s (%s); wiping this lane's compile cache",
+                self.lane_id,
+                lane_config.model,
+                ", ".join(f"{k}: {old}→{new}" for k, (old, new) in mismatched.items()),
+            )
+        else:
+            # Cache exists but no meta — produced by a worker version that
+            # predates the per-lane meta check. Treat as unknown and wipe so
+            # we start from a known-good baseline.
+            logger.warning(
+                "[%s] Compile cache present for %s but no %s; wiping to avoid poisoning",
+                self.lane_id,
+                lane_config.model,
+                self._CACHE_META_FILENAME,
+            )
+        return self._purge_compile_caches(lane_config.model)
+
+    def _write_lane_cache_meta(self, lane_config: LaneConfig) -> None:
+        """Record the current environment fingerprint in the lane's compile cache dir."""
+        lane_cache_dir = self._lane_compile_cache_dir(lane_config)
+        if lane_cache_dir is None:
+            return
+        meta = self._current_cache_meta(lane_config)
+        if not meta:
+            return
+        path = os.path.join(lane_cache_dir, self._CACHE_META_FILENAME)
+        import json as _json
+
+        try:
+            os.makedirs(lane_cache_dir, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                _json.dump(meta, fh, sort_keys=True)
+        except OSError:
+            logger.debug(
+                "[%s] Could not write compile cache meta at %s",
+                self.lane_id,
+                path,
+                exc_info=True,
+            )
+
+    def _log_cache_auto_recovered(self, model: str, fingerprint: str, purged: list[str]) -> None:
+        """Emit the structured auto-recovery log line (greppable in metrics)."""
+        logger.warning(
+            "[%s] cache_auto_recovered=true model=%s fingerprint=%s purged=%s",
+            self.lane_id,
+            model,
+            fingerprint,
+            ",".join(purged) or "none",
+        )
+
     def _purge_compile_caches_if_versions_changed(self) -> list[str]:
         """Purge compile caches when the recorded versions no longer match.
 
@@ -765,7 +1049,7 @@ class VllmProcessHandle:
         # No cache on disk yet → nothing to do, and writing a stamp ahead of
         # time would be misleading. The stamp gets written after the next
         # successful spawn produces real artifacts.
-        if not any(os.path.isdir(os.path.join(cache_root, sub)) for sub in self._PURGEABLE_COMPILE_CACHE_SUBDIRS):
+        if not self._compile_artifact_paths(None):
             return []
         current = self._current_compile_versions()
         if not current:
@@ -1495,16 +1779,11 @@ class VllmProcessHandle:
         # first (crashing in inductor with "Expected tensors only" /
         # IndexError in copy_misaligned_inputs).
         if not self._has_compilation_config_override(vc.extra_args):
-            import json as _json
+            lane_cache_dir = self._lane_compile_cache_dir(lane_config)
+            if lane_cache_dir is not None:
+                import json as _json
 
-            cache_root = os.path.join(
-                self._resolve_persistent_cache_root(self._global_config),
-                ".cache",
-                "vllm",
-                "lanes",
-                lane_config.model.replace("/", "__"),
-            )
-            cmd.extend(["--compilation-config", _json.dumps({"cache_dir": cache_root})])
+                cmd.extend(["--compilation-config", _json.dumps({"cache_dir": lane_cache_dir})])
         # Custom chat template: resolved against the persistent, operator-managed
         # template directory. Passing the resolved absolute path (rather than the
         # configured name) keeps the vLLM command line self-documenting in logs.

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -2169,6 +2169,57 @@ async def test_spawn_does_not_retry_on_unrelated_startup_failure(tmp_path: Path,
     assert paths["inductor"].exists()
 
 
+@pytest.mark.asyncio
+async def test_spawn_does_not_widen_worker_wide_on_fingerprint_only(tmp_path: Path, monkeypatch) -> None:
+    """A fingerprint match whose traceback names no compile-cache file, on a
+    lane with an empty per-lane dir, must NOT widen to the worker-wide purge —
+    that would force every other model on the node to recompile on a
+    heuristic match. The failure propagates instead."""
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    import json as _json
+
+    # Stamp matches so the proactive purge stays out of the way.
+    (paths["cache_root"] / handle._COMPILE_CACHE_STAMP_FILENAME).write_text(
+        _json.dumps({"vllm": "0.22.0", "torch": "2.11.0"})
+    )
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="org/brand-new-model", vllm=True, vllm_config=VllmConfig())
+    calls: list[int] = []
+
+    async def _fake_spawn_once(_lc):  # noqa: ANN001
+        calls.append(1)
+        # copy_misaligned_inputs fingerprint, but the traceback names only
+        # torch internals — no compile-cache path, so no strong signal.
+        handle._recent_logs.extend(
+            [
+                '  File "/opt/venv/lib/python3.12/site-packages/torch/_inductor/utils.py", '
+                "line 3442, in copy_misaligned_inputs",
+                "AssertionError: Expected tensors only, but got: <class 'int'>",
+            ]
+        )
+        raise RuntimeError("Engine core init failed")
+
+    monkeypatch.setattr(handle, "_spawn_once", _fake_spawn_once)
+
+    with pytest.raises(RuntimeError, match="Engine core init failed"):
+        await handle.spawn(lane)
+    # No retry: the fingerprint-only match on an empty per-lane dir did not
+    # widen to the worker-wide cache.
+    assert len(calls) == 1
+    # The shared compile cache is untouched.
+    assert (paths["vllm"] / "torch_compile_cache").exists()
+    assert (paths["vllm"] / "rank_0_0").exists()
+    assert paths["inductor"].exists()
+
+
 # Fingerprint matching — failures that die inside torch/vllm library code,
 # where no frame of the traceback points into the cache directory.
 
@@ -2237,13 +2288,48 @@ def test_matched_cache_poisoning_fingerprints(fingerprint: str, log_lines: list[
 def test_matched_cache_poisoning_fingerprint_requires_all_fragments() -> None:
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
     # A KeyError that is not from the compilation cache module, and a
-    # FileNotFoundError that is not from torch/_inductor, must not match.
+    # FileNotFoundError whose path is not under the compile cache, must not
+    # match.
     handle._recent_logs.extend(
         [
             '  File ".../vllm/config.py", line 10, in load',
             "KeyError: 'model'",
             '  File ".../vllm/worker/worker.py", line 5, in init_device',
             "FileNotFoundError: '/models/weights.safetensors'",
+        ]
+    )
+    assert handle._matched_cache_poisoning_fingerprint() is None
+    assert handle.has_poisoned_compile_cache is False
+
+
+def test_inductor_artifact_missing_matches_cache_path_file_not_found() -> None:
+    """A FileNotFoundError under a compile-cache path is a genuinely missing
+    cache artifact. The path uses a custom cache root so it is not one of the
+    generic path fragments — only the tightened fingerprint can match it."""
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._recent_logs.extend(
+        [
+            '  File ".../torch/_inductor/standalone_compile.py", line 122, in _compiled_fn',
+            "FileNotFoundError: [Errno 2] No such file or directory: "
+            "'/mnt/custom-root/vllm/torch_compile_cache/deadbeef/ol/frag.py'",
+        ]
+    )
+    assert handle._matched_cache_poisoning_fingerprint() == "inductor_artifact_missing"
+    assert handle.has_poisoned_compile_cache is True
+
+
+def test_inductor_artifact_missing_ignores_unrelated_file_not_found() -> None:
+    """The false positive from review: a brand-new model that fails to load
+    (mistyped repo id, gated repo) raises FileNotFoundError, and ordinary
+    torch.compile output logs torch/_inductor frames in the same window. The
+    missing file is a HuggingFace path, not a compile-cache artifact, so the
+    fingerprint must NOT match."""
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._recent_logs.extend(
+        [
+            '  File "/opt/venv/lib/python3.12/site-packages/torch/_inductor/runtime/' "triton_heuristics.py",
+            " line 12, in run",
+            "FileNotFoundError: [Errno 2] No such file or directory: " "'/models/org__typo-model/weights.safetensors'",
         ]
     )
     assert handle._matched_cache_poisoning_fingerprint() is None
@@ -2413,7 +2499,11 @@ async def test_spawn_reactive_recovery_is_capped_per_model_hour(tmp_path: Path, 
     monkeypatch.setattr("logos_worker_node.vllm_process._last_reactive_cache_recovery", {})
 
     lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    # A strong-signal poisoning: the traceback names a compile-cache file
+    # (path fragment), so the worker-wide fallback fires on this empty
+    # per-lane (legacy shared-location) fixture.
     poisoned_logs = [
+        '  File "/tmp/x/.cache/vllm/torch_compile_cache/abc/inductor_cache/ol/frag.py", line 1, in call',
         '  File ".../torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
         "AssertionError: Expected tensors only, but got: <class 'int'>",
     ]
@@ -2477,8 +2567,12 @@ async def test_spawn_logs_structured_auto_recovery_line(tmp_path: Path, monkeypa
     async def _fake_spawn_once(_lc):  # noqa: ANN001
         attempts.append(1)
         if len(attempts) == 1:
+            # Strong signal (cache path in the traceback) so the worker-wide
+            # fallback fires on this empty per-lane fixture, plus the
+            # copy_misaligned_inputs fingerprint the assertion checks for.
             handle._recent_logs.extend(
                 [
+                    '  File "/tmp/x/.cache/vllm/torch_compile_cache/abc/inductor_cache/ol/frag.py", line 1, in call',
                     '  File ".../torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
                     "AssertionError: Expected tensors only, but got: <class 'int'>",
                 ]

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1862,22 +1862,32 @@ def test_build_cmd_explicit_chat_template_kwargs_win_over_inferred(monkeypatch) 
 
 
 def _populate_compile_cache(root: Path) -> dict[str, Path]:
-    """Build a realistic <cache_root>/.cache/ subtree and return key paths."""
+    """Build a realistic <cache_root>/.cache/ subtree and return key paths.
+
+    Idempotent — a previous (narrowed) purge leaves modelinfos/ and friends
+    behind, and a re-populate must not trip over them.
+    """
     cache_root = root / ".cache"
     vllm_cache = cache_root / "vllm"
     inductor_cache = cache_root / "torch_inductor"
     flashinfer_cache = cache_root / "flashinfer"
-    (vllm_cache / "torch_compile_cache" / "deadbeef" / "inductor_cache" / "ol").mkdir(parents=True)
+    modelinfos = vllm_cache / "modelinfos"
+    modelinfos.mkdir(parents=True, exist_ok=True)
+    (modelinfos / "model.json").write_text("{}")
+    (vllm_cache / "rank_0_0" / "backbone").mkdir(parents=True, exist_ok=True)
+    (vllm_cache / "rank_0_0" / "backbone" / "artifact.bin").write_text("blob")
+    (vllm_cache / "torch_compile_cache" / "deadbeef" / "inductor_cache" / "ol").mkdir(parents=True, exist_ok=True)
     (vllm_cache / "torch_compile_cache" / "deadbeef" / "inductor_cache" / "ol" / "frag.py").write_text("x = 1\n")
-    inductor_cache.mkdir(parents=True)
+    inductor_cache.mkdir(parents=True, exist_ok=True)
     (inductor_cache / "artifact.bin").write_text("blob")
-    flashinfer_cache.mkdir(parents=True)
+    flashinfer_cache.mkdir(parents=True, exist_ok=True)
     (flashinfer_cache / "keep.so").write_text("preserved")
     return {
         "cache_root": cache_root,
         "vllm": vllm_cache,
         "inductor": inductor_cache,
         "flashinfer": flashinfer_cache,
+        "modelinfos": modelinfos,
     }
 
 
@@ -1912,20 +1922,55 @@ def test_has_poisoned_compile_cache_false_when_no_logs() -> None:
     assert handle.has_poisoned_compile_cache is False
 
 
-def test_purge_compile_caches_removes_vllm_and_inductor_only(tmp_path: Path, monkeypatch) -> None:
+def test_purge_compile_caches_removes_artifacts_only(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
     paths = _populate_compile_cache(tmp_path)
     handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
 
     removed = handle._purge_compile_caches()
 
-    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
-    assert not paths["vllm"].exists()
+    assert set(removed) == {
+        str(paths["vllm"] / "torch_compile_cache"),
+        str(paths["vllm"] / "rank_0_0"),
+        str(paths["inductor"]),
+    }
+    assert not (paths["vllm"] / "torch_compile_cache").exists()
+    assert not (paths["vllm"] / "rank_0_0").exists()
     assert not paths["inductor"].exists()
+    # The vllm cache dir itself survives — only the artifact subdirs are wiped.
+    assert paths["vllm"].exists()
+    # modelinfos/ is safe JSON metadata and must never be touched by
+    # auto-recovery.
+    assert (paths["modelinfos"] / "model.json").exists()
     # FlashInfer JIT cache + HF weights are not implicated in compile-cache
     # poisoning and must survive a purge.
     assert paths["flashinfer"].exists()
     assert (paths["flashinfer"] / "keep.so").exists()
+
+
+def test_purge_compile_caches_per_model_only_touches_that_lane(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    lanes_root = paths["vllm"] / "lanes"
+    for lane_name in ("alpha__model-a", "beta__model-b"):
+        (lanes_root / lane_name / "torch_compile_cache" / "deadbeef").mkdir(parents=True)
+        (lanes_root / lane_name / "rank_0_0" / "backbone").mkdir(parents=True)
+        (lanes_root / lane_name / "modelinfos").mkdir(parents=True)
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    removed = handle._purge_compile_caches("alpha/model-a")
+
+    assert set(removed) == {
+        str(lanes_root / "alpha__model-a" / "torch_compile_cache"),
+        str(lanes_root / "alpha__model-a" / "rank_0_0"),
+    }
+    # A poisoned model must not force every other model on the node to
+    # recompile — the sibling lane's cache is left in place.
+    assert (lanes_root / "beta__model-b" / "torch_compile_cache").exists()
+    assert (lanes_root / "beta__model-b" / "rank_0_0").exists()
+    # And modelinfos/ is never touched, even for the purged lane.
+    assert (lanes_root / "alpha__model-a" / "modelinfos").exists()
+    assert (paths["modelinfos"] / "model.json").exists()
 
 
 def test_purge_compile_caches_is_noop_when_nothing_to_remove(tmp_path: Path, monkeypatch) -> None:
@@ -1952,8 +1997,14 @@ def test_purge_compile_caches_if_versions_changed_purges_on_mismatch(tmp_path: P
     )
 
     removed = handle._purge_compile_caches_if_versions_changed()
-    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
-    assert not paths["vllm"].exists()
+    assert set(removed) == {
+        str(paths["vllm"] / "torch_compile_cache"),
+        str(paths["vllm"] / "rank_0_0"),
+        str(paths["inductor"]),
+    }
+    assert not (paths["vllm"] / "torch_compile_cache").exists()
+    assert not paths["inductor"].exists()
+    assert (paths["modelinfos"] / "model.json").exists()
     assert paths["flashinfer"].exists()
 
 
@@ -1990,7 +2041,12 @@ def test_purge_compile_caches_if_versions_changed_purges_when_no_stamp(tmp_path:
     )
 
     removed = handle._purge_compile_caches_if_versions_changed()
-    assert set(removed) == {str(paths["vllm"]), str(paths["inductor"])}
+    assert set(removed) == {
+        str(paths["vllm"] / "torch_compile_cache"),
+        str(paths["vllm"] / "rank_0_0"),
+        str(paths["inductor"]),
+    }
+    assert (paths["modelinfos"] / "model.json").exists()
 
 
 def test_purge_compile_caches_if_versions_changed_skips_when_no_cache(tmp_path: Path, monkeypatch) -> None:
@@ -2068,9 +2124,13 @@ async def test_spawn_retries_once_on_poisoned_compile_cache(tmp_path: Path, monk
     await handle.spawn(lane)
 
     assert attempt_calls == [1, 2]
-    # The reactive purge wiped vllm + inductor caches between attempts.
-    assert not paths["vllm"].exists()
+    # The reactive purge wiped the compile artifacts between attempts. The
+    # per-lane dir held nothing (this fixture uses the legacy shared
+    # location), so the worker-wide fallback fired.
+    assert not (paths["vllm"] / "torch_compile_cache").exists()
+    assert not (paths["vllm"] / "rank_0_0").exists()
     assert not paths["inductor"].exists()
+    assert (paths["modelinfos"] / "model.json").exists()
     assert paths["flashinfer"].exists()
 
 
@@ -2107,6 +2167,336 @@ async def test_spawn_does_not_retry_on_unrelated_startup_failure(tmp_path: Path,
     # Unrelated failure must not wipe the compile cache.
     assert paths["vllm"].exists()
     assert paths["inductor"].exists()
+
+
+# Fingerprint matching — failures that die inside torch/vllm library code,
+# where no frame of the traceback points into the cache directory.
+
+
+def test_has_poisoned_compile_cache_detects_copy_misaligned_inputs_fingerprint() -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    # The GLM-OCR incident: the cached AOT artifact asserts deep inside
+    # torch on a stale input signature — the traceback never names the
+    # cache directory, only the fingerprint does.
+    handle._recent_logs.extend(
+        [
+            "(EngineCore) ERROR core.py:1140 Traceback (most recent call last):",
+            "(EngineCore) ERROR core.py:1140   File "
+            '"/opt/venv/lib/python3.12/site-packages/transformers/models/glm4_1v/modeling_glm4_1v.py", '
+            "line 1679, in forward",
+            '(EngineCore) ERROR core.py:1140   File "/opt/venv/lib/python3.12/site-packages/'
+            'torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
+            "(EngineCore) ERROR core.py:1140 AssertionError: Expected tensors only, but got: <class 'int'>",
+            "(EngineCore) ERROR core.py:1140 RuntimeError: Engine core initialization failed.",
+        ]
+    )
+    assert handle.has_poisoned_compile_cache is True
+    assert handle._matched_cache_poisoning_fingerprint() == "copy_misaligned_inputs"
+
+
+@pytest.mark.parametrize(
+    ("fingerprint", "log_lines"),
+    [
+        (
+            "copy_misaligned_inputs",
+            [
+                '  File ".../torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
+                "AssertionError: Expected tensors only, but got: <class 'int'>",
+            ],
+        ),
+        (
+            "aot_artifact_assertion",
+            [
+                '  File ".../torch/_inductor/standalone_compile.py", line 122, in CacheCompiledArtifact._compiled_fn',
+                "AssertionError: shape mismatch in cached graph",
+            ],
+        ),
+        (
+            "inductor_artifact_missing",
+            [
+                '  File ".../torch/_inductor/standalone_compile.py", line 122, in _compiled_fn',
+                "FileNotFoundError: .../torch_compile_cache/torch_aot_compile/deadbeef/graph",
+            ],
+        ),
+        (
+            "compilation_cache_key_error",
+            [
+                '  File ".../vllm/compilation/caching.py", line 217, in optimized_call',
+                "KeyError: 'f5096f3c'",
+            ],
+        ),
+    ],
+)
+def test_matched_cache_poisoning_fingerprints(fingerprint: str, log_lines: list[str]) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    handle._recent_logs.extend(log_lines)
+    assert handle._matched_cache_poisoning_fingerprint() == fingerprint
+    assert handle.has_poisoned_compile_cache is True
+
+
+def test_matched_cache_poisoning_fingerprint_requires_all_fragments() -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    # A KeyError that is not from the compilation cache module, and a
+    # FileNotFoundError that is not from torch/_inductor, must not match.
+    handle._recent_logs.extend(
+        [
+            '  File ".../vllm/config.py", line 10, in load',
+            "KeyError: 'model'",
+            '  File ".../vllm/worker/worker.py", line 5, in init_device',
+            "FileNotFoundError: '/models/weights.safetensors'",
+        ]
+    )
+    assert handle._matched_cache_poisoning_fingerprint() is None
+    assert handle.has_poisoned_compile_cache is False
+
+
+# Per-lane cache_meta.json pre-flight validation
+
+
+def _populate_lane_cache(root: Path, model: str) -> Path:
+    """Build the per-lane compile cache dir for ``model`` and return it."""
+    lane_dir = root / ".cache" / "vllm" / "lanes" / model.replace("/", "__")
+    (lane_dir / "torch_compile_cache" / "deadbeef").mkdir(parents=True)
+    (lane_dir / "rank_0_0" / "backbone").mkdir(parents=True)
+    (lane_dir / "modelinfos").mkdir(parents=True)
+    (lane_dir / "modelinfos" / "model.json").write_text("{}")
+    return lane_dir
+
+
+def test_purge_lane_cache_if_meta_changed_purges_on_version_mismatch(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    lane_dir = _populate_lane_cache(tmp_path, "zai-org/GLM-OCR")
+    import json
+
+    # The meta records the vLLM version that produced the cached artifacts.
+    meta = handle._current_cache_meta(lane)
+    meta["vllm"] = "0.21.0"
+    (lane_dir / handle._CACHE_META_FILENAME).write_text(json.dumps(meta, sort_keys=True))
+
+    removed = handle._purge_lane_cache_if_meta_changed(lane)
+
+    assert set(removed) == {str(lane_dir / "torch_compile_cache"), str(lane_dir / "rank_0_0")}
+    assert not (lane_dir / "torch_compile_cache").exists()
+    assert not (lane_dir / "rank_0_0").exists()
+    # modelinfos/ is never touched by auto-recovery.
+    assert (lane_dir / "modelinfos" / "model.json").exists()
+
+
+def test_purge_lane_cache_if_meta_changed_noop_on_match(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    lane_dir = _populate_lane_cache(tmp_path, "zai-org/GLM-OCR")
+    import json
+
+    (lane_dir / handle._CACHE_META_FILENAME).write_text(json.dumps(handle._current_cache_meta(lane), sort_keys=True))
+
+    assert handle._purge_lane_cache_if_meta_changed(lane) == []
+    assert (lane_dir / "torch_compile_cache").exists()
+    assert (lane_dir / "rank_0_0").exists()
+
+
+def test_purge_lane_cache_if_meta_changed_purges_when_no_meta(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    lane_dir = _populate_lane_cache(tmp_path, "zai-org/GLM-OCR")
+
+    # Cache exists but no meta — produced by a worker version that predates
+    # the per-lane meta check. Treated as unknown and wiped.
+    removed = handle._purge_lane_cache_if_meta_changed(lane)
+
+    assert set(removed) == {str(lane_dir / "torch_compile_cache"), str(lane_dir / "rank_0_0")}
+    assert (lane_dir / "modelinfos" / "model.json").exists()
+
+
+def test_purge_lane_cache_if_meta_changed_noop_without_artifacts(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    # No artifacts yet (first start of this model) — nothing to validate,
+    # and no meta is read either.
+    assert handle._purge_lane_cache_if_meta_changed(lane) == []
+
+
+def test_purge_lane_cache_if_meta_changed_skips_user_overridden_compilation_config(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+
+    # The lane manages its own --compilation-config — that cache dir is not
+    # one we resolve, so no pre-flight validation and no meta are applied.
+    lane = LaneConfig(
+        model="zai-org/GLM-OCR",
+        vllm=True,
+        vllm_config=VllmConfig(extra_args=["--compilation-config", '{"cache_dir": "/custom"}']),
+    )
+    assert handle._lane_compile_cache_dir(lane) is None
+    assert handle._purge_lane_cache_if_meta_changed(lane) == []
+    handle._write_lane_cache_meta(lane)
+    assert not (tmp_path / ".cache" / "vllm" / "lanes").exists()
+
+
+@pytest.mark.asyncio
+async def test_spawn_writes_lane_cache_meta_after_healthy_start(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LOGOS_IMAGE_VERSION", "logos-workernode-vllm:2026.08.29")
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    calls: list[int] = []
+
+    async def _fake_spawn_once(_lc):  # noqa: ANN001
+        calls.append(1)
+        return handle.status()
+
+    monkeypatch.setattr(handle, "_spawn_once", _fake_spawn_once)
+
+    await handle.spawn(lane)
+    assert calls == [1]
+
+    import json
+
+    lane_dir = tmp_path / ".cache" / "vllm" / "lanes" / "zai-org__GLM-OCR"
+    meta_path = lane_dir / handle._CACHE_META_FILENAME
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["vllm"] == "0.22.0"
+    assert meta["torch"] == "2.11.0"
+    assert meta["model"] == "zai-org/GLM-OCR"
+    assert meta["image"] == "logos-workernode-vllm:2026.08.29"
+    assert "compilation_config" in meta
+
+
+# Reactive recovery cooldown + structured log line
+
+
+@pytest.mark.asyncio
+async def test_spawn_reactive_recovery_is_capped_per_model_hour(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    import json as _json
+
+    (paths["cache_root"] / VllmProcessHandle._COMPILE_CACHE_STAMP_FILENAME).write_text(
+        _json.dumps({"vllm": "0.22.0", "torch": "2.11.0"})
+    )
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+    monkeypatch.setattr("logos_worker_node.vllm_process._last_reactive_cache_recovery", {})
+
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    poisoned_logs = [
+        '  File ".../torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
+        "AssertionError: Expected tensors only, but got: <class 'int'>",
+    ]
+
+    # First handle: one auto-recovery (purge + retry) succeeds.
+    handle1 = VllmProcessHandle("lane-1", 19000, OllamaConfig())
+    attempts1: list[int] = []
+
+    async def _spawn_once_fail_then_ok(_lc):  # noqa: ANN001
+        attempts1.append(1)
+        if len(attempts1) == 1:
+            handle1._recent_logs.extend(poisoned_logs)
+            raise RuntimeError("Engine core init failed")
+        handle1._recent_logs.clear()
+        return handle1.status()
+
+    monkeypatch.setattr(handle1, "_spawn_once", _spawn_once_fail_then_ok)
+    await handle1.spawn(lane)
+    assert attempts1 == [1, 1]
+
+    # The lane manager restarts the lane (a fresh handle). The same failure
+    # must NOT trigger a second recovery within the cooldown window.
+    _populate_compile_cache(tmp_path)
+    handle2 = VllmProcessHandle("lane-2", 19001, OllamaConfig())
+    attempts2: list[int] = []
+
+    async def _spawn_once_always_fail(_lc):  # noqa: ANN001
+        attempts2.append(1)
+        handle2._recent_logs.extend(poisoned_logs)
+        raise RuntimeError("Engine core init failed")
+
+    monkeypatch.setattr(handle2, "_spawn_once", _spawn_once_always_fail)
+    with pytest.raises(RuntimeError, match="Engine core init failed"):
+        await handle2.spawn(lane)
+    assert attempts2 == [1]  # no second retry
+    # ... and the cache was not purged again.
+    assert (tmp_path / ".cache" / "vllm" / "torch_compile_cache").exists()
+
+
+@pytest.mark.asyncio
+async def test_spawn_logs_structured_auto_recovery_line(tmp_path: Path, monkeypatch, caplog) -> None:
+    monkeypatch.setenv("LOGOS_WORKER_CACHE_ROOT", str(tmp_path))
+    paths = _populate_compile_cache(tmp_path)
+    import json as _json
+    import logging
+
+    (paths["cache_root"] / VllmProcessHandle._COMPILE_CACHE_STAMP_FILENAME).write_text(
+        _json.dumps({"vllm": "0.22.0", "torch": "2.11.0"})
+    )
+    monkeypatch.setattr(
+        VllmProcessHandle,
+        "_current_compile_versions",
+        staticmethod(lambda: {"vllm": "0.22.0", "torch": "2.11.0"}),
+    )
+    monkeypatch.setattr("logos_worker_node.vllm_process._last_reactive_cache_recovery", {})
+
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    lane = LaneConfig(model="zai-org/GLM-OCR", vllm=True, vllm_config=VllmConfig())
+    attempts: list[int] = []
+
+    async def _fake_spawn_once(_lc):  # noqa: ANN001
+        attempts.append(1)
+        if len(attempts) == 1:
+            handle._recent_logs.extend(
+                [
+                    '  File ".../torch/_inductor/utils.py", line 3442, in copy_misaligned_inputs',
+                    "AssertionError: Expected tensors only, but got: <class 'int'>",
+                ]
+            )
+            raise RuntimeError("Engine core init failed")
+        handle._recent_logs.clear()
+        return handle.status()
+
+    monkeypatch.setattr(handle, "_spawn_once", _fake_spawn_once)
+
+    with caplog.at_level(logging.WARNING, logger="logos_worker_node.vllm_process"):
+        await handle.spawn(lane)
+
+    recovered = [r for r in caplog.records if "cache_auto_recovered=true" in r.getMessage()]
+    assert len(recovered) == 1
+    message = recovered[0].getMessage()
+    assert "model=zai-org/GLM-OCR" in message
+    assert "fingerprint=copy_misaligned_inputs" in message
 
 
 def test_build_cmd_emits_speculative_config(monkeypatch) -> None:


### PR DESCRIPTION
## Fixes #579

## Summary

On `deioma`, loading `zai-org/GLM-OCR` repeatedly failed during `add_lane` because vLLM replayed a stale AOT/torch.compile cache (`AssertionError: Expected tensors only, but got: <class 'int'>` in `copy_misaligned_inputs`). The manual fix was an `rm -rf` of the compile-cache directories on the host. This PR makes the worker detect and recover from exactly this class of failure without manual intervention.

The sibling incident (#580, gemma-4) already landed the core of this feature in `f1816c82a`: a worker-wide version stamp (`.logos_compile_cache_stamp.json`) plus a reactive stack-trace-path detector with a one-shot purge + retry. This PR adds what was still missing against #579's acceptance criteria:

### Changes (`logos/logos-workernode/logos_worker_node/vllm_process.py`)

1. **Per-lane pre-flight `cache_meta.json` (issue approach A).** After a healthy start the worker writes a `cache_meta.json` into each lane's own compile-cache dir (`.cache/vllm/lanes/<model>/`) recording the vLLM version, torch version, CUDA runtime version, `LOGOS_IMAGE_VERSION` (when set), the model identifier, and a hash of the `--compilation-config`. Before every subsequent start of that lane the meta is compared against the current environment; on any mismatch (or a cache without meta, produced by a worker that predates this check) only that lane's `torch_compile_cache/` + `rank_*/` are wiped and vLLM recompiles.

2. **Fingerprint classifier (issue approach B).** `has_poisoned_compile_cache` now also matches a small allowlist of high-confidence cache-corruption message fingerprints — `copy_misaligned_inputs … Expected tensors only`, `CacheCompiledArtifact … AssertionError`, `torch/_inductor … FileNotFoundError` (truncated artifact from a killed mid-AOT-write start), `vllm/compilation/caching.py … KeyError` — in addition to the existing stack-trace-path detector. This catches the #579 incident, where the traceback dies deep inside torch and never names the cache directory.

3. **Cooldown for reactive recovery.** The reactive wipe + retry is capped at **one per (model, hour)** (module-level state, so it survives lane-manager restarts / handle recreation). A genuinely broken model can no longer loop purge → retry → fail.

4. **Narrowed purge — `modelinfos/` is never touched.** The purge no longer removes the whole `.cache/vllm` directory (which contained `modelinfos/`); it removes only the compile artifacts (`torch_compile_cache/`, `rank_*/`, and the shared `torch_inductor/` on a worker-wide wipe). Reactive recovery purges only the failing model's per-lane dir (falling back to the worker-wide set when the artifacts live in the legacy shared location), so a poisoned model does not force every other model on the node to recompile.

5. **Structured, greppable recovery log.** Every auto-recovery event (proactive version stamp, proactive meta mismatch, reactive fingerprint) emits `[lane] cache_auto_recovered=true model=… fingerprint=… purged=…`.

### Tests (`tests/test_vllm_process.py`)

- Updated the existing purge/stamp tests to the narrowed purge (asserting `modelinfos/`, the FlashInfer cache, and sibling lanes' caches survive).
- New: per-lane meta write after a healthy start; version-mismatch / missing-meta / matching-meta / no-artifacts / user-overridden-`--compilation-config` cases; all four fingerprints plus a negative case (fragments must appear together); per-model purge isolation; reactive cooldown across handles (exactly one recovery per (model, hour)); the structured log line.

## Verification

- `pytest` in `logos/logos-workernode`: **541 passed, 2 skipped** — full suite including `test_model_cache.py`, `test_calibration.py` and `test_lane_manager.py`, which CI excludes for GitHub-runner reasons.
- `black`, `isort`, `autoflake`, `flake8` clean on both changed files (versions pinned to `logos/.pre-commit-config.yaml`).
- No live deployment (docker compose / vLLM workers / GPUs) is available in this environment; verification is via the unit tests above and careful reading against the incident's saved failure log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic recovery from known compilation-cache failures with more precise failure detection.
  * Limited cleanup to affected model artifacts while preserving metadata and unrelated caches.
  * Added validation to refresh stale caches when model, runtime, or cache settings change.
  * Added cooldowns to prevent repeated recovery actions within a short period.

* **Observability**
  * Added structured logging for proactive and automatic cache recovery events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->