### PR TITLE
`Logos`: Fix orchestrator build layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,12 @@
 # and untracked local files (benchmarks, calibration data, .git, …) never
 # get uploaded to the builder.
 *
-!shared
+# Shared dependency: only the files the orchestrator's dependency layer
+# installs from (metadata, declared readme, package source) — not the whole
+# directory, so e.g. shared/poetry.lock churn never enters the build context.
+!shared/pyproject.toml
+!shared/README.md
+!shared/shared
 !logos/db
 !logos/logos-orchestrator/pyproject.toml
 !logos/logos-orchestrator/src

--- a/.github/workflows/logos_build-and-push-docker.yml
+++ b/.github/workflows/logos_build-and-push-docker.yml
@@ -41,10 +41,21 @@ jobs:
       # GHA build cache. Without this the reusable workflow defaults to
       # cache=false, so every build re-runs every layer on a fresh runner
       # (apt toolchain, uv venv, full dependency install) even when only
-      # source files changed. A fixed scope lets all PRs/main/release builds
-      # share the same cached layers.
+      # source files changed.
+      #
+      # The GHA cache isolates entries by branch: builds on main populate
+      # the cache, PR builds read it, but PR branches never share caches
+      # with each other and never write into main's — the first build
+      # after a merge is the one that refreshes it. The fixed scope keeps
+      # all of a branch's builds on the same key.
+      #
+      # cache-mode: max — the expensive layers (apt toolchain, uv venv,
+      # full dependency install) live in the non-final `builder` stage;
+      # the default min mode only exports the resulting image's layers
+      # and would leave the builder stage cold on every fresh runner.
       cache: true
       cache-scope: logos-orchestrator
+      cache-mode: max
       sign: false
       meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos
       meta-tags: |
@@ -73,6 +84,12 @@ jobs:
       file: Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest
+      # Same cold-runner problem: the expensive mvn build runs in the
+      # non-final `builder` stage, so max mode is needed to export those
+      # layers (default min would only cache the final JRE stage).
+      cache: true
+      cache-scope: logos-webservice
+      cache-mode: max
       sign: false
       meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos-webservice
       meta-tags: |
@@ -101,6 +118,12 @@ jobs:
       file: Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest
+      # Same cold-runner problem: `npm ci` and `ng build` run in the
+      # non-final `build` stage, so max mode is needed to export those
+      # layers (default min would only cache the final nginx stage).
+      cache: true
+      cache-scope: logos-ui
+      cache-mode: max
       sign: false
       meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos-ui
       meta-tags: |
@@ -129,6 +152,10 @@ jobs:
       file: Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest
+      # min mode (the default) is sufficient: everything runs in the final
+      # stage, so the resulting image's layers are the whole cache.
+      cache: true
+      cache-scope: logos-db
       sign: false
       meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos-db
       meta-tags: |
@@ -157,6 +184,13 @@ jobs:
       file: Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest
+      # min mode (the default) stays here: everything runs in the final
+      # stage, and this is by far the largest image — max mode would
+      # export every intermediate CUDA/vLLM layer and could consume the
+      # 10 GB per-repo GHA cache budget on its own, LRU-evicting the
+      # other caches.
+      cache: true
+      cache-scope: logos-workernode-vllm
       sign: false
       build-args: |
         BASE_IMAGE=ubuntu:24.04

--- a/.github/workflows/logos_build-and-push-docker.yml
+++ b/.github/workflows/logos_build-and-push-docker.yml
@@ -38,6 +38,13 @@ jobs:
       file: logos/logos-orchestrator/Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest
+      # GHA build cache. Without this the reusable workflow defaults to
+      # cache=false, so every build re-runs every layer on a fresh runner
+      # (apt toolchain, uv venv, full dependency install) even when only
+      # source files changed. A fixed scope lets all PRs/main/release builds
+      # share the same cached layers.
+      cache: true
+      cache-scope: logos-orchestrator
       sign: false
       meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos
       meta-tags: |

--- a/logos/logos-orchestrator/Dockerfile
+++ b/logos/logos-orchestrator/Dockerfile
@@ -19,9 +19,17 @@ RUN uv venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# ── Dependency layer (cached unless pyproject.toml or shared/ changes) ──
+# ── Dependency layer (cached unless pyproject.toml or the shared package changes) ──
+# Copy ONLY the files `uv pip install .` reads to build the `shared` path
+# dependency: its metadata (pyproject.toml), its declared readme (required
+# by the poetry-core build backend) and the package source itself. The rest
+# of shared/ (its own poetry.lock, .flake8, ...) is NOT an input to this
+# install — copying it would invalidate this layer (and re-run the whole
+# dependency install) on every unrelated shared/ change.
 COPY logos/logos-orchestrator/pyproject.toml ./
-COPY shared/ ./shared/
+COPY shared/pyproject.toml ./shared/pyproject.toml
+COPY shared/README.md ./shared/README.md
+COPY shared/shared/ ./shared/shared/
 
 # Create a minimal package stub so the poetry-core build backend can
 # resolve metadata without needing the real source tree.
@@ -36,8 +44,15 @@ RUN mkdir -p src/logos && echo '__version__ = "0.1.0"' > src/logos/__init__.py \
 # torch is pinned to PyTorch's CPU-only wheel index via tool.uv.sources + an
 # explicit index in pyproject.toml, so no extra install-time flags are needed
 # here to steer it away from PyPI's default CUDA build.
+#
+# --refresh: re-validate cached builds against the current source tree.
+# Without it, uv's build cache can serve a STALE wheel for the local `shared`
+# path dependency: the cache entry is keyed by path+version, not content, so
+# after a shared/ source change the (re-run) install layer would silently
+# install the previously built code. Reproduced with uv 0.11.3 and 0.12.5.
+# Registry wheels already in the cache are still reused (no re-download).
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install .
+    uv pip install --refresh .
 
 # ──────────────────────────────────────────────────────────
 # Stage 2: Runtime – slim image without compilers or build tools

--- a/logos/logos-orchestrator/Dockerfile
+++ b/logos/logos-orchestrator/Dockerfile
@@ -45,14 +45,16 @@ RUN mkdir -p src/logos && echo '__version__ = "0.1.0"' > src/logos/__init__.py \
 # explicit index in pyproject.toml, so no extra install-time flags are needed
 # here to steer it away from PyPI's default CUDA build.
 #
-# --refresh: re-validate cached builds against the current source tree.
-# Without it, uv's build cache can serve a STALE wheel for the local `shared`
-# path dependency: the cache entry is keyed by path+version, not content, so
+# --refresh-package shared: rebuild the local `shared` path dependency from
+# current source. Without it, uv's build cache can serve a STALE wheel for
+# that dependency: the cache entry is keyed by path+version, not content, so
 # after a shared/ source change the (re-run) install layer would silently
 # install the previously built code. Reproduced with uv 0.11.3 and 0.12.5.
-# Registry wheels already in the cache are still reused (no re-download).
+# The narrow flag invalidates exactly that one build-cache entry — index
+# resolution and the cached registry wheels stay untouched, so two builds
+# of the same commit keep resolving to the same dependency versions.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --refresh .
+    uv pip install --refresh-package shared .
 
 # ──────────────────────────────────────────────────────────
 # Stage 2: Runtime – slim image without compilers or build tools


### PR DESCRIPTION
## Fixes #698

The orchestrator image (`logos` container, built from `logos/logos-orchestrator/Dockerfile`) rebuilt its expensive layers on essentially every build. This PR finds the root causes, fixes the ones fixable in-repo, and documents the remaining environmental factors.

## Root causes

1. **No build cache in CI (dominant cause).** `logos_build-and-push-docker.yml` calls the `docker/github-builder` reusable workflow, whose `cache` input defaults to **`false`** — and Logos never set it. Every orchestrator build in CI therefore ran on a fresh runner with zero cached layers: base image, the apt toolchain (gcc/build-essential/rustc/cargo), `uv venv`, and the full `uv pip install .` (~450 packages incl. the CPU-only torch wheel) — on *every* PR, *every* push, regardless of what changed.
2. **The dependency layer over-copies `shared/`.** `COPY shared/ ./shared/` placed the entire `shared/` directory — including `shared/poetry.lock` (shared's own dev lockfile), `shared/README.md`, and `shared/.flake8`, none of which are inputs to the install — into the layer directly above the expensive `uv pip install .`. Any change to any of them (e.g. a lockfile churn commit) invalidated the whole dependency chain and the ~2 GB venv copy, even though the dependency set had not changed.
3. **Stale build cache for the `shared` path dependency (correctness bug found during verification).** `uv pip install .` serves the locally built `shared` wheel from its build cache, and that cache entry is keyed by path+version rather than content. After a genuine `shared/` source change, the re-run install layer silently installs the **previously built** code into the image. Reproduced with both uv 0.11.3 (local) and 0.12.5 (the version pinned in the image). Fixed with `uv pip install --refresh-package shared`, which invalidates exactly that one build-cache entry while leaving index resolution and the cached registry wheels untouched.

## Changes

- `.github/workflows/logos_build-and-push-docker.yml` — enable the GHA BuildKit layer cache on all five image builds:
  - `build-server` (orchestrator): `cache: true`, `cache-scope: logos-orchestrator`, `cache-mode: max`.
  - `build-webservice` / `build-ui`: `cache: true`, own scope, `cache-mode: max` — the expensive work (the mvn build / `npm ci` + `ng build`) sits in a non-final stage, which the default `min` mode would not export.
  - `build-db` / `build-workernode-vllm`: `cache: true`, own scope, default `min` mode — everything runs in the final stage, and workernode-vllm is by far the largest image; `max` there could consume the 10 GB per-repo GHA cache budget on its own and LRU-evict the other caches.

  Note on what "shared" means: the GHA cache isolates entries by branch — builds on `main` populate the cache, PR builds read it, but PR branches never share caches with each other and anything a PR writes never becomes visible to `main`. The first build after a merge is the one that refreshes it; the fixed scope only keeps all of a branch's builds on the same key.
- `logos/logos-orchestrator/Dockerfile`
  - Dependency layer now copies only what `uv pip install .` reads for the `shared` path dependency: `shared/pyproject.toml` (metadata), `shared/README.md` (required by the poetry-core build backend — the build fails without it, verified), and `shared/shared/` (package source). `shared/poetry.lock` / `.flake8` no longer invalidate the layer.
  - `uv pip install .` → `uv pip install --refresh-package shared .` to prevent the stale-wheel bug above. The narrow flag fixes the bug without re-resolving the registry graph on every run, so two builds of the same commit keep resolving to the same dependency versions.
- `.dockerignore` — whitelist narrowed from `!shared` to the three paths above, so non-input files never enter the build context (iris/memiris entries untouched; iris does not use `shared/`).

## Verification (empirical, local Docker buildx, repo-root context as in CI)

Baseline (unmodified `main` Dockerfile):

| scenario | result |
|---|---|
| cold build | 52 s, all layers executed (uv install 21 s with a warm `--mount=type=cache` uv cache) |
| no-change rebuild | 3.2 s — 15/15 layers CACHED |
| 2-line change to `shared/poetry.lock` | **11.3 s — `COPY shared/`, stub RUN, `uv pip install .`, the 2 GB venv copy and all of stage 2 re-ran** (spurious invalidation) |
| revert | 0.9 s — 15/15 CACHED |

After the fix:

| scenario | result |
|---|---|
| first build with new COPYs | 18 s — only the new COPY chain + one uv install re-run |
| no-change rebuild | 0.9 s — 17/17 layers CACHED |
| 2-line change to `shared/poetry.lock` | **0.6 s — 17/17 layers CACHED** (same change re-ran the whole dependency chain before) |
| change to `shared/shared/health.py` (a real install input) | dependency chain correctly re-runs |
| source-marker test with `--refresh-package shared` | marker present in source → present in the image's installed `shared`; removed → absent (no stale build in either direction; a plain install kept the stale wheel) |
| image smoke test | `from logos.main import app` succeeds in the final image; installed `shared` is byte-identical to the repo source |

The CI-side fix (GHA cache) cannot be executed from this environment; the input names/defaults were verified against the current `docker/github-builder` workflow definition. The first CI run of this PR is the cold baseline, and subsequent runs of the branch should show cached layers (per the branch isolation above: a PR branch only sees what `main` wrote and what it wrote itself). One caveat to keep in mind: the `cache-to` the action generates uses `ignore-error=true`, so cache export failures — including hitting the size limit — are swallowed silently and a degraded cache will not show up as a failing build. Actual cache usage should therefore be verified in the repository's Actions cache list after the first few runs, rather than assumed from green builds.

## Remaining / follow-ups (documented, not changed here)

- `python:3.13-slim` is a floating tag: when upstream pushes a new 3.13.x, the whole stage legitimately rebuilds (expected behavior, desirable for security patches).
- `uv pip install .` does not use the committed `logos/logos-orchestrator/uv.lock` (no workflow references it; it also records the `shared` dependency with a machine-specific absolute path), so cold builds re-resolve the registry graph and can silently pick up new upstream releases. Pinning the install to a portable lockfile (`uv sync --frozen` with a lock recorded relative to the project) would make images fully reproducible — suggested follow-up, kept out of this PR to keep the diff focused on caching.
- No Python code was touched, so the existing test suites (`logos_test.yml`) are unaffected; they will run in CI.
