### PR TITLE
`Logos`: Add volatile temporary providers (in-memory, auto-discovered, self-expiring)

### DIFF
--- a/logos/logos-orchestrator/src/logos/dbutils/dbrequest.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbrequest.py
@@ -23,6 +23,20 @@ class ConnectModelProviderRequest(LogosKeyModel):
     endpoint: Optional[str] = None
 
 
+class AddTempProviderRequest(LogosKeyModel):
+    base_url: str
+    api_key: str = ""
+    name: Optional[str] = None
+    # Logos key of the user (group) the temporary provider is tied to: only
+    # that key (plus logos_admins) may list or route to its models. Defaults
+    # to the registering admin key when omitted.
+    owner_api_key: Optional[str] = None
+
+
+class DeleteTempProviderRequest(LogosKeyModel):
+    provider_id: str
+
+
 class LogosNodeAuthRequest(BaseModel):
     shared_key: str
     capabilities_models: list[str] = Field(default_factory=list)

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -51,7 +51,7 @@ from logos.logosnode_registry import (
     LogosNodeSessionConflictError,
 )
 from logos.monitoring.prometheus_metrics import metrics_response as _prometheus_metrics_response
-from logos.pipeline.context_resolver import ContextResolver
+from logos.pipeline.context_resolver import ContextResolver, ExecutionContext
 from logos.pipeline.correcting_scheduler import ClassificationCorrectingScheduler
 from logos.pipeline.executor import ExecutionResult, Executor, StreamingExecutionStatus
 from logos.pipeline.pipeline import PipelineRequest, RequestPipeline
@@ -75,6 +75,7 @@ from logos.sdi.azure_deployment_sync import AzureDeploymentSyncService
 from logos.sdi.azure_facade import AzureSchedulingDataFacade
 from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
 from logos.sdi.providers.azure_provider import extract_azure_deployment_name
+from logos.temp_providers import TempProvider, TempProviderError, TempProviderRegistry, match_model_name
 from logos.terminal_logging import (
     GREEN,
     RED,
@@ -176,6 +177,17 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 # max(1, ...): a fractional LOGOS_TIMEOUT_S (e.g. 0.5) must not floor to 0 and
 # cause immediate timeouts — clamp to at least 1 second.
 _LOGOSNODE_INFER_TIMEOUT_SECONDS = max(1, int(global_timeout_s(_env_int("LOGOSNODE_INFER_TIMEOUT_SECONDS", 120))))
@@ -198,6 +210,18 @@ _LOGOSNODE_STATS_STALE_AFTER_SECONDS = _env_int("LOGOSNODE_STATS_STALE_AFTER_SEC
 # backoff so the lane finishes waking. Never retries once a token has streamed.
 _LOGOSNODE_PRETOKEN_RETRIES = _env_int("LOGOSNODE_PRETOKEN_RETRIES", 3)
 _LOGOSNODE_PRETOKEN_RETRY_BACKOFF_S = float(os.getenv("LOGOSNODE_PRETOKEN_RETRY_BACKOFF_S", "1.0") or 1.0)
+
+# Temporary (volatile) providers: in-memory only, never persisted to the DB.
+# The health loop probes every registered provider, marks it unhealthy as soon
+# as its probes start failing (fail fast: a dead host must stop receiving
+# requests), and removes it entirely once it has stayed unreachable for the
+# expiry window (see logos.temp_providers).
+_temp_providers = TempProviderRegistry(
+    health_interval_s=_env_float("LOGOS_TEMP_PROVIDER_HEALTH_INTERVAL_S", 30.0),
+    unhealthy_after=_env_int("LOGOS_TEMP_PROVIDER_UNHEALTHY_AFTER", 1),
+    expiry_s=_env_float("LOGOS_TEMP_PROVIDER_EXPIRY_S", 86400.0),
+    probe_timeout_s=_env_float("LOGOS_TEMP_PROVIDER_PROBE_TIMEOUT_S", 10.0),
+)
 
 
 def _record_azure_rate_limits(
@@ -1680,9 +1704,13 @@ async def lifespan(app: FastAPI):
     _grpc_server.add_insecure_port("[::]:50051")
     await _grpc_server.start()
 
+    # Health loop for temporary (volatile, in-memory) providers
+    await _temp_providers.start()
+
     yield
 
     # Shutdown logic
+    await _temp_providers.stop()
     if _capacity_planner:
         await _capacity_planner.stop()
     if _calibration_orchestrator:
@@ -2547,6 +2575,16 @@ def _extract_policy(headers: dict, logos_key: str, body: dict):
 def _require_root_access(logos_key: str) -> None:
     with DBManager() as db:
         require_logos_admin_key(logos_key, db)
+
+
+def _caller_is_logos_admin(logos_key: str) -> bool:
+    """True when the key belongs to a logos_admin user (False on any error)."""
+    try:
+        with DBManager() as db:
+            require_logos_admin_key(logos_key, db)
+    except Exception:  # noqa: BLE001 — a failed lookup is "not admin", never a crash
+        return False
+    return True
 
 
 def _normalize_provider_type(provider_type: str | None) -> str:
@@ -4048,6 +4086,278 @@ async def _proxy_sync_response(
         )
 
 
+async def _try_execute_temp_provider(
+    path: str,
+    body: Dict[str, Any],
+    auth: "AuthContext",
+    log_id: Optional[int],
+    is_async_job: bool,
+    request_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Route the request to a temporary provider when it serves the model.
+
+    Returns the response to hand back to the client, or ``None`` when no
+    temporary provider this key may use serves the requested model — the
+    caller then continues the normal (DB) flow, which yields the usual 404.
+    Only proxy-mode requests carry a model name; resource-mode requests
+    (classification/scheduling) never touch temporary providers.
+    """
+    if _temp_providers is None or not path:
+        return None
+    requested = str(body.get("model") or "").strip()
+    if not requested:
+        return None
+    hit = _temp_providers.find_by_model(requested)
+    if hit is None:
+        return None
+    entry, model_name = hit
+    # The owner check is in-memory; only a non-owner pays the admin DB lookup.
+    if entry.owner_api_key_id != auth.api_key_id and not _caller_is_logos_admin(auth.key_value):
+        return None
+
+    if not entry.is_healthy:
+        # The host is known to be unreachable: fail fast with a clear error
+        # instead of letting the request hang until the probe timeout.
+        message = (
+            f"Temporary provider '{entry.name}' ({entry.base_url}) is currently unreachable; "
+            "the model is temporarily unavailable."
+        )
+        _record_log_failure(log_id, request_id, message, result_status="error")
+        if is_async_job:
+            return {"status_code": 503, "data": {"error": message}}
+        return openai_error_response(503, message, code="temp_provider_unavailable", headers={"Retry-After": "30"})
+
+    return await _execute_temp_provider_request(entry, model_name, path, body, log_id, is_async_job, request_id)
+
+
+def _temp_provider_forward_context(entry: TempProvider, model_name: str, path: str) -> ExecutionContext:
+    """Execution context for forwarding to a temporary provider.
+
+    The base URL is OpenAI-shaped (``.../v1``), so forwarding is like-for-like
+    on the inbound path, exactly like a cloud provider. The discovered name is
+    what the upstream serves the model under, so it doubles as the model to
+    rewrite into the payload (mirroring ``prepare_headers_and_payload``).
+    """
+    return ExecutionContext(
+        model_id=0,
+        provider_id=0,
+        provider_name=entry.name,
+        provider_type="cloud",
+        forward_url=ContextResolver._cloud_forward_url(entry.base_url, path, None),
+        auth_header="Authorization",
+        auth_value=f"Bearer {entry.api_key}" if entry.api_key else "",
+        model_name=model_name,
+    )
+
+
+async def _execute_temp_provider_request(
+    entry: TempProvider,
+    model_name: str,
+    path: str,
+    body: Dict[str, Any],
+    log_id: Optional[int],
+    is_async_job: bool,
+    request_id: Optional[str] = None,
+):
+    """Forward one request to a temporary provider and log it.
+
+    Temporary provider models have no DB identity, so the usage log row keeps
+    NULL model/provider references; the executor and logging machinery are
+    reused as-is.
+    """
+    context = _temp_provider_forward_context(entry, model_name, path)
+    payload = set_payload_field(dict(body), "model", model_name)
+    proxy_headers, prepared_payload = ContextResolver.prepare_headers_and_payload(context, payload)
+
+    # Same streaming decision as resource mode: stream unless the payload is a
+    # Whisper one (Whisper answers synchronously even with stream=true).
+    if (
+        not is_async_job
+        and payload_requests_streaming(body)
+        and not (is_whisper_payload(body) or "whisper" in model_name.lower())
+    ):
+        return await _temp_provider_streaming_response(context, prepared_payload, log_id, request_id)
+    return await _temp_provider_sync_response(context, prepared_payload, log_id, is_async_job, request_id)
+
+
+async def _temp_provider_streaming_response(
+    context: ExecutionContext,
+    payload: dict,
+    log_id: Optional[int],
+    request_id: Optional[str] = None,
+):
+    """Build the streaming response for a temporary provider request.
+
+    Peeks the first chunk before committing to a ``StreamingResponse`` so a
+    non-2xx upstream answer becomes a proper JSON error response instead of a
+    broken stream (same pattern as the resource-mode HTTP path).
+    """
+    import datetime
+
+    stream_status = StreamingExecutionStatus()
+    chunk_iter = _pipeline.executor.execute_streaming(
+        context.forward_url,
+        _temp_provider_stream_headers(context),
+        payload,
+        status=stream_status,
+    )
+    try:
+        first_chunk = await chunk_iter.__anext__()
+    except UpstreamStreamError as exc:
+        logger.error("Pre-stream error from temporary provider %s: HTTP %s", context.provider_name, exc.status_code)
+        await _close_temp_provider_chunk_iter(chunk_iter)
+        return await _temp_provider_pre_stream_error_response(exc.status_code, exc.body, str(exc), log_id)
+    except StopAsyncIteration:
+        first_chunk = None
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "Pre-stream transport error from temporary provider %s: %s: %s",
+            context.provider_name,
+            type(exc).__name__,
+            exc,
+        )
+        await _close_temp_provider_chunk_iter(chunk_iter)
+        return await _temp_provider_pre_stream_error_response(502, {"error": str(exc)}, str(exc), log_id)
+
+    async def all_chunks():
+        if first_chunk:
+            yield first_chunk
+        async with aclosing(chunk_iter) as chunks:
+            async for chunk in chunks:
+                yield chunk
+
+    async def streamer():
+        stream_log = _StreamingLogAccumulator()
+        ttft = None
+        error_message = None
+        # Publish to the live view like every other streamer: start is
+        # non-destructive (the handler already started it with a prompt
+        # estimate) and the finally drops the entry when the stream ends.
+        _live_streams.start(request_id, context.model_name)
+        try:
+            async for chunk in all_chunks():
+                if ttft is None:
+                    ttft = datetime.datetime.now(datetime.timezone.utc)
+                    if log_id:
+                        with DBManager() as db:
+                            db.set_time_at_first_token(log_id)
+                yield chunk
+                stream_log.feed(chunk)
+                _live_streams.update(request_id, stream_log.streamed_tokens())
+        except Exception as exc:  # noqa: BLE001
+            error_message = str(exc)
+            raise
+        finally:
+            if error_message is None:
+                error_message = stream_status.error
+            failed = error_message is not None
+            _live_streams.finish(request_id)
+            if log_id:
+                stream_log.finish()
+                response_payload = stream_log.response_payload()
+                usage_tokens = _usage_tokens_from_payload(response_payload)
+                with DBManager() as db:
+                    if ttft is None and stream_log.first_chunk is not None and not error_message:
+                        db.set_time_at_first_token(log_id)
+                    db.set_response_payload(
+                        log_id,
+                        response_payload,
+                        None,
+                        None,
+                        usage_tokens,
+                        -1,
+                        {},
+                    )
+                    db.update_log_entry_metrics(
+                        log_id=log_id,
+                        result_status="error" if failed else "success",
+                        error_message=error_message,
+                    )
+
+    response_headers = {"X-Request-ID": request_id} if request_id else None
+    return StreamingResponse(streamer(), media_type="text/event-stream", headers=response_headers)
+
+
+async def _close_temp_provider_chunk_iter(chunk_iter) -> None:
+    """Best-effort close of an abandoned executor stream (nothing sent yet)."""
+    with suppress(Exception):
+        await chunk_iter.aclose()
+
+
+async def _temp_provider_pre_stream_error_response(
+    status_code: int, body: Any, error_message: str, log_id: Optional[int]
+) -> JSONResponse:
+    """OpenAI-shaped error for a temporary provider failure before streaming began."""
+    corrected_status, error_body = coerce_upstream_error(status_code, body)
+    if log_id:
+        with DBManager() as db:
+            db.set_response_payload(log_id, error_body, None, None, {}, -1, {})
+            db.update_log_entry_metrics(
+                log_id=log_id,
+                result_status="error",
+                error_message=error_message,
+            )
+    return JSONResponse(content=error_body, status_code=corrected_status)
+
+
+def _temp_provider_stream_headers(context: ExecutionContext) -> dict:
+    """Headers for the provider call: Content-Type plus the provider auth."""
+    headers = {"Content-Type": "application/json"}
+    if context.auth_header and context.auth_value:
+        headers[context.auth_header] = context.auth_value
+    return headers
+
+
+async def _temp_provider_sync_response(
+    context: ExecutionContext,
+    payload: dict,
+    log_id: Optional[int],
+    is_async_job: bool,
+    request_id: Optional[str] = None,
+):
+    """Build the synchronous response for a temporary provider request."""
+    exec_result = await _pipeline.executor.execute_sync(
+        context.forward_url, _temp_provider_stream_headers(context), payload
+    )
+
+    response_payload = exec_result.response
+    if not exec_result.success and not response_payload and exec_result.error:
+        response_payload = {"error": exec_result.error}
+
+    if log_id:
+        usage_tokens = _usage_tokens_from_payload(response_payload)
+        with DBManager() as db:
+            if exec_result.success:
+                db.set_time_at_first_token(log_id)
+            db.set_response_payload(
+                log_id,
+                response_payload,
+                None,
+                None,
+                usage_tokens,
+                -1,
+                {},
+            )
+            db.update_log_entry_metrics(
+                log_id=log_id,
+                result_status="success" if exec_result.success else "error",
+                error_message=None if exec_result.success else exec_result.error,
+            )
+
+    status_code = (
+        exec_result.status_code if exec_result.status_code is not None else (200 if exec_result.success else 500)
+    )
+    if not exec_result.success:
+        status_code, response_payload = coerce_upstream_error(
+            status_code, response_payload or {"error": exec_result.error}
+        )
+
+    if is_async_job:
+        return {"status_code": status_code, "data": response_payload}
+    resp_headers = {"X-Request-ID": request_id} if request_id else None
+    return JSONResponse(content=response_payload, status_code=status_code, headers=resp_headers)
+
+
 async def _execute_proxy_mode(
     body: Dict[str, Any],
     headers: Dict[str, str],
@@ -4076,6 +4386,12 @@ async def _execute_proxy_mode(
         [str(row["name"]) for row in models_info if row.get("name")],
     )
     if model_name is None:
+        # Not in the DB for this key — a temporary provider (in-memory only)
+        # may still serve it. DB deployments always win: this fallback runs
+        # only when the DB has no model of this name for the key.
+        response = await _try_execute_temp_provider(request_path, body, auth, log_id, is_async_job, request_id)
+        if response is not None:
+            return response
         raise HTTPException(
             status_code=404,
             detail=f"Model '{requested_model_name}' not available for this key",
@@ -4100,6 +4416,11 @@ async def _execute_proxy_mode(
     # Narrow deployments to the requested model to preserve provider metadata
     model_deployments = [d for d in deployments if d["model_id"] == model_id]
     if not model_deployments:
+        # The key may the model but no deployment routes it — a temporary
+        # provider (in-memory only) may still serve it.
+        response = await _try_execute_temp_provider(request_path, body, auth, log_id, is_async_job, request_id)
+        if response is not None:
+            return response
         raise HTTPException(status_code=404, detail=f"No deployment found for model '{model_name}'")
 
     # Proxy mode reuses the scheduling/execution pipeline. Policy + token
@@ -4413,8 +4734,12 @@ async def route_and_execute(
         _execute_proxy_mode(): PROXY mode implementation
         _execute_resource_mode(): RESOURCE mode implementation
     """
-    # No models available → ERROR
+    # No models available → ERROR — unless a temporary provider (in-memory
+    # only, never in the DB) serves the requested model to this key.
     if not deployments:
+        response = await _try_execute_temp_provider(path, body, auth, log_id, is_async_job, request_id)
+        if response is not None:
+            return response
         _record_log_failure(
             log_id,
             request_id,
@@ -5440,6 +5765,82 @@ async def connect_model_provider(data: ConnectModelProviderRequest):
     return result
 
 
+@app.post("/logosdb/temp_providers", tags=["admin"])
+async def add_temp_provider(data: AddTempProviderRequest):
+    """Register a temporary (volatile) OpenAI-compatible provider.
+
+    Takes only a base URL and an upstream auth key: the provider's models are
+    discovered via its ``/v1/models`` endpoint and kept in orchestrator
+    memory only — nothing is persisted to the database. The provider is tied
+    to the user (group) given by ``owner_api_key`` (default: the registering
+    key), which is the only key besides logos_admins that may list or route
+    to its models.
+
+    Returns 201 with the provider state (models, provider_id), or 502 when
+    the initial model discovery fails (bad URL, bad key, host offline).
+    """
+    _require_root_access(data.logos_key)
+
+    with DBManager() as db:
+        caller = db.get_user_by_api_key(data.logos_key)
+        owner_key_id = caller["api_key_id"] if caller else None
+        if owner_key_id is None:
+            raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
+        if data.owner_api_key:
+            owner = db.get_user_by_api_key(data.owner_api_key)
+            if owner is None:
+                raise HTTPException(status_code=400, detail="owner_api_key is unknown or inactive")
+            owner_key_id = owner["api_key_id"]
+
+    try:
+        entry = await _temp_providers.add_provider(
+            base_url=data.base_url,
+            api_key=data.api_key,
+            owner_api_key_id=owner_key_id,
+            name=data.name,
+        )
+    except TempProviderError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    return JSONResponse(content={"result": "Temporary provider registered.", **entry.to_public_dict()}, status_code=201)
+
+
+@app.get("/logosdb/temp_providers", tags=["admin"])
+async def list_temp_providers(request: Request):
+    """List temporary providers visible to the calling key.
+
+    Admins see every registered provider; any other key sees only the
+    providers it owns. Entries carry live status (healthy/unhealthy) and the
+    currently discovered model list.
+    """
+    auth = authenticate_api_key(dict(request.headers))
+    is_admin = _caller_is_logos_admin(auth.key_value)
+    entries = _temp_providers.list_for_api_key(auth.api_key_id, is_admin=is_admin)
+    return JSONResponse(content={"temp_providers": [entry.to_public_dict() for entry in entries]})
+
+
+@app.post("/logosdb/temp_providers/delete", tags=["admin"])
+async def delete_temp_provider(data: DeleteTempProviderRequest):
+    """Remove a temporary provider (its models become unroutable immediately).
+
+    Allowed for logos_admins and for the owning key of the provider.
+    """
+    with DBManager() as db:
+        caller = db.get_user_by_api_key(data.logos_key)
+    if caller is None:
+        raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
+
+    entry = _temp_providers.get(data.provider_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Temporary provider not found")
+    is_admin = (caller.get("role") or "") == "logos_admin"
+    if not is_admin and entry.owner_api_key_id != caller["api_key_id"]:
+        raise HTTPException(status_code=403, detail="Only the owner or a Logos Admin may delete this provider")
+
+    _temp_providers.remove_provider(data.provider_id)
+    return JSONResponse(content={"result": "Temporary provider removed."})
+
+
 @app.get("/logosdb/scheduler_state", tags=["admin"])
 async def scheduler_state(request: Request):
     """
@@ -5752,7 +6153,38 @@ async def list_models(request: Request):
         for model in models
     ]
 
+    # Temporary provider models live only in the orchestrator's memory; they
+    # are listed on top of the DB models (a DB model of the same name wins).
+    seen = {entry["id"] for entry in data}
+    data.extend(entry for entry in _temp_provider_model_entries(auth) if entry["id"] not in seen)
+
     return JSONResponse(content={"object": "list", "data": data})
+
+
+def _temp_provider_model_entries(auth: "AuthContext") -> list[dict]:
+    """OpenAI-style entries for the temporary provider models this key may use.
+
+    Only the owning key and logos_admins see a temporary provider's models
+    (see TempProviderRegistry). Unhealthy providers are still listed, with
+    their status, so the owner can see that their host went offline.
+    """
+    if _temp_providers is None or len(_temp_providers) == 0:
+        return []
+    is_admin = _caller_is_logos_admin(auth.key_value)
+    entries = []
+    for provider in _temp_providers.list_for_api_key(auth.api_key_id, is_admin=is_admin):
+        for model_name in provider.models:
+            entries.append(
+                {
+                    "id": model_name,
+                    "object": "model",
+                    "created": int(provider.registered_at),
+                    "owned_by": "logos",
+                    "logos_temp_provider": provider.name,
+                    "logos_temp_provider_status": provider.status,
+                }
+            )
+    return entries
 
 
 @app.get("/v1/models/{model_id:path}", tags=["user-facing"])
@@ -5791,6 +6223,13 @@ async def retrieve_model(model_id: str, request: Request):
                 )
 
     if not model:
+        # Fall back to temporary provider models (in-memory only), with the
+        # same owner/admin access rule as the listing above.
+        temp_entries = _temp_provider_model_entries(auth)
+        matched = match_model_name(model_id, [entry["id"] for entry in temp_entries])
+        temp_entry = next((entry for entry in temp_entries if entry["id"] == matched), None)
+        if temp_entry is not None:
+            return JSONResponse(content=temp_entry)
         raise HTTPException(status_code=404, detail="Model not found or access denied")
 
     stats = _served_context_window_stats()

--- a/logos/logos-orchestrator/src/logos/temp_providers.py
+++ b/logos/logos-orchestrator/src/logos/temp_providers.py
@@ -79,7 +79,9 @@ def match_model_name(requested: str, available: List[str]) -> Optional[str]:
     for name in available:
         if name == requested:
             return name
-    alias_matches = {name for name in available if requested in {_planner_alias(name), f"planner-{_planner_alias(name)}"}}
+    alias_matches = {
+        name for name in available if requested in {_planner_alias(name), f"planner-{_planner_alias(name)}"}
+    }
     if len(alias_matches) == 1:
         return next(iter(alias_matches))
     return None
@@ -312,9 +314,7 @@ class TempProviderRegistry:
         entry.failures_started_mono = None
         entry.last_success_at = time.time()
         if set(models) != set(entry.models):
-            logger.info(
-                "Temporary provider '%s' model list changed: %s -> %s", entry.name, entry.models, models
-            )
+            logger.info("Temporary provider '%s' model list changed: %s -> %s", entry.name, entry.models, models)
             entry.models = models
         if entry.status == STATUS_UNHEALTHY:
             entry.status = STATUS_HEALTHY

--- a/logos/logos-orchestrator/src/logos/temp_providers.py
+++ b/logos/logos-orchestrator/src/logos/temp_providers.py
@@ -1,0 +1,357 @@
+"""
+Temporary (volatile) provider registry.
+
+A temporary provider is an OpenAI-compatible host — e.g. LM Studio on a laptop
+reachable through a tunnel — that an operator wants to route through Logos for
+a short period. It is registered at runtime with only a base URL and an auth
+key, automatically discovers its models via ``GET /v1/models``, and lives
+purely in orchestrator memory: nothing about it is ever written to the
+database, so a restart of the orchestrator makes it disappear, which is
+exactly the volatility the feature is about.
+
+A background health loop probes every registered provider. As soon as its
+probes fail (by default: the first one) the provider is marked ``unhealthy``
+and its models stop being routed — requests fail fast with a clear error
+instead of hanging on a dead host. Once the host is gone for longer than the
+expiry window the entry is removed on its own. When the host comes back, the
+provider becomes healthy again and routing resumes — no re-registration
+needed.
+
+Access: a temporary provider is owned by the API key it was registered for
+(the "add to user" privacy aspect of issue #421). Only that key and
+``logos_admin`` keys may list or route to its models.
+"""
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+STATUS_HEALTHY = "healthy"
+STATUS_UNHEALTHY = "unhealthy"
+
+
+class TempProviderError(Exception):
+    """Raised when a temporary provider cannot be reached or is malformed."""
+
+
+def normalize_base_url(base_url: str) -> str:
+    """Normalise an OpenAI-compatible base URL to a ``.../v1`` form.
+
+    ``http://host:1234`` becomes ``http://host:1234/v1`` (LM Studio, Ollama
+    and friends expose their OpenAI surface under ``/v1``); a URL that already
+    ends in ``/v1`` or ``/v2`` is kept as-is, only trailing slashes are
+    dropped. Raises :class:`TempProviderError` for non-http(s) URLs so the
+    registry never points at a non-absolute or local-file target.
+    """
+    url = (base_url or "").strip().rstrip("/")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise TempProviderError(f"base_url must be an absolute http(s) URL, got: {base_url!r}")
+    last_segment = parsed.path.rstrip("/").rsplit("/", 1)[-1].lower()
+    if last_segment not in {"v1", "v2"}:
+        url = f"{url}/v1"
+    return url
+
+
+def _planner_alias(model_name: str) -> str:
+    """Same alias form main.py's model resolution uses (``/``, ``:``, space → ``_``)."""
+    return str(model_name or "").strip().replace("/", "_").replace(":", "_").replace(" ", "_")
+
+
+def match_model_name(requested: str, available: List[str]) -> Optional[str]:
+    """Resolve a requested name against discovered model names.
+
+    Accepts the exact name or — like ``main._resolve_requested_model_name`` —
+    the planner-safe alias with underscores, returning the canonical name on
+    an unambiguous match and ``None`` otherwise.
+    """
+    requested = str(requested or "").strip()
+    if not requested:
+        return None
+    for name in available:
+        if name == requested:
+            return name
+    alias_matches = {name for name in available if requested in {_planner_alias(name), f"planner-{_planner_alias(name)}"}}
+    if len(alias_matches) == 1:
+        return next(iter(alias_matches))
+    return None
+
+
+@dataclass
+class TempProvider:
+    """One volatile, in-memory provider registration."""
+
+    provider_id: str
+    name: str
+    base_url: str
+    api_key: str
+    owner_api_key_id: int
+    registered_at: float  # wall-clock epoch, for display
+    models: List[str] = field(default_factory=list)
+    status: str = STATUS_HEALTHY
+    consecutive_failures: int = 0
+    last_success_at: Optional[float] = None  # wall-clock epoch, for display
+    failures_started_mono: Optional[float] = None  # monotonic anchor for the expiry window
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.status == STATUS_HEALTHY
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        """JSON-safe view. The upstream API key is in-memory only and never exported."""
+        return {
+            "provider_id": self.provider_id,
+            "name": self.name,
+            "base_url": self.base_url,
+            "status": self.status,
+            "models": list(self.models),
+            "owner_api_key_id": self.owner_api_key_id,
+            "registered_at": self.registered_at,
+            "last_success_at": self.last_success_at,
+            "consecutive_failures": self.consecutive_failures,
+        }
+
+
+class TempProviderRegistry:
+    """In-memory registry of temporary providers with a background health loop.
+
+    The registry never touches the database. All state is lost when the
+    orchestrator process stops, by design.
+    """
+
+    def __init__(
+        self,
+        health_interval_s: float = 30.0,
+        unhealthy_after: int = 1,
+        expiry_s: float = 86400.0,
+        probe_timeout_s: float = 10.0,
+        probe: Optional[Callable[[str, str], List[str]]] = None,
+    ):
+        """
+        Args:
+            health_interval_s: Seconds between health/model-discovery probes.
+            unhealthy_after: Consecutive failed probes before a provider is
+                marked unhealthy (and its models stop being routed). The
+                default of 1 fails fast: a probe that just succeeded a moment
+                ago rarely fails because of a transient glitch, and a dead
+                host must stop receiving requests quickly. Raise it for hosts
+                behind a flaky tunnel.
+            expiry_s: How long an unhealthy provider may stay unreachable
+                before it is removed from the registry entirely.
+            probe_timeout_s: Per-probe HTTP timeout in seconds.
+            probe: Optional async override ``probe(base_url, api_key) -> model
+                names`` — the unit tests use this instead of real HTTP.
+        """
+        self._providers: Dict[str, TempProvider] = {}
+        self._interval_s = float(health_interval_s)
+        self._unhealthy_after = max(1, int(unhealthy_after))
+        self._expiry_s = float(expiry_s)
+        self._probe_timeout_s = float(probe_timeout_s)
+        self._probe = probe
+        self._task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    async def add_provider(
+        self,
+        base_url: str,
+        api_key: str,
+        owner_api_key_id: int,
+        name: Optional[str] = None,
+    ) -> TempProvider:
+        """Register a temporary provider and immediately discover its models.
+
+        Raises:
+            TempProviderError: If the URL is malformed, a provider for the
+                same URL already exists, or the initial ``/models`` probe
+                fails (bad URL, bad key, host already offline).
+        """
+        normalized = normalize_base_url(base_url)
+        for existing in self._providers.values():
+            if existing.base_url == normalized:
+                raise TempProviderError(f"A temporary provider for {normalized} is already registered")
+
+        if name:
+            provider_name = name.strip()
+        else:
+            provider_name = urlparse(normalized).netloc
+
+        try:
+            models = await self._fetch_models(normalized, api_key)
+        except TempProviderError as exc:
+            raise TempProviderError(f"Initial model discovery failed: {exc}") from exc
+        if not models:
+            raise TempProviderError(f"No models discovered at {normalized}/models")
+
+        entry = TempProvider(
+            provider_id=f"tmp-{uuid.uuid4().hex[:8]}",
+            name=provider_name,
+            base_url=normalized,
+            api_key=api_key or "",
+            owner_api_key_id=int(owner_api_key_id),
+            registered_at=time.time(),
+            models=models,
+            status=STATUS_HEALTHY,
+            last_success_at=time.time(),
+        )
+        self._providers[entry.provider_id] = entry
+        logger.info(
+            "Registered temporary provider '%s' (%s) with %d model(s) for api_key_id=%s",
+            provider_name,
+            normalized,
+            len(models),
+            owner_api_key_id,
+        )
+        return entry
+
+    def remove_provider(self, provider_id: str) -> bool:
+        """Remove a provider by id. Returns True if it existed."""
+        removed = self._providers.pop(provider_id, None)
+        if removed is not None:
+            logger.info("Removed temporary provider '%s' (%s)", removed.name, removed.base_url)
+        return removed is not None
+
+    def get(self, provider_id: str) -> Optional[TempProvider]:
+        return self._providers.get(provider_id)
+
+    def __len__(self) -> int:
+        return len(self._providers)
+
+    # ------------------------------------------------------------------
+    # Lookup / access control
+    # ------------------------------------------------------------------
+
+    def find_by_model(self, requested: str) -> Optional[tuple[TempProvider, str]]:
+        """(provider, canonical model name) if any registered provider serves the name."""
+        for entry in self._providers.values():
+            matched = match_model_name(requested, entry.models)
+            if matched is not None:
+                return entry, matched
+        return None
+
+    def list_for_api_key(self, api_key_id: int, is_admin: bool = False) -> List[TempProvider]:
+        """Providers visible to a key: its own, plus everything for admins."""
+        visible = [entry for entry in self._providers.values() if is_admin or entry.owner_api_key_id == api_key_id]
+        return sorted(visible, key=lambda entry: entry.registered_at)
+
+    def can_access(self, entry: TempProvider, api_key_id: int, is_admin: bool) -> bool:
+        return is_admin or entry.owner_api_key_id == api_key_id
+
+    # ------------------------------------------------------------------
+    # Health loop
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the background health loop (no-op if already running)."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._health_loop())
+
+    async def stop(self) -> None:
+        """Cancel the background health loop and wait for it to finish."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _health_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval_s)
+            for entry in list(self._providers.values()):
+                try:
+                    await self._probe_entry(entry)
+                except Exception:  # noqa: BLE001 — one broken probe must not kill the loop
+                    logger.exception("Temporary provider health probe crashed for %s", entry.name)
+
+    async def _probe_entry(self, entry: TempProvider) -> None:
+        """Probe one provider: refresh its model list or record the failure."""
+        now_mono = time.monotonic()
+        try:
+            models = await self._fetch_models(entry.base_url, entry.api_key)
+        except Exception as exc:  # noqa: BLE001 — any probe error counts as unreachable
+            entry.consecutive_failures += 1
+            newly_unhealthy = entry.status == STATUS_HEALTHY and entry.consecutive_failures >= self._unhealthy_after
+            if newly_unhealthy:
+                entry.status = STATUS_UNHEALTHY
+                entry.failures_started_mono = now_mono
+            logger.warning(
+                "Temporary provider '%s' (%s) probe failed (%d consecutive%s): %s",
+                entry.name,
+                entry.base_url,
+                entry.consecutive_failures,
+                " — marked unhealthy" if newly_unhealthy else "",
+                exc,
+            )
+            if (
+                entry.status == STATUS_UNHEALTHY
+                and entry.failures_started_mono is not None
+                and now_mono - entry.failures_started_mono >= self._expiry_s
+            ):
+                self.remove_provider(entry.provider_id)
+                logger.warning(
+                    "Temporary provider '%s' (%s) expired after %ds unreachable and was removed",
+                    entry.name,
+                    entry.base_url,
+                    int(self._expiry_s),
+                )
+            return
+
+        entry.consecutive_failures = 0
+        entry.failures_started_mono = None
+        entry.last_success_at = time.time()
+        if set(models) != set(entry.models):
+            logger.info(
+                "Temporary provider '%s' model list changed: %s -> %s", entry.name, entry.models, models
+            )
+            entry.models = models
+        if entry.status == STATUS_UNHEALTHY:
+            entry.status = STATUS_HEALTHY
+            logger.info("Temporary provider '%s' (%s) is reachable again", entry.name, entry.base_url)
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+
+    async def _fetch_models(self, base_url: str, api_key: str) -> List[str]:
+        """GET ``{base_url}/models`` and return the list of model names.
+
+        Raises:
+            TempProviderError: On any transport error, non-2xx status, or a
+                body that is not the OpenAI model-list shape.
+        """
+        if self._probe is not None:
+            return await self._probe(base_url, api_key)
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        try:
+            async with httpx.AsyncClient(timeout=self._probe_timeout_s) as client:
+                response = await client.get(f"{base_url}/models", headers=headers)
+        except httpx.HTTPError as exc:
+            raise TempProviderError(f"{type(exc).__name__}: {exc}") from exc
+
+        if response.status_code >= 400:
+            raise TempProviderError(f"model discovery failed with HTTP {response.status_code}")
+        try:
+            payload = response.json()
+            data = payload.get("data") if isinstance(payload, dict) else None
+        except (ValueError, AttributeError):
+            raise TempProviderError("model discovery returned a non-JSON body") from None
+        if not isinstance(data, list):
+            raise TempProviderError("model discovery body is not an OpenAI model list")
+
+        names: List[str] = []
+        for item in data:
+            if isinstance(item, dict) and isinstance(item.get("id"), str) and item["id"].strip():
+                names.append(item["id"].strip())
+        return names

--- a/logos/logos-orchestrator/tests/unit/main/test_temp_provider_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_temp_provider_endpoints.py
@@ -1,0 +1,552 @@
+"""
+Tests for temporary provider admin endpoints, model listing, and routing.
+
+The registry's HTTP probe and the request executor are faked; the DB is a
+stub with user/model lookups and log-write recording.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse, StreamingResponse
+
+import logos as main
+from logos.pipeline.executor import ExecutionResult
+from logos.temp_providers import STATUS_UNHEALTHY, TempProviderError, TempProviderRegistry
+
+ADMIN_KEY = "lg-admin"
+OWNER_KEY = "lg-owner"
+OTHER_KEY = "lg-other"
+
+USERS = {
+    ADMIN_KEY: {"role": "logos_admin", "api_key_id": 100},
+    OWNER_KEY: {"role": "app_developer", "api_key_id": 1},
+    OTHER_KEY: {"role": "app_developer", "api_key_id": 2},
+}
+
+
+class DummyDB:
+    """In-memory DBManager stub: user/model lookups plus log-write recording."""
+
+    def __init__(self, users=None, models=None):
+        self._users = users if users is not None else {}
+        self._models = models if models is not None else []
+        self.log_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get_user_by_api_key(self, key_value):
+        return self._users.get(key_value)
+
+    def get_models_for_api_key(self, api_key_id):
+        return self._models
+
+    def get_model_for_api_key(self, api_key_id, model_name):
+        return next((m for m in self._models if m["name"] == model_name), None)
+
+    def get_models_info(self, key_value):
+        return [{"id": m["id"], "name": m["name"]} for m in self._models]
+
+    def update_log_entry_metrics(self, **fields):
+        self.log_calls.append(("update_log_entry_metrics", fields))
+
+    def set_response_payload(self, log_id, payload, provider_id, model_id, usage, policy_id, classified, **kw):
+        self.log_calls.append(("set_response_payload", (log_id, provider_id, model_id)))
+
+    def set_time_at_first_token(self, log_id):
+        self.log_calls.append(("set_time_at_first_token", log_id))
+
+
+class FakeExecutor:
+    """Stands in for _pipeline.executor: records calls, returns canned results."""
+
+    def __init__(self):
+        self.calls = []
+        self.sync_result = None
+        self.stream_chunks: list[bytes] = []
+
+    async def execute_sync(self, url, headers, payload):
+        self.calls.append(("sync", url, headers, payload))
+        return self.sync_result
+
+    async def execute_streaming(self, url, headers, payload, on_headers=None, on_response_start=None, status=None):
+        self.calls.append(("stream", url, headers, payload))
+        for chunk in self.stream_chunks:
+            yield chunk
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = TempProviderRegistry(health_interval_s=3600.0, unhealthy_after=3, expiry_s=86400.0, probe_timeout_s=5.0)
+    monkeypatch.setattr(main, "_temp_providers", reg)
+    return reg
+
+
+async def _register(registry, owner_api_key_id=1, models=("llama-3.1-8b", "mistral-7b"), base_url="http://mac.example.com/v1"):
+    async def probe(base_url_, api_key_):
+        return list(models)
+
+    registry._probe = probe
+    return await registry.add_provider(base_url=base_url, api_key="lm-key", owner_api_key_id=owner_api_key_id)
+
+
+def _patch_db(monkeypatch, users=None, models=None):
+    db = DummyDB(users=users if users is not None else USERS, models=models)
+    monkeypatch.setattr(main, "DBManager", lambda: db)
+    return db
+
+
+def _patch_auth(monkeypatch, key_value):
+    monkeypatch.setattr(
+        main,
+        "authenticate_api_key",
+        lambda headers: MagicMock(api_key_id=USERS[key_value]["api_key_id"], key_value=key_value),
+    )
+
+
+def _request(headers=None):
+    req = MagicMock()
+    req.headers = headers if headers is not None else {"authorization": f"Bearer {OWNER_KEY}"}
+    return req
+
+
+# ---------------------------------------------------------------------------
+# POST /logosdb/temp_providers
+# ---------------------------------------------------------------------------
+
+
+async def test_add_temp_provider_admin(registry, monkeypatch):
+    _patch_db(monkeypatch)
+
+    async def probe(base_url, api_key):
+        assert api_key == "lm-key"
+        return ["llama-3.1-8b"]
+
+    registry._probe = probe
+    data = main.AddTempProviderRequest(logos_key=ADMIN_KEY, base_url="http://mac.example.com", api_key="lm-key")
+    response = await main.add_temp_provider(data)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 201
+    body = json.loads(response.body)
+    assert body["base_url"] == "http://mac.example.com/v1"
+    assert body["models"] == ["llama-3.1-8b"]
+    assert body["owner_api_key_id"] == 100  # defaults to the registering admin key
+    assert len(registry) == 1
+
+
+async def test_add_temp_provider_non_admin_forbidden(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    data = main.AddTempProviderRequest(logos_key=OWNER_KEY, base_url="http://mac.example.com", api_key="lm-key")
+    with pytest.raises(HTTPException) as exc:
+        await main.add_temp_provider(data)
+    assert exc.value.status_code == 403
+    assert len(registry) == 0
+
+
+async def test_add_temp_provider_owner_binding(registry, monkeypatch):
+    """owner_api_key ties the provider to that user: only they (and admins) may use it."""
+    _patch_db(monkeypatch)
+
+    async def probe(base_url, api_key):
+        return ["llama-3.1-8b"]
+
+    registry._probe = probe
+    data = main.AddTempProviderRequest(
+        logos_key=ADMIN_KEY, base_url="http://mac.example.com", api_key="lm-key", owner_api_key=OWNER_KEY
+    )
+    response = await main.add_temp_provider(data)
+    body = json.loads(response.body)
+    assert body["owner_api_key_id"] == 1  # OWNER_KEY's api key id
+
+
+async def test_add_temp_provider_unknown_owner(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    data = main.AddTempProviderRequest(
+        logos_key=ADMIN_KEY, base_url="http://mac.example.com", api_key="lm-key", owner_api_key="lg-unknown"
+    )
+    with pytest.raises(HTTPException) as exc:
+        await main.add_temp_provider(data)
+    assert exc.value.status_code == 400
+
+
+async def test_add_temp_provider_discovery_failure(registry, monkeypatch):
+    _patch_db(monkeypatch)
+
+    async def dead_probe(base_url, api_key):
+        raise TempProviderError("ConnectError: connection refused")
+
+    registry._probe = dead_probe
+    data = main.AddTempProviderRequest(logos_key=ADMIN_KEY, base_url="http://gone.example.com", api_key="lm-key")
+    with pytest.raises(HTTPException) as exc:
+        await main.add_temp_provider(data)
+    assert exc.value.status_code == 502
+    assert len(registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /logosdb/temp_providers
+# ---------------------------------------------------------------------------
+
+
+async def test_list_temp_providers_owner_sees_own(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    await _register(registry, owner_api_key_id=1)
+    await _register(registry, owner_api_key_id=2, base_url="http://other.example.com/v1")
+    _patch_auth(monkeypatch, OWNER_KEY)
+
+    response = await main.list_temp_providers(_request())
+    body = json.loads(response.body)
+    assert len(body["temp_providers"]) == 1
+    assert body["temp_providers"][0]["base_url"] == "http://mac.example.com/v1"
+
+
+async def test_list_temp_providers_admin_sees_all(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    await _register(registry, owner_api_key_id=1)
+    await _register(registry, owner_api_key_id=2, base_url="http://other.example.com/v1")
+    _patch_auth(monkeypatch, ADMIN_KEY)
+
+    response = await main.list_temp_providers(_request())
+    body = json.loads(response.body)
+    assert len(body["temp_providers"]) == 2
+
+
+async def test_list_temp_providers_other_key_sees_none(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OTHER_KEY)
+
+    response = await main.list_temp_providers(_request())
+    assert json.loads(response.body)["temp_providers"] == []
+
+
+# ---------------------------------------------------------------------------
+# POST /logosdb/temp_providers/delete
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_temp_provider_admin(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    entry = await _register(registry, owner_api_key_id=1)
+    data = main.DeleteTempProviderRequest(logos_key=ADMIN_KEY, provider_id=entry.provider_id)
+    response = await main.delete_temp_provider(data)
+    assert json.loads(response.body)["result"] == "Temporary provider removed."
+    assert len(registry) == 0
+
+
+async def test_delete_temp_provider_owner(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    entry = await _register(registry, owner_api_key_id=1)
+    data = main.DeleteTempProviderRequest(logos_key=OWNER_KEY, provider_id=entry.provider_id)
+    await main.delete_temp_provider(data)
+    assert len(registry) == 0
+
+
+async def test_delete_temp_provider_other_key_forbidden(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    entry = await _register(registry, owner_api_key_id=1)
+    data = main.DeleteTempProviderRequest(logos_key=OTHER_KEY, provider_id=entry.provider_id)
+    with pytest.raises(HTTPException) as exc:
+        await main.delete_temp_provider(data)
+    assert exc.value.status_code == 403
+    assert len(registry) == 1
+
+
+async def test_delete_temp_provider_not_found(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    data = main.DeleteTempProviderRequest(logos_key=ADMIN_KEY, provider_id="tmp-doesnotexist")
+    with pytest.raises(HTTPException) as exc:
+        await main.delete_temp_provider(data)
+    assert exc.value.status_code == 404
+
+
+async def test_delete_temp_provider_invalid_key(registry, monkeypatch):
+    _patch_db(monkeypatch)
+    data = main.DeleteTempProviderRequest(logos_key="lg-unknown", provider_id="tmp-x")
+    with pytest.raises(HTTPException) as exc:
+        await main.delete_temp_provider(data)
+    assert exc.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /v1/models and /v1/models/{id} include temp provider models
+# ---------------------------------------------------------------------------
+
+
+async def test_list_models_includes_temp_models_for_owner(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[{"id": 5, "name": "gpt-4o", "description": None}])
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OWNER_KEY)
+
+    response = await main.list_models(_request())
+    ids = [entry["id"] for entry in json.loads(response.body)["data"]]
+
+    assert "gpt-4o" in ids  # DB models still listed
+    assert "llama-3.1-8b" in ids
+    assert "mistral-7b" in ids
+
+
+async def test_list_models_temp_models_hidden_from_other_keys(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OTHER_KEY)
+
+    response = await main.list_models(_request())
+    ids = [entry["id"] for entry in json.loads(response.body)["data"]]
+    assert "llama-3.1-8b" not in ids
+
+
+async def test_list_models_db_model_of_same_name_wins(registry, monkeypatch):
+    """A persistent DB model shadows a same-named temporary provider model."""
+    _patch_db(monkeypatch, models=[{"id": 5, "name": "llama-3.1-8b", "description": None}])
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OWNER_KEY)
+
+    response = await main.list_models(_request())
+    entries = json.loads(response.body)["data"]
+    matches = [e for e in entries if e["id"] == "llama-3.1-8b"]
+    assert len(matches) == 1
+    assert "logos_temp_provider" not in matches[0]  # the DB entry, not the temp one
+
+
+async def test_retrieve_model_temp_model(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OWNER_KEY)
+
+    response = await main.retrieve_model("llama-3.1-8b", _request())
+    body = json.loads(response.body)
+    assert body["id"] == "llama-3.1-8b"
+    assert body["logos_temp_provider_status"] == "healthy"
+
+
+async def test_retrieve_model_temp_model_no_access(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    _patch_auth(monkeypatch, OTHER_KEY)
+
+    with pytest.raises(HTTPException) as exc:
+        await main.retrieve_model("llama-3.1-8b", _request())
+    assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Routing: _try_execute_temp_provider
+# ---------------------------------------------------------------------------
+
+
+def _patch_pipeline(monkeypatch, executor):
+    pipeline = MagicMock()
+    pipeline.executor = executor
+    # _pipeline only exists once start_pipeline() has run; create it if absent.
+    monkeypatch.setattr(main, "_pipeline", pipeline, raising=False)
+
+
+def _auth(key_value):
+    return MagicMock(api_key_id=USERS[key_value]["api_key_id"], key_value=key_value)
+
+
+async def test_try_temp_provider_routes_sync_for_owner(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    entry = await _register(registry, owner_api_key_id=1)
+    executor = FakeExecutor()
+    executor.sync_result = ExecutionResult(
+        success=True,
+        response={"id": "cmpl-1", "choices": [{"message": {"content": "hi"}}], "usage": {"prompt_tokens": 3, "completion_tokens": 2}},
+        error=None,
+        usage={"prompt_tokens": 3, "completion_tokens": 2},
+        is_streaming=False,
+        status_code=200,
+    )
+    _patch_pipeline(monkeypatch, executor)
+    db = main.DBManager()
+
+    response = await main._try_execute_temp_provider(
+        "v1/chat/completions",
+        {"model": "llama-3.1-8b", "messages": [{"role": "user", "content": "hi"}]},
+        _auth(OWNER_KEY),
+        log_id=42,
+        is_async_job=False,
+        request_id="req-1",
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert json.loads(response.body)["choices"][0]["message"]["content"] == "hi"
+
+    # Forwarded to the temp provider with its auth, model name pinned,
+    # like-for-like on the inbound path (no duplicated /v1).
+    kind, url, headers, payload = executor.calls[0]
+    assert kind == "sync"
+    assert url == "http://mac.example.com/v1/chat/completions"
+    assert headers["Authorization"] == "Bearer lm-key"
+    assert payload["model"] == "llama-3.1-8b"
+
+    # Usage logged without DB model/provider references (in-memory only).
+    assert ("set_response_payload", (42, None, None)) in db.log_calls
+    assert ("update_log_entry_metrics", {"log_id": 42, "result_status": "success", "error_message": None}) in db.log_calls
+
+
+async def test_try_temp_provider_admin_can_route_to_others_provider(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    executor = FakeExecutor()
+    executor.sync_result = ExecutionResult(
+        success=True, response={"ok": True}, error=None, usage={}, is_streaming=False, status_code=200
+    )
+    _patch_pipeline(monkeypatch, executor)
+
+    response = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"model": "llama-3.1-8b"}, _auth(ADMIN_KEY), log_id=None, is_async_job=False
+    )
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+
+
+async def test_try_temp_provider_other_key_gets_none(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    result = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"model": "llama-3.1-8b"}, _auth(OTHER_KEY), log_id=None, is_async_job=False
+    )
+    assert result is None  # normal flow continues → 404 as usual
+
+
+async def test_try_temp_provider_no_model_in_body(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    result = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"messages": []}, _auth(OWNER_KEY), log_id=None, is_async_job=False
+    )
+    assert result is None
+
+
+async def test_try_temp_provider_unhealthy_fails_fast_sync(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    entry = await _register(registry, owner_api_key_id=1)
+    entry.status = STATUS_UNHEALTHY
+    executor = FakeExecutor()
+    _patch_pipeline(monkeypatch, executor)
+
+    response = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"model": "llama-3.1-8b"}, _auth(OWNER_KEY), log_id=None, is_async_job=False
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 503
+    body = json.loads(response.body)
+    assert body["error"]["code"] == "temp_provider_unavailable"
+    assert executor.calls == []  # no upstream request was even attempted
+
+
+async def test_try_temp_provider_unhealthy_async_job(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    entry = await _register(registry, owner_api_key_id=1)
+    entry.status = STATUS_UNHEALTHY
+
+    result = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"model": "llama-3.1-8b"}, _auth(OWNER_KEY), log_id=None, is_async_job=True
+    )
+    assert result["status_code"] == 503
+    assert "unreachable" in result["data"]["error"]
+
+
+async def test_try_temp_provider_upstream_error_relays_status(registry, monkeypatch):
+    """A 400 from the temp host is relayed with its status (OpenAI shape)."""
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    executor = FakeExecutor()
+    executor.sync_result = ExecutionResult(
+        success=False,
+        response={"error": {"message": "model not loaded", "type": "invalid_request_error"}},
+        error="model not loaded",
+        usage={},
+        is_streaming=False,
+        status_code=400,
+    )
+    _patch_pipeline(monkeypatch, executor)
+
+    response = await main._try_execute_temp_provider(
+        "v1/chat/completions", {"model": "llama-3.1-8b"}, _auth(OWNER_KEY), log_id=None, is_async_job=False
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"]["message"] == "model not loaded"
+
+
+async def test_try_temp_provider_streaming(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    executor = FakeExecutor()
+    executor.stream_chunks = [
+        b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        b'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\ndata: [DONE]\n\n',
+    ]
+    _patch_pipeline(monkeypatch, executor)
+
+    response = await main._try_execute_temp_provider(
+        "v1/chat/completions",
+        {"model": "llama-3.1-8b", "stream": True, "messages": [{"role": "user", "content": "hi"}]},
+        _auth(OWNER_KEY),
+        log_id=7,
+        is_async_job=False,
+        request_id="req-stream",
+    )
+
+    assert isinstance(response, StreamingResponse)
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+    assert b'"hi"' in b"".join(chunks)
+    assert b"data: [DONE]" in b"".join(chunks)
+
+    # The streamer ends the live-view entry.
+    assert main._live_streams.snapshot() == []
+
+
+async def test_route_and_execute_falls_back_to_temp_provider(registry, monkeypatch):
+    """A key without any DB deployment gets its temp provider model routed."""
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+    executor = FakeExecutor()
+    executor.sync_result = ExecutionResult(
+        success=True, response={"ok": True}, error=None, usage={}, is_streaming=False, status_code=200
+    )
+    _patch_pipeline(monkeypatch, executor)
+
+    response = await main.route_and_execute(
+        deployments=[],
+        body={"model": "llama-3.1-8b"},
+        headers={},
+        auth=_auth(OWNER_KEY),
+        path="v1/chat/completions",
+        log_id=None,
+        is_async_job=False,
+        request_id="req-route",
+    )
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+
+
+async def test_route_and_execute_still_404_without_temp_match(registry, monkeypatch):
+    _patch_db(monkeypatch, models=[])
+    await _register(registry, owner_api_key_id=1)
+
+    with pytest.raises(HTTPException) as exc:
+        await main.route_and_execute(
+            deployments=[],
+            body={"model": "unknown-model"},
+            headers={},
+            auth=_auth(OWNER_KEY),
+            path="v1/chat/completions",
+            log_id=None,
+            is_async_job=False,
+            request_id="req-404",
+        )
+    assert exc.value.status_code == 404

--- a/logos/logos-orchestrator/tests/unit/main/test_temp_provider_endpoints.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_temp_provider_endpoints.py
@@ -6,7 +6,7 @@ stub with user/model lookups and log-write recording.
 """
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -88,7 +88,9 @@ def registry(monkeypatch):
     return reg
 
 
-async def _register(registry, owner_api_key_id=1, models=("llama-3.1-8b", "mistral-7b"), base_url="http://mac.example.com/v1"):
+async def _register(
+    registry, owner_api_key_id=1, models=("llama-3.1-8b", "mistral-7b"), base_url="http://mac.example.com/v1"
+):
     async def probe(base_url_, api_key_):
         return list(models)
 
@@ -359,7 +361,11 @@ async def test_try_temp_provider_routes_sync_for_owner(registry, monkeypatch):
     executor = FakeExecutor()
     executor.sync_result = ExecutionResult(
         success=True,
-        response={"id": "cmpl-1", "choices": [{"message": {"content": "hi"}}], "usage": {"prompt_tokens": 3, "completion_tokens": 2}},
+        response={
+            "id": "cmpl-1",
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        },
         error=None,
         usage={"prompt_tokens": 3, "completion_tokens": 2},
         is_streaming=False,
@@ -391,7 +397,10 @@ async def test_try_temp_provider_routes_sync_for_owner(registry, monkeypatch):
 
     # Usage logged without DB model/provider references (in-memory only).
     assert ("set_response_payload", (42, None, None)) in db.log_calls
-    assert ("update_log_entry_metrics", {"log_id": 42, "result_status": "success", "error_message": None}) in db.log_calls
+    assert (
+        "update_log_entry_metrics",
+        {"log_id": 42, "result_status": "success", "error_message": None},
+    ) in db.log_calls
 
 
 async def test_try_temp_provider_admin_can_route_to_others_provider(registry, monkeypatch):

--- a/logos/logos-orchestrator/tests/unit/test_temp_providers.py
+++ b/logos/logos-orchestrator/tests/unit/test_temp_providers.py
@@ -152,7 +152,9 @@ async def test_remove_provider():
 
 async def test_public_dict_never_exposes_api_key():
     registry = _registry()
-    entry = await registry.add_provider(base_url="http://secret.example.com", api_key="super-secret", owner_api_key_id=1)
+    entry = await registry.add_provider(
+        base_url="http://secret.example.com", api_key="super-secret", owner_api_key_id=1
+    )
     public = entry.to_public_dict()
     assert "super-secret" not in str(public)
     assert public["base_url"] == "http://secret.example.com/v1"

--- a/logos/logos-orchestrator/tests/unit/test_temp_providers.py
+++ b/logos/logos-orchestrator/tests/unit/test_temp_providers.py
@@ -1,0 +1,285 @@
+"""
+Unit tests for the temporary (volatile) provider registry.
+
+The registry lives purely in orchestrator memory and never touches the
+database; the HTTP probe is injected so no network access is needed.
+"""
+
+import asyncio
+
+import pytest
+
+from logos.temp_providers import (
+    STATUS_HEALTHY,
+    STATUS_UNHEALTHY,
+    TempProviderError,
+    TempProviderRegistry,
+    match_model_name,
+    normalize_base_url,
+)
+
+# ---------------------------------------------------------------------------
+# Base URL normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_base_url_appends_v1():
+    assert normalize_base_url("http://192.168.1.10:1234") == "http://192.168.1.10:1234/v1"
+
+
+def test_normalize_base_url_keeps_existing_v1():
+    assert normalize_base_url("https://mac.example.com/v1") == "https://mac.example.com/v1"
+    assert normalize_base_url("https://mac.example.com/v1/") == "https://mac.example.com/v1"
+    assert normalize_base_url("https://mac.example.com/v2") == "https://mac.example.com/v2"
+
+
+def test_normalize_base_url_appends_v1_under_path():
+    assert normalize_base_url("https://tunnel.example.com/host") == "https://tunnel.example.com/host/v1"
+
+
+def test_normalize_base_url_rejects_non_http():
+    with pytest.raises(TempProviderError):
+        normalize_base_url("file:///etc/passwd")
+    with pytest.raises(TempProviderError):
+        normalize_base_url("localhost:1234")
+    with pytest.raises(TempProviderError):
+        normalize_base_url("")
+
+
+# ---------------------------------------------------------------------------
+# Model name matching
+# ---------------------------------------------------------------------------
+
+
+def test_match_model_name_exact():
+    assert match_model_name("llama-3.1-8b", ["llama-3.1-8b", "mistral-7b"]) == "llama-3.1-8b"
+
+
+def test_match_model_name_planner_alias():
+    canonical = "Qwen/Qwen2.5-0.5B-Instruct"
+    assert match_model_name("Qwen_Qwen2.5-0.5B-Instruct", [canonical]) == canonical
+    assert match_model_name(f"planner-{canonical.replace('/', '_')}", [canonical]) == canonical
+
+
+def test_match_model_name_ambiguous_alias_returns_none():
+    # Both names share the same underscore alias; the match is ambiguous.
+    assert match_model_name("a_b", ["a/b", "a b"]) is None
+
+
+def test_match_model_name_no_match():
+    assert match_model_name("nope", ["llama-3.1-8b"]) is None
+    assert match_model_name("", ["llama-3.1-8b"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def _registry(probe=None, **kwargs):
+    defaults = dict(health_interval_s=3600.0, unhealthy_after=3, expiry_s=86400.0, probe_timeout_s=5.0)
+    defaults.update(kwargs)
+    if probe is None:
+
+        async def probe(base_url: str, api_key: str):
+            return ["llama-3.1-8b", "mistral-7b"]
+
+    return TempProviderRegistry(probe=probe, **defaults)
+
+
+async def test_add_provider_discovers_models():
+    registry = _registry()
+    entry = await registry.add_provider(
+        base_url="http://192.168.1.10:1234",
+        api_key="lm-secret",
+        owner_api_key_id=7,
+    )
+    assert entry.base_url == "http://192.168.1.10:1234/v1"
+    assert entry.name == "192.168.1.10:1234"
+    assert entry.models == ["llama-3.1-8b", "mistral-7b"]
+    assert entry.is_healthy
+    assert entry.owner_api_key_id == 7
+    assert entry.provider_id.startswith("tmp-")
+    assert registry.get(entry.provider_id) is entry
+    assert len(registry) == 1
+
+
+async def test_add_provider_explicit_name():
+    registry = _registry()
+    entry = await registry.add_provider(
+        base_url="http://mac.example.com",
+        api_key="k",
+        owner_api_key_id=1,
+        name="Tobias' Mac",
+    )
+    assert entry.name == "Tobias' Mac"
+
+
+async def test_add_provider_fails_when_host_offline():
+    async def dead_probe(base_url: str, api_key: str):
+        raise TempProviderError("ConnectError: [Errno 61] Connection refused")
+
+    registry = _registry(probe=dead_probe)
+    with pytest.raises(TempProviderError, match="Initial model discovery failed"):
+        await registry.add_provider(base_url="http://gone.example.com", api_key="k", owner_api_key_id=1)
+    assert len(registry) == 0
+
+
+async def test_add_provider_fails_without_models():
+    async def empty_probe(base_url: str, api_key: str):
+        return []
+
+    registry = _registry(probe=empty_probe)
+    with pytest.raises(TempProviderError, match="No models discovered"):
+        await registry.add_provider(base_url="http://empty.example.com", api_key="k", owner_api_key_id=1)
+
+
+async def test_add_provider_rejects_duplicate_url():
+    registry = _registry()
+    await registry.add_provider(base_url="http://dup.example.com", api_key="k", owner_api_key_id=1)
+    with pytest.raises(TempProviderError, match="already registered"):
+        await registry.add_provider(base_url="http://dup.example.com/v1/", api_key="other", owner_api_key_id=2)
+
+
+async def test_remove_provider():
+    registry = _registry()
+    entry = await registry.add_provider(base_url="http://rm.example.com", api_key="k", owner_api_key_id=1)
+    assert registry.remove_provider(entry.provider_id) is True
+    assert registry.remove_provider(entry.provider_id) is False
+    assert registry.get(entry.provider_id) is None
+    assert len(registry) == 0
+
+
+async def test_public_dict_never_exposes_api_key():
+    registry = _registry()
+    entry = await registry.add_provider(base_url="http://secret.example.com", api_key="super-secret", owner_api_key_id=1)
+    public = entry.to_public_dict()
+    assert "super-secret" not in str(public)
+    assert public["base_url"] == "http://secret.example.com/v1"
+    assert public["status"] == STATUS_HEALTHY
+    assert public["models"] == ["llama-3.1-8b", "mistral-7b"]
+
+
+# ---------------------------------------------------------------------------
+# Lookup and access control
+# ---------------------------------------------------------------------------
+
+
+async def test_find_by_model():
+    registry = _registry()
+    entry = await registry.add_provider(base_url="http://find.example.com", api_key="k", owner_api_key_id=1)
+    assert registry.find_by_model("llama-3.1-8b") == (entry, "llama-3.1-8b")
+    assert registry.find_by_model("missing") is None
+
+
+async def test_list_for_api_key_owner_and_admin():
+    registry = _registry()
+    mine = await registry.add_provider(base_url="http://mine.example.com", api_key="k", owner_api_key_id=1)
+    await registry.add_provider(base_url="http://theirs.example.com", api_key="k", owner_api_key_id=2)
+
+    assert [e.provider_id for e in registry.list_for_api_key(1)] == [mine.provider_id]
+    assert len(registry.list_for_api_key(3)) == 0
+    assert len(registry.list_for_api_key(3, is_admin=True)) == 2
+    assert registry.can_access(mine, 1, False) is True
+    assert registry.can_access(mine, 3, False) is False
+    assert registry.can_access(mine, 3, True) is True
+
+
+# ---------------------------------------------------------------------------
+# Health probing: failure, recovery, expiry
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_failure_marks_unhealthy_after_threshold():
+    registry = _registry(unhealthy_after=2)
+    entry = await registry.add_provider(base_url="http://flaky.example.com", api_key="k", owner_api_key_id=1)
+
+    async def dead_probe(base_url: str, api_key: str):
+        raise TempProviderError("ConnectError: host down")
+
+    registry._probe = dead_probe
+
+    await registry._probe_entry(entry)  # first failure: still healthy
+    assert entry.status == STATUS_HEALTHY
+    assert entry.consecutive_failures == 1
+
+    await registry._probe_entry(entry)  # second failure: unhealthy
+    assert entry.status == STATUS_UNHEALTHY
+    assert entry.is_healthy is False
+
+
+async def test_probe_success_recovers_and_refreshes_models():
+    registry = _registry(unhealthy_after=2)
+    entry = await registry.add_provider(base_url="http://recover.example.com", api_key="k", owner_api_key_id=1)
+
+    calls = {"n": 0}
+
+    async def flaky_probe(base_url: str, api_key: str):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise TempProviderError("down")
+        # The host came back and loaded a different model meanwhile.
+        return ["llama-3.1-8b", "new-model-9b"]
+
+    registry._probe = flaky_probe
+    await registry._probe_entry(entry)
+    await registry._probe_entry(entry)
+    assert entry.status == STATUS_UNHEALTHY
+
+    await registry._probe_entry(entry)
+    assert entry.status == STATUS_HEALTHY
+    assert entry.consecutive_failures == 0
+    assert entry.models == ["llama-3.1-8b", "new-model-9b"]
+    assert entry.last_success_at is not None
+
+
+async def test_unhealthy_provider_expires_and_is_removed():
+    registry = _registry(unhealthy_after=1, expiry_s=60.0)
+    entry = await registry.add_provider(base_url="http://expire.example.com", api_key="k", owner_api_key_id=1)
+
+    async def dead_probe(base_url: str, api_key: str):
+        raise TempProviderError("down")
+
+    registry._probe = dead_probe
+    await registry._probe_entry(entry)
+    assert entry.status == STATUS_UNHEALTHY
+    assert registry.get(entry.provider_id) is not None
+
+    # Simulate the expiry window having elapsed.
+    entry.failures_started_mono -= 61.0
+    await registry._probe_entry(entry)
+    assert registry.get(entry.provider_id) is None
+    assert len(registry) == 0
+
+
+async def test_health_loop_start_stop():
+    registry = _registry(health_interval_s=0.01)
+    await registry.add_provider(base_url="http://loop.example.com", api_key="k", owner_api_key_id=1)
+
+    await registry.start()
+    assert registry._task is not None
+    # Double start must not create a second loop.
+    await registry.start()
+    await registry.stop()
+    assert registry._task is None
+    # The entry survives the loop stopping — only expiry or delete removes it.
+    assert len(registry) == 1
+
+
+async def test_health_loop_survives_probe_crashes():
+    registry = _registry(health_interval_s=0.01)
+    entry = await registry.add_provider(base_url="http://crash.example.com", api_key="k", owner_api_key_id=1)
+
+    async def crashing_probe(base_url: str, api_key: str):
+        raise RuntimeError("boom")
+
+    registry._probe = crashing_probe
+    await registry.start()
+    try:
+        await asyncio.sleep(0.05)  # a few loop iterations with crashing probes
+    finally:
+        await registry.stop()
+    # The loop is still alive (task finished cleanly via stop) and the entry
+    # was only marked unhealthy, not lost.
+    assert entry.status == STATUS_UNHEALTHY
+    assert registry.get(entry.provider_id) is not None


### PR DESCRIPTION
## What

Adds **temporary (volatile) providers** to the orchestrator, per #421: an operator can register an OpenAI-compatible host (e.g. LM Studio on a laptop behind a tunnel) with only a base URL and an auth key. The orchestrator immediately discovers its models via `GET /v1/models`, routes requests to it, watches its health in the background, and fails fast with a clear 503 while the host is down. Nothing is written to the database — a registry entry lives purely in orchestrator memory and vanishes on restart, which is exactly the volatility the issue asks for.

Per the issue discussion, each temporary provider is **tied to a user (group) API key** ("add auth token and add to user"): only that key plus `logos_admin` keys may list or route to its models. The "LLM Node docker container" approach from comment 1 is intentionally out of scope here and tracked as a follow-up.

## Changes

- **`src/logos/temp_providers.py` (new)** — `TempProviderRegistry`: in-memory registry with
  - base-URL normalisation (appends `/v1`, rejects non-http(s) targets),
  - OpenAI `/v1/models` discovery with Bearer auth (injectable `probe` for tests),
  - background asyncio health loop: consecutive-failure threshold → `unhealthy` (models stop being routed), auto-recovery when the host is back (no re-registration), model-list refresh, and auto-removal after the expiry window,
  - owner-based access control (`owner_api_key_id` + admin),
  - `to_public_dict()` that never exposes the upstream API key.
- **`src/logos/main.py`**
  - Registry instance configured via env vars, started/stopped in the app lifespan.
  - **New admin endpoints:**
    | Method & path | Auth | Purpose |
    |---|---|---|
    | `POST /logosdb/temp_providers` | `logos_admin` | Register a provider (`base_url`, `api_key`, optional `name`, optional `owner_api_key`); fails with 502 if discovery fails |
    | `GET /logosdb/temp_providers` | any API key | List own providers (all for admins) |
    | `POST /logosdb/temp_providers/delete` | owner or admin | Remove a provider by id |
  - `/v1/models` and `/v1/models/{id}` include the caller's temporary-provider models (DB models of the same name win; hidden from non-owners).
  - **Routing integration (proxy mode only):** when normal DB-based resolution finds no deployment for the requested model, the request falls back to a matching healthy temporary provider — persistent DB deployments always win. Unhealthy providers return `503` with an OpenAI-shaped error (`code: temp_provider_unavailable`, `Retry-After: 30`) instead of hanging on a dead host. Both sync and streaming requests are supported; requests are logged with NULL model/provider refs (the logging pipeline is already NULL-safe).
- **`src/logos/dbutils/dbrequest.py`** — `AddTempProviderRequest` / `DeleteTempProviderRequest`.

### Configuration (env vars)

| Variable | Default | Meaning |
|---|---|---|
| `LOGOS_TEMP_PROVIDER_HEALTH_INTERVAL_S` | `30.0` | Seconds between health/model probes |
| `LOGOS_TEMP_PROVIDER_UNHEALTHY_AFTER` | `1` | Consecutive failed probes before a provider is marked unhealthy (fail-fast; raise for hosts behind flaky tunnels) |
| `LOGOS_TEMP_PROVIDER_EXPIRY_S` | `86400.0` | How long an unhealthy provider may stay unreachable before it is removed |
| `LOGOS_TEMP_PROVIDER_PROBE_TIMEOUT_S` | `10.0` | Per-probe HTTP timeout |

## How it was verified

- **50 new unit tests** (25 for the registry: URL normalisation, model-name matching, discovery, access control, failure threshold, recovery, expiry, health-loop crash resistance; 25 for the endpoints: registration/permission matrix, listing, deletion, `/v1/models` visibility and DB-wins precedence, sync/streaming routing with the real header/payload/URL construction, 503 while unhealthy, 404 without a match).
- Full orchestrator unit suite: **1067 passed, 1 xfailed** (no regressions).
- `pre-commit run --all-files` with the logos hook config (autoflake, isort, black, flake8, pre-commit-hooks): **all passed**.
- No deployment environment was available, so end-to-end verification against a real LM Studio instance was not performed; see limitations.

## Limitations

- **Proxy-mode routing only**: a temporary model can be requested by name (e.g. `{"model": "llama-3.1-8b"}`), but there is no classification/resource-mode scheduling for it — it cannot be picked up by the deployment/scheduling machinery.
- **Access is per API key**: the owner key plus `logos_admin` keys only; sharing with a team/group key set is not supported yet (the owner binding from the issue comment is implemented at key granularity).
- **In-memory by design**: orchestrator restart removes all temporary providers; they must be re-registered.
- The self-connecting **LLM Node docker container** (comment 1) is a follow-up; for now the host must be reachable from the orchestrator (e.g. via a tunnel) while up.

Fixes #421