### PR TITLE
`Logos`: Size GPU auto-placement on the effective vLLM memory reservation

### DIFF
--- a/logos/logos-workernode/config.example.yml
+++ b/logos/logos-workernode/config.example.yml
@@ -241,16 +241,19 @@ engines:
     #   dtype: str                 — compute dtype: "auto" | "float16" | "bfloat16".
     #     "auto" picks bfloat16 on Ampere+ and float16 on older cards.
     #
-    #   gpu_memory_utilization: float  — fraction of GPU VRAM vLLM may use for
-    #     its own KV cache (0.1–1.0). Only relevant when kv_cache_memory_bytes
-    #     is NOT set. Default when kv_cache_memory_bytes is set: 0.1 (passthrough).
+    #   gpu_memory_utilization: float  — fraction of per-GPU VRAM vLLM may use
+    #     (0.1–1.0). vLLM enforces it as a startup gate — free_per_gpu >=
+    #     gmu * total_per_gpu or the engine refuses to start — and uses it to
+    #     size the KV cache unless kv_cache_memory_bytes is set.
     #
     #   kv_cache_memory_bytes: str — exact KV-cache allocation passed to vLLM at
     #     launch (e.g. "4G", "2048M"). This is a vLLM invocation flag — it controls
     #     how much GPU memory vLLM actually reserves for KV cache at runtime.
     #     If you also set base_residency_mb manually in capabilities_models, set
     #     this to the same value so the scheduler's VRAM estimate matches reality.
-    #     When set, gpu_memory_utilization is ignored by vLLM (overridden to 0.1).
+    #     When set, the KV cache is sized from this value instead of
+    #     gpu_memory_utilization, but the startup gate above still applies, so
+    #     keep gpu_memory_utilization at a value the node's GPUs can satisfy.
     #     Preferred over gpu_memory_utilization for predictable, reproducible budgets.
     #
     #   disable_custom_all_reduce: bool  — disable vLLM's custom all-reduce kernel.

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -1702,11 +1702,19 @@ class LaneManager:
         per_gpu_required_mb = required_total_mb / float(tp_size)
         per_gpu_threshold_mb = per_gpu_required_mb * _GPU_PLACEMENT_SECURITY_RATIO + _GPU_PLACEMENT_HEADROOM_OFFSET_MB
 
-        # When vLLM sizes its KV cache from gpu_memory_utilization, it clamps a
-        # small model's GMU up to _VLLM_GMU_FLOOR and pre-allocates that fraction
-        # of total GPU memory at startup; checking only the calibrated footprint
-        # would let placement succeed here but vLLM startup fail with
-        # "free memory < desired gpu_memory_utilization".
+        # When vLLM sizes its KV cache from gpu_memory_utilization, it
+        # pre-allocates effective-GMU × total per GPU at startup and refuses
+        # to start if free is below that; checking only the calibrated
+        # footprint would let placement succeed here but vLLM startup fail
+        # with "free memory < desired gpu_memory_utilization".
+        #
+        # The effective GMU is what VllmProcessHandle._resolve_gmu passes to
+        # vLLM: an explicit operator gpu_memory_utilization wins verbatim (no
+        # clamping), while the auto-derived value is clamped to
+        # [_VLLM_GMU_FLOOR, 0.95] — so _VLLM_GMU_FLOOR is the minimum the
+        # auto-derivation can reach. Gating the explicit value on the
+        # derivation floor would understate e.g. a 0.95 reservation as 0.5 and
+        # place the lane on a GPU vLLM cannot start on (#570).
         #
         # BUT when the lane pins kv_cache_memory_bytes, vLLM skips memory
         # profiling and ignores gpu_memory_utilization entirely (it logs exactly
@@ -1719,15 +1727,19 @@ class LaneManager:
         gpu_totals = [float(row.get("total_mb", 0.0)) for row in allowed_rows if row.get("total_mb", 0.0) > 0]
         if gpu_totals and not kv_pinned:
             min_gpu_total_mb = min(gpu_totals)
-            vllm_floor_mb = _VLLM_GMU_FLOOR * min_gpu_total_mb
+            gmu = _VLLM_GMU_FLOOR
+            explicit_gmu = lane_config.vllm_config.gpu_memory_utilization
+            if explicit_gmu is not None:
+                gmu = float(explicit_gmu)
+            vllm_floor_mb = gmu * min_gpu_total_mb
             if vllm_floor_mb > per_gpu_threshold_mb:
                 logger.debug(
                     "Auto-placement lane '%s': raising per-GPU threshold from %.0fMB to %.0fMB "
-                    "(vLLM GMU floor %.2f × %.0fMB GPU total)",
+                    "(vLLM GMU %.2f × %.0fMB GPU total)",
                     lane_id,
                     per_gpu_threshold_mb,
                     vllm_floor_mb,
-                    _VLLM_GMU_FLOOR,
+                    gmu,
                     min_gpu_total_mb,
                 )
                 per_gpu_threshold_mb = vllm_floor_mb

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -27,7 +27,7 @@ from logos_worker_node.models import (
     VllmEngineConfig,
 )
 from logos_worker_node.ollama_process import OllamaProcessHandle
-from logos_worker_node.vllm_process import VllmProcessHandle
+from logos_worker_node.vllm_process import VllmProcessHandle, effective_gmu
 
 logger = logging.getLogger("logos_worker_node.lane_manager")
 
@@ -46,13 +46,23 @@ _HANDLE_CLOSE_TIMEOUT = 10
 # on top of the estimate. OFFSET_MB adds a fixed safety margin on top.
 _GPU_PLACEMENT_SECURITY_RATIO = 1.005
 _GPU_PLACEMENT_HEADROOM_OFFSET_MB = 0.0
-# vLLM clamps auto-derived gpu_memory_utilization to this floor (see VllmProcessHandle).
-# Placement must treat this as the minimum per-GPU reservation when the model's actual
-# footprint is smaller, otherwise placement succeeds but vLLM startup fails with
-# "Free memory ... less than desired GPU memory utilization".
-_VLLM_GMU_FLOOR = 0.5
 _CRASH_RESTART_COOLDOWN_S = 30.0
 _MAX_CRASH_RESTARTS = 5  # per lane; budget resets on confirmed successful restart
+
+
+def _placement_threshold_mb(row: dict[str, float], base_threshold_mb: float, gmu: float | None) -> float:
+    """Per-GPU placement threshold for one snapshot row.
+
+    vLLM's startup gate (vllm/v1/worker/utils.py:request_memory) checks
+    free >= gmu × total on each card individually, so on mixed-size nodes the
+    GMU reservation must be sized against the row's own total rather than a
+    global minimum. Rows with an unknown total — or no GMU bound in play (kv
+    pinned) — fall back to the base (footprint-derived) threshold alone.
+    """
+    total_mb = float(row.get("total_mb", 0.0) or 0.0)
+    if gmu is None or total_mb <= 0:
+        return base_threshold_mb
+    return max(base_threshold_mb, gmu * total_mb)
 
 
 # Bounded drain of in-flight requests before sleeping/stopping a lane, so an
@@ -1590,8 +1600,16 @@ class LaneManager:
         multi_gpu_indices: set[int] | None = None,
         awake_lanes_by_gpu: dict[int, int] | None = None,
         awake_used_mb_by_gpu: dict[int, float] | None = None,
+        gmu: float | None = None,
     ) -> list[int] | None:
-        feasible = [row for row in device_rows if float(row["free_mb"]) >= per_gpu_threshold_mb]
+        # Per-row: vLLM's startup gate is per card (free >= gmu × that card's
+        # total), so on mixed-size nodes each row is checked against its own
+        # total (None gmu = kv-pinned lane, base threshold only).
+        feasible = [
+            row
+            for row in device_rows
+            if float(row["free_mb"]) >= _placement_threshold_mb(row, per_gpu_threshold_mb, gmu)
+        ]
         if len(feasible) < tp_size:
             return None
 
@@ -1702,47 +1720,45 @@ class LaneManager:
         per_gpu_required_mb = required_total_mb / float(tp_size)
         per_gpu_threshold_mb = per_gpu_required_mb * _GPU_PLACEMENT_SECURITY_RATIO + _GPU_PLACEMENT_HEADROOM_OFFSET_MB
 
-        # When vLLM sizes its KV cache from gpu_memory_utilization, it
-        # pre-allocates effective-GMU × total per GPU at startup and refuses
-        # to start if free is below that; checking only the calibrated
-        # footprint would let placement succeed here but vLLM startup fail
-        # with "free memory < desired gpu_memory_utilization".
+        # vLLM's startup gate (vllm/v1/worker/utils.py:request_memory, called
+        # unconditionally at worker init) pre-allocates effective-GMU × total
+        # per card and refuses to start if free is below that; checking only
+        # the calibrated footprint would let placement succeed here but vLLM
+        # startup fail with "free memory < desired gpu_memory_utilization".
+        # The gate runs per card, so the bound is checked against each row's
+        # own total (see _placement_threshold_mb) — on a mixed-size node,
+        # gating a 48 GB card on its 24 GB neighbour's reservation would
+        # understate the requirement.
         #
         # The effective GMU is what VllmProcessHandle._resolve_gmu passes to
-        # vLLM: an explicit operator gpu_memory_utilization wins verbatim (no
-        # clamping), while the auto-derived value is clamped to
-        # [_VLLM_GMU_FLOOR, 0.95] — so _VLLM_GMU_FLOOR is the minimum the
-        # auto-derivation can reach. Gating the explicit value on the
-        # derivation floor would understate e.g. a 0.95 reservation as 0.5 and
-        # place the lane on a GPU vLLM cannot start on (#570).
+        # vLLM (see effective_gmu() for the shared definition): an explicit
+        # operator value verbatim (no clamping), else the auto-derivation
+        # floor, the minimum the clamped derivation can reach.
         #
-        # BUT when the lane pins kv_cache_memory_bytes, vLLM skips memory
-        # profiling and ignores gpu_memory_utilization entirely (it logs exactly
-        # this), reserving only weights + the explicit KV. The floor would then
-        # demand free VRAM the lane never uses and wrongly reject small models
-        # (e.g. a 4B model needing ~6GB rejected for not having ~24GB free). KV
-        # size / concurrency is governed by the planner's calibrated
-        # parallelity-aware pair selection instead, so skip the floor here.
+        # When the lane pins kv_cache_memory_bytes, the *steady-state*
+        # footprint is weights + the explicit KV regardless of GMU: vLLM
+        # skips memory profiling for KV sizing and reserves exactly the
+        # pinned bytes (its "skipped memory profiling ... does not respect
+        # the gpu_memory_utilization config" log refers to that sizing step
+        # only). Gating placement on the GMU reservation would then demand
+        # free VRAM the lane never uses and wrongly reject small models (e.g.
+        # a 4B model needing ~6GB rejected for not having ~24GB free), so the
+        # bound is skipped here. The startup gate itself still applies to
+        # pinned lanes, so a pinned lane placed into tight free VRAM can
+        # still fail it at spawn — honouring the gate here would re-introduce
+        # the over-rejection above, so that trade-off is left to a follow-up.
         kv_pinned = bool(lane_config.vllm_config is not None and lane_config.vllm_config.kv_cache_memory_bytes)
-        gpu_totals = [float(row.get("total_mb", 0.0)) for row in allowed_rows if row.get("total_mb", 0.0) > 0]
-        if gpu_totals and not kv_pinned:
-            min_gpu_total_mb = min(gpu_totals)
-            gmu = _VLLM_GMU_FLOOR
-            explicit_gmu = lane_config.vllm_config.gpu_memory_utilization
-            if explicit_gmu is not None:
-                gmu = float(explicit_gmu)
-            vllm_floor_mb = gmu * min_gpu_total_mb
-            if vllm_floor_mb > per_gpu_threshold_mb:
-                logger.debug(
-                    "Auto-placement lane '%s': raising per-GPU threshold from %.0fMB to %.0fMB "
-                    "(vLLM GMU %.2f × %.0fMB GPU total)",
-                    lane_id,
-                    per_gpu_threshold_mb,
-                    vllm_floor_mb,
-                    gmu,
-                    min_gpu_total_mb,
-                )
-                per_gpu_threshold_mb = vllm_floor_mb
+        gmu: float | None = None
+        if not kv_pinned and any(float(row.get("total_mb", 0.0)) > 0 for row in allowed_rows):
+            gmu = effective_gmu(lane_config.vllm_config)
+            logger.debug(
+                "Auto-placement lane '%s': per-GPU threshold is the estimate "
+                "(%.0fMB) plus the vLLM startup reservation (effective GMU "
+                "%.2f × per-card total)",
+                lane_id,
+                per_gpu_threshold_mb,
+                gmu,
+            )
 
         # Collect GPU indices occupied by active TP>1 lanes so placement can
         # prefer GPUs that aren't already shared with multi-GPU model shards.
@@ -1797,7 +1813,7 @@ class LaneManager:
         if len(sticky_indices) == tp_size:
             sticky_rows = [row for row in allowed_rows if int(row["index"]) in set(sticky_indices)]
             if len(sticky_rows) == tp_size and all(
-                float(row["free_mb"]) >= per_gpu_threshold_mb for row in sticky_rows
+                float(row["free_mb"]) >= _placement_threshold_mb(row, per_gpu_threshold_mb, gmu) for row in sticky_rows
             ):
                 selected_indices = sorted(sticky_indices)
 
@@ -1809,21 +1825,24 @@ class LaneManager:
                 multi_gpu_indices,
                 awake_lanes_by_gpu,
                 awake_used_mb_by_gpu,
+                gmu,
             )
         if selected_indices is None:
             # Fail fast: an unset gpu_devices makes vLLM default to cuda:0,
             # masking the placement failure as an opaque startup OOM.
+            gmu_note = " + vLLM GMU reservation (effective GMU × per-card total)" if gmu is not None else ""
             per_gpu_summary = ", ".join(
-                f"gpu{int(row['index'])}={float(row['free_mb']):.0f}MB"
+                f"gpu{int(row['index'])}={float(row['free_mb']):.0f}MB free "
+                f"(needs {_placement_threshold_mb(row, per_gpu_threshold_mb, gmu):.0f}MB)"
                 for row in sorted(allowed_rows, key=lambda r: int(r["index"]))
             )
             raise RuntimeError(
                 f"Auto-placement: no feasible GPU subset for lane '{lane_id}' "
                 f"model={lane_config.model} (required≈{required_total_mb:.0f}MB total, "
-                f"tp={tp_size}, per-GPU threshold≈{per_gpu_threshold_mb:.0f}MB "
+                f"tp={tp_size}, base per-GPU threshold≈{per_gpu_threshold_mb:.0f}MB "
                 f"(estimate {per_gpu_required_mb:.0f}MB × {_GPU_PLACEMENT_SECURITY_RATIO:.3f} "
-                f"+ {_GPU_PLACEMENT_HEADROOM_OFFSET_MB:.0f}MB); "
-                f"per-GPU free: {per_gpu_summary})"
+                f"+ {_GPU_PLACEMENT_HEADROOM_OFFSET_MB:.0f}MB{gmu_note}); "
+                f"per-GPU: {per_gpu_summary})"
             )
 
         selector = ",".join(str(index) for index in selected_indices)

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -46,6 +46,29 @@ from logos_worker_node.models import (
 
 logger = logging.getLogger("logos_worker_node.vllm_process")
 
+# Bounds of the auto-derived gpu_memory_utilization (see _resolve_gmu below).
+# The placement planner (lane_manager) gates on the reservation these values
+# produce — via effective_gmu() — so both sides share these constants and the
+# explicit/floor branches instead of re-declaring them.
+GMU_AUTO_FLOOR = 0.5
+GMU_AUTO_CEILING = 0.95
+
+
+def effective_gmu(vllm_config: VllmConfig) -> float:
+    """The gpu_memory_utilization vLLM is started with when the calibrated
+    auto-derivation is not the binding branch.
+
+    An explicit operator ``gpu_memory_utilization`` wins verbatim (vLLM
+    receives it unclamped); otherwise the auto-derivation floor applies — it
+    is the minimum the clamped derivation can reach. The spawner
+    (``_resolve_gmu``) and the placement planner both gate on the reservation
+    this value describes (gmu × per-card total at vLLM startup), so they
+    share this definition instead of each re-implementing the branches.
+    """
+    if vllm_config.gpu_memory_utilization is not None:
+        return float(vllm_config.gpu_memory_utilization)
+    return GMU_AUTO_FLOOR
+
 
 def _env_ready_timeout() -> int:
     """Ready-wait timeout, configurable via ``LOGOS_VLLM_READY_TIMEOUT_S``.
@@ -1162,8 +1185,11 @@ class VllmProcessHandle:
         if self._http is None:
             raise RuntimeError(f"[{self.lane_id}] HTTP client is not initialized")
 
-    _GMU_AUTO_FLOOR: ClassVar[float] = 0.5
-    _GMU_AUTO_CEILING: ClassVar[float] = 0.95
+    # Aliases of the module-level constants so the explicit/floor branches and
+    # the clamp bounds have a single definition shared with the placement
+    # planner (see effective_gmu / GMU_AUTO_FLOOR above).
+    _GMU_AUTO_FLOOR: ClassVar[float] = GMU_AUTO_FLOOR
+    _GMU_AUTO_CEILING: ClassVar[float] = GMU_AUTO_CEILING
 
     def _resolve_gmu(
         self,
@@ -1184,7 +1210,8 @@ class VllmProcessHandle:
              apply its own default (0.9 in current versions).
         """
         if vc.gpu_memory_utilization is not None:
-            return float(vc.gpu_memory_utilization)
+            # Same definition the placement planner gates on (shared helper).
+            return effective_gmu(vc)
         if self._model_profiles is None:
             return None
         profile = self._model_profiles.get_profile(lane_config.model)

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -839,6 +839,221 @@ async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> No
 
 
 @pytest.mark.asyncio
+async def test_auto_place_accounts_for_explicit_gmu_reservation() -> None:
+    """Reproduces #570 (deioma, 3× ~96 GiB): DeepSeek-OCR-2 sits on GPU 0, a
+    tp=2 gemma-3-27b lane with an explicit gpu_memory_utilization=0.95 must
+    land on the two empty GPUs (1,2). GPU 0 has ~81 GB free — above the
+    0.5 auto-derivation floor (48.9 GB) but below the 0.95 × 97.9 GB ≈ 93 GB
+    vLLM actually reserves, so it must be treated as infeasible, not merely
+    undesirable.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["deepseek-ai/DeepSeek-OCR-2"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=16_000.0, engine="vllm"
+    )
+    profiles._profiles["google/gemma-3-27b-it"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=94_000.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: awake DeepSeek-OCR-2 lane, ~16 GB used.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=81_500.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: empty (~2 GB unknown usage).
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=96_000.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: empty (~1 GB unknown usage).
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=97_000.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=81_500.0 + 96_000.0 + 97_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-deepseek-ai_DeepSeek-OCR-2"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-deepseek-ai_DeepSeek-OCR-2",
+        LaneConfig(model="deepseek-ai/DeepSeek-OCR-2", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    lane = LaneConfig(
+        model="google/gemma-3-27b-it",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=2, gpu_memory_utilization=0.95),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-google_gemma-3-27b-it", lane)  # noqa: SLF001
+    # 0.95 × 97887 ≈ 92993 MB per GPU: GPU 0 (81500 free) fails it, so the
+    # only feasible pair is (1,2).
+    assert placed.gpu_devices == "1,2"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_rejects_when_no_gpu_meets_explicit_gmu() -> None:
+    """Same node as #570, but only one GPU has enough free VRAM for the
+    explicit 0.95 reservation: placement must fail fast with a clear error
+    instead of picking a pair that passes the 0.5 floor yet crashes vLLM
+    startup with "free memory < desired gpu_memory_utilization".
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["deepseek-ai/DeepSeek-OCR-2"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=16_000.0, engine="vllm"
+    )
+    profiles._profiles["google/gemma-3-27b-it"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=94_000.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: awake DeepSeek-OCR-2 lane.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=81_500.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: 37 GB unknown usage — above the 0.5 floor, below 0.95.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=60_000.0,
+                    extra={"index": 1},
+                ),
+                # GPU 2: the only GPU meeting the 0.95 reservation.
+                DeviceInfo(
+                    device_id="gpu2",
+                    kind="nvidia",
+                    memory_total_mb=97_887.0,
+                    memory_free_mb=97_000.0,
+                    extra={"index": 2},
+                ),
+            ],
+            total_memory_mb=3 * 97_887.0,
+            free_memory_mb=81_500.0 + 60_000.0 + 97_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    manager._handles["planner-deepseek-ai_DeepSeek-OCR-2"] = _OccupyingLaneStub(  # noqa: SLF001
+        "planner-deepseek-ai_DeepSeek-OCR-2",
+        LaneConfig(model="deepseek-ai/DeepSeek-OCR-2", vllm=True, gpu_devices="0", vllm_config=VllmConfig()),
+        sleeping=False,
+    )
+    lane = LaneConfig(
+        model="google/gemma-3-27b-it",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=2, gpu_memory_utilization=0.95),
+    )
+
+    # With the 0.5 floor the (0,1)/(0,2)/(1,2) pairs all "fit" and the lane
+    # would be spawned to crash; the 0.95 reservation leaves no tp=2 pair.
+    with pytest.raises(RuntimeError, match="no feasible GPU subset"):
+        await manager._auto_place_gpu_devices("planner-google_gemma-3-27b-it", lane)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_auto_place_explicit_gmu_below_floor_uses_operator_value() -> None:
+    """An explicit gpu_memory_utilization below the 0.5 auto-derivation floor
+    is honoured as-is (vLLM receives it unclamped), so placement must not
+    inflate it to the floor: a small model with GMU 0.25 fits into 7 GB free
+    on a 24 GB GPU even though the floor would demand 12.3 GB.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen2.5-0.5B-Instruct"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=4000.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: 7 GB free — above 0.25 × 24576 = 6144 MB, below the
+                # 0.5 floor of 12288 MB.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=7000.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: below the 0.25 reservation too.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=5000.0,
+                    extra={"index": 1},
+                ),
+            ],
+            total_memory_mb=2 * 24576.0,
+            free_memory_mb=12_000.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, gpu_memory_utilization=0.25),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
+    # Threshold = max(~4020 MB footprint, 6144 MB reservation) — only GPU 0
+    # clears it.
+    assert placed.gpu_devices == "0"
+
+
+@pytest.mark.asyncio
 async def test_auto_place_gpu_devices_avoids_collocating_with_tp2_lane() -> None:
     """A single-GPU lane must be placed on a GPU not already occupied by a
     TP=2 lane, even if those GPUs have more free memory than the isolated GPU.

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -840,12 +840,12 @@ async def test_auto_place_skips_gmu_floor_when_kv_cache_memory_bytes_set() -> No
 
 @pytest.mark.asyncio
 async def test_auto_place_accounts_for_explicit_gmu_reservation() -> None:
-    """Reproduces #570 (deioma, 3× ~96 GiB): DeepSeek-OCR-2 sits on GPU 0, a
-    tp=2 gemma-3-27b lane with an explicit gpu_memory_utilization=0.95 must
-    land on the two empty GPUs (1,2). GPU 0 has ~81 GB free — above the
-    0.5 auto-derivation floor (48.9 GB) but below the 0.95 × 97.9 GB ≈ 93 GB
-    vLLM actually reserves, so it must be treated as infeasible, not merely
-    undesirable.
+    """Reproduces the deioma scenario (3× ~96 GiB): DeepSeek-OCR-2 sits on
+    GPU 0, a tp=2 gemma-3-27b lane with an explicit
+    gpu_memory_utilization=0.95 must land on the two empty GPUs (1,2). GPU 0
+    has ~81 GB free — above the 0.5 auto-derivation floor (48.9 GB) but below
+    the 0.95 × 97.9 GB ≈ 93 GB vLLM actually reserves, so it must be treated
+    as infeasible, not merely undesirable.
     """
     from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
 
@@ -918,10 +918,10 @@ async def test_auto_place_accounts_for_explicit_gmu_reservation() -> None:
 
 @pytest.mark.asyncio
 async def test_auto_place_rejects_when_no_gpu_meets_explicit_gmu() -> None:
-    """Same node as #570, but only one GPU has enough free VRAM for the
-    explicit 0.95 reservation: placement must fail fast with a clear error
-    instead of picking a pair that passes the 0.5 floor yet crashes vLLM
-    startup with "free memory < desired gpu_memory_utilization".
+    """Same node as the deioma scenario, but only one GPU has enough free
+    VRAM for the explicit 0.95 reservation: placement must fail fast with a
+    clear error instead of picking a pair that passes the 0.5 floor yet
+    crashes vLLM startup with "free memory < desired gpu_memory_utilization".
     """
     from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
 
@@ -1050,6 +1050,67 @@ async def test_auto_place_explicit_gmu_below_floor_uses_operator_value() -> None
     placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
     # Threshold = max(~4020 MB footprint, 6144 MB reservation) — only GPU 0
     # clears it.
+    assert placed.gpu_devices == "0"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_gates_mixed_size_gpus_on_own_card_total() -> None:
+    """vLLM's startup gate is per card (free >= gmu × that card's total), so on
+    a mixed-size node the GMU bound must use each card's own total rather than
+    the smallest one: with explicit GMU 0.9 the 48 GB card needs 44.2 GB free
+    even though the 24 GB neighbour only needs 22.1 GB.
+    """
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen2.5-0.5B-Instruct"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=6000.0, engine="vllm"
+    )
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                # GPU 0: 24 GB card, 23 GB free — above 0.9 × 24576 = 22118 MB.
+                DeviceInfo(
+                    device_id="gpu0",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=23000.0,
+                    extra={"index": 0},
+                ),
+                # GPU 1: 48 GB card, 25 GB free — below 0.9 × 49152 = 44237 MB,
+                # even though a global-min threshold (22118 MB) would pass it.
+                DeviceInfo(
+                    device_id="gpu1",
+                    kind="nvidia",
+                    memory_total_mb=49152.0,
+                    memory_free_mb=25600.0,
+                    extra={"index": 1},
+                ),
+            ],
+            total_memory_mb=24576.0 + 49152.0,
+            free_memory_mb=23000.0 + 25600.0,
+        )
+
+    manager = LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15100,
+        lane_port_end=15110,
+        model_profiles=profiles,
+        gpu_snapshot=_snapshot,
+    )
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1, gpu_memory_utilization=0.9),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
+    # Per-card gating: GPU 1 (48 GB total) needs 0.9 × 49152 ≈ 44237 MB free
+    # and fails with 25600 MB; only the 24 GB card is feasible.
     assert placed.gpu_devices == "0"
 
 


### PR DESCRIPTION
## Fixes #570

## Context

On a mixed-occupancy multi-GPU worker, a vLLM lane with an explicit `gpu_memory_utilization` (deioma: `0.95`) could be placed on GPUs where vLLM then refuses to start:

```
ValueError: Free memory on device cuda:0 (79.12/94.97 GiB) on startup is less
than desired GPU memory utilization (0.95, 90.22 GiB).
```

The auto-placement feasibility floor in `LaneManager._auto_place_gpu_devices` used the constant `_VLLM_GMU_FLOOR = 0.5` for every non-kv-pinned lane — correct for vLLM's *auto-derived* GMU, which `VllmProcessHandle._resolve_gmu` clamps to `[0.5, 0.95]`. But `_resolve_gmu` passes an *explicit* operator `gpu_memory_utilization` to vLLM **verbatim, unclamped**, so vLLM reserved `0.95 × total` per GPU while placement only guaranteed `0.5 × total`. Any GPU with 48–90 GiB free on a 96 GiB card passed the placement gate, then vLLM crashed at startup. The planner's numbers and vLLM's reservation disagreed — the exact mismatch #570 describes.

The spread-placement change from #787 already stopped the planner from *preferring* a GPU with an awake lane (deioma's specific (0,1) pick no longer happens), but the accounting mismatch remained: whenever no fully-empty pair is available, placement could still select a subset that fits the 0.5 floor but not the actual reservation.

## Changes

- `logos/logos-workernode/logos_worker_node/lane_manager.py` — the per-GPU feasibility floor for non-kv-pinned lanes now uses the **effective GMU**, i.e. exactly what `VllmProcessHandle._resolve_gmu` hands to vLLM:
  - explicit `vllm_config.gpu_memory_utilization` → that value verbatim (no clamping, mirroring `_resolve_gmu`);
  - otherwise → `_VLLM_GMU_FLOOR` (the minimum the clamped auto-derivation can reach), as before.

  The floor still only *raises* the threshold on top of the calibrated-footprint estimate, and the existing kv-pinned skip (vLLM ignores GMU entirely when `kv_cache_memory_bytes` is pinned) is untouched. An explicit sub-floor value (e.g. 0.25) is honoured as-is instead of being inflated to 0.5 — the same accurate-accounting reasoning as the existing kv-pinned fix.

This is fix option A from the issue in the current architecture: the GMU reservation was deliberately moved out of `_estimate_lane_vram_mb` into the placement threshold (see the comment block there), so that is where the effective GMU is now accounted for. Option B (dropping explicit `gpu_memory_utilization` from worker configs) applies to production deployment configs such as deioma's, which are not in this repo — the planner is now defensive against them either way.

The issue's footnote (dead `profile_model_permissions` INSERT in `sync_logosnode_capabilities`) is intentionally left for a separate fix — it lives in the orchestrator's `dbmanager.py`, outside this area, and the issue itself flags it as "worth a separate small fix".

## Tests

Three new tests in `logos/logos-workernode/tests/test_lane_manager.py` covering the accounting with realistic multi-GPU, mixed-occupancy scenarios (tp=2, deioma-shaped 3× ~96 GiB node):

1. `test_auto_place_accounts_for_explicit_gmu_reservation` — the deioma topology from #570: awake DeepSeek-OCR lane on GPU 0, tp=2 gemma with explicit GMU 0.95. GPU 0 clears the old 0.5 floor (81 GiB free) but not the 0.95 reservation (~93 GiB), so the lane must land on `1,2`.
2. `test_auto_place_rejects_when_no_gpu_meets_explicit_gmu` — only one GPU meets the 0.95 reservation: placement must fail fast with a clear "no feasible GPU subset" error instead of spawning a lane that crashes vLLM at startup. **Fails on the pre-fix code** (it placed the lane).
3. `test_auto_place_explicit_gmu_below_floor_uses_operator_value` — an explicit sub-floor GMU is honoured verbatim (vLLM receives it unclamped), so a small model can place into a tight VRAM gap the old floor wrongly rejected. **Fails on the pre-fix code.**

## Verification

- `pytest tests/` in `logos/logos-workernode`: **529 passed, 2 skipped** (skips pre-existing) — no regressions.
- Verified tests 2–3 against the pre-fix `lane_manager.py` (temporarily restored via `git stash`): both fail there, both pass with the fix.
- Lint clean on the changed files: black 25.1.0, isort (profile=black), autoflake, flake8 with the repo config.
- CI note: the workernode CI job excludes `test_lane_manager.py` (GitHub-runner shutdown-signal issue documented in `logos_test.yml`; "The tests pass locally on macOS and Linux"), so the new tests are covered by the local verification above; the CI-run workernode suite is unaffected.
