### PR TITLE
`Logos`: Support RoPE scaling techniques (YaRN & friends) for long-context models

### DIFF
--- a/logos/logos-workernode/config.example.yml
+++ b/logos/logos-workernode/config.example.yml
@@ -307,6 +307,32 @@ engines:
     #     Example: {enable_thinking: false} to opt-out of Gemma 4 thinking mode.
     #     Example: {enable_thinking: false} to disable Qwen3 chain-of-thought.
     #
+    #   rope_scaling: dict        — RoPE scaling for long-context variants,
+    #     e.g. YaRN to extend the context window beyond the model's native
+    #     limit. vLLM reads the technique from the model's HF config, so this
+    #     is passed as an --hf-overrides deep merge into that config (there
+    #     is no dedicated CLI flag). Unset (default) = disabled: the model's
+    #     own rope settings are used as-is.
+    #     Keys:
+    #       rope_type: str (required) — "yarn" | "linear" | "dynamic" |
+    #         "llama3" | "longrope" | "deepseek_yarn" | "dynamic_yarn"
+    #         (| "default" to suppress a scaling the model config ships).
+    #       factor: float — scaling factor, e.g. 4.0 = 4x the native window.
+    #         Required for the yarn techniques.
+    #       original_max_position_embeddings: int — the model's native context
+    #         limit in tokens, before scaling. Required for the yarn
+    #         techniques.
+    #       rope_theta: float — rotary base frequency, e.g. 10000000. Optional.
+    #       config_path: str — where in the model config the dict is written;
+    #         default "rope_scaling". Qwen3.5/3.8-style multimodal configs
+    #         keep their rope settings under "text_config.rope_parameters".
+    #     Any further keys (mrope_section, partial_rotary_factor, ...) are
+    #     passed through to vLLM verbatim. Mutually exclusive with a
+    #     --hf-overrides flag in extra_args. The calibration probe receives
+    #     the same setting, so the profile describes the lane that serves.
+    #     Example: {rope_type: yarn, factor: 4.0,
+    #               original_max_position_embeddings: 32768}
+    #
     #   extra_args: list           — arbitrary extra CLI flags passed verbatim to
     #     "vllm serve". Use for features not yet exposed as first-class fields.
 
@@ -346,6 +372,14 @@ engines:
       some-org/some-qwen3-model:
         chat_template_kwargs:
           enable_thinking: false          # disable chain-of-thought
+
+      # Long-context variant: YaRN scaling 4x on a 32K model (issue #744).
+      # Lane and calibration run with the scaled context window.
+      some-org/some-32k-model-long:
+        rope_scaling:
+          rope_type: yarn
+          factor: 4.0
+          original_max_position_embeddings: 32768
 
       # Custom chat template: the file must exist in the persistent template
       # directory (/opt/logos-workernode/chat-templates on the host, mounted at
@@ -397,6 +431,8 @@ engines:
 #     chat_template: str          — template file name under
 #                                   /opt/logos-workernode/chat-templates.
 #     chat_template_kwargs: dict  — merged on top of inferred family defaults.
+#     rope_scaling: dict          — RoPE scaling (e.g. YaRN long-context);
+#                                   see model_overrides above.
 #     extra_args: list[str]
 
 lanes: []

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -888,6 +888,25 @@ def _build_vllm_cmd(
         cmd.extend(["--quantization", quant])
     if kv_cache_dtype:
         cmd.extend(["--kv-cache-dtype", kv_cache_dtype])
+    # RoPE scaling (e.g. YaRN) has to reach the probe the same way extra_args
+    # does (plans_from_config carries both through from model_overrides):
+    # calibrating without it measures the unscaled model's context window,
+    # and the planner then sizes KV budgets against a window the serving lane
+    # never runs.
+    rope_scaling = plan.get("rope_scaling")
+    if rope_scaling is not None:
+        from logos_worker_node.models import RopeScalingConfig, extra_args_has_hf_overrides  # noqa: PLC0415
+
+        if extra_args_has_hf_overrides(extra_args):
+            raise ValueError(
+                "rope_scaling and a --hf-overrides flag in extra_args are "
+                "mutually exclusive — both set vLLM's --hf-overrides, and only "
+                "the last occurrence would take effect. Either drop "
+                "rope_scaling and pass the rope settings inside the existing "
+                "--hf-overrides JSON, or remove the --hf-overrides flag from "
+                "extra_args."
+            )
+        cmd.extend(["--hf-overrides", json.dumps(RopeScalingConfig.model_validate(rope_scaling).to_hf_overrides())])
     if enforce_eager:
         cmd.append("--enforce-eager")
     if disable_custom_all_reduce:

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -224,6 +224,7 @@ def _lane_needs_restart(current: LaneConfig, desired: LaneConfig) -> bool:
         or cv.enable_auto_tool_choice != dv.enable_auto_tool_choice
         or cv.tool_call_parser != dv.tool_call_parser
         or cv.reasoning_parser != dv.reasoning_parser
+        or cv.rope_scaling != dv.rope_scaling
         or cv.extra_args != dv.extra_args
         or current.gpu_devices != desired.gpu_devices
     )

--- a/logos/logos-workernode/logos_worker_node/models.py
+++ b/logos/logos-workernode/logos_worker_node/models.py
@@ -33,6 +33,21 @@ def _gpu_device_count(value: str) -> int | None:
     return len(normalized.split(","))
 
 
+# RoPE scaling techniques vLLM can apply, and the subset of them that builds
+# on YaRN and therefore needs both the scaling factor and the model's original
+# context limit to compute the rescaled rotary frequencies.
+_ROPE_SCALING_TYPES = frozenset(
+    {"default", "linear", "yarn", "dynamic", "llama3", "longrope", "deepseek_yarn", "dynamic_yarn"}
+)
+_ROPE_SCALING_TYPES_REQUIRING_FACTOR = frozenset({"yarn", "deepseek_yarn", "dynamic_yarn"})
+_ROPE_CONFIG_PATH_SEGMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def extra_args_has_hf_overrides(extra_args: list[str] | None) -> bool:
+    """True when extra_args already carries a vLLM --hf-overrides flag."""
+    return any(str(arg) == "--hf-overrides" or str(arg).startswith("--hf-overrides=") for arg in (extra_args or []))
+
+
 class OllamaConfig(BaseModel):
     """Shared Ollama engine defaults for all non-vLLM lanes."""
 
@@ -53,6 +68,105 @@ class OllamaConfig(BaseModel):
     @classmethod
     def _validate_gpu_devices(cls, value: str) -> str:
         return _normalize_gpu_devices(value)
+
+
+class RopeScalingConfig(BaseModel):
+    """RoPE scaling settings for long-context model variants (e.g. YaRN).
+
+    vLLM has no dedicated CLI flag for RoPE scaling — it reads the technique
+    from the model's HF config — so this is passed as an ``--hf-overrides``
+    deep merge into that config (see :meth:`to_hf_overrides`). Extra keys are
+    passed through verbatim so family-specific settings (attention_factor,
+    beta_fast/beta_slow, mrope_section, partial_rotary_factor, ...) work
+    without extending the schema.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    rope_type: str = Field(
+        description=(
+            "RoPE scaling technique: 'yarn', 'linear', 'dynamic', 'llama3', "
+            "'longrope', 'deepseek_yarn', 'dynamic_yarn' — or 'default' to "
+            "suppress a scaling the model config ships with."
+        ),
+    )
+    factor: float | None = Field(
+        default=None,
+        ge=1.0,
+        description="Context scaling factor (e.g. 4.0 = 4x the native window). " "Required for the yarn techniques.",
+    )
+    original_max_position_embeddings: int | None = Field(
+        default=None,
+        gt=0,
+        description="The model's native context limit in tokens, before scaling. " "Required for the yarn techniques.",
+    )
+    rope_theta: float | None = Field(
+        default=None,
+        gt=0,
+        description="Base frequency of the rotary embeddings (e.g. 10000000). Optional.",
+    )
+    config_path: str | None = Field(
+        default=None,
+        description=(
+            "Where in the model's HF config the scaling dict is written. "
+            "Default 'rope_scaling' (Llama, Qwen2.5, ...). Models that nest "
+            "their rope settings elsewhere set the dotted path instead — "
+            "Qwen3.5/3.8-style multimodal configs use 'text_config.rope_parameters'."
+        ),
+    )
+
+    @field_validator("rope_type")
+    @classmethod
+    def _validate_rope_type(cls, value: str) -> str:
+        cleaned = (value or "").strip().lower()
+        if cleaned not in _ROPE_SCALING_TYPES:
+            raise ValueError(f"Invalid rope_type: {value!r}. " f"Supported: {', '.join(sorted(_ROPE_SCALING_TYPES))}.")
+        return cleaned
+
+    @field_validator("config_path")
+    @classmethod
+    def _validate_config_path(cls, value: str | None) -> str | None:
+        cleaned = (value or "").strip()
+        if not cleaned:
+            return None
+        for segment in cleaned.split("."):
+            if not _ROPE_CONFIG_PATH_SEGMENT.fullmatch(segment):
+                raise ValueError(
+                    f"Invalid config_path: {value!r}. Use a dotted path of plain "
+                    "identifiers like 'text_config.rope_parameters'."
+                )
+        return cleaned
+
+    @model_validator(mode="after")
+    def _validate_yarn_requirements(self) -> RopeScalingConfig:
+        if self.rope_type in _ROPE_SCALING_TYPES_REQUIRING_FACTOR:
+            missing = [
+                name
+                for name, value in (
+                    ("factor", self.factor),
+                    ("original_max_position_embeddings", self.original_max_position_embeddings),
+                )
+                if value is None
+            ]
+            if missing:
+                raise ValueError(f"rope_type '{self.rope_type}' requires {', '.join(missing)} in rope_scaling.")
+        return self
+
+    def to_hf_overrides(self) -> dict[str, Any]:
+        """Build the ``--hf-overrides`` payload for this setting.
+
+        The scaling dict is written under ``config_path`` (default
+        'rope_scaling'). Unset optional keys are omitted so the deep merge
+        into the model config never clobbers the model's own values with nulls.
+        """
+        value = {key: val for key, val in self.model_dump(exclude={"config_path"}).items() if val is not None}
+        path = (self.config_path or "rope_scaling").split(".")
+        root: dict[str, Any] = {}
+        node = root
+        for segment in path[:-1]:
+            node = node.setdefault(segment, {})
+        node[path[-1]] = value
+        return root
 
 
 class VllmConfig(BaseModel):
@@ -195,6 +309,23 @@ class VllmConfig(BaseModel):
         "draft model in the same format as the main model, and a pre-sharded cache has no "
         'shards for it ("only pre-sharded checkpoints are currently supported").',
     )
+    rope_scaling: RopeScalingConfig | None = Field(
+        default=None,
+        description=(
+            "RoPE scaling for long-context variants (e.g. YaRN to extend the "
+            "context window beyond the model's native limit). vLLM reads the "
+            "technique from the model's HF config, so this is passed as "
+            "--hf-overrides, which deep-merges into that config. None "
+            "(default) = disabled: the model's own rope settings are used "
+            "as-is, so an unconfigured lane can never silently serve a scaled "
+            "context. Requires rope_type; the yarn techniques also require "
+            "factor and original_max_position_embeddings. For models that "
+            "store their rope settings under a different config key (Qwen3.5/"
+            "3.8-style text_config.rope_parameters) set config_path "
+            "accordingly. Mutually exclusive with a --hf-overrides flag in "
+            "extra_args — see RopeScalingConfig."
+        ),
+    )
     extra_args: list[str] = Field(default_factory=list)
     env_overrides: dict[str, str] = Field(
         default_factory=dict,
@@ -231,6 +362,22 @@ class VllmConfig(BaseModel):
         if re.fullmatch(r"\d+(\.\d+)?[GMK]?", v):
             return v
         raise ValueError(f"Invalid kv_cache_memory_bytes: {value!r}. " "Use e.g. '4G', '2048M', or raw byte count.")
+
+    @model_validator(mode="after")
+    def _validate_rope_scaling_conflicts(self) -> VllmConfig:
+        # Both rope_scaling and a --hf-overrides extra arg set vLLM's
+        # --hf-overrides; only the last occurrence on the command line would
+        # take effect, so the pair is a silent-wrong-config hazard.
+        if self.rope_scaling is not None and extra_args_has_hf_overrides(self.extra_args):
+            raise ValueError(
+                "vllm_config.rope_scaling and a --hf-overrides flag in "
+                "extra_args are mutually exclusive — both set vLLM's "
+                "--hf-overrides, and only the last occurrence would take "
+                "effect. Either drop rope_scaling and pass the rope settings "
+                "inside the existing --hf-overrides JSON, or remove the "
+                "--hf-overrides flag from extra_args."
+            )
+        return self
 
 
 class VllmEngineConfig(BaseModel):

--- a/logos/logos-workernode/logos_worker_node/vllm_process.py
+++ b/logos/logos-workernode/logos_worker_node/vllm_process.py
@@ -1436,6 +1436,16 @@ class VllmProcessHandle:
             cmd.extend(["--speculative-config", vc.speculative_config.strip()])
         if vc.quantization:
             cmd.extend(["--quantization", vc.quantization])
+        # RoPE scaling (e.g. YaRN long-context variants): vLLM reads the
+        # technique from the model's HF config, so it is passed as an
+        # --hf-overrides deep merge — there is no dedicated CLI flag. Must
+        # match what calibration ran with (see calibration.py), otherwise the
+        # profile describes the unscaled model while the lane serves the
+        # scaled one.
+        if vc.rope_scaling is not None:
+            import json as _json
+
+            cmd.extend(["--hf-overrides", _json.dumps(vc.rope_scaling.to_hf_overrides())])
         # enforce_eager defaults to False (CUDA graph capture enabled).
         # Set enforce_eager=True in vllm_config to skip torch.compile + graph
         # capture — required on Turing (SM 7.5) and other pre-Ampere boards

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -2317,6 +2317,72 @@ def test_plans_from_config_forwards_extra_args(tmp_path: Path) -> None:
     assert hf in _build_vllm_cmd(plan, "vllm", "127.0.0.1", 9000, "4G")
 
 
+def test_plans_from_config_forwards_rope_scaling(tmp_path: Path) -> None:
+    """rope_scaling has to reach calibration like --hf-overrides does (#744).
+
+    Without it the probe measures the unscaled model's context window, and the
+    planner sizes KV budgets against a window the serving lane never runs.
+    """
+    import json
+
+    from logos_worker_node.calibration import _build_vllm_cmd, plans_from_config
+
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(
+        "logos:\n"
+        "  capabilities_models:\n"
+        "    - model: Qwen/Qwen2.5-Coder-14B-Instruct-AWQ\n"
+        "engines:\n"
+        "  vllm:\n"
+        "    model_overrides:\n"
+        "      Qwen/Qwen2.5-Coder-14B-Instruct-AWQ:\n"
+        "        rope_scaling:\n"
+        "          rope_type: yarn\n"
+        "          factor: 4.0\n"
+        "          original_max_position_embeddings: 32768\n"
+    )
+    plan = next(p for p in plans_from_config(cfg) if "Coder" in p["model"])
+    assert plan["rope_scaling"]["rope_type"] == "yarn"
+    cmd = _build_vllm_cmd(plan, "vllm", "127.0.0.1", 9000, "4G")
+    idx = cmd.index("--hf-overrides")
+    assert json.loads(cmd[idx + 1]) == {
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+        }
+    }
+
+
+def test_build_vllm_cmd_rejects_rope_scaling_with_hf_overrides_extra_arg() -> None:
+    """Same conflict rule as the lane's VllmConfig — both paths must agree."""
+    from logos_worker_node.calibration import _build_vllm_cmd
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _build_vllm_cmd(
+            {
+                "model": "m",
+                "rope_scaling": {
+                    "rope_type": "yarn",
+                    "factor": 4.0,
+                    "original_max_position_embeddings": 32768,
+                },
+                "extra_args": ['--hf-overrides={"rope_scaling":{"rope_type":"linear","factor":2}}'],
+            },
+            "vllm",
+            "127.0.0.1",
+            9000,
+            "4G",
+        )
+
+
+def test_build_vllm_cmd_omits_hf_overrides_without_rope_scaling() -> None:
+    from logos_worker_node.calibration import _build_vllm_cmd
+
+    cmd = _build_vllm_cmd({"model": "m"}, "vllm", "127.0.0.1", 9000, "4G")
+    assert "--hf-overrides" not in cmd
+
+
 def test_plans_from_config_never_takes_internal_bookkeeping(tmp_path: Path) -> None:
     """The retry counters steer the sweep and must not be settable from config."""
     from logos_worker_node.calibration import plans_from_config

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 from pydantic import ValidationError
 
-from logos_worker_node.lane_manager import LaneManager, PortAllocator
+from logos_worker_node.lane_manager import LaneManager, PortAllocator, _lane_needs_restart
 from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.models import (
     DeviceInfo,
@@ -2358,3 +2358,50 @@ def test_model_overrides_unknown_key_does_not_fail_lane_creation() -> None:
     merged = manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
 
     assert merged.vllm_config is not None
+
+
+def test_model_overrides_can_set_rope_scaling() -> None:
+    """model_overrides is where an operator pins YaRN for a served model (#744)."""
+    manager = LaneManager(
+        OllamaConfig(),
+        VllmEngineConfig(
+            model_overrides={
+                "org/model-27b": {
+                    "rope_scaling": {
+                        "rope_type": "yarn",
+                        "factor": 4.0,
+                        "original_max_position_embeddings": 32768,
+                    }
+                }
+            }
+        ),
+        lane_port_start=15000,
+        lane_port_end=15010,
+    )
+    lane = LaneConfig(model="org/model-27b", vllm=True, vllm_config=VllmConfig())
+
+    merged = manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
+
+    assert merged.vllm_config is not None
+    assert merged.vllm_config.rope_scaling is not None
+    assert merged.vllm_config.rope_scaling.rope_type == "yarn"
+    assert merged.vllm_config.rope_scaling.factor == 4.0
+
+
+def test_lane_needs_restart_on_rope_scaling_change() -> None:
+    """RoPE scaling changes the vLLM startup args — the lane must restart."""
+    base = LaneConfig(model="org/model-27b", vllm=True, vllm_config=VllmConfig())
+    scaled = LaneConfig(
+        model="org/model-27b",
+        vllm=True,
+        vllm_config=VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 32768,
+            }
+        ),
+    )
+    assert not _lane_needs_restart(base, base)
+    assert _lane_needs_restart(base, scaled)
+    assert _lane_needs_restart(scaled, base)

--- a/logos/logos-workernode/tests/test_lane_models.py
+++ b/logos/logos-workernode/tests/test_lane_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from logos_worker_node.models import LaneConfig, LaneSetRequest, LogosConfig, VllmConfig
+from logos_worker_node.models import LaneConfig, LaneSetRequest, LogosConfig, RopeScalingConfig, VllmConfig
 
 
 def test_lane_config_normalizes_gpu_devices() -> None:
@@ -82,3 +82,151 @@ def test_logos_config_extracts_inline_capability_overrides() -> None:
         "kv_budget_mb": 2048,
         "max_context_length": 4096,
     }
+
+
+# ── RoPE scaling (issue #744) ────────────────────────────────────────────────
+
+
+def test_vllm_config_rope_scaling_defaults_to_disabled() -> None:
+    cfg = VllmConfig()
+    assert cfg.rope_scaling is None
+
+
+def test_rope_scaling_yarn_round_trips() -> None:
+    cfg = VllmConfig(
+        rope_scaling={
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+            "rope_theta": 10000000,
+        }
+    )
+    rs = cfg.rope_scaling
+    assert isinstance(rs, RopeScalingConfig)
+    assert rs.rope_type == "yarn"
+    assert rs.factor == 4.0
+    assert rs.original_max_position_embeddings == 32768
+
+
+def test_rope_scaling_requires_rope_type() -> None:
+    with pytest.raises(ValidationError):
+        VllmConfig(rope_scaling={"factor": 4.0})
+
+
+def test_rope_scaling_rejects_unknown_rope_type() -> None:
+    with pytest.raises(ValidationError, match="Invalid rope_type"):
+        VllmConfig(rope_scaling={"rope_type": "yarnn"})
+
+
+def test_rope_scaling_yarn_requires_factor_and_original_max() -> None:
+    with pytest.raises(ValidationError, match="factor"):
+        VllmConfig(rope_scaling={"rope_type": "yarn", "original_max_position_embeddings": 32768})
+    with pytest.raises(ValidationError, match="original_max_position_embeddings"):
+        VllmConfig(rope_scaling={"rope_type": "yarn", "factor": 4.0})
+
+
+def test_rope_scaling_rejects_factor_below_one() -> None:
+    with pytest.raises(ValidationError):
+        VllmConfig(rope_scaling={"rope_type": "yarn", "factor": 0.5, "original_max_position_embeddings": 32768})
+
+
+def test_rope_scaling_hf_overrides_default_key_and_strips_unset_keys() -> None:
+    # Unset optional keys must not be emitted: the hf-overrides merge is a
+    # deep merge, so a null factor would clobber the model's own value.
+    cfg = VllmConfig(
+        rope_scaling={
+            "rope_type": "yarn",
+            "factor": 2.0,
+            "original_max_position_embeddings": 32768,
+        }
+    )
+    assert cfg.rope_scaling.to_hf_overrides() == {
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 2.0,
+            "original_max_position_embeddings": 32768,
+        }
+    }
+
+
+def test_rope_scaling_passes_through_family_specific_keys() -> None:
+    # The Qwen3.5/3.8-style block from issue #744: family-specific keys are
+    # not part of the schema and must still reach vLLM.
+    cfg = VllmConfig(
+        rope_scaling={
+            "rope_type": "yarn",
+            "rope_theta": 10000000,
+            "partial_rotary_factor": 0.25,
+            "factor": 4.0,
+            "original_max_position_embeddings": 262144,
+            "mrope_interleaved": True,
+            "mrope_section": [11, 11, 10],
+            "config_path": "text_config.rope_parameters",
+        }
+    )
+    assert cfg.rope_scaling.to_hf_overrides() == {
+        "text_config": {
+            "rope_parameters": {
+                "rope_type": "yarn",
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 0.25,
+                "factor": 4.0,
+                "original_max_position_embeddings": 262144,
+                "mrope_interleaved": True,
+                "mrope_section": [11, 11, 10],
+            }
+        }
+    }
+
+
+def test_rope_scaling_rejects_path_traversal_in_config_path() -> None:
+    with pytest.raises(ValidationError, match="Invalid config_path"):
+        VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 2.0,
+                "original_max_position_embeddings": 32768,
+                "config_path": "../escape",
+            }
+        )
+
+
+def test_rope_scaling_equality_sees_family_specific_keys() -> None:
+    # _lane_needs_restart compares RopeScalingConfig values; extra keys must
+    # participate in equality or a mrope_section change would not restart.
+    base = {"rope_type": "yarn", "factor": 4.0, "original_max_position_embeddings": 262144}
+    a = RopeScalingConfig.model_validate({**base, "mrope_section": [11, 11, 10]})
+    b = RopeScalingConfig.model_validate({**base, "mrope_section": [11, 11, 10]})
+    c = RopeScalingConfig.model_validate(base)
+    assert a == b
+    assert a != c
+
+
+def test_vllm_config_rejects_rope_scaling_with_hf_overrides_extra_arg() -> None:
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 32768,
+            },
+            extra_args=["--hf-overrides", '{"rope_scaling":{"rope_type":"linear","factor":2}}'],
+        )
+
+
+def test_vllm_config_rejects_rope_scaling_with_hf_overrides_equals_form() -> None:
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 32768,
+            },
+            extra_args=['--hf-overrides={"rope_scaling":{"rope_type":"linear","factor":2}}'],
+        )
+
+
+def test_vllm_config_accepts_rope_scaling_alone() -> None:
+    cfg = VllmConfig(rope_scaling={"rope_type": "linear", "factor": 2.0})
+    assert cfg.rope_scaling is not None
+    assert cfg.rope_scaling.rope_type == "linear"

--- a/logos/logos-workernode/tests/test_vllm_process.py
+++ b/logos/logos-workernode/tests/test_vllm_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from pathlib import Path
 
@@ -276,6 +277,82 @@ def test_build_cmd_omits_kv_cache_dtype_when_empty(monkeypatch) -> None:
     )
     cmd = handle._build_cmd(lane)
     assert "--kv-cache-dtype" not in cmd
+
+
+def test_build_cmd_omits_hf_overrides_without_rope_scaling(monkeypatch) -> None:
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: ["/tmp/vllm"])
+
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-Coder-7B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(),
+    )
+    cmd = handle._build_cmd(lane)
+    assert "--hf-overrides" not in cmd
+
+
+def test_build_cmd_emits_rope_scaling_as_hf_overrides(monkeypatch) -> None:
+    # YaRN is read by vLLM from the model's HF config, so Logos passes it as
+    # an --hf-overrides deep merge under the 'rope_scaling' key (#744).
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: ["/tmp/vllm"])
+
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-Coder-14B-Instruct-AWQ",
+        vllm=True,
+        vllm_config=VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 32768,
+            }
+        ),
+    )
+    cmd = handle._build_cmd(lane)
+    idx = cmd.index("--hf-overrides")
+    assert json.loads(cmd[idx + 1]) == {
+        "rope_scaling": {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+        }
+    }
+
+
+def test_build_cmd_emits_nested_rope_scaling_config_path(monkeypatch) -> None:
+    # Qwen3.5/3.8-style multimodal configs keep their rope settings under
+    # text_config.rope_parameters, not top-level rope_scaling (issue #744).
+    handle = VllmProcessHandle("lane-test", 19000, OllamaConfig())
+    monkeypatch.setattr(handle, "_resolve_vllm_binary", lambda _configured: ["/tmp/vllm"])
+
+    lane = LaneConfig(
+        model="Qwen/Qwen3.8-27B",
+        vllm=True,
+        vllm_config=VllmConfig(
+            rope_scaling={
+                "rope_type": "yarn",
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25,
+                "factor": 4.0,
+                "original_max_position_embeddings": 262144,
+                "config_path": "text_config.rope_parameters",
+            }
+        ),
+    )
+    cmd = handle._build_cmd(lane)
+    idx = cmd.index("--hf-overrides")
+    assert json.loads(cmd[idx + 1]) == {
+        "text_config": {
+            "rope_parameters": {
+                "rope_type": "yarn",
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 0.25,
+                "factor": 4.0,
+                "original_max_position_embeddings": 262144,
+            }
+        }
+    }
 
 
 def test_build_cmd_uses_default_chat_template_kwargs_flag(monkeypatch) -> None:


### PR DESCRIPTION
## Fixes #744

## Summary

Long-horizon workloads exceed a model's native context window; the usual remedy is a RoPE scaling technique (e.g. YaRN), which vLLM applies by reading the scaling settings from the model's HF config. Operators previously could only reach that knob through the raw `extra_args` pass-through with a hand-written `--hf-overrides` JSON blob. This change exposes `rope_scaling` as a first-class, validated option in the worker node's per-model configuration so it can be enabled per model/provider.

## Changes

- `logos/logos-workernode/logos_worker_node/models.py`
  - New `RopeScalingConfig` schema: `rope_type` (required, validated against the techniques vLLM supports: yarn, linear, dynamic, llama3, longrope, deepseek_yarn, dynamic_yarn, default), `factor` (≥ 1.0), `original_max_position_embeddings` (> 0), `rope_theta`, and `config_path` (dotted path into the model config, default `rope_scaling`). The yarn techniques require `factor` + `original_max_position_embeddings`; unknown `rope_type`s and `config_path` values with path traversal are rejected at config-validation time. Family-specific keys (`mrope_section`, `partial_rotary_factor`, `attention_factor`, …) pass through verbatim (`extra="allow"`).
  - `VllmConfig.rope_scaling: RopeScalingConfig | None = None` — **disabled by default**; an unconfigured lane can never silently serve a scaled context. A model validator makes `rope_scaling` mutually exclusive with a `--hf-overrides` flag in `extra_args` (both would set the same vLLM flag and only the last occurrence would take effect — a silent-wrong-config hazard).
  - `to_hf_overrides()` builds the `--hf-overrides` payload: the scaling dict under `config_path` (default top-level `rope_scaling`; e.g. `text_config.rope_parameters` for Qwen3.5/3.8-style multimodal configs — the exact layout from the issue), with unset optionals omitted so the deep merge never clobbers the model's own values with nulls.
- `logos/logos-workernode/logos_worker_node/vllm_process.py` — `_build_cmd` emits `--hf-overrides <json>` when `rope_scaling` is set (vLLM has no dedicated CLI flag for RoPE scaling).
- `logos/logos-workernode/logos_worker_node/calibration.py` — the calibration probe receives the same setting (`plans_from_config` already carries `model_overrides` keys through, same as `extra_args`/`--hf-overrides`). Without this, calibration would measure the *unscaled* model's context window and the planner would size KV budgets against a window the serving lane never runs. The same conflict rule as `VllmConfig` is enforced here.
- `logos/logos-workernode/logos_worker_node/lane_manager.py` — `_lane_needs_restart` compares `rope_scaling`, so changing the setting (incl. family-specific extras) restarts the lane instead of silently keeping the old engine args.
- `logos/logos-workernode/config.example.yml` — documents the new key (full key reference under `model_overrides`, one-liner in the static-lane field list, worked YaRN example).

Per-model reach for both lane sources: static lanes via `lanes[].vllm_config.rope_scaling`, and — for server-driven lanes — via `engines.vllm.model_overrides.<model>.rope_scaling`, which the worker merges into every incoming lane config at spawn. No DB/orchestrator changes: the orchestrator's `vllm_config` already flows through the same `VllmConfig` validation, and the operator-facing per-model vLLM knobs live in the worker config.

## Testing

- New schema-validation tests in `tests/test_lane_models.py` (defaults, type/requirement validation, factor ≥ 1, unknown types, path traversal, family-key pass-through, `to_hf_overrides()` shape incl. the issue's `text_config.rope_parameters` block, unset keys omitted, extra-args conflict in both flag forms).
- New arg-assembly tests in `tests/test_vllm_process.py` (`_build_cmd` emits no `--hf-overrides` by default; emits the exact JSON for the default and the nested `config_path` case).
- New tests in `tests/test_calibration.py` (plan forwarding of `rope_scaling` from `model_overrides` to the probe command, conflict rule, no flag when unset) and `tests/test_lane_manager.py` (override merge sets `rope_scaling`; `_lane_needs_restart` on change in both directions).
- Verified the issue's Qwen3.8-27B example end-to-end through the schema: it produces exactly the `--hf-overrides` payload quoted in the issue.
- Ran the full worker-node suite: **547 passed, 2 skipped** (was 526/2 before this change). Also ran the CI-equivalent selection (`pytest --timeout=30` excluding the three files CI ignores) and the repo's pre-commit hooks (black, isort, autoflake, flake8, yaml checks) on all touched files.

Note: full deployment (GPU, vLLM) is not available in this environment; vLLM-side behaviour is covered by the schema/assembly tests plus the payload matching the issue's documented example. If a model needs an env-level bypass such as `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`, that remains available via the existing `env_overrides`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RoPE scaling for vLLM models, including YaRN and other supported techniques.
  * Supports long-context model configurations and nested model-specific settings.
  * Scaling options are applied automatically when starting model processes.

* **Bug Fixes**
  * Invalid or conflicting scaling configurations now produce clear validation errors.
  * Lane processes automatically restart when RoPE scaling settings change.

* **Documentation**
  * Added configuration guidance and a working long-context model example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->