### PR TITLE
`Logos`: Use remaining GPUs during calibration on heterogeneous nodes

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/calibration_orchestrator.py
+++ b/logos/logos-orchestrator/src/logos/capacity/calibration_orchestrator.py
@@ -289,18 +289,82 @@ class CalibrationOrchestrator:
             return False
         return not bool(node_health.get("healthy", True))
 
+    def _calibration_gpu_subset(self, provider_id: int) -> frozenset[int]:
+        """GPUs the calibration holds on *provider_id* (issue #592).
+
+        Derived from the worker's nvidia GPU count as the largest power-of-two
+        slice — the same slice the worker's lane manager holds and the probe is
+        pinned to (see ``calibration_gpu_slice`` in the worker). Returns an
+        empty set when the count cannot be determined, in which case the caller
+        treats the whole node as busy (conservative, the old behaviour).
+        """
+        try:
+            snap = self._registry.peek_runtime_snapshot(provider_id)
+        except Exception:
+            snap = None
+        if not isinstance(snap, dict):
+            return frozenset()
+        device_list = ((snap.get("runtime") or {}).get("devices") or {}).get("devices") or []
+        n_gpus = 0
+        for dev in device_list:
+            if not isinstance(dev, dict):
+                continue
+            if dev.get("kind") not in (None, "nvidia"):
+                continue
+            try:
+                index = int((dev.get("extra") or {}).get("index"))
+            except (TypeError, ValueError):
+                continue
+            if index >= 0:
+                n_gpus += 1
+        if n_gpus < 1:
+            return frozenset()
+        slice_size = 1 << (n_gpus.bit_length() - 1)
+        return frozenset(range(slice_size))
+
+    @staticmethod
+    def _lane_touches_subset(gpu_devices: str, subset: frozenset[int]) -> bool:
+        """True when a lane's GPU set intersects the calibration *subset*.
+
+        Mirrors the worker's lane-manager guard: a blank/"all" selector spans
+        every GPU (so it intersects), "none" spans none, and an explicit list
+        is tested by intersection.
+        """
+        raw = (gpu_devices or "").strip().replace(" ", "")
+        lowered = raw.lower()
+        if lowered in {"", "all"}:
+            return True
+        if lowered == "none":
+            return False
+        indices = {int(part) for part in raw.split(",") if part.isdigit()}
+        return bool(indices & subset)
+
     def _provider_has_active_requests(self, provider_id: int) -> bool:
-        """Return True if the provider has any active inference requests."""
+        """Return True if the provider has active requests on the calibration slice.
+
+        A lane busy only on the leftover GPUs (outside the calibration's
+        power-of-two slice) no longer blocks scheduling a calibration
+        (issue #592) — the probe only uses the slice, so a busy leftover GPU is
+        irrelevant. When the slice cannot be determined, any busy lane blocks
+        (the previous, conservative behaviour).
+        """
         try:
             signals = self._facade.get_all_provider_lane_signals(provider_id)
         except Exception:
             # Telemetry unavailable — assume busy to avoid interrupting work.
             return True
+        subset = self._calibration_gpu_subset(provider_id)
         for sig in signals:
-            if int(getattr(sig, "active_requests", 0) or 0) > 0:
-                return True
-            if float(getattr(sig, "queue_waiting", 0.0) or 0.0) > 0.0:
-                return True
+            busy = (
+                int(getattr(sig, "active_requests", 0) or 0) > 0
+                or float(getattr(sig, "queue_waiting", 0.0) or 0.0) > 0.0
+            )
+            if not busy:
+                continue
+            if subset and not self._lane_touches_subset(str(getattr(sig, "gpu_devices", "") or ""), subset):
+                # Busy only on a leftover GPU the probe does not touch.
+                continue
+            return True
         return False
 
     def _provider_has_uncalibrated_models(self, provider_id: int) -> bool:

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_orchestrator_gpu_slice.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_orchestrator_gpu_slice.py
@@ -1,0 +1,229 @@
+"""CalibrationOrchestrator GPU-slice eligibility (issue #592).
+
+On a heterogeneous node (e.g. 3 GPUs) the calibration probe only uses a
+power-of-two slice of the GPUs — the largest slice, ``{0..tp-1}``. A lane that
+is busy only on the *leftover* GPU(s) outside that slice does not touch the
+probe, so it must not block the orchestrator from starting a session.
+
+These tests pin down three helpers that implement that rule:
+
+* ``_calibration_gpu_subset`` — derive the slice from the worker's reported
+  NVIDIA GPU count (the same count the worker uses to pin its probe).
+* ``_lane_touches_subset`` — does a lane's ``gpu_devices`` selector intersect
+  the slice? (blank / "all" spans every GPU, "none" spans none).
+* ``_provider_has_active_requests`` — a worker is only "busy" when a lane that
+  touches the slice has active requests / queued demand. When the slice cannot
+  be determined (no telemetry, no known GPU count) the old conservative
+  behaviour applies: any busy lane blocks.
+
+The orchestrator is exercised the same way the neighbouring tests do it —
+``CalibrationOrchestrator.__new__`` plus fake ``_registry`` / ``_facade`` — so
+we test the pure decision logic without a live registry or a tick loop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from logos.capacity.calibration_orchestrator import CalibrationOrchestrator
+
+# ---------------------------------------------------------------------------
+# Fakes / helpers
+# ---------------------------------------------------------------------------
+
+
+def _nvidia_snapshot(n_gpus: int, *, kinds=None) -> dict:
+    """A runtime snapshot exposing *n_gpus* devices.
+
+    ``kinds`` optionally overrides the ``kind`` per index (a device without a
+    ``kind`` key is treated as NVIDIA — matching how real snapshots look).
+    """
+    devices = []
+    for i in range(n_gpus):
+        dev = {"device_id": f"GPU-{i}", "extra": {"index": i}}
+        if kinds is not None and kinds[i] is not None:
+            dev["kind"] = kinds[i]
+        devices.append(dev)
+    return {"runtime": {"lanes": [], "devices": {"devices": devices}}}
+
+
+def _signal(*, active_requests=0, queue_waiting=0.0, gpu_devices=""):
+    """A lane signal as the orchestrator reads it (only these attrs matter)."""
+    sig = MagicMock()
+    sig.active_requests = active_requests
+    sig.queue_waiting = queue_waiting
+    sig.gpu_devices = gpu_devices
+    return sig
+
+
+_USE_DEFAULT_SNAPSHOT = object()
+
+
+def _orch(n_gpus, signals, *, snapshot=_USE_DEFAULT_SNAPSHOT, facade_raises=False):
+    """A CalibrationOrchestrator wired with a fake registry and facade.
+
+    ``snapshot`` defaults to a snapshot with *n_gpus* NVIDIA GPUs; pass an
+    explicit dict (or ``None`` for "no snapshot") to override it.
+    """
+    orch = CalibrationOrchestrator.__new__(CalibrationOrchestrator)
+    registry = MagicMock()
+    registry.peek_runtime_snapshot.return_value = (
+        _nvidia_snapshot(n_gpus) if snapshot is _USE_DEFAULT_SNAPSHOT else snapshot
+    )
+    facade = MagicMock()
+    if facade_raises:
+        facade.get_all_provider_lane_signals.side_effect = RuntimeError("telemetry down")
+    else:
+        facade.get_all_provider_lane_signals.return_value = signals
+    orch._registry = registry
+    orch._facade = facade
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# _calibration_gpu_subset
+# ---------------------------------------------------------------------------
+
+
+def test_subset_is_largest_power_of_two_slice_3gpu():
+    """3 GPUs → the calibration holds {0, 1} and GPU 2 is the leftover."""
+    orch = _orch(3, [])
+    assert orch._calibration_gpu_subset(7) == frozenset({0, 1})
+
+
+def test_subset_is_largest_power_of_two_slice_5gpu():
+    """5 GPUs → the calibration holds {0, 1, 2, 3} and GPU 4 is the leftover."""
+    orch = _orch(5, [])
+    assert orch._calibration_gpu_subset(7) == frozenset({0, 1, 2, 3})
+
+
+def test_subset_single_gpu():
+    orch = _orch(1, [])
+    assert orch._calibration_gpu_subset(7) == frozenset({0})
+
+
+def test_subset_8gpu_is_the_whole_node():
+    orch = _orch(8, [])
+    assert orch._calibration_gpu_subset(7) == frozenset(set(range(8)))
+
+
+def test_subset_empty_when_no_snapshot():
+    orch = _orch(3, [], snapshot=None)
+    assert orch._calibration_gpu_subset(7) == frozenset()
+
+
+def test_subset_empty_when_devices_missing():
+    orch = _orch(3, [], snapshot={"runtime": {}})
+    assert orch._calibration_gpu_subset(7) == frozenset()
+
+
+def test_subset_counts_only_nvidia_devices():
+    """2 NVIDIA + 1 AMD → the probe slice is sized from the NVIDIA count only."""
+    orch = _orch(3, [], snapshot=_nvidia_snapshot(3, kinds=[None, None, "amd"]))
+    assert orch._calibration_gpu_subset(7) == frozenset({0, 1})
+
+
+def test_subset_empty_when_indexes_malformed():
+    """A device whose ``extra.index`` is not an int cannot be counted."""
+    snap = {
+        "runtime": {
+            "devices": {
+                "devices": [{"device_id": "GPU-0", "extra": {"index": "not-an-int"}}],
+            },
+        },
+    }
+    orch = _orch(1, [], snapshot=snap)
+    assert orch._calibration_gpu_subset(7) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# _lane_touches_subset
+# ---------------------------------------------------------------------------
+
+
+def _touch(gpu_devices, subset):
+    return CalibrationOrchestrator._lane_touches_subset(gpu_devices, subset)
+
+
+def test_touch_blank_spans_all_gpus():
+    assert _touch("", frozenset({0, 1})) is True
+    assert _touch(None, frozenset({0, 1})) is True
+
+
+def test_touch_all_keyword_spans_all_gpus():
+    assert _touch("all", frozenset({0, 1})) is True
+    assert _touch(" ALL ", frozenset({0, 1})) is True
+
+
+def test_touch_none_keyword_spans_nothing():
+    assert _touch("none", frozenset({0, 1})) is False
+
+
+def test_touch_explicit_selector_by_intersection():
+    assert _touch("0", frozenset({0, 1})) is True
+    assert _touch("2", frozenset({0, 1})) is False
+    assert _touch("0,2", frozenset({0, 1})) is True
+    assert _touch("2,3", frozenset({0, 1})) is False
+    assert _touch("0, 1", frozenset({0, 1})) is True
+
+
+# ---------------------------------------------------------------------------
+# _provider_has_active_requests
+# ---------------------------------------------------------------------------
+
+
+def test_leftover_gpu_lane_does_not_block():
+    """Acceptance #3: a lane busy only on the leftover GPU (2) does not block
+    a calibration of the {0, 1} slice on a 3-GPU worker."""
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="2")])
+    assert orch._provider_has_active_requests(7) is False
+
+
+def test_slice_gpu_lane_blocks():
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="0")])
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_all_selector_lane_blocks():
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="all")])
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_blank_selector_lane_blocks():
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="")])
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_partial_slice_lane_blocks():
+    """A lane on "1,2" touches the slice via GPU 1, so it still blocks."""
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="1,2")])
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_idle_lanes_do_not_block():
+    orch = _orch(3, [_signal(active_requests=0, gpu_devices="0"), _signal(active_requests=0, gpu_devices="2")])
+    assert orch._provider_has_active_requests(7) is False
+
+
+def test_queue_waiting_on_slice_blocks():
+    """active_requests=0 but queue_waiting>0 counts as busy on the slice."""
+    orch = _orch(3, [_signal(active_requests=0, queue_waiting=2.0, gpu_devices="1")])
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_mixed_idle_slice_and_busy_leftover():
+    """One idle slice lane plus one busy leftover lane → still not blocking."""
+    orch = _orch(3, [_signal(active_requests=0, gpu_devices="0"), _signal(active_requests=3, gpu_devices="2")])
+    assert orch._provider_has_active_requests(7) is False
+
+
+def test_unknown_subset_falls_back_to_conservative():
+    """No snapshot → slice unknown → any busy lane blocks (previous behaviour)."""
+    orch = _orch(3, [_signal(active_requests=4, gpu_devices="2")], snapshot=None)
+    assert orch._provider_has_active_requests(7) is True
+
+
+def test_facade_exception_is_conservative():
+    """Telemetry unavailable → assume busy rather than interrupting work."""
+    orch = _orch(3, [], facade_raises=True)
+    assert orch._provider_has_active_requests(7) is True

--- a/logos/logos-workernode/logos_worker_node/calibration.py
+++ b/logos/logos-workernode/logos_worker_node/calibration.py
@@ -2910,6 +2910,53 @@ def _max_tp_for_plan(plan: dict[str, Any], available_gpus: int) -> int:
     return 1 << (n.bit_length() - 1)
 
 
+def calibration_gpu_slice(available_gpus: int) -> list[int]:
+    """Return the GPU indices a calibration run should be pinned to.
+
+    The largest power-of-two slice of the node's GPUs, starting at index 0
+    (3 GPUs → ``[0, 1]``, 5 → ``[0, 1, 2, 3]``, 8 → ``[0..7]``). The slice
+    length equals the maximum tensor-parallel size the node supports, so the
+    existing max-first TP escalation fits inside it unchanged.
+
+    Pinning the calibration to this concrete slice (issue #592) leaves the
+    leftover GPUs (``slice_size..N-1``) free for production lanes, which would
+    otherwise sit idle for the entire calibration window, and makes the VRAM
+    baseline a well-defined sum over exactly the GPUs the probe uses.
+    """
+    n = int(available_gpus) if available_gpus else 0
+    if n < 1:
+        return []
+    slice_size = 1 << (n.bit_length() - 1)
+    return list(range(slice_size))
+
+
+def _plan_needs_gpu_pin(gpu_devices: str) -> bool:
+    """True when a plan's ``gpu_devices`` is still the 'use every GPU' default.
+
+    Blank and "all" mean the plan has not been pinned yet, so the calibration
+    slice may be filled in. A specific set ("0,1") or "none" is an explicit
+    operator choice and is never overridden.
+    """
+    return (gpu_devices or "").strip().lower() in {"", "all"}
+
+
+def pin_plan_gpu_devices(plan: dict[str, Any], available_gpus: int) -> dict[str, Any]:
+    """Return *plan* with a concrete ``gpu_devices`` slice.
+
+    A plan that already names a specific GPU set — or "none" — is returned
+    unchanged: the operator's choice is authoritative. A plan left at
+    "all"/blank is pinned to the node's calibration slice so the probe only
+    touches that slice (``CUDA_VISIBLE_DEVICES``) and its VRAM baseline is
+    measured over a well-defined set of GPUs (issue #592).
+    """
+    if not _plan_needs_gpu_pin(str(plan.get("gpu_devices") or "")):
+        return plan
+    slice_ = calibration_gpu_slice(available_gpus)
+    if not slice_:
+        return plan
+    return {**plan, "gpu_devices": ",".join(str(i) for i in slice_)}
+
+
 def _reset_calibration_log(log_dir: Path, model_name: str) -> None:
     log_path = log_dir / f"{model_name.replace('/', '__')}.log"
     try:
@@ -2995,6 +3042,12 @@ def calibrate_with_tp_escalation(
             available_gpus = len(query_gpu_vram())
         except Exception:
             available_gpus = 1
+
+    # Pin the run to a concrete GPU slice before any probe: with "all"/blank
+    # the probe sees every GPU and its VRAM baseline sums them all, so a
+    # production lane on a leftover GPU silently inflates base_residency_mb.
+    # The slice length equals the max TP below, so the escalation is unchanged.
+    plan = pin_plan_gpu_devices(plan, available_gpus)
 
     original_tp = int(plan.get("tensor_parallel_size", 1))
     max_tp = _max_tp_for_plan(plan, available_gpus)

--- a/logos/logos-workernode/logos_worker_node/lane_manager.py
+++ b/logos/logos-workernode/logos_worker_node/lane_manager.py
@@ -11,6 +11,7 @@ from itertools import combinations
 from typing import Any, Awaitable, Callable, Iterable
 
 from logos_worker_node import prometheus_metrics as prom
+from logos_worker_node.calibration import calibration_gpu_slice
 from logos_worker_node.host_ram import measure_process_tree_host_ram_mb
 from logos_worker_node.model_profiles import ModelProfileRegistry
 from logos_worker_node.models import (
@@ -338,6 +339,11 @@ class LaneManager:
         self._last_crash_restart_attempt_at: dict[str, float] = {}
         self._crash_restart_counts: dict[str, int] = {}
         self._static_lane_ids: set[str] = set()
+        # GPUs held by a running calibration session (issue #592). Non-None while
+        # a session is live: auto-placement must not put new lanes on these GPUs
+        # and an explicit lane targeting them is refused, so the calibration's
+        # probe keeps the slice's VRAM to itself. Leftover GPUs stay placeable.
+        self._calibration_gpu_subset: frozenset[int] | None = None
 
     def validate_capabilities(self, capabilities_models: list[str]) -> list[str]:
         """Check which capabilities_models are available locally.
@@ -385,6 +391,37 @@ class LaneManager:
     def is_static_lane(self, lane_id: str) -> bool:
         """Return True if the given lane_id is a static lane."""
         return lane_id in self._static_lane_ids
+
+    # ------------------------------------------------------------------
+    # Calibration session (issue #592)
+    # ------------------------------------------------------------------
+
+    @property
+    def calibration_gpu_subset(self) -> frozenset[int] | None:
+        """GPUs held by a running calibration session, or ``None`` when idle."""
+        return self._calibration_gpu_subset
+
+    def begin_calibration_session(self) -> frozenset[int]:
+        """Hold the node's largest power-of-two GPU slice for a calibration run.
+
+        Returns the held slice (GPUs ``0..slice_size-1``). While it is held,
+        auto-placement excludes these GPUs and any new lane targeting them is
+        refused, so the calibration probe keeps the slice's VRAM to itself.
+        Lanes on the leftover GPUs (``slice_size..N-1``) are unaffected and keep
+        serving during the session.
+        """
+        self._calibration_gpu_subset = frozenset(calibration_gpu_slice(self._gpu_device_count()))
+        if self._calibration_gpu_subset:
+            logger.info(
+                "Calibration session holds GPU(s) %s — new lanes on these are refused; "
+                "leftover GPU(s) stay placeable",
+                sorted(self._calibration_gpu_subset),
+            )
+        return self._calibration_gpu_subset
+
+    def end_calibration_session(self) -> None:
+        """Release the calibration GPU slice held by :meth:`begin_calibration_session`."""
+        self._calibration_gpu_subset = None
 
     def _validate_vllm_runtime_requirements(self, lanes: Iterable[LaneConfig]) -> None:
         vllm_lane_ids = [_lane_id_from_config(lane) for lane in lanes if lane.vllm]
@@ -1268,6 +1305,43 @@ class LaneManager:
             return_exceptions=False,
         )
 
+    async def destroy_lanes_on_gpus(self, gpu_set: set[int]) -> int:
+        """Stop only the vLLM lanes that occupy a GPU in *gpu_set* (issue #592).
+
+        Used at the start of a calibration session to free the held GPU slice
+        for the probe without touching lanes on the leftover GPUs, which keep
+        serving for the rest of the session. The server re-spawns the stopped
+        slice lanes via the normal apply_lanes path once the session ends.
+        Returns the number of lanes stopped.
+        """
+        if not gpu_set:
+            return 0
+        async with self._lock:
+            detached: list[tuple[str, ProcessHandle, int | None]] = []
+            for lid in list(self._handles.keys()):
+                handle = self._handles[lid]
+                lc = handle.lane_config
+                if lc is None or not lc.vllm:
+                    continue
+                if self._lane_touches_gpus(lc.gpu_devices, gpu_set):
+                    h, port = self._detach_lane_unlocked(lid)
+                    if h is not None:
+                        detached.append((lid, h, port))
+
+        if not detached:
+            return 0
+
+        logger.info(
+            "Calibration: stopping %d lane(s) on GPU(s) %s (leftover lanes kept serving)",
+            len(detached),
+            sorted(gpu_set),
+        )
+        await asyncio.gather(
+            *(self._finalize_detached_lane(lid, handle, port) for lid, handle, port in detached),
+            return_exceptions=False,
+        )
+        return len(detached)
+
     async def close(self) -> None:
         """Release HTTP clients for all handles."""
         for handle in self._handles.values():
@@ -1509,6 +1583,30 @@ class LaneManager:
             result.append(index)
         return result
 
+    @staticmethod
+    def _lane_gpu_set(gpu_devices: str | None) -> frozenset[int] | None:
+        """Return the GPU indices a lane occupies, or ``None`` for "all".
+
+        ``None`` means the lane spans every GPU (the "all"/blank selector — an
+        unplaced vLLM lane defaults to cuda:0, so it must be treated as
+        occupying the slice). An empty frozenset means the lane holds no GPU
+        ("none").
+        """
+        raw = (gpu_devices or "").strip().replace(" ", "")
+        lowered = raw.lower()
+        if lowered in {"", "all"}:
+            return None
+        if lowered == "none":
+            return frozenset()
+        return frozenset(int(part) for part in raw.split(",") if part.isdigit())
+
+    def _lane_touches_gpus(self, gpu_devices: str | None, gpu_set: set[int]) -> bool:
+        """True when a lane's GPU set intersects *gpu_set* (issue #592 guard)."""
+        lanes = self._lane_gpu_set(gpu_devices)
+        if lanes is None:
+            return True  # spans all GPUs → intersects any non-empty set
+        return bool(lanes & gpu_set)
+
     def _estimate_lane_vram_mb(self, lane_config: LaneConfig) -> float:
         """Estimate total lane VRAM footprint for placement decisions."""
         if self._model_profiles is None:
@@ -1680,8 +1778,22 @@ class LaneManager:
             return lane_config
 
         allowed_rows = [row for row in device_rows if int(row["index"]) in set(allowed_indices)]
+        if self._calibration_gpu_subset:
+            # A running calibration holds its slice's VRAM for the probe — a new
+            # lane may only take the leftover GPUs (issue #592).
+            held = set(self._calibration_gpu_subset)
+            allowed_rows = [row for row in allowed_rows if int(row["index"]) not in held]
         tp_size = max(1, int(lane_config.vllm_config.tensor_parallel_size))
         if len(allowed_rows) < tp_size:
+            if self._calibration_gpu_subset:
+                # Fail fast rather than fall back to cuda:0 (a held slice GPU):
+                # the lane simply cannot be placed until the session ends.
+                raise RuntimeError(
+                    f"Auto-placement: no leftover GPU subset for lane '{lane_id}' "
+                    f"model={lane_config.model} (tp={tp_size}) — a calibration session "
+                    f"holds GPU(s) {sorted(self._calibration_gpu_subset)}. "
+                    "The lane is placed once the session ends."
+                )
             logger.warning(
                 "Auto-placement skipped for lane '%s': only %d allowed GPU(s) for tp=%d",
                 lane_id,
@@ -1962,6 +2074,19 @@ class LaneManager:
         lane_config = self._apply_model_vllm_overrides(lane_config)
         lane_config = self._auto_tensor_parallel(lane_config)
         lane_config = await self._auto_place_gpu_devices(lane_id, lane_config)
+        # Last line of defence at the resource itself: an operator-explicit
+        # gpu_devices pin that lands on the calibration's held slice is refused
+        # (auto-placement already avoids the slice). Leftover GPUs are allowed.
+        if (
+            self._calibration_gpu_subset
+            and lane_config.vllm
+            and self._lane_touches_gpus(lane_config.gpu_devices, self._calibration_gpu_subset)
+        ):
+            raise ValueError(
+                f"Lane '{lane_id}' would run on GPU(s) {lane_config.gpu_devices or 'all'} held by a "
+                f"running calibration session (slice {sorted(self._calibration_gpu_subset)}). "
+                "Placement is refused until the session ends; leftover GPU(s) remain available."
+            )
         await self._wait_for_vram_headroom(lane_id, lane_config)
         port = self._port_alloc.allocate(lane_id)
         handle = _create_handle(

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -1099,18 +1099,26 @@ class LogosBridgeClient:
             all_plans = plans_from_config(config_path) if config_path.exists() else []
             plan_by_model = {p["model"]: p for p in all_plans}
 
-            # Free all VRAM up front. Live lanes compete with the calibration
-            # probe for GPU memory: the kv-cache search starts against an
-            # already-loaded model, every probe size OOMs, and the blacklist
-            # fills up with bogus entries even though the model could have
-            # calibrated on a clean GPU. The Logos server re-spawns lanes via
-            # the normal apply_lanes path once the session ends.
+            # Free the calibration's GPU slice up front — but only that slice
+            # (issue #592). The probe is pinned to the slice (CUDA_VISIBLE_DEVICES),
+            # so it only competes for the slice's VRAM; lanes on the leftover
+            # GPUs keep serving for the rest of the session instead of sitting
+            # idle. Without the pin the kv-cache search would start against an
+            # already-loaded model on the measured GPUs and OOM at sizes that
+            # would otherwise fit. The Logos server re-spawns the stopped slice
+            # lanes via the normal apply_lanes path once the session ends.
             if lane_manager is not None:
                 try:
-                    await lane_manager.destroy_all()
-                    logger.info("[Calibration] Stopped all lanes to free VRAM for calibration session")
+                    calibration_gpus = lane_manager.begin_calibration_session()
+                    stopped = await lane_manager.destroy_lanes_on_gpus(calibration_gpus)
+                    logger.info(
+                        "[Calibration] Calibration holds GPU(s) %s — stopped %d lane(s) on them; "
+                        "leftover lanes kept serving",
+                        sorted(calibration_gpus),
+                        stopped,
+                    )
                 except Exception:  # noqa: BLE001
-                    logger.exception("[Calibration] destroy_all failed — continuing anyway")
+                    logger.exception("[Calibration] calibration slice setup failed — continuing anyway")
 
             for model_name in models:
                 if session.cancel_event.is_set():
@@ -1329,6 +1337,10 @@ class LogosBridgeClient:
                 details=f"sleep_level={session.sleep_level}",
             )
             if lane_manager is not None:
+                try:
+                    lane_manager.end_calibration_session()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[Calibration] end_calibration_session failed", exc_info=True)
                 try:
                     lane_manager._mark_status_dirty()  # noqa: SLF001
                 except Exception:  # noqa: BLE001

--- a/logos/logos-workernode/tests/test_calibration.py
+++ b/logos/logos-workernode/tests/test_calibration.py
@@ -36,15 +36,19 @@ from logos_worker_node.calibration import (
     _load_unsupported_models,
     _max_tp_for_plan,
     _parse_kv_to_mb,
+    _plan_needs_gpu_pin,
     _record_unsupported_model,
     _remove_unsupported_model,
     auto_calibrate_models,
     calibrate_model,
+    calibration_gpu_slice,
     is_model_unsupported,
     load_existing_profiles,
     parse_gpu_indices,
+    pin_plan_gpu_devices,
     plans_from_config,
     result_to_profile_dict,
+    sample_vram_mb,
     save_profiles,
 )
 from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
@@ -661,6 +665,54 @@ def test_auto_calibrate_no_escalation_when_already_max_tp(tmp_path):
     assert not results["big-model"].success
 
 
+def test_escalation_pins_plan_to_gpu_slice_on_heterogeneous_node(tmp_path):
+    """On a 3-GPU host the probe is pinned to the power-of-two slice "0,1", so
+    GPU 2 stays free for production and the baseline never sums it (#592). The
+    TP escalation itself is unchanged: max-first from tp=2, then down to tp=1.
+    """
+    config_path = _write_config(tmp_path, ["big-model"])
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    def side_effect(plan, **kw):
+        tp = plan.get("tensor_parallel_size", 1)
+        if tp == 1:
+            return _fail_result("big-model", error="OOM on tp=1")
+        return _success_result("big-model", tensor_parallel_size=tp)
+
+    with (
+        patch("logos_worker_node.calibration.calibrate_model") as mock_cm,
+        patch("logos_worker_node.calibration.query_gpu_vram", return_value=_mock_gpu_snap(3)),
+    ):
+        mock_cm.side_effect = side_effect
+        results = auto_calibrate_models(["big-model"], config_path, state_dir)
+
+    assert results["big-model"].success
+    assert results["big-model"].tensor_parallel_size == 2
+    # Every probe attempt is pinned to the slice, not "all" / every GPU.
+    for call in mock_cm.call_args_list:
+        passed_plan = call[0][0]
+        assert passed_plan["gpu_devices"] == "0,1"
+
+
+def test_escalation_respects_an_explicit_plan_pin(tmp_path):
+    """An operator-pinned gpu_devices is passed through to the probe untouched."""
+    cfg = {"logos": {"capabilities_models": [{"model": "big-model", "gpu_devices": "1,2"}]}}
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(yaml.safe_dump(cfg))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    with (
+        patch("logos_worker_node.calibration.calibrate_model") as mock_cm,
+        patch("logos_worker_node.calibration.query_gpu_vram", return_value=_mock_gpu_snap(3)),
+    ):
+        mock_cm.return_value = _success_result("big-model", tensor_parallel_size=2)
+        auto_calibrate_models(["big-model"], config_path, state_dir)
+
+    assert mock_cm.call_args[0][0]["gpu_devices"] == "1,2"
+
+
 def test_max_tp_for_plan():
     # Power-of-2 rounding: 4 GPUs → tp=4, 3 GPUs → tp=2, 5 → 4, 7 → 4
     assert _max_tp_for_plan({"model": "x"}, available_gpus=4) == 4
@@ -675,6 +727,78 @@ def test_max_tp_for_plan():
     assert _max_tp_for_plan({"model": "x", "gpu_devices": "all"}, available_gpus=4) == 4
     assert _max_tp_for_plan({"model": "x", "gpu_devices": "all"}, available_gpus=3) == 2
     assert _max_tp_for_plan({"model": "x", "gpu_devices": ""}, available_gpus=4) == 4
+
+
+def test_calibration_gpu_slice_power_of_two_prefix():
+    assert calibration_gpu_slice(3) == [0, 1]
+    assert calibration_gpu_slice(5) == [0, 1, 2, 3]
+    assert calibration_gpu_slice(6) == [0, 1, 2, 3]
+    assert calibration_gpu_slice(7) == [0, 1, 2, 3]
+    assert calibration_gpu_slice(8) == [0, 1, 2, 3, 4, 5, 6, 7]
+    assert calibration_gpu_slice(1) == [0]
+
+
+def test_calibration_gpu_slice_no_gpus_is_empty():
+    assert calibration_gpu_slice(0) == []
+    assert calibration_gpu_slice(None) == []
+    assert calibration_gpu_slice(-2) == []
+
+
+def test_pin_plan_uses_slice_only_when_gpu_devices_blank_or_all():
+    assert pin_plan_gpu_devices({"model": "x"}, 3)["gpu_devices"] == "0,1"
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": "all"}, 3)["gpu_devices"] == "0,1"
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": ""}, 3)["gpu_devices"] == "0,1"
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": "none"}, 3) == {"model": "x", "gpu_devices": "none"}
+
+
+def test_pin_plan_keeps_operator_specific_gpu_set():
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": "1,2"}, 3) == {
+        "model": "x",
+        "gpu_devices": "1,2",
+    }
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": "  2  "}, 3) == {
+        "model": "x",
+        "gpu_devices": "  2  ",
+    }
+
+
+def test_pin_plan_no_gpus_leaves_blank_plan_alone():
+    assert pin_plan_gpu_devices({"model": "x"}, 0) == {"model": "x"}
+    assert pin_plan_gpu_devices({"model": "x", "gpu_devices": "all"}, None) == {
+        "model": "x",
+        "gpu_devices": "all",
+    }
+
+
+def test_pin_needs_gpu_pin_only_for_blank_and_all():
+    assert _plan_needs_gpu_pin("")
+    assert _plan_needs_gpu_pin("all")
+    assert _plan_needs_gpu_pin("  ALL  ")
+    assert _plan_needs_gpu_pin(None)
+    assert not _plan_needs_gpu_pin("1,2")
+    assert not _plan_needs_gpu_pin("none")
+
+
+def test_calibration_baseline_ignores_leftover_gpu_lane(monkeypatch):
+    """Pinned slice [0,1] on a 3-GPU host: a leftover lane on GPU 2 must not
+    inflate the calibration baseline — only the slice's own GPUs are summed."""
+    snap = {
+        0: {"total_mb": 24000.0, "used_mb": 100.0, "free_mb": 23900.0},
+        1: {"total_mb": 24000.0, "used_mb": 200.0, "free_mb": 23800.0},
+        2: {"total_mb": 24000.0, "used_mb": 9999.0, "free_mb": 14001.0},
+    }
+
+    monkeypatch.setattr(
+        "logos_worker_node.calibration.query_gpu_vram",
+        lambda gpu_indices=None: {k: v for k, v in snap.items() if gpu_indices is None or k in gpu_indices},
+    )
+    monkeypatch.setattr("logos_worker_node.calibration._VRAM_SAMPLE_COUNT", 1)
+    monkeypatch.setattr("logos_worker_node.calibration.time.sleep", lambda _s: None)
+
+    plan = pin_plan_gpu_devices({"model": "x"}, 3)
+    gpu_indices = parse_gpu_indices(plan["gpu_devices"])
+    assert gpu_indices == [0, 1]
+    assert sample_vram_mb(gpu_indices) == 300.0  # 100 + 200, never the 9999 on GPU 2
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/logos/logos-workernode/tests/test_lane_manager.py
+++ b/logos/logos-workernode/tests/test_lane_manager.py
@@ -2358,3 +2358,219 @@ def test_model_overrides_unknown_key_does_not_fail_lane_creation() -> None:
     merged = manager._apply_model_vllm_overrides(lane)  # noqa: SLF001
 
     assert merged.vllm_config is not None
+
+
+# ---------------------------------------------------------------------------
+# Calibration GPU-slice guard (issue #592)
+# ---------------------------------------------------------------------------
+
+
+def test_begin_end_calibration_session_holds_power_of_two_slice() -> None:
+    manager = LaneManager(OllamaConfig(), gpu_device_count=lambda: 3)
+    assert manager.calibration_gpu_subset is None
+
+    held = manager.begin_calibration_session()
+    assert held == frozenset({0, 1})  # 3 GPUs → largest power-of-two slice
+    assert manager.calibration_gpu_subset == frozenset({0, 1})
+
+    manager.end_calibration_session()
+    assert manager.calibration_gpu_subset is None
+
+
+def test_calibration_session_slice_on_power_of_two_node_holds_all_gpus() -> None:
+    manager = LaneManager(OllamaConfig(), gpu_device_count=lambda: 4)
+    assert manager.begin_calibration_session() == frozenset({0, 1, 2, 3})
+
+
+def test_lane_gpu_set_parses_selectors() -> None:
+    assert LaneManager._lane_gpu_set("all") is None
+    assert LaneManager._lane_gpu_set("") is None
+    assert LaneManager._lane_gpu_set(None) is None
+    assert LaneManager._lane_gpu_set("none") == frozenset()
+    assert LaneManager._lane_gpu_set("0,1") == frozenset({0, 1})
+    assert LaneManager._lane_gpu_set(" 2 ") == frozenset({2})
+
+
+def test_lane_touches_gpus_intersection() -> None:
+    manager = LaneManager(OllamaConfig())
+    # "all"/blank spans every GPU → intersects any non-empty slice.
+    assert manager._lane_touches_gpus("all", {2}) is True
+    assert manager._lane_touches_gpus("", {2}) is True
+    assert manager._lane_touches_gpus("0,1", {0, 1}) is True
+    assert manager._lane_touches_gpus("2", {0, 1}) is False
+    assert manager._lane_touches_gpus("none", {0, 1}) is False
+
+
+class _StubHandle:
+    def __init__(self, lane_config: LaneConfig) -> None:
+        self.lane_config = lane_config
+        self.destroyed = False
+        self.closed = False
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _manager_with_handles(handles: dict) -> LaneManager:
+    manager = LaneManager(OllamaConfig(), lane_port_start=15200, lane_port_end=15210)
+    manager._handles.update(handles)  # noqa: SLF001
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_destroy_lanes_on_gpus_stops_only_slice_vllm_lanes() -> None:
+    slice_lane = _StubHandle(LaneConfig(model="m-slice", vllm=True, gpu_devices="0,1"))
+    leftover_lane = _StubHandle(LaneConfig(model="m-left", vllm=True, gpu_devices="2"))
+    ollama_lane = _StubHandle(LaneConfig(model="m-ollama", vllm=False, gpu_devices="0"))
+
+    manager = _manager_with_handles({"a": slice_lane, "b": leftover_lane, "c": ollama_lane})
+    stopped = await manager.destroy_lanes_on_gpus({0, 1})
+
+    assert stopped == 1
+    assert slice_lane.destroyed is True
+    assert "a" not in manager._handles  # noqa: SLF001
+    # Leftover and non-vLLM lanes are untouched and keep serving.
+    assert leftover_lane.destroyed is False
+    assert "b" in manager._handles  # noqa: SLF001
+    assert "c" in manager._handles  # noqa: SLF001
+
+
+def _snapshot_3gpu(free: dict) -> DeviceSummary:
+    return DeviceSummary(
+        timestamp=datetime.now(timezone.utc),
+        mode="nvidia",
+        nvidia_smi_available=True,
+        devices=[
+            DeviceInfo(
+                device_id=f"gpu{i}",
+                kind="nvidia",
+                memory_total_mb=24576.0,
+                memory_free_mb=free[i],
+                extra={"index": i},
+            )
+            for i in range(3)
+        ],
+        total_memory_mb=3 * 24576.0,
+        free_memory_mb=sum(free.values()),
+    )
+
+
+def _placement_manager(snapshot, n_gpus: int) -> LaneManager:
+    from logos_worker_node.model_profiles import ModelProfileRecord, ModelProfileRegistry
+
+    profiles = ModelProfileRegistry()
+    profiles._profiles["Qwen/Qwen2.5-0.5B-Instruct"] = ModelProfileRecord(  # noqa: SLF001
+        loaded_vram_mb=6000.0,
+        engine="vllm",
+    )
+    return LaneManager(
+        OllamaConfig(gpu_devices="all"),
+        lane_port_start=15200,
+        lane_port_end=15210,
+        model_profiles=profiles,
+        gpu_device_count=lambda: n_gpus,
+        gpu_snapshot=snapshot,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_place_excludes_calibrating_slice() -> None:
+    """GPUs 0,1 are the emptiest but held by a calibration — a tp=1 lane must
+    land on the leftover GPU 2 instead (#592)."""
+
+    async def _snapshot() -> DeviceSummary:
+        return _snapshot_3gpu({0: 20000.0, 1: 19000.0, 2: 13000.0})
+
+    manager = _placement_manager(_snapshot, 3)
+    manager.begin_calibration_session()  # holds {0, 1}
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1),
+    )
+
+    placed = await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
+    assert placed.gpu_devices == "2"
+
+
+@pytest.mark.asyncio
+async def test_auto_place_raises_when_calibration_holds_all_gpus() -> None:
+    """On a 2-GPU node the slice is the whole node — no leftover, so a new lane
+    cannot be placed rather than silently defaulting to a held GPU."""
+
+    async def _snapshot() -> DeviceSummary:
+        return DeviceSummary(
+            timestamp=datetime.now(timezone.utc),
+            mode="nvidia",
+            nvidia_smi_available=True,
+            devices=[
+                DeviceInfo(
+                    device_id=f"gpu{i}",
+                    kind="nvidia",
+                    memory_total_mb=24576.0,
+                    memory_free_mb=20000.0,
+                    extra={"index": i},
+                )
+                for i in range(2)
+            ],
+            total_memory_mb=2 * 24576.0,
+            free_memory_mb=40000.0,
+        )
+
+    manager = _placement_manager(_snapshot, 2)
+    manager.begin_calibration_session()  # holds {0, 1} = the whole node
+    lane = LaneConfig(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1),
+    )
+
+    with pytest.raises(RuntimeError, match="calibration session"):
+        await manager._auto_place_gpu_devices("planner-Qwen_Qwen2.5-0.5B-Instruct", lane)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_add_lane_refuses_explicit_slice_gpu(monkeypatch) -> None:
+    """An operator-pinned gpu_devices that lands on the held slice is refused."""
+    manager = LaneManager(OllamaConfig(), lane_port_start=15300, lane_port_end=15310, gpu_device_count=lambda: 3)
+    manager.begin_calibration_session()  # holds {0, 1}
+    monkeypatch.setattr(manager, "_wait_for_vram_headroom", AsyncMock())
+    lane = LaneConfig(
+        model="org/slice-model",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=2),
+        gpu_devices="0,1",
+    )
+
+    with pytest.raises(ValueError, match="calibration session"):
+        await manager._add_lane_unlocked("org_slice-model", lane)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_add_lane_allows_leftover_gpu(monkeypatch) -> None:
+    """The same explicit pin on a leftover GPU is allowed to proceed."""
+
+    class _RunningHandle(_StubHandle):
+        async def init(self) -> None:
+            return None
+
+        async def spawn(self, _lc: LaneConfig) -> ProcessStatus:
+            return ProcessStatus(state=ProcessState.RUNNING)
+
+    manager = LaneManager(OllamaConfig(), lane_port_start=15300, lane_port_end=15310, gpu_device_count=lambda: 3)
+    manager.begin_calibration_session()  # holds {0, 1}, leftover = {2}
+    monkeypatch.setattr(manager, "_wait_for_vram_headroom", AsyncMock())
+    monkeypatch.setattr("logos_worker_node.lane_manager._create_handle", lambda *a, **k: _RunningHandle(a[4]))
+    lane = LaneConfig(
+        model="org/left-model",
+        vllm=True,
+        vllm_config=VllmConfig(tensor_parallel_size=1),
+        gpu_devices="2",
+    )
+
+    await manager._add_lane_unlocked("org_left-model", lane)  # noqa: SLF001
+    assert "org_left-model" in manager._handles  # noqa: SLF001
+    manager.end_calibration_session()

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -691,6 +691,11 @@ def _make_app_for_calibration(tmp_path, *, vllm_disable_sleep=False, per_model_o
     lane_manager._MAX_EVENT_LOG = 500
     lane_manager._mark_status_dirty = lambda: None
     lane_manager.destroy_all = AsyncMock(return_value=None)
+    # Calibration-session GPU-slice guard (issue #592): the session holds a
+    # power-of-two slice and frees only the lanes on it, keeping leftover lanes.
+    lane_manager.begin_calibration_session = MagicMock(return_value=frozenset({0, 1}))
+    lane_manager.destroy_lanes_on_gpus = AsyncMock(return_value=1)
+    lane_manager.end_calibration_session = MagicMock()
     app.state.lane_manager = lane_manager
     return app
 
@@ -728,9 +733,11 @@ async def test_start_calibration_session_returns_ok_and_runs_in_background(tmp_p
     events = [e.event for e in app.state.lane_manager._event_log]
     assert "calibration_session_started" in events
     assert "calibration_session_finished" in events
-    # destroy_all is only called when there is at least one model to calibrate;
-    # an empty configured_models list ends the session before that step.
+    # The slice is only held and freed when there is at least one model to
+    # calibrate; an empty configured_models list ends the session before that.
     app.state.lane_manager.destroy_all.assert_not_awaited()
+    app.state.lane_manager.begin_calibration_session.assert_not_called()
+    app.state.lane_manager.destroy_lanes_on_gpus.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1033,9 +1040,11 @@ async def test_nosleep_model_with_profile_is_not_recalibrated(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_session_destroys_lanes_before_calibrating(tmp_path, monkeypatch):
-    """Live lanes hold VRAM. The session must free everything up front or
-    the kv-cache search OOMs and blacklists every probe size."""
+async def test_session_frees_calibrating_slice_before_calibrating(tmp_path, monkeypatch):
+    """Live lanes on the calibration's GPU slice hold VRAM. The session must
+    free that slice up front (issue #592) or the kv-cache search OOMs and
+    blacklists every probe size — but it must NOT free the whole node: lanes
+    on the leftover GPUs keep serving during the session."""
     from logos_worker_node import config as _wcfg
     from logos_worker_node.calibration import CalibrationResult
 
@@ -1074,7 +1083,12 @@ async def test_session_destroys_lanes_before_calibrating(tmp_path, monkeypatch):
     assert response["ok"] is True
     await _drain_session(client)
 
-    app.state.lane_manager.destroy_all.assert_awaited_once()
+    # The session holds the slice and frees only the lanes on it — never the
+    # whole node (which would idle the leftover GPUs for the session).
+    app.state.lane_manager.begin_calibration_session.assert_called_once()
+    app.state.lane_manager.destroy_lanes_on_gpus.assert_awaited_once_with(frozenset({0, 1}))
+    app.state.lane_manager.destroy_all.assert_not_awaited()
+    app.state.lane_manager.end_calibration_session.assert_called_once()
 
 
 # ── Streaming: defer stream_start until first token byte (wake-readiness fix) ──


### PR DESCRIPTION
## Fixes #592

## Summary
On a heterogeneous node (e.g. 3 GPUs) the calibration pinned its vLLM probe to *every* GPU — the plan left `gpu_devices` blank/"all" — so the leftover GPUs sat idle for the whole nightly window, and any production lane already running on a leftover GPU silently inflated the measured `base_residency_mb`. This PR pins the calibration to the node's largest power-of-two GPU slice, tears down **only that slice** at session start (leftover lanes keep serving), guards the slice in the lane manager, and relaxes the orchestrator's "is this worker busy" check so leftover-GPU lanes no longer block a session.

All four changes proposed in the issue are implemented; all three acceptance criteria are covered by tests.

## Changes
- `logos-workernode/logos_worker_node/calibration.py`: new `calibration_gpu_slice()`, `_plan_needs_gpu_pin()`, `pin_plan_gpu_devices()`. The pin is applied at the single `calibrate_with_tp_escalation()` choke point, so the probe gets a concrete `gpu_devices` slice — scoping `CUDA_VISIBLE_DEVICES` and making the VRAM baseline a well-defined sum over exactly the GPUs the probe uses. The slice length equals the max tensor-parallel size, so the existing max-first TP escalation is unchanged.
- `logos-workernode/logos_worker_node/lane_manager.py`: `begin_calibration_session()` / `end_calibration_session()` hold the slice; `destroy_lanes_on_gpus()` frees only the slice's vLLM lanes; auto-placement excludes the held slice and fails fast if no leftover subset fits; an explicit lane pin landing on the slice is refused. Leftover GPUs stay placeable.
- `logos-workernode/logos_worker_node/logos_bridge.py`: the calibration session now calls `begin_calibration_session()` + `destroy_lanes_on_gpus()` (instead of `destroy_all()`) so leftover lanes keep serving, and releases the slice in the `finally` block.
- `logos-orchestrator/src/logos/capacity/calibration_orchestrator.py`: `_provider_has_active_requests()` now counts only lanes that touch the calibration slice (new `_calibration_gpu_subset()` + `_lane_touches_subset()` helpers). When the slice cannot be determined (no telemetry / unknown GPU count) the previous conservative behaviour applies — any busy lane blocks.

## New Endpoints
n/a

## Testing
- **22 new tests** in `logos-orchestrator/tests/unit/capacity/test_calibration_orchestrator_gpu_slice.py`: slice derivation from the reported GPU count, selector-vs-slice intersection (blank/"all" span everything, "none" spans nothing, explicit lists intersect), leftover-GPU lanes no longer blocking, and the conservative fallbacks.
- **18 new tests** in `logos-workernode/tests/` across `test_calibration.py` (incl. the VRAM regression — a leftover-GPU lane does **not** inflate `base_residency_mb`; and TP escalation stays unchanged when the plan is pinned to the slice), `test_lane_manager.py` (slice hold/release, slice-only teardown, auto-placement exclusion, explicit-pin refusal), and `test_logos_bridge.py` (the session frees only the slice, not all lanes).
- Full suites green: worker **544 passed, 2 skipped** (pre-existing skips); orchestrator **1039 passed, 1 xfailed** (pre-existing xfail). Linters clean (black, isort, flake8, autoflake).

## CI status
- **All checks passing.** `Logos - Test` (runs both the orchestrator and worker Python suites), `Logos - Lint`, `Logos - Build`, and `Validate PR Title` are green.
- Note for reviewers: the `Logos - Build` worker-vLLM image push **initially** failed with a **shared Harbor registry storage-quota** error (registry at 199.2 GiB of its 200 GiB project cap: `denied: adding 3.6 GiB ... will exceed the configured upper limit of 200.0 GiB`). The failure was at the final **push** step, after every code-copy/dependency step succeeded — i.e. not a code regression. It passed on re-run once the registry had headroom.

## Open questions / current status
- Server-planner-driven **new** placements onto the leftover GPUs during a live session are intentionally **not** enabled here: the capacity planner still excludes calibrating workers via `_is_plannable`, and actively co-locating a new tp=1 lane on the third GPU alongside a tp=2 probe is worth verifying on a real 3-GPU host (NCCL behaviour) before flipping that default. What **is** enabled and verified is the issue's core: the leftover GPUs are no longer torn down, so **existing** leftover lanes keep serving while the probe runs on the slice, and their traffic no longer distorts the calibration.
