### PR TITLE
`Athena`: Upgrade Poetry to 2.4.1 in Dockerfiles

### DIFF
--- a/athena/assessment_module_manager/Dockerfile
+++ b/athena/assessment_module_manager/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -20,7 +24,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/athena/Dockerfile
+++ b/athena/athena/Dockerfile
@@ -3,17 +3,21 @@
 # This is the Dockerfile for the athena package.
 # Its output is used as a dependency in the module_* Dockerfiles.
 
-FROM python:3.11 as athena
+FROM python:3.11 AS athena
 
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/llm_core/Dockerfile
+++ b/athena/llm_core/Dockerfile
@@ -3,19 +3,23 @@
 # This is the Dockerfile for the shared llm package.
 # Its output is used as a dependency in the module_* Dockerfiles.
 
-FROM python:3.11 as llm_core
+FROM python:3.11 AS llm_core
 
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
 COPY --from=athena /code /athena
 
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/log_viewer/Dockerfile
+++ b/athena/log_viewer/Dockerfile
@@ -11,14 +11,18 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/modeling/module_modeling_llm/Dockerfile
+++ b/athena/modules/modeling/module_modeling_llm/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -21,7 +25,7 @@ COPY --from=llm_core /code /llm_core
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_example/Dockerfile
+++ b/athena/modules/programming/module_example/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -20,7 +24,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_programming_apted/Dockerfile
+++ b/athena/modules/programming/module_programming_apted/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -20,7 +24,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_programming_llm/Dockerfile
+++ b/athena/modules/programming/module_programming_llm/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -21,7 +25,7 @@ COPY --from=llm_core /code /llm_core
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_programming_quality_llm/Dockerfile
+++ b/athena/modules/programming/module_programming_quality_llm/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -21,7 +25,7 @@ COPY --from=llm_core /code /llm_core
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_programming_themisml/Dockerfile
+++ b/athena/modules/programming/module_programming_themisml/Dockerfile
@@ -12,7 +12,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.6.1
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -21,7 +25,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/programming/module_programming_winnowing/Dockerfile
+++ b/athena/modules/programming/module_programming_winnowing/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -20,7 +24,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/text/module_text_cofee/Dockerfile
+++ b/athena/modules/text/module_text_cofee/Dockerfile
@@ -22,7 +22,11 @@ WORKDIR /code
 COPY --from=cofee_protobuf /proto/cofee_pb2.py ./module_text_cofee/protobuf/
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -31,7 +35,7 @@ COPY --from=athena /code /athena
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./

--- a/athena/modules/text/module_text_llm/Dockerfile
+++ b/athena/modules/text/module_text_llm/Dockerfile
@@ -11,7 +11,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 
 # Poetry
-RUN pip install --no-cache-dir poetry==1.5.0
+ARG POETRY_VERSION=2.4.1
+ENV POETRY_HOME=/opt/poetry
+ENV PATH="/opt/poetry/bin:${PATH}"
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/pip" install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 # Dependencies
 COPY pyproject.toml poetry.lock ./
@@ -21,7 +25,7 @@ COPY --from=llm_core /code /llm_core
 # install dependencies
 RUN poetry config virtualenvs.create true \
     && poetry config virtualenvs.in-project true \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Project files
 COPY . ./


### PR DESCRIPTION
Install Poetry in an isolated environment and skip root project installation when resolving container dependencies.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test1)](https://athena-test1.aet.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/edutelligence/athena-test2)](https://athena-test2.aet.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build environments to Poetry 2.4.1.
  * Isolated Poetry installations in dedicated virtual environments for improved build consistency.
  * Added configurable Poetry versioning where applicable.
  * Dependency installation now excludes the project package itself, streamlining image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->