### PR TITLE
`Logos`: Fix the agent gateway, the network check, and the agents page styling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,9 @@
 !logos/logos-agent/app
 !logos/logos-agent/workspace/run_session.py
 !logos/logos-agent/workspace/screenshot.js
+# The model gateway's nginx configuration, shipped in its image rather than
+# bind-mounted: a deployment copies only the compose file to its VM.
+!logos/agent-gateway/nginx.conf
 !iris/pyproject.toml
 !iris/poetry.lock
 !iris/src/iris

--- a/.github/workflows/logos_build-and-push-docker.yml
+++ b/.github/workflows/logos_build-and-push-docker.yml
@@ -239,6 +239,37 @@ jobs:
           username: ${{ vars.LOGOS_HARBOR_USER }}
           password: ${{ secrets.LOGOS_HARBOR_PASSWORD }}
 
+  build-agent-gateway:
+    name: Build Logos Agent Gateway
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ls1intum/edutelligence' }}
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      output: image
+      push: true
+      # The gateway's own directory is the context: it needs nothing but its
+      # nginx configuration, and a root context would put the whole
+      # repository through the .dockerignore whitelist for one small file.
+      context: ./logos/agent-gateway
+      file: logos/agent-gateway/Dockerfile
+      platforms: linux/amd64
+      runner: ubuntu-latest
+      sign: false
+      meta-images: ${{ vars.LOGOS_HARBOR_REGISTRY }}/logos/logos-agent-gateway
+      meta-tags: |
+        type=ref,event=pr
+        type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
+        type=semver,pattern={{version}}
+      meta-flavor: |
+        latest=false
+    secrets:
+      registry-auths: |
+        - registry: ${{ vars.LOGOS_HARBOR_REGISTRY }}
+          username: ${{ vars.LOGOS_HARBOR_USER }}
+          password: ${{ secrets.LOGOS_HARBOR_PASSWORD }}
+
   build-agent-workspace:
     name: Build Logos Agent Workspace
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ls1intum/edutelligence' }}

--- a/.github/workflows/logos_build-and-push-docker.yml
+++ b/.github/workflows/logos_build-and-push-docker.yml
@@ -249,10 +249,10 @@ jobs:
     with:
       output: image
       push: true
-      # The gateway's own directory is the context: it needs nothing but its
-      # nginx configuration, and a root context would put the whole
-      # repository through the .dockerignore whitelist for one small file.
-      context: ./logos/agent-gateway
+      # Built from the repository root like the other agent images: the
+      # `file` path is resolved relative to the context, so a context of the
+      # gateway's own directory would look for the Dockerfile inside itself.
+      context: .
       file: logos/agent-gateway/Dockerfile
       platforms: linux/amd64
       runner: ubuntu-latest

--- a/logos/agent-gateway/Dockerfile
+++ b/logos/agent-gateway/Dockerfile
@@ -1,0 +1,19 @@
+# The model gateway the agent's session containers talk to.
+#
+# The configuration is baked in rather than bind-mounted from the host. A
+# deployment of this stack copies exactly one file to its VM — the compose
+# file — so a mount of `./agent-gateway/nginx.conf` resolved to a path that
+# does not exist there, Docker created an empty *directory* in its place,
+# and nginx came up with its stock configuration: no /v1 proxying, no
+# credential injection, no /healthz. The container then failed its health
+# check forever and the runner's `service_healthy` dependency never
+# released. Shipping the file inside the image removes the whole class of
+# that failure.
+#
+# It stays a *template*: the image's entrypoint runs envsubst over
+# /etc/nginx/templates at container start, which is what puts
+# ${LOGOS_AGENT_API_KEY} into the live configuration — the key belongs in
+# the running container, not in an image layer.
+FROM nginx:1.28-alpine
+
+COPY nginx.conf /etc/nginx/templates/default.conf.template

--- a/logos/agent-gateway/Dockerfile
+++ b/logos/agent-gateway/Dockerfile
@@ -16,4 +16,4 @@
 # the running container, not in an image layer.
 FROM nginx:1.28-alpine
 
-COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY logos/agent-gateway/nginx.conf /etc/nginx/templates/default.conf.template

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -456,7 +456,12 @@ services:
   # it is also where the model credential lives, injected into the traffic
   # so the session containers never carry it. See agent-gateway/nginx.conf.
   logos-agent-gateway:
-    image: nginx:1.28-alpine
+    # The nginx configuration is baked into this image, not mounted from the
+    # host: a deployment copies only the compose file to its VM, so a bind
+    # mount of ./agent-gateway/nginx.conf resolved to a missing path there,
+    # Docker created an empty directory in its place, and the gateway served
+    # its stock configuration and failed its health check forever.
+    image: ${REGISTRY:-ghcr.io/ls1intum/edutelligence}/logos-agent-gateway:${IMAGE_TAG:-latest}
     container_name: logos-agent-gateway
     restart: unless-stopped
     profiles: ["agent"]
@@ -472,16 +477,12 @@ services:
     depends_on:
       - logos-orchestrator
     environment:
-      # The Logos key the gateway injects into the agent's model calls. It
-      # is substituted into the nginx configuration by the image's envsubst
-      # at container start (the file is mounted as a template for exactly
-      # this), so it never has to be passed to a session container.
+      # The Logos key the gateway injects into the agent's model calls. The
+      # image ships the configuration as a template, and its entrypoint runs
+      # envsubst at container start, so the key enters the running
+      # configuration here and never has to be passed to a session
+      # container — nor does it sit in an image layer.
       LOGOS_AGENT_API_KEY: "${LOGOS_AGENT_API_KEY:-}"
-    volumes:
-      # Mounted into /etc/nginx/templates/ so the image's envsubst renders
-      # ${LOGOS_AGENT_API_KEY} into the live configuration at startup;
-      # nginx's own $variables are left untouched.
-      - ./agent-gateway/nginx.conf:/etc/nginx/templates/default.conf.template:ro
     networks:
       - internal
       - agent

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -106,6 +106,13 @@ session's behaviour drift between builds.
 > *whitelist*. Anything a Dockerfile copies must be listed there, or the build
 > fails with `failed to compute cache key: … not found`.
 
+> **Adding a file the gateway or the runner reads at runtime?** Put it in an
+> image. A deployment copies exactly one file to its VM — the compose file —
+> so a bind mount of anything else resolves to a path that does not exist
+> there, and Docker creates an empty *directory* in its place rather than
+> failing. That is how the gateway once came up with nginx's stock
+> configuration and failed its health check forever.
+
 ## What a session may and may not do
 
 **May:** read and change the working copy, run tests and linters, push a branch

--- a/logos/logos-agent/app/docker_engine.py
+++ b/logos/logos-agent/app/docker_engine.py
@@ -112,12 +112,12 @@ async def ensure_network(name: str, *, internal: bool = False) -> None:
     operator removing it while nothing runs.
     """
     try:
-        existing = await _request("GET", f"/networks/{name}")
+        response = await _request("GET", f"/networks/{name}")
     except DockerError as exc:
         if exc.status != 404:
             raise
     else:
-        actual = bool(existing.get("Internal", False))
+        actual = bool(response.json().get("Internal", False))
         if actual != internal:
             raise DockerError(
                 409,

--- a/logos/logos-agent/tests/test_docker_engine.py
+++ b/logos/logos-agent/tests/test_docker_engine.py
@@ -71,8 +71,8 @@ class TestNetworkIsolation:
         async def fake_request(method, path, **kwargs):
             calls.append((method, path))
             if method == "GET":
-                return {"Name": "logos-agent-net", "Internal": True}
-            return {}
+                return _FakeResponse({"Name": "logos-agent-net", "Internal": True})
+            return _FakeResponse({})
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
 
@@ -84,8 +84,8 @@ class TestNetworkIsolation:
     async def test_a_plain_bridge_is_refused_rather_than_used(self, monkeypatch):
         async def fake_request(method, path, **kwargs):
             if method == "GET":
-                return {"Name": "logos-agent-net", "Internal": False}
-            return {}
+                return _FakeResponse({"Name": "logos-agent-net", "Internal": False})
+            return _FakeResponse({})
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
 
@@ -99,7 +99,7 @@ class TestNetworkIsolation:
             if method == "GET":
                 raise docker_engine.DockerError(404, "no such network")
             created.update(kwargs.get("json") or {})
-            return {}
+            return _FakeResponse({})
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
 
@@ -117,7 +117,7 @@ class TestPauseReportsReality:
 
     async def test_a_successful_pause_is_reported(self, monkeypatch):
         async def fake_request(method, path, **kwargs):
-            return {}
+            return _FakeResponse({})
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
         assert await docker_engine.pause_container("cid") is True
@@ -153,7 +153,7 @@ class TestNetworkDetach:
 
         async def fake_request(method, path, **kwargs):
             sent.update({"method": method, "path": path, "json": kwargs.get("json")})
-            return {}
+            return _FakeResponse({})
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
 

--- a/logos/logos-ui/src/app/features/agents/agents.scss
+++ b/logos/logos-ui/src/app/features/agents/agents.scss
@@ -6,12 +6,12 @@
 .page-title {
   font-size: var(--font-size-xl, 1.5rem);
   font-weight: var(--font-weight-bold);
-  color: var(--color-typography-700);
+  color: rgb(var(--color-typography-700));
   margin: 0 0 0.25rem;
 }
 
 .page-subtitle {
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   font-size: var(--font-size-sm);
   line-height: var(--line-height-loose);
   margin: 0 0 1.5rem;
@@ -23,34 +23,34 @@
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--letter-spacing-widest);
   text-transform: uppercase;
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   margin: 2rem 0 0.75rem;
 }
 
 /* ── Capacity ─────────────────────────────────────────────────────────────── */
 .capacity {
-  border: 1px solid var(--color-outline-200);
+  border: 1px solid rgb(var(--color-outline-200));
   border-radius: 10px;
   padding: 1rem;
-  background: var(--color-background-50);
+  background: rgb(var(--color-background-50));
   margin-bottom: 1.25rem;
 
   &--blocked {
-    border-color: var(--color-warning);
+    border-color: rgb(var(--color-warning));
   }
 }
 
 .capacity__meter {
   height: 6px;
   border-radius: 3px;
-  background: var(--color-background-200);
+  background: rgb(var(--color-background-200));
   overflow: hidden;
   margin-bottom: 0.75rem;
 }
 
 .capacity__fill {
   height: 100%;
-  background: var(--color-primary-500);
+  background: rgb(var(--color-primary-500));
   transition: width 0.4s ease;
 }
 
@@ -59,18 +59,18 @@
   flex-wrap: wrap;
   gap: 0.25rem 1.25rem;
   font-size: var(--font-size-sm);
-  color: var(--color-typography-500);
+  color: rgb(var(--color-typography-500));
 }
 
 .capacity__load {
   font-weight: var(--font-weight-semibold);
-  color: var(--color-typography-700);
+  color: rgb(var(--color-typography-700));
 }
 
 .capacity__reason {
   margin: 0.5rem 0 0;
   font-size: var(--font-size-xs);
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
 }
 
 /* ── Toolbar and buttons ──────────────────────────────────────────────────── */
@@ -86,15 +86,15 @@
   gap: 0.4rem;
   padding: 0.45rem 0.9rem;
   border-radius: 8px;
-  border: 1px solid var(--color-outline-200);
-  background: var(--color-background-50);
-  color: var(--color-typography-700);
+  border: 1px solid rgb(var(--color-outline-200));
+  background: rgb(var(--color-background-50));
+  color: rgb(var(--color-typography-700));
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
 
   &:hover:not(:disabled) {
-    background: var(--color-background-200);
+    background: rgb(var(--color-background-200));
   }
 
   &:disabled {
@@ -103,18 +103,18 @@
   }
 
   &--primary {
-    background: var(--color-primary-500);
-    border-color: var(--color-primary-500);
+    background: rgb(var(--color-primary-500));
+    border-color: rgb(var(--color-primary-500));
     color: #fff;
 
     &:hover:not(:disabled) {
-      background: var(--color-primary-600);
+      background: rgb(var(--color-primary-600));
     }
   }
 
   &--danger {
-    color: var(--color-error);
-    border-color: var(--color-error);
+    color: rgb(var(--color-error));
+    border-color: rgb(var(--color-error));
     background: transparent;
   }
 
@@ -125,23 +125,23 @@
   &--ghost {
     border-color: transparent;
     background: transparent;
-    color: var(--color-typography-300);
+    color: rgb(var(--color-typography-300));
   }
 }
 
 /* ── Form ─────────────────────────────────────────────────────────────────── */
 .card {
-  border: 1px solid var(--color-outline-200);
+  border: 1px solid rgb(var(--color-outline-200));
   border-radius: 10px;
   padding: 1.25rem;
-  background: var(--color-background-50);
+  background: rgb(var(--color-background-50));
   margin-bottom: 1.5rem;
 }
 
 .card__title {
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-typography-700);
+  color: rgb(var(--color-typography-700));
   margin: 0 0 1rem;
 }
 
@@ -162,7 +162,7 @@
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--letter-spacing-widest);
   text-transform: uppercase;
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   margin-bottom: 0.35rem;
 }
 
@@ -175,7 +175,7 @@
 .field__hint {
   display: block;
   font-size: var(--font-size-xs);
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   margin: 0.35rem 0 0;
   line-height: var(--line-height-loose);
 }
@@ -184,9 +184,9 @@
   width: 100%;
   padding: 0.5rem 0.7rem;
   border-radius: 8px;
-  border: 1px solid var(--color-outline-200);
-  background: var(--color-background-50);
-  color: var(--color-typography-700);
+  border: 1px solid rgb(var(--color-outline-200));
+  background: rgb(var(--color-background-50));
+  color: rgb(var(--color-typography-700));
   font-size: var(--font-size-sm);
   font-family: inherit;
 }
@@ -208,7 +208,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: var(--font-size-sm);
-  color: var(--color-typography-500);
+  color: rgb(var(--color-typography-500));
   cursor: pointer;
 }
 
@@ -230,13 +230,13 @@
 }
 
 .session {
-  border: 1px solid var(--color-outline-200);
+  border: 1px solid rgb(var(--color-outline-200));
   border-radius: 10px;
-  background: var(--color-background-50);
+  background: rgb(var(--color-background-50));
   overflow: hidden;
 
   &--open {
-    border-color: var(--color-primary-400);
+    border-color: rgb(var(--color-primary-400));
   }
 }
 
@@ -255,13 +255,13 @@
   font-family: inherit;
 
   &:hover {
-    background: var(--color-background-200);
+    background: rgb(var(--color-background-200));
   }
 }
 
 .session__task {
   font-size: var(--font-size-sm);
-  color: var(--color-typography-700);
+  color: rgb(var(--color-typography-700));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -271,7 +271,7 @@
   display: flex;
   gap: 0.75rem;
   font-size: var(--font-size-xs);
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
 }
 
 .status {
@@ -288,35 +288,35 @@
 
   &--queued,
   &--starting {
-    color: var(--color-typography-500);
-    border-color: var(--color-outline-200);
+    color: rgb(var(--color-typography-500));
+    border-color: rgb(var(--color-outline-200));
   }
 
   &--running {
-    color: var(--color-primary-600);
-    border-color: var(--color-primary-400);
+    color: rgb(var(--color-primary-600));
+    border-color: rgb(var(--color-primary-400));
   }
 
   &--paused {
-    color: var(--color-warning);
-    border-color: var(--color-warning);
+    color: rgb(var(--color-warning));
+    border-color: rgb(var(--color-warning));
   }
 
   &--succeeded {
-    color: var(--color-accent-green);
-    border-color: var(--color-accent-green);
+    color: rgb(var(--color-accent-green));
+    border-color: rgb(var(--color-accent-green));
   }
 
   &--failed,
   &--cancelled {
-    color: var(--color-error);
-    border-color: var(--color-error);
+    color: rgb(var(--color-error));
+    border-color: rgb(var(--color-error));
   }
 }
 
 .session__detail {
   padding: 0 1rem 1rem;
-  border-top: 1px solid var(--color-outline-200);
+  border-top: 1px solid rgb(var(--color-outline-200));
 }
 
 .facts {
@@ -329,13 +329,13 @@
     font-size: var(--font-size-xs);
     text-transform: uppercase;
     letter-spacing: var(--letter-spacing-widest);
-    color: var(--color-typography-300);
+    color: rgb(var(--color-typography-300));
   }
 
   dd {
     margin: 0.2rem 0 0;
     font-size: var(--font-size-sm);
-    color: var(--color-typography-700);
+    color: rgb(var(--color-typography-700));
     word-break: break-word;
   }
 }
@@ -344,7 +344,7 @@
   font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-widest);
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   margin: 1.25rem 0 0.5rem;
 }
 
@@ -354,8 +354,8 @@
   margin: 0;
   padding: 0.75rem;
   border-radius: 8px;
-  background: var(--color-background-200);
-  color: var(--color-typography-700);
+  background: rgb(var(--color-background-200));
+  color: rgb(var(--color-typography-700));
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--font-size-xs);
   line-height: 1.5;
@@ -371,11 +371,11 @@
 
 .screenshot {
   display: block;
-  border: 1px solid var(--color-outline-200);
+  border: 1px solid rgb(var(--color-outline-200));
   border-radius: 8px;
   overflow: hidden;
   text-decoration: none;
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   font-size: var(--font-size-xs);
 
   img {
@@ -396,26 +396,26 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 1rem;
-  border: 1px solid var(--color-outline-200);
+  border: 1px solid rgb(var(--color-outline-200));
   border-radius: 8px;
-  background: var(--color-background-50);
+  background: rgb(var(--color-background-50));
   font-size: var(--font-size-sm);
 }
 
 .workspace__name {
   font-weight: var(--font-weight-medium);
-  color: var(--color-typography-700);
+  color: rgb(var(--color-typography-700));
 }
 
 .workspace__branch {
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   font-size: var(--font-size-xs);
   flex: 1;
 }
 
 .workspace__busy {
   font-size: var(--font-size-xs);
-  color: var(--color-warning);
+  color: rgb(var(--color-warning));
 }
 
 /* ── Misc ─────────────────────────────────────────────────────────────────── */
@@ -426,13 +426,13 @@
   margin: 0.75rem 0;
 
   &--error {
-    color: var(--color-error);
-    border: 1px solid var(--color-error);
+    color: rgb(var(--color-error));
+    border: 1px solid rgb(var(--color-error));
   }
 }
 
 .empty {
-  color: var(--color-typography-300);
+  color: rgb(var(--color-typography-300));
   font-size: var(--font-size-sm);
   padding: 1.5rem 0;
 


### PR DESCRIPTION
Three faults from #772 that showed up on its first real deployment. All three are needed for the agent runner to work at all on a deployed environment.

## 1. The gateway had no configuration

A deployment copies exactly one file to its VM — `docker-compose.yaml` — so the bind mount of `./agent-gateway/nginx.conf` resolved to a path that does not exist there. Docker does not fail on a missing bind source: it creates an empty **directory** in its place. nginx therefore started with its stock configuration, and the health check probed a route that configuration does not have:

```
"GET /healthz HTTP/1.1" 404 — open() "/usr/share/nginx/html/healthz" failed
FailingStreak: 15 → unhealthy
Container logos-agent-gateway Error dependency failed to start: container logos-agent-gateway is unhealthy
```

The configuration now ships inside a `logos-agent-gateway` image, built alongside the other two agent images. It stays a *template*, so the entrypoint still runs envsubst at container start: the Logos key enters the running configuration, never an image layer. Verified by running the built image — `/healthz` answers 200, `Authorization: Bearer <key>` is rendered, and nginx's own `$host` survives envsubst untouched.

## 2. The network check read a response as a dict

`ensure_network()`'s new `Internal`-flag verification called `.get()` on the return of `_request()`, which is an `httpx.Response`. The runner raised `AttributeError` inside `manager.start()` and exited before serving anything:

```
File "/srv/app/docker_engine.py", line 120, in ensure_network
    actual = bool(existing.get("Internal", False))
AttributeError: 'Response' object has no attribute 'get'
```

The tests passed because they stubbed `_request` with plain dicts. They now answer with a response object — the shape the function really has — so a dict stub fails the check instead of hiding this class of bug.

## 3. Every colour on the agents page was invalid CSS

This design system stores colour tokens as raw RGB channels (`--color-background-50: 18 8 43`), so a declaration has to wrap them: `rgb(var(--color-background-50))`. The agents stylesheet used all 62 of them bare. The browser drops those declarations, so the page kept its spacing, padding and radii and lost every background, border and text colour — cards, buttons, inputs and the error banner rendered as plain text on the page background.

Confirmed against the deployed page, whose live rules read `color: var(--color-typography-700)`, and the fix verified there by re-applying the same rules through the wrapper: buttons, banner and typography come back in the app's own palette.

## Also

A note in the runner's README: anything the gateway or the runner reads at runtime belongs in an image, because a bind mount of a file the deployment does not copy becomes an empty directory rather than an error.

## Verification

- 209 agent tests and 107 UI tests pass; pre-commit clean; UI production build clean.
- The gateway image built and run locally: health endpoint, credential injection, nginx variable handling.
- Prod was unblocked by hand in the meantime (the real `nginx.conf` placed on the host, the runner's `docker_engine.py` patched in its container) — both become unnecessary with this change, and `/opt/logos/agent-gateway/` can be removed after it deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLK1R5FwY2LnG5LeHnnWAb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated container image builds and publishing for the Agent Gateway.
  * Agent Gateway deployments now use a packaged nginx configuration for more reliable startup.

* **Bug Fixes**
  * Corrected network status handling when checking existing Docker networks.

* **Documentation**
  * Added deployment guidance explaining that runtime-read files must be included in container images.

* **Style**
  * Updated agent interface color styling for consistent theme rendering.

* **Tests**
  * Updated Docker Engine test fixtures to match response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->