### PR TITLE
`Logos`: Use the agent's GitHub account the way you use a colleague's

### DIFF
--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -416,8 +416,12 @@ services:
       # Optional: a second token of the same account without 'workflow' scope,
       # handed to session containers. Falls back to the token above.
       LOGOS_AGENT_SESSION_GITHUB_TOKEN: "${LOGOS_AGENT_SESSION_GITHUB_TOKEN:-}"
-      # Queue sessions in response to labelled issues and reviews.
-      LOGOS_AGENT_TRIGGERS_ENABLED: "${LOGOS_AGENT_TRIGGERS_ENABLED:-false}"
+      # Whether the agent's GitHub account may be used like a colleague's:
+      # assignments, reviews on its pull requests, and comments addressed to
+      # it queue sessions. On unless explicitly switched off — running this
+      # service is already the deliberate step, and the assignment or the
+      # mention is the per-item consent.
+      LOGOS_AGENT_TRIGGERS_ENABLED: "${LOGOS_AGENT_TRIGGERS_ENABLED:-true}"
       LOGOS_AGENT_DEPLOY_ENABLED: "${LOGOS_AGENT_DEPLOY_ENABLED:-false}"
       LOGOS_AGENT_DEV_BASE_URL: "${LOGOS_AGENT_DEV_BASE_URL:-https://logos-dev.aet.cit.tum.de}"
     volumes:

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -215,15 +215,21 @@ use it the way you use a person's:
 |---|---|
 | assign it an issue | works on it and opens a draft pull request |
 | assign it a pull request | takes it over, on that pull request's own branch |
-| ask one of its pull requests for changes | addresses the review on that branch |
-| comment on a pull request it is responsible for | reads the thread and answers |
-| mention it anywhere by name | answers there; changes code only if that is what was asked |
+| request changes on one of its pull requests | addresses that review on its branch |
+| comment on a pull request it is responsible for | reads the thread and answers (within a day of writing) |
+| mention it anywhere by name | answers there (within a day); changes code only if that is what was asked |
 
 No labels and no separate vocabulary — the ordinary gestures. **Consent is
 per item:** nothing is picked up because it exists, only because somebody
 assigned it, reviewed its work, or asked it something by name. That is why
 this needs no service-wide opt-in to be safe; `LOGOS_AGENT_TRIGGERS_ENABLED`
 exists as a kill switch, not as a second consent.
+
+Only a **changes-requested** review is work — an approval or a plain comment
+is not, and an approval submitted after a change request withdraws it.
+Comments are read from the last 24 hours: assignments and reviews are read
+from the repository's current state, but comments are a stream, and without a
+bound the first pass after a restart would read years of them.
 
 **It says it heard you.** The moment a session is queued it reacts with 👀 on
 what triggered it, so a question does not sit there looking ignored while the

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -225,6 +225,13 @@ assigned it, reviewed its work, or asked it something by name. That is why
 this needs no service-wide opt-in to be safe; `LOGOS_AGENT_TRIGGERS_ENABLED`
 exists as a kill switch, not as a second consent.
 
+**Who may ask for what.** Anybody can comment on a public repository, and a
+session that commits does so with the runner's credentials — so the ability
+to direct a code change is checked against the repository's own collaborator
+permissions. A question from outside is answered in words, with no branch;
+a review from outside is left to a person. Assignment needs write access
+anyway: GitHub only assigns collaborators.
+
 Only a **changes-requested** review is work — an approval or a plain comment
 is not, and an approval submitted after a change request withdraws it.
 Comments are read from the last 24 hours: assignments and reviews are read

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -109,7 +109,7 @@ session's behaviour drift between builds.
 ## What a session may and may not do
 
 **May:** read and change the working copy, run tests and linters, push a branch
-under `agent/`, open a draft pull request, and — if enabled — have its result
+under `logos/agent/`, open a draft pull request, and — if enabled — have its result
 deployed to dev and screenshotted.
 
 **May not:** reach the Docker daemon, run as root, push to `main` or any
@@ -119,7 +119,8 @@ only for `logos_deploy-dev.yml`; any other workflow is refused in code.
 
 Branch names are derived from the session id, not chosen by the agent, so two
 sessions cannot collide and no workspace name can steer a push at a protected
-branch.
+branch. The exception is a pull request handed to it, which keeps its own
+branch — checked against the protected list all the same.
 
 ## Configuration
 
@@ -132,7 +133,7 @@ has a default that is right for this deployment.
 | `LOGOS_AGENT_GITHUB_TOKEN` | — | The agent account's token. **Required.** |
 | `LOGOS_AGENT_GITHUB_LOGIN` | `LogosOSSAgent` | The account every token must belong to |
 | `LOGOS_AGENT_DEFAULT_MODEL` | — | Model when a session does not name one. Optional: with exactly one local model reachable, that one is the default |
-| `LOGOS_AGENT_TRIGGERS_ENABLED` | `false` | React to labelled issues and reviews |
+| `LOGOS_AGENT_TRIGGERS_ENABLED` | `true` | Kill switch for reacting to the repository |
 | `LOGOS_AGENT_MAX_PARALLEL_SESSIONS` | `10` | Hard ceiling on concurrent sessions |
 | `LOGOS_AGENT_START_BELOW_LOAD` | `0.60` | Start only below this load |
 | `LOGOS_AGENT_PAUSE_ABOVE_LOAD` | `0.85` | Pause at or above this load |
@@ -205,38 +206,54 @@ are data, and a key can be granted a cloud provider at any time. A model that
 is served both locally and in the cloud counts as cloud — the scheduler may
 route to either.
 
-## Reacting to the repository
+## Working with it like a colleague
 
-With `LOGOS_AGENT_TRIGGERS_ENABLED`, the runner queues sessions of its own:
+The agent has a GitHub account (`LogosOSSAgent`), and the point is that you
+use it the way you use a person's:
 
-| What happens on GitHub | What the runner does |
+| What you do | What it does |
 |---|---|
-| an issue labelled `logos-agent` is opened or updated | queues a session to work on it and open a draft pull request |
-| a review asks a labelled pull request for changes | queues a session that updates that pull request's own branch |
+| assign it an issue | works on it and opens a draft pull request |
+| assign it a pull request | takes it over, on that pull request's own branch |
+| ask one of its pull requests for changes | addresses the review on that branch |
+| comment on a pull request it is responsible for | reads the thread and answers |
+| mention it anywhere by name | answers there; changes code only if that is what was asked |
 
-**Opt-in by label**, because the repository is shared with people who did not
-ask for an agent to answer their issue. **Polling, not webhooks** — every two
-minutes — because a webhook needs an endpoint GitHub can reach, and this
-service is deliberately reachable only from the stack's own network. **Idempotent
-by reference:** each session records what it reacted to (`issue-812`,
-`pr-772-review-5085681761`), and a poll that sees the same event again queues
-nothing. A pass that cannot take on everything it saw leaves its window where
-it was, so deferred work is picked up rather than lost.
+No labels and no separate vocabulary — the ordinary gestures. **Consent is
+per item:** nothing is picked up because it exists, only because somebody
+assigned it, reviewed its work, or asked it something by name. That is why
+this needs no service-wide opt-in to be safe; `LOGOS_AGENT_TRIGGERS_ENABLED`
+exists as a kill switch, not as a second consent.
 
-A review session works **on the pull request it answers**: the workspace is
-prepared from that branch, the session pushes to it, and no second pull
-request is opened. That only applies to pull requests the runner itself
-opened — a head in this repository, under the `agent/` prefix. A fork's branch
-is not ours to push, and a human's branch is exactly what the branch rules
-exist to keep agent pushes away from; a review on either is a person's to
-answer, and the runner says so in its log rather than quietly doing something
-else. The task carries the review's inline comments as well as its body, since
-most changes-requested reviews put everything in the former.
+**It says it heard you.** The moment a session is queued it reacts with 👀 on
+what triggered it, so a question does not sit there looking ignored while the
+platform waits for idle GPUs.
 
-The automation is bounded: at most half the parallel ceiling may be its own
-sessions, so an operator queueing work by hand always finds room. Workspaces
-are created on demand up to that ceiling, since a session the runner queued
-has nobody to prepare a working copy for it.
+**It can answer.** The agent phase holds no GitHub credential, so it writes
+its answer into its artefact directory and the runner posts it when the
+session settles — in the thread the question was asked in, inline if it was
+an inline question. The reply is produced by the untrusted phase; the posting
+is done by the trusted one.
+
+**Branches.** Work it starts itself goes on `logos/agent/…`. A pull request
+handed to it keeps its own branch name, because renaming it would abandon the
+pull request it belongs to. It never pushes to a fork (not ours to push) or
+to a protected branch.
+
+**Remembered forever.** Every reaction is recorded on the session as the
+thing it reacted to — `issue-812`, `pr-772-assigned`,
+`pr-772-review-5085681761`, `thread-772-3910035243`. A reference that already
+has a session is never queued again, so an issue that stays assigned does not
+produce a second pull request next week, and an answered question is not
+answered twice. Only the *newest* changes-requested review of a pull request
+counts as work; the older ones were answered by it. A session that failed is
+re-queued by a person, who can see why it failed.
+
+**Bounded.** At most half the parallel ceiling may be self-queued sessions,
+so an operator queueing work by hand always finds room. Bots are ignored:
+their findings reach the agent through the next review, not as a session per
+note. Workspaces are created on demand up to the ceiling, since a session the
+runner queued has nobody to prepare a working copy for it.
 
 ## Running it
 

--- a/logos/logos-agent/app/config.py
+++ b/logos/logos-agent/app/config.py
@@ -42,6 +42,13 @@ def _csv(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(part.strip() for part in raw.split(",") if part.strip())
 
 
+# The file a session writes an answer into, relative to its artefact
+# directory. Shared contract: the task text tells the agent to write it, the
+# runner reads it and posts what it finds. It lives here rather than in
+# either of those modules so neither has to import the other.
+REPLY_FILE = "reply.md"
+
+
 @dataclass(frozen=True)
 class Settings:
     # --- database ---------------------------------------------------------

--- a/logos/logos-agent/app/config.py
+++ b/logos/logos-agent/app/config.py
@@ -185,23 +185,32 @@ class Settings:
     allowed_environment: str = os.getenv("LOGOS_AGENT_ALLOWED_ENVIRONMENT", "logos-dev")
     dev_base_url: str = os.getenv("LOGOS_AGENT_DEV_BASE_URL", "https://logos-dev.aet.cit.tum.de")
 
-    # Branch names a session may push. Anything outside this prefix is refused
-    # by the service before the container is even started.
-    branch_prefix: str = os.getenv("LOGOS_AGENT_BRANCH_PREFIX", "agent/")
+    # The prefix of branches this runner *creates*. Everything in this
+    # repository lives under `logos/`, and agent work is a subtree of that,
+    # so a glance at a branch name says both what it belongs to and who made
+    # it. A branch the runner did not create — a pull request handed to it by
+    # a person — keeps its own name: renaming it would abandon the pull
+    # request it belongs to.
+    branch_prefix: str = os.getenv("LOGOS_AGENT_BRANCH_PREFIX", "logos/agent/")
     protected_branches: tuple[str, ...] = field(
         default_factory=lambda: _csv("LOGOS_AGENT_PROTECTED_BRANCHES", ("main", "develop"))
     )
 
     # --- reacting to the repository --------------------------------------
     # Whether the runner queues sessions of its own when something happens on
-    # GitHub. This is the only knob the feature has: everything else about it
-    # — how often the repository is polled, how far back a restarted runner
-    # looks, how many self-queued sessions may be active at once — is a
-    # constant in `triggers.py`, derived where it depends on anything. An
-    # operator turns this on deliberately, because it is the difference
-    # between a tool that runs what it is told and one that decides for
-    # itself what to work on.
-    triggers_enabled: bool = _bool("LOGOS_AGENT_TRIGGERS_ENABLED", False)
+    # GitHub. On by default: starting this service at all is already the
+    # deliberate decision (it lives behind a compose profile), and the real
+    # consent is per item — an issue or pull request only becomes agent work
+    # by carrying the label or being assigned to the agent account. A second,
+    # invisible switch on top of those would only be a way to have the
+    # feature deployed and quietly not working. It remains configurable as a
+    # kill switch: turning it off stops the automation without taking the
+    # runner and its UI down with it.
+    #
+    # Everything else about the feature — poll interval, how far back a
+    # restarted runner looks, how many self-queued sessions may be active —
+    # is a constant in `triggers.py`, derived where it depends on anything.
+    triggers_enabled: bool = _bool("LOGOS_AGENT_TRIGGERS_ENABLED", True)
 
     # --- storage ----------------------------------------------------------
     # Where session artefacts (logs, screenshots) are kept, on a volume shared

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -16,7 +16,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
 from .config import settings
-from .schemas import ACTIVE_STATUSES, EventKind, SessionStatus
+from .schemas import ACTIVE_STATUSES, TERMINAL_STATUSES, EventKind, SessionStatus
 
 _engine: AsyncEngine | None = None
 _sessionmaker: async_sessionmaker | None = None
@@ -399,6 +399,56 @@ async def session_is_starting(session_id: int) -> bool:
             await db.execute(text("SELECT status FROM agent_sessions WHERE id = :id"), {"id": session_id})
         ).scalar_one_or_none()
     return status == SessionStatus.STARTING.value
+
+
+async def sessions_owing_a_reply(max_attempts: int) -> list[dict[str, Any]]:
+    """Finished sessions whose answer has not reached GitHub yet.
+
+    The reply is attempted once when a session settles; a timeout or a 5xx
+    at that moment would otherwise lose it, because the trigger reference
+    counts as handled and nothing looks at it again. This is what a later
+    pass retries.
+    """
+    async with sessionmaker()() as db:
+        rows = (
+            (
+                await db.execute(
+                    text(
+                        """
+                    SELECT id, reply_target, reply_attempts
+                      FROM agent_sessions
+                     WHERE reply_target IS NOT NULL
+                       AND reply_posted_at IS NULL
+                       AND reply_attempts < :max_attempts
+                       AND status = ANY(:terminal)
+                     ORDER BY id
+                     LIMIT 20
+                    """
+                    ),
+                    {"max_attempts": max_attempts, "terminal": [s.value for s in TERMINAL_STATUSES]},
+                )
+            )
+            .mappings()
+            .all()
+        )
+    return [dict(row) for row in rows]
+
+
+async def record_reply_attempt(session_id: int, *, delivered: bool) -> None:
+    """Count an attempt, and stamp the delivery when it worked."""
+    async with sessionmaker()() as db:
+        await db.execute(
+            text(
+                """
+                UPDATE agent_sessions
+                   SET reply_attempts = reply_attempts + 1,
+                       reply_posted_at = CASE WHEN :delivered THEN :now ELSE reply_posted_at END
+                 WHERE id = :id
+                """
+            ),
+            {"id": session_id, "delivered": delivered, "now": _now()},
+        )
+        await db.commit()
 
 
 async def count_active_trigger_sessions() -> int:

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -308,6 +308,7 @@ async def create_session(
     trigger_kind: str | None = None,
     trigger_ref: str | None = None,
     branch: str | None = None,
+    reply_target: str | None = None,
 ) -> int:
     async with sessionmaker()() as db:
         # Lock the workspace row before inserting. delete_workspace takes
@@ -333,11 +334,11 @@ async def create_session(
                     INSERT INTO agent_sessions
                         (workspace_id, task, model, status, created_by,
                          open_pull_request, deploy_to_dev, screenshot_paths,
-                         trigger_kind, trigger_ref, branch_name)
+                         trigger_kind, trigger_ref, branch_name, reply_target)
                     VALUES
                         (:workspace_id, :task, :model, 'queued', :created_by,
                          :open_pr, :deploy, CAST(:paths AS jsonb),
-                         :trigger_kind, :trigger_ref, :branch)
+                         :trigger_kind, :trigger_ref, :branch, :reply_target)
                     RETURNING id
                     """
                 ),
@@ -356,6 +357,7 @@ async def create_session(
                     # answers. Otherwise the launch derives the branch from
                     # the session id.
                     "branch": branch,
+                    "reply_target": reply_target,
                 },
             )
         ).scalar_one()
@@ -363,29 +365,23 @@ async def create_session(
     return int(session_id)
 
 
-async def handled_trigger_refs(refs: Sequence[str], since: datetime) -> set[str]:
-    """Which of these GitHub events already have a session.
+async def handled_trigger_refs(refs: Sequence[str]) -> set[str]:
+    """Which of these GitHub events already have a session — ever.
 
-    A reference counts as handled while its session is still active, and for
-    as long as ``since`` looks back once it has finished. Both halves matter:
-    without the first, a poll would queue a second session for an event the
-    first is still working on; without the second, a finished session would
-    let the same review trigger the same work forever.
+    Deliberately without a time window. A reference names one thing that
+    happened once: an issue was assigned, a review was submitted, somebody
+    asked a question. Answering it a second time a week later would be a
+    duplicate pull request or a duplicate answer, not a retry — and an issue
+    that simply stays assigned would produce one every week. A session that
+    failed is re-queued by a person, who can see why it failed.
     """
     if not refs:
         return set()
     async with sessionmaker()() as db:
         rows = (
             await db.execute(
-                text(
-                    """
-                    SELECT DISTINCT trigger_ref
-                      FROM agent_sessions
-                     WHERE trigger_ref = ANY(:refs)
-                       AND (status = ANY(:active) OR created_at >= :since)
-                    """
-                ),
-                {"refs": list(refs), "active": [s.value for s in ACTIVE_STATUSES], "since": since},
+                text("SELECT DISTINCT trigger_ref FROM agent_sessions WHERE trigger_ref = ANY(:refs)"),
+                {"refs": list(refs)},
             )
         ).all()
     return {row[0] for row in rows}
@@ -432,7 +428,7 @@ _SESSION_SELECT = """
            s.model, s.branch_name, s.pr_url, s.created_by, s.created_at,
            s.started_at, s.finished_at, s.exit_code, s.error,
            s.container_id, s.open_pull_request, s.deploy_to_dev,
-           s.screenshot_paths, s.trigger_kind, s.trigger_ref,
+           s.screenshot_paths, s.trigger_kind, s.trigger_ref, s.reply_target,
            COALESCE(s.tokens_in, 0) AS tokens_in,
            COALESCE(s.tokens_out, 0) AS tokens_out,
            COALESCE(s.cost_usd, 0) AS cost_usd,

--- a/logos/logos-agent/app/github.py
+++ b/logos/logos-agent/app/github.py
@@ -384,36 +384,56 @@ async def pull_request(number: int) -> dict[str, Any]:
 
 
 async def latest_changes_requested_review(number: int) -> dict[str, Any] | None:
-    """The newest review on a pull request that asked for changes.
+    """The open request for changes on a pull request, if there is one.
 
-    Only the newest one is work: an older changes-requested review on the
-    same pull request has been superseded by it, and answering both would
-    mean two sessions writing to one branch about overlapping points.
+    GitHub tracks an opinion *per reviewer*, and so does this. Each
+    reviewer's latest opinionated review — `APPROVED` or
+    `CHANGES_REQUESTED` — is their current position; a `COMMENTED` review is
+    not an opinion and does not clear one, and a `DISMISSED` review is a
+    withdrawn one. The newest request for changes among the reviewers who
+    currently hold that position is the work.
 
-    The newest review is chosen across *all* states and only then checked,
-    so an approval or a comment that came after a change request withdraws
-    it — which is what the reviewer meant by submitting it. Returns None
-    when the newest review is not a request for changes, and when there are
-    no reviews at all.
+    A single globally newest review would get this wrong in both
+    directions: reviewer B approving would appear to withdraw reviewer A's
+    objection, and anybody's passing comment would bury it.
 
     Every page is read: the endpoint answers oldest-first and ignores a
-    direction parameter, so on a long-running pull request the newest review
-    is on the last page, not the first.
+    direction parameter, so on a long-running pull request the newest
+    review is on the last page, not the first.
     """
     payload = await _get_all(f"/repos/{settings.repo_slug}/pulls/{number}/reviews")
     if not isinstance(payload, list):
         return None
-    newest: dict[str, Any] | None = None
-    newest_at: datetime | None = None
+
+    # Per reviewer: their latest opinionated review, in submission order.
+    positions: dict[str, tuple[datetime | None, dict[str, Any]]] = {}
     for review in payload:
         if not isinstance(review, dict) or not isinstance(review.get("id"), int):
             continue
+        state = str(review.get("state") or "").upper()
+        if state not in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
+            # COMMENTED and PENDING say nothing about whether the reviewer
+            # is still asking for changes.
+            continue
+        author = str((review.get("user") or {}).get("login") or "")
+        if not author:
+            continue
         submitted = _parse_time(review.get("submitted_at"))
-        if newest is None or (submitted is not None and (newest_at is None or submitted >= newest_at)):
-            newest, newest_at = review, submitted
-    if newest is None or str(newest.get("state") or "").upper() != "CHANGES_REQUESTED":
+        held = positions.get(author)
+        if held is None or submitted is None or held[0] is None or submitted >= held[0]:
+            positions[author] = (submitted, review)
+
+    outstanding = [
+        (submitted, review)
+        for submitted, review in positions.values()
+        if str(review.get("state") or "").upper() == "CHANGES_REQUESTED"
+    ]
+    if not outstanding:
         return None
-    return newest
+    # The newest of the open objections: one session answers the review it
+    # names, and the others are seen again once it has.
+    outstanding.sort(key=lambda item: (item[0] is not None, item[0] or datetime.min.replace(tzinfo=timezone.utc)))
+    return outstanding[-1][1]
 
 
 async def review_comments(number: int, review_id: int) -> list[dict[str, Any]]:
@@ -506,6 +526,34 @@ def _trailing_number(url: str) -> int | None:
 
 def _stamp(moment: datetime) -> str:
     return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# Repository permissions that mean "may change this code". GitHub's
+# `read` and `none` do not.
+_WRITE_PERMISSIONS = frozenset({"admin", "maintain", "write"})
+
+
+async def may_push(login: str) -> bool:
+    """Whether an account may write to this repository.
+
+    On a public repository anybody can comment, review, and ask the agent
+    for things. What they cannot do is push — and a session that commits on
+    their say-so would push for them. So the ability to direct code changes
+    is checked against the repository's own collaborator permissions, not
+    inferred from being able to type in a comment box.
+
+    A lookup that fails answers False: an unknown permission is not a
+    permission.
+    """
+    if not login:
+        return False
+    try:
+        payload = await _get(f"/repos/{settings.repo_slug}/collaborators/{login}/permission")
+    except GitHubError as exc:
+        # 404 is the ordinary answer for "not a collaborator".
+        logger.info("could not establish repository permission for %s: %s", login, exc)
+        return False
+    return str(payload.get("permission") or "").lower() in _WRITE_PERMISSIONS
 
 
 async def react(path: str, content: str = "eyes") -> bool:

--- a/logos/logos-agent/app/github.py
+++ b/logos/logos-agent/app/github.py
@@ -389,8 +389,12 @@ async def latest_changes_requested_review(number: int) -> dict[str, Any] | None:
     Only the newest one is work: an older changes-requested review on the
     same pull request has been superseded by it, and answering both would
     mean two sessions writing to one branch about overlapping points.
-    Returns None when the newest review is an approval or a comment, or
-    when there are no reviews at all.
+
+    The newest review is chosen across *all* states and only then checked,
+    so an approval or a comment that came after a change request withdraws
+    it — which is what the reviewer meant by submitting it. Returns None
+    when the newest review is not a request for changes, and when there are
+    no reviews at all.
 
     Every page is read: the endpoint answers oldest-first and ignores a
     direction parameter, so on a long-running pull request the newest review
@@ -404,11 +408,11 @@ async def latest_changes_requested_review(number: int) -> dict[str, Any] | None:
     for review in payload:
         if not isinstance(review, dict) or not isinstance(review.get("id"), int):
             continue
-        if str(review.get("state") or "").upper() != "CHANGES_REQUESTED":
-            continue
         submitted = _parse_time(review.get("submitted_at"))
-        if newest_at is None or (submitted is not None and submitted >= newest_at):
+        if newest is None or (submitted is not None and (newest_at is None or submitted >= newest_at)):
             newest, newest_at = review, submitted
+    if newest is None or str(newest.get("state") or "").upper() != "CHANGES_REQUESTED":
+        return None
     return newest
 
 
@@ -468,6 +472,31 @@ def pull_number_of(comment: dict[str, Any]) -> int | None:
     """The pull request an inline review comment belongs to."""
     url = str(comment.get("pull_request_url") or "")
     return _trailing_number(url)
+
+
+def thread_root_of(comment: dict[str, Any]) -> int | None:
+    """The inline thread a review comment belongs to.
+
+    A reply carries the id of the comment that started the thread; the
+    starter carries its own. Answering a line-specific question means
+    answering *in that thread*, so the root is what identifies it — a whole
+    pull request's inline comments are several conversations, not one.
+    """
+    root = comment.get("in_reply_to_id")
+    if isinstance(root, int):
+        return root
+    own = comment.get("id")
+    return own if isinstance(own, int) else None
+
+
+def created_at_of(comment: dict[str, Any]) -> datetime | None:
+    """When a comment was written.
+
+    Issue comments and review comments have independent id sequences, so a
+    newer comment can carry a smaller id than an older one of the other
+    kind. Time is the only order the two share.
+    """
+    return _parse_time(comment.get("created_at"))
 
 
 def _trailing_number(url: str) -> int | None:

--- a/logos/logos-agent/app/github.py
+++ b/logos/logos-agent/app/github.py
@@ -332,43 +332,49 @@ async def _get_all(path: str, params: dict[str, Any] | None = None) -> list[Any]
     return collected
 
 
-async def labelled_issues(label: str, *, since: datetime) -> list[dict[str, Any]]:
-    """Open issues carrying ``label`` that were updated since ``since``.
+async def _assigned(login: str) -> list[dict[str, Any]]:
+    """Every open issue and pull request assigned to an account.
 
-    Pull requests are issues to this endpoint and are filtered out here: a
-    pull request carrying the label is picked up through its reviews, not as
-    a fresh piece of work.
+    One listing for both: to this endpoint a pull request *is* an issue, and
+    the entries it returns carry the number and title, which is all the
+    callers need. No time filter — assignment is the signal, and a session
+    that already answered one is remembered by its reference, so an issue
+    assigned months ago is picked up once and then left alone.
     """
     payload = await _get_all(
         f"/repos/{settings.repo_slug}/issues",
-        {
-            "labels": label,
-            "state": "open",
-            "since": since.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "sort": "created",
-            "direction": "desc",
-        },
+        {"assignee": login, "state": "open", "sort": "updated", "direction": "desc"},
     )
-    return [item for item in payload if isinstance(item, dict) and "pull_request" not in item]
+    return [item for item in payload if isinstance(item, dict)]
 
 
-async def labelled_pull_requests(label: str) -> list[dict[str, Any]]:
-    """Open pull requests carrying ``label``.
+async def assigned_issues(login: str) -> list[dict[str, Any]]:
+    """Open issues assigned to an account — pull requests excluded."""
+    return [item for item in await _assigned(login) if "pull_request" not in item]
 
-    The issues endpoint is the one that filters by label, so pull requests
-    are read through it too — the entries it returns for them carry the
-    number, which is all the review lookup needs.
+
+async def assigned_pull_requests(login: str) -> list[dict[str, Any]]:
+    """Open pull requests assigned to an account."""
+    return [item for item in await _assigned(login) if "pull_request" in item]
+
+
+async def authored_pull_requests(login: str) -> list[dict[str, Any]]:
+    """Open pull requests an account opened.
+
+    Its own pull requests are the ones whose reviews it has to answer, and
+    they are not necessarily assigned to it — GitHub does not assign an
+    author to their own pull request.
     """
     payload = await _get_all(
-        f"/repos/{settings.repo_slug}/issues",
-        {
-            "labels": label,
-            "state": "open",
-            "sort": "updated",
-            "direction": "desc",
-        },
+        f"/repos/{settings.repo_slug}/pulls",
+        {"state": "open", "sort": "updated", "direction": "desc"},
     )
-    return [item for item in payload if isinstance(item, dict) and "pull_request" in item]
+    wanted = login.strip().lower()
+    return [
+        pull
+        for pull in payload
+        if isinstance(pull, dict) and str(((pull.get("user") or {}).get("login")) or "").lower() == wanted
+    ]
 
 
 async def pull_request(number: int) -> dict[str, Any]:
@@ -377,25 +383,33 @@ async def pull_request(number: int) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-async def reviews_since(number: int, since: datetime) -> list[dict[str, Any]]:
-    """Reviews submitted on a pull request after ``since``.
+async def latest_changes_requested_review(number: int) -> dict[str, Any] | None:
+    """The newest review on a pull request that asked for changes.
 
-    The reviews endpoint returns oldest first and ignores a direction
-    parameter, so every page is read and filtered here — asking for the last
-    few would return the *first* few, and on a long-running pull request the
-    newest review is on the last page, not the first.
+    Only the newest one is work: an older changes-requested review on the
+    same pull request has been superseded by it, and answering both would
+    mean two sessions writing to one branch about overlapping points.
+    Returns None when the newest review is an approval or a comment, or
+    when there are no reviews at all.
+
+    Every page is read: the endpoint answers oldest-first and ignores a
+    direction parameter, so on a long-running pull request the newest review
+    is on the last page, not the first.
     """
     payload = await _get_all(f"/repos/{settings.repo_slug}/pulls/{number}/reviews")
     if not isinstance(payload, list):
-        return []
-    fresh: list[dict[str, Any]] = []
+        return None
+    newest: dict[str, Any] | None = None
+    newest_at: datetime | None = None
     for review in payload:
-        if not isinstance(review, dict):
+        if not isinstance(review, dict) or not isinstance(review.get("id"), int):
+            continue
+        if str(review.get("state") or "").upper() != "CHANGES_REQUESTED":
             continue
         submitted = _parse_time(review.get("submitted_at"))
-        if submitted is not None and submitted > since:
-            fresh.append(review)
-    return fresh
+        if newest_at is None or (submitted is not None and submitted >= newest_at):
+            newest, newest_at = review, submitted
+    return newest
 
 
 async def review_comments(number: int, review_id: int) -> list[dict[str, Any]]:
@@ -409,6 +423,108 @@ async def review_comments(number: int, review_id: int) -> list[dict[str, Any]]:
     """
     payload = await _get_all(f"/repos/{settings.repo_slug}/pulls/{number}/reviews/{review_id}/comments")
     return [comment for comment in payload if isinstance(comment, dict)]
+
+
+async def recent_issue_comments(since: datetime) -> list[dict[str, Any]]:
+    """Every issue and pull-request comment in the repository since ``since``.
+
+    One repository-wide listing rather than one request per thread: the
+    agent has to notice a question on a pull request nobody assigned it, and
+    walking every open thread to find that would cost a request each.
+    """
+    return [
+        comment
+        for comment in await _get_all(
+            f"/repos/{settings.repo_slug}/issues/comments",
+            {"since": _stamp(since), "sort": "created", "direction": "desc"},
+        )
+        if isinstance(comment, dict)
+    ]
+
+
+async def recent_review_comments(since: datetime) -> list[dict[str, Any]]:
+    """Every inline review comment in the repository since ``since``."""
+    return [
+        comment
+        for comment in await _get_all(
+            f"/repos/{settings.repo_slug}/pulls/comments",
+            {"since": _stamp(since), "sort": "created", "direction": "desc"},
+        )
+        if isinstance(comment, dict)
+    ]
+
+
+def issue_number_of(comment: dict[str, Any]) -> int | None:
+    """The issue or pull request an issue comment belongs to.
+
+    The repository-wide listing does not carry the number as a field; it is
+    the last segment of the thread's API url.
+    """
+    url = str(comment.get("issue_url") or "")
+    return _trailing_number(url)
+
+
+def pull_number_of(comment: dict[str, Any]) -> int | None:
+    """The pull request an inline review comment belongs to."""
+    url = str(comment.get("pull_request_url") or "")
+    return _trailing_number(url)
+
+
+def _trailing_number(url: str) -> int | None:
+    tail = url.rstrip("/").rsplit("/", 1)[-1]
+    return int(tail) if tail.isdigit() else None
+
+
+def _stamp(moment: datetime) -> str:
+    return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+async def react(path: str, content: str = "eyes") -> bool:
+    """Leave a reaction, so a person can see their request was picked up.
+
+    ``path`` is the API path of the thing reacted to — an issue, an issue
+    comment, or an inline review comment. Returns whether the reaction is
+    there now; a duplicate (GitHub answers 200 instead of 201) counts, since
+    the point is the state, not who created it.
+    """
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(f"{_API}{path}/reactions", headers=_headers(), json={"content": content})
+    if response.status_code in (200, 201):
+        return True
+    raise GitHubError(f"reaction on {path} failed ({response.status_code}): {response.text[:200]}")
+
+
+async def post_issue_comment(number: int, body: str) -> str:
+    """Answer in an issue or pull-request thread. Returns the comment url."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{_API}/repos/{settings.repo_slug}/issues/{number}/comments",
+            headers=_headers(),
+            json={"body": body},
+        )
+    if response.status_code != 201:
+        raise GitHubError(f"comment on #{number} failed ({response.status_code}): {response.text[:200]}")
+    return str(response.json().get("html_url") or "")
+
+
+async def reply_to_review_comment(number: int, comment_id: int, body: str) -> str:
+    """Answer inside an inline review thread. Returns the comment url.
+
+    The reply lands in the thread the question was asked in, which is where
+    its author is looking — a top-level comment would answer a line-specific
+    question somewhere else entirely.
+    """
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            f"{_API}/repos/{settings.repo_slug}/pulls/{number}/comments/{comment_id}/replies",
+            headers=_headers(),
+            json={"body": body},
+        )
+    if response.status_code != 201:
+        raise GitHubError(
+            f"reply to comment {comment_id} on #{number} failed ({response.status_code}): {response.text[:200]}"
+        )
+    return str(response.json().get("html_url") or "")
 
 
 def head_of(pull: dict[str, Any]) -> tuple[str, str]:

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -33,6 +33,7 @@ import httpx
 from . import capacity, db, docker_engine, github, model_policy
 from .config import settings
 from .schemas import EventKind, SessionStatus
+from .triggers import REPLY_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -522,10 +523,20 @@ class SessionManager:
         # the same check below: a preset branch is no more trusted than a
         # derived one, and it is the only place a bug could aim a push at a
         # protected branch.
-        branch = str(session.get("branch_name") or "") or branch_for(sid, workspace["name"])
-        if branch.rsplit("/", 1)[-1] in settings.protected_branches or not branch.startswith(settings.branch_prefix):
-            # Cannot happen with the derivation above, but the check is cheap
-            # and this is the one place where a bug would push to main.
+        # A session queued against an existing branch — a review answered, or
+        # a pull request handed over — carries it on the row and keeps that
+        # name: renaming somebody's branch would abandon the pull request it
+        # belongs to. Everything else gets the branch derived from the
+        # session id, under the runner's own prefix.
+        taken_over = str(session.get("branch_name") or "")
+        branch = taken_over or branch_for(sid, workspace["name"])
+        if branch in settings.protected_branches or branch.rsplit("/", 1)[-1] in settings.protected_branches:
+            # This is the one place where a bug would push to main.
+            await self._settle(sid, exit_code=None, error=f"refusing branch '{branch}'")
+            return
+        if not taken_over and not branch.startswith(settings.branch_prefix):
+            # The prefix binds branches the runner creates; it says nothing
+            # about one it was handed.
             await self._settle(sid, exit_code=None, error=f"refusing branch '{branch}'")
             return
 
@@ -677,6 +688,10 @@ class SessionManager:
             # /artifacts is its output root; there is no per-session prefix
             # to get wrong.
             "LOGOS_ARTIFACT_DIR": "/artifacts",
+            # Where an answer goes when the session was asked something. The
+            # task text names the same file; this is what makes it available
+            # to anything else in the container that wants it.
+            "LOGOS_SESSION_REPLY_FILE": f"/artifacts/{REPLY_FILE}",
         }
         if model:
             for key in (
@@ -1011,6 +1026,14 @@ class SessionManager:
         if result.get("pr_url"):
             await db.add_event(session_id, EventKind.PULL_REQUEST, {"url": result["pr_url"]})
 
+        # Somebody asked this session a question. The agent phase holds no
+        # GitHub credential, so it wrote the answer into its artefact
+        # directory and this is where the answer is posted — by the process
+        # that does hold the token. Posted even for a failed session: a
+        # partial answer beats silence on a thread where a person is
+        # waiting.
+        await self._post_reply(session_id)
+
         deploy: str | None = None
         after_run_id: int | None = None
         if succeeded:
@@ -1029,6 +1052,47 @@ class SessionManager:
                 await self._capture_screenshots(session_id, deploy, after_run_id)
         else:
             await self._cleanup_container(session_id)
+
+    async def _post_reply(self, session_id: int) -> None:
+        """Post the answer a session wrote, if it was asked for one."""
+        session = await db.get_session(session_id)
+        target = str((session or {}).get("reply_target") or "")
+        if not target:
+            return
+        path = artifact_dir(session_id) / REPLY_FILE
+        try:
+            body = path.read_text().strip()
+        except OSError:
+            logger.info("session %s was asked a question but wrote no answer", session_id)
+            return
+        if not body:
+            logger.info("session %s wrote an empty answer; nothing to post", session_id)
+            return
+        try:
+            url = await self._send_reply(target, body)
+        except Exception as exc:
+            logger.warning("could not post the answer of session %s: %s", session_id, exc)
+            await db.add_event(session_id, EventKind.ERROR, {"error": f"could not post the reply: {exc}"})
+            return
+        await db.add_event(session_id, EventKind.PULL_REQUEST, {"url": url, "reply": True})
+        logger.info("session %s answered at %s", session_id, url)
+
+    @staticmethod
+    async def _send_reply(target: str, body: str) -> str:
+        """Post one answer where its question was asked.
+
+        ``target`` is what the trigger recorded: ``issue:<n>`` for a thread,
+        or ``review_comment:<n>:<id>`` to answer inside an inline review
+        thread — where the question was asked, and where its author is
+        looking.
+        """
+        kind, _, rest = target.partition(":")
+        if kind == "issue":
+            return await github.post_issue_comment(int(rest), body)
+        if kind == "review_comment":
+            number, _, comment_id = rest.partition(":")
+            return await github.reply_to_review_comment(int(number), int(comment_id), body)
+        raise ValueError(f"unknown reply target '{target}'")
 
     def _read_result(self, session_id: int) -> dict[str, Any]:
         """Read the result file the container writes before it exits.

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -31,9 +31,8 @@ from typing import Any
 import httpx
 
 from . import capacity, db, docker_engine, github, model_policy
-from .config import settings
+from .config import REPLY_FILE, settings
 from .schemas import EventKind, SessionStatus
-from .triggers import REPLY_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +50,10 @@ _BRANCH_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
 # a stopped helper container to be reaped, short enough that a wedged Docker
 # call cannot hold the cancel API open.
 _CANCEL_LAUNCH_WAIT_S = 60.0
+
+# GitHub rejects a comment body longer than 65536 characters; the margin
+# leaves room for the truncation note.
+_MAX_REPLY_CHARS = 60000
 
 
 def container_name(session_id: int) -> str:
@@ -517,12 +520,6 @@ class SessionManager:
             await self._settle(sid, exit_code=None, error="workspace disappeared")
             return
 
-        # A session queued against an existing branch — a review session
-        # updating the pull request it answers — carries it on the row. Every
-        # other session gets the branch derived from its id. Both go through
-        # the same check below: a preset branch is no more trusted than a
-        # derived one, and it is the only place a bug could aim a push at a
-        # protected branch.
         # A session queued against an existing branch — a review answered, or
         # a pull request handed over — carries it on the row and keeps that
         # name: renaming somebody's branch would abandon the pull request it
@@ -1068,6 +1065,12 @@ class SessionManager:
         if not body:
             logger.info("session %s wrote an empty answer; nothing to post", session_id)
             return
+        if len(body) > _MAX_REPLY_CHARS:
+            # GitHub refuses a comment above its length limit outright, and
+            # an answer nobody receives is worse than a shortened one on a
+            # thread where somebody is waiting.
+            body = body[:_MAX_REPLY_CHARS].rstrip() + "\n\n_[answer truncated]_"
+            logger.info("the answer of session %s was truncated to fit a GitHub comment", session_id)
         try:
             url = await self._send_reply(target, body)
         except Exception as exc:

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -55,6 +55,9 @@ _CANCEL_LAUNCH_WAIT_S = 60.0
 # leaves room for the truncation note.
 _MAX_REPLY_CHARS = 60000
 
+# How often an undelivered answer is retried before it is left alone.
+_MAX_REPLY_ATTEMPTS = 5
+
 
 def container_name(session_id: int) -> str:
     return f"{_CONTAINER_PREFIX}{session_id}"
@@ -352,6 +355,16 @@ class SessionManager:
                 raise
             except Exception:
                 logger.exception("scheduler pass failed")
+            try:
+                # Answers that did not reach GitHub when their session
+                # settled. Beside the pass rather than inside it: a pass is
+                # about admitting and yielding, and every session creation
+                # schedules one of those.
+                await self.deliver_pending_replies()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("retrying undelivered answers failed")
             try:
                 await asyncio.wait_for(self._stopping.wait(), timeout=settings.scheduler_interval_s)
             except asyncio.TimeoutError:
@@ -1050,11 +1063,30 @@ class SessionManager:
         else:
             await self._cleanup_container(session_id)
 
+    async def deliver_pending_replies(self) -> None:
+        """Try again for answers that did not reach GitHub the first time.
+
+        Delivery happens once when a session settles, and a timeout or a 5xx
+        at that moment would otherwise lose the answer for good: the trigger
+        reference counts as handled, so nothing looks at it again. Every
+        scheduler pass gives the few outstanding ones another go, until they
+        land or the attempts run out.
+        """
+        try:
+            owing = await db.sessions_owing_a_reply(_MAX_REPLY_ATTEMPTS)
+        except Exception as exc:
+            logger.warning("could not look for undelivered answers: %s", exc)
+            return
+        for row in owing:
+            await self._post_reply(int(row["id"]))
+
     async def _post_reply(self, session_id: int) -> None:
         """Post the answer a session wrote, if it was asked for one."""
         session = await db.get_session(session_id)
         target = str((session or {}).get("reply_target") or "")
         if not target:
+            return
+        if (session or {}).get("reply_posted_at"):
             return
         path = artifact_dir(session_id) / REPLY_FILE
         try:
@@ -1074,9 +1106,13 @@ class SessionManager:
         try:
             url = await self._send_reply(target, body)
         except Exception as exc:
-            logger.warning("could not post the answer of session %s: %s", session_id, exc)
+            # Counted, not given up on: the next scheduler pass tries again
+            # until it lands or the attempts run out.
+            await db.record_reply_attempt(session_id, delivered=False)
+            logger.warning("could not post the answer of session %s (will retry): %s", session_id, exc)
             await db.add_event(session_id, EventKind.ERROR, {"error": f"could not post the reply: {exc}"})
             return
+        await db.record_reply_attempt(session_id, delivered=True)
         await db.add_event(session_id, EventKind.PULL_REQUEST, {"url": url, "reply": True})
         logger.info("session %s answered at %s", session_id, url)
 

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -263,6 +263,8 @@ class TriggerPoller:
         self._last_error: str = ""
         self._last_pass: datetime | None = None
         self._queued_total = 0
+        # login -> may push, for the duration of one pass.
+        self._writers: dict[str, bool] = {}
         # Called after a pass queued something, so the work starts on the
         # next admission rather than at the scheduler's own tick. Set by the
         # service on startup; the poller does not import the session manager
@@ -326,6 +328,9 @@ class TriggerPoller:
             self._last_pass = now
             return []
 
+        # Permission answers are cached per pass: they can change, and a
+        # pass is short enough that reading them once is honest.
+        self._writers = {}
         candidates = await self._candidates(now)
         self._last_pass = now
         self._last_error = ""
@@ -403,6 +408,19 @@ class TriggerPoller:
                     # cannot update the pull request its task is about.
                     logger.info("review on pull request %s has no writable branch; leaving it to a person", number)
                     continue
+                reviewer = str((review.get("user") or {}).get("login") or "")
+                if not await self._writer(reviewer):
+                    # Anybody may review a public pull request, and a review
+                    # is a request to change code: acting on one from
+                    # outside the repository would let a stranger direct
+                    # what the agent commits.
+                    logger.info(
+                        "review on pull request %s is by %s, who may not write to this repository; "
+                        "leaving it to a person",
+                        number,
+                        reviewer or "an unknown account",
+                    )
+                    continue
                 found.append(
                     {
                         "ref": f"pr-{number}-review-{review_id}",
@@ -458,6 +476,25 @@ class TriggerPoller:
         for entry in await github.authored_pull_requests(login):
             await remember(entry, assigned=False)
         return pulls
+
+    async def _writer(self, login: str) -> bool:
+        """Whether an account may write to this repository.
+
+        Cached for the pass: one conversation is usually one person, and a
+        lookup per comment would spend requests on the same answer.
+        """
+        key = login.lower()
+        if key not in self._writers:
+            self._writers[key] = await github.may_push(login)
+        return self._writers[key]
+
+    async def _may_direct_changes(self, comments: list[dict[str, Any]]) -> bool:
+        """Whether anyone in this conversation may direct a code change."""
+        for comment in comments:
+            author = str((comment.get("user") or {}).get("login") or "")
+            if author and await self._writer(author):
+                return True
+        return False
 
     async def _writable_head(self, number: int) -> str | None:
         """The branch of a pull request the agent may push to, or None.
@@ -549,8 +586,15 @@ class TriggerPoller:
         for (kind, key), thread in threads.items():
             number = thread["number"]
             pull = responsible.get(number)
-            branch = pull["branch"] if pull else None
             title = pull["title"] if pull else f"#{number}"
+            # Anybody may comment on a public repository; not everybody may
+            # direct a change to it. A conversation with no writer in it is
+            # answered in words and gets no branch, so the credentialed
+            # finalizer cannot be made to push on a stranger's say-so.
+            branch = pull["branch"] if pull else None
+            if branch is not None and not await self._may_direct_changes(thread["comments"]):
+                logger.info("comments on #%s come from outside the repository; answering without a branch", number)
+                branch = None
             newest = thread["newest_id"]
             inline = kind == "inline"
             candidates.append(

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -385,25 +385,35 @@ class TriggerPoller:
             )
 
         responsible = await self._responsible_pulls(login)
+        # Inline comments a review task already carries: the repository scan
+        # below sees the same objects, and a second candidate for them would
+        # be a second session writing to one branch about one request.
+        consumed: set[int] = set()
         for number, pull in responsible.items():
             branch = pull["branch"]
             review = await github.latest_changes_requested_review(number)
             if review is not None:
                 review_id = int(review["id"])
+                comments = await github.review_comments(number, review_id)
+                consumed.update(c["id"] for c in comments if isinstance(c.get("id"), int))
+                if branch is None:
+                    # Nowhere to put the fix: a fork's head, or a protected
+                    # branch. Queueing it anyway would start a session from
+                    # the default branch on a fresh branch of its own, which
+                    # cannot update the pull request its task is about.
+                    logger.info("review on pull request %s has no writable branch; leaving it to a person", number)
+                    continue
                 found.append(
                     {
                         "ref": f"pr-{number}-review-{review_id}",
                         "kind": "review",
-                        "task": review_task(
-                            number, pull["title"], review, await github.review_comments(number, review_id)
-                        ),
+                        "task": review_task(number, pull["title"], review, comments),
                         "branch": branch,
                         "workspace": f"pr-{number}",
-                        "reaction": (
-                            f"/repos/{settings.repo_slug}/pulls/comments/{review_id}"
-                            if review.get("body")
-                            else f"/repos/{settings.repo_slug}/issues/{number}"
-                        ),
+                        # A submitted review is not a review *comment*: the
+                        # two have independent id sequences, so the
+                        # acknowledgement goes on the pull request itself.
+                        "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
                         "reply_target": f"issue:{number}",
                     }
                 )
@@ -419,7 +429,7 @@ class TriggerPoller:
                     }
                 )
 
-        found.extend(await self._comment_candidates(now, responsible))
+        found.extend(await self._comment_candidates(now, responsible, consumed))
         return found
 
     async def _responsible_pulls(self, login: str) -> dict[int, dict[str, Any]]:
@@ -476,67 +486,92 @@ class TriggerPoller:
             return None
         return ref
 
-    async def _comment_candidates(self, now: datetime, responsible: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
-        """Comments the agent should answer, one candidate per thread.
+    async def _comment_candidates(
+        self, now: datetime, responsible: dict[int, dict[str, Any]], consumed: set[int]
+    ) -> list[dict[str, Any]]:
+        """Comments the agent should answer, one candidate per conversation.
 
         Two kinds count: anything on a pull request it is responsible for,
         and anything anywhere that mentions it by name. Its own comments and
         those of bots are skipped — the first would be a conversation with
         itself, the second a stampede.
 
-        Fresh comments on one thread become *one* task, keyed on the newest
-        of them: a person writing three notes in a row is asking one thing,
-        and three sessions writing to one branch would not be an answer.
+        A *conversation* is the unit, not a pull request: an inline thread is
+        its own question, asked about one place in the diff and answered
+        there, while ordinary comments on a thread are one running
+        discussion. Grouping every inline thread of a pull request together
+        would answer one of them and leave the rest without a reply.
+
+        Comments already carried by a review task are skipped: they are being
+        worked on, and answering them twice is not answering them better.
         """
         since = now - COMMENT_LOOKBACK
-        threads: dict[int, dict[str, Any]] = {}
+        threads: dict[tuple[str, int], dict[str, Any]] = {}
 
-        def consider(comment: dict[str, Any], number: int, *, review_comment: bool) -> None:
+        def consider(comment: dict[str, Any], number: int, *, root: int | None) -> None:
             author = str((comment.get("user") or {}).get("login") or "")
             if not author or author.lower() == settings.github_login.lower() or is_bot(author):
+                return
+            comment_id = comment.get("id")
+            if not isinstance(comment_id, int) or comment_id in consumed:
                 return
             body = str(comment.get("body") or "")
             if number not in responsible and not mentions_agent(body):
                 return
-            comment_id = comment.get("id")
-            if not isinstance(comment_id, int):
-                return
-            thread = threads.setdefault(number, {"comments": [], "newest": 0, "review_comment": review_comment})
+            key = ("inline", root) if root is not None else ("issue", number)
+            thread = threads.setdefault(
+                key,
+                {"number": number, "comments": [], "newest_id": comment_id, "newest_at": None, "root": root},
+            )
             thread["comments"].append(comment)
-            if comment_id > thread["newest"]:
-                thread["newest"] = comment_id
-                thread["review_comment"] = review_comment
+            # Newest by time, not by id: issue comments and review comments
+            # have independent id sequences, so a newer one of either kind
+            # can carry a smaller number than an older one of the other. Ids
+            # decide only between two comments that carry no timestamp,
+            # which within one thread means one kind and one sequence.
+            written = github.created_at_of(comment)
+            best = thread["newest_at"]
+            if written is not None and (best is None or written >= best):
+                thread["newest_at"], thread["newest_id"] = written, comment_id
+            elif written is None and best is None and comment_id > thread["newest_id"]:
+                thread["newest_id"] = comment_id
 
         for comment in await github.recent_issue_comments(since):
             number = github.issue_number_of(comment)
             if number is not None:
-                consider(comment, number, review_comment=False)
+                consider(comment, number, root=None)
         for comment in await github.recent_review_comments(since):
             number = github.pull_number_of(comment)
             if number is not None:
-                consider(comment, number, review_comment=True)
+                consider(comment, number, root=github.thread_root_of(comment))
 
         candidates: list[dict[str, Any]] = []
-        for number, thread in threads.items():
+        for (kind, key), thread in threads.items():
+            number = thread["number"]
             pull = responsible.get(number)
             branch = pull["branch"] if pull else None
             title = pull["title"] if pull else f"#{number}"
-            newest = thread["newest"]
+            newest = thread["newest_id"]
+            inline = kind == "inline"
             candidates.append(
                 {
-                    "ref": f"thread-{number}-{newest}",
+                    # The reference names the conversation and its latest
+                    # word, so a later comment in it is new work and the same
+                    # one never is. An inline thread carries its root, since
+                    # one pull request has many of them.
+                    "ref": (f"thread-{number}-inline-{key}-{newest}" if inline else f"thread-{number}-issue-{newest}"),
                     "kind": "comment",
                     "task": thread_task(number, title, thread["comments"], branch=branch),
                     "branch": branch,
                     "workspace": f"pr-{number}" if branch else None,
                     "reaction": (
                         f"/repos/{settings.repo_slug}/pulls/comments/{newest}"
-                        if thread["review_comment"]
+                        if inline
                         else f"/repos/{settings.repo_slug}/issues/comments/{newest}"
                     ),
-                    "reply_target": (
-                        f"review_comment:{number}:{newest}" if thread["review_comment"] else f"issue:{number}"
-                    ),
+                    # An inline question is answered in its own thread, where
+                    # the person who asked it is looking.
+                    "reply_target": (f"review_comment:{number}:{key}" if inline else f"issue:{number}"),
                 }
             )
         return candidates

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -1,36 +1,51 @@
-"""Queueing work the repository asked for, without anyone asking the runner.
+"""Working with the agent the way you work with a colleague.
 
-Two things happen in a repository that an agent can act on without being
-told: an issue is opened, and a review asks a pull request for changes. This
-module watches for both and queues a session for each — the same sessions an
-operator would have created by hand, with the same capacity gating, the same
-local-only model policy, and the same isolation.
+The agent has a GitHub account, and this module is what makes that account
+usable like a person's. The gestures are the ordinary ones:
 
-**Opt-in by label.** Only issues and pull requests carrying `logos-agent`
-are picked up. The repository is shared with people who did not ask for an
-agent to answer their issue, and "everything that moves" would be a promise
-this runner has no business making. The label is the promise.
+| What you do on GitHub | What the agent does |
+|---|---|
+| assign it an issue | works on the issue and opens a draft pull request |
+| assign it a pull request | takes that pull request over, on its own branch |
+| ask one of its pull requests for changes | addresses the review on that branch |
+| comment on a pull request it is responsible for | reads the comment and answers it |
+| mention it in any comment | answers there, and changes code only if that is what was asked |
+
+No labels, no separate vocabulary. **Consent is per item:** nothing is picked
+up because it exists, only because somebody assigned it, reviewed its work,
+or asked it something by name.
+
+**It says it heard you.** The moment a session is queued, the runner reacts
+with 👀 on the thing that triggered it — so a question does not sit there
+looking ignored while the platform waits for idle GPUs.
+
+**It can answer.** The agent phase holds no GitHub credential, so it writes
+its answer to a file in its artefact directory and the runner posts it when
+the session settles. The reply is data produced by the untrusted phase; the
+posting is done by the trusted one.
 
 **Polling, not webhooks.** A webhook needs an endpoint GitHub can reach, and
 this service is deliberately reachable only from the stack's own network.
 The trade is minutes of latency for work whose whole premise is "when the
 GPUs are idle anyway".
 
-**Idempotent by reference.** Every reaction is recorded on the session as the
-thing it reacted to — `issue-812`, `pr-772-review-5085681761`. A poll that
-sees the same issue or review again finds that session and queues nothing.
-References are stable identities, not timestamps, so a restarted runner with
-a fresh clock cannot duplicate work.
+**Remembered by reference, forever.** Every reaction is recorded on the
+session as the thing it reacted to — `issue-812`, `pr-772-assigned`,
+`pr-772-review-5085681761`, `thread-772-3910035243`. A reference that
+already has a session is never queued again, so an issue that stays assigned
+does not produce a second pull request next week, and an answered question
+is not answered twice. Only the *newest* changes-requested review of a pull
+request is work; the older ones were answered by it.
 
-**Bounded.** At most a few self-queued sessions are active at once, and the
-runner never crowds out an operator: the ceiling counts only sessions it
-queued itself, and the parallel-session ceiling applies on top.
+**Bounded.** At most half the parallel ceiling may be self-queued sessions,
+so an operator queueing work by hand always finds room.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -40,28 +55,27 @@ from .config import settings
 
 logger = logging.getLogger(__name__)
 
-# How often the repository is polled. Frequent enough that a review posted
-# during a working day is picked up while its author is still around, rare
-# enough to stay far inside GitHub's rate limits (a pass is a handful of
-# requests).
+# How often the repository is polled. Frequent enough that a question asked
+# during a working day is seen while its author is still around, rare enough
+# to stay far inside GitHub's rate limits (a pass is a handful of requests).
 POLL_INTERVAL_S = 120.0
 
-# How far back the first pass after a start looks. A runner that was down
-# over a weekend must not wake up and queue the whole weekend at once; six
-# hours is "what is currently going on", not "the backlog".
-FIRST_PASS_LOOKBACK = timedelta(hours=6)
+# How far back a pass looks for comments. Assignments and reviews need no
+# window — they are read from the current state of the repository — but
+# comments are a stream, and without a bound the first pass after a restart
+# would read years of them. A day is generous for "somebody asked something
+# and is waiting"; anything older is not a live question.
+COMMENT_LOOKBACK = timedelta(hours=24)
 
-# How long a handled reference stays handled after its session finished.
-# Long enough that a finished session is not re-queued by the next poll,
-# short enough that a genuinely new review on the same pull request — which
-# carries a new review id anyway — is never suppressed by it.
-DEDUP_WINDOW = timedelta(days=7)
-
-# The label that opts a thread into agent work.
-LABEL = "logos-agent"
+# At most this many comments are carried into one task, and this much of each.
+MAX_THREAD_COMMENTS = 20
+MAX_COMMENT_CHARS = 3000
 
 # The account sessions are attributed to when the runner queued them itself.
 CREATED_BY = "logos-agent (trigger)"
+
+# Where a session writes an answer for the runner to post.
+REPLY_FILE = "reply.md"
 
 
 def _next_auto_name(existing: set[str]) -> str:
@@ -88,20 +102,39 @@ def max_active_sessions() -> int:
     return max(1, settings.max_parallel_sessions // 2)
 
 
-def issue_task(issue: dict[str, Any]) -> str:
-    """The task text for an opened issue.
+def mentions_agent(body: str) -> bool:
+    """Whether a comment addresses the agent by name.
 
-    The issue's own words are the task; what this adds is the frame the
-    session needs — where the work came from, and that it ends as a draft
-    pull request a person reviews.
+    Matched on a word boundary so `@LogosOSSAgentBot` is not this account,
+    and case-insensitively because GitHub logins are.
     """
+    return re.search(rf"@{re.escape(settings.github_login)}\b", body or "", re.IGNORECASE) is not None
+
+
+def is_bot(login: str) -> bool:
+    """Whether an author is a bot.
+
+    Bots comment a great deal — a review bot can post a dozen notes on one
+    push — and a session per note would be a stampede, not a colleague. Their
+    findings still reach the agent: they are part of the pull request the
+    next review or assignment brings it back to.
+    """
+    return login.endswith("[bot]") or login.lower() in {"github-actions", "coderabbitai"}
+
+
+# --- what the agent is asked to do ----------------------------------------
+
+
+def issue_task(issue: dict[str, Any]) -> str:
+    """The task text for an issue assigned to the agent."""
     number = issue.get("number")
     title = str(issue.get("title") or "").strip()
     body = str(issue.get("body") or "").strip()
     if len(body) > 6000:
         body = body[:6000] + "\n\n[issue body truncated]"
     return (
-        f"Work on this repository issue and open a draft pull request with your result.\n\n"
+        f"You have been assigned issue #{number}. Work on it and open a draft pull "
+        f"request with your result.\n\n"
         f"Issue #{number}: {title}\n\n"
         f"{body}\n\n"
         f"Scope your change to what the issue asks for. Add or adjust tests for what you "
@@ -110,6 +143,26 @@ def issue_task(issue: dict[str, Any]) -> str:
         f"than it looks, do the part you are confident about and say plainly in your "
         f"final message what you left out and why. Do not reference the issue number in "
         f"code comments, docstrings, or test names."
+    )
+
+
+def takeover_task(number: int, title: str, body: str, branch: str) -> str:
+    """The task text for a pull request handed to the agent."""
+    text = (body or "").strip()
+    if len(text) > 6000:
+        text = text[:6000] + "\n\n[description truncated]"
+    return (
+        f"Pull request #{number} ('{title}') has been assigned to you: somebody wants you "
+        f"to carry it the rest of the way. You are working in a checkout of its own "
+        f"branch `{branch}`, and your commit updates that pull request — do not open a "
+        f"new one, and do not rename or move the branch.\n\n"
+        f"What the pull request says about itself:\n\n{text or '(no description)'}\n\n"
+        f"Read the existing review conversation before you change anything, and start "
+        f"from whatever is still open in it. Bring the change to a state its author would "
+        f"recognise: tests and linters of the part you touched pass, the description "
+        f"still matches what the branch does. Say in your final message what you did and "
+        f"what you deliberately left alone. Do not merge the pull request and do not "
+        f"force-push over anybody else's commits."
     )
 
 
@@ -128,8 +181,8 @@ def _inline_block(comments: list[dict[str, Any]]) -> str:
         body = str(comment.get("body") or "").strip()
         if not body:
             continue
-        if len(body) > 3000:
-            body = body[:3000] + " […]"
+        if len(body) > MAX_COMMENT_CHARS:
+            body = body[:MAX_COMMENT_CHARS] + " […]"
         rendered.append(f"- {path}:{line}\n  {body}")
     if not rendered:
         return ""
@@ -153,9 +206,51 @@ def review_task(number: int, title: str, review: dict[str, Any], comments: list[
         f"Check each point against the current code before you change anything — lines "
         f"move, and some of it may already be addressed. Fix what is still valid, add "
         f"regression coverage for it, and run the tests and linters of the part you "
-        f"touched. Reply to the review in English on GitHub, saying for each point what "
-        f"you changed and how you verified it, or why it needed no change. Do not merge "
-        f"the pull request and do not force-push."
+        f"touched. Write your reply to the review into `$LOGOS_ARTIFACT_DIR/{REPLY_FILE}` "
+        f"— in English, saying for each point what you changed and how you verified it, "
+        f"or why it needed no change; the runner posts it for you. Do not merge the pull "
+        f"request and do not force-push."
+    )
+
+
+def thread_task(number: int, title: str, comments: list[dict[str, Any]], *, branch: str | None) -> str:
+    """The task text for comments addressed to the agent.
+
+    The answer is the deliverable. Whether code changes at all is the
+    comment's business: "why does this fail?" wants an explanation, "can you
+    also handle X?" wants a commit. Saying so plainly beats guessing.
+    """
+    rendered = []
+    for comment in comments[:MAX_THREAD_COMMENTS]:
+        author = str((comment.get("user") or {}).get("login") or "somebody")
+        body = str(comment.get("body") or "").strip()
+        if len(body) > MAX_COMMENT_CHARS:
+            body = body[:MAX_COMMENT_CHARS] + " […]"
+        path = comment.get("path")
+        where = f" on {path}:{comment.get('line') or comment.get('original_line') or '?'}" if path else ""
+        rendered.append(f"{author}{where} wrote:\n{body}")
+    conversation = "\n\n---\n\n".join(rendered)
+    if branch:
+        place = (
+            f"You are working in a checkout of that pull request's own branch `{branch}`. "
+            f"If — and only if — answering means changing code, commit it there; it updates "
+            f"the existing pull request rather than opening a new one."
+        )
+    else:
+        place = (
+            "You are working in a checkout of the default branch, and you have no business "
+            "pushing to this pull request — it is somebody else's. Answer in words. If the "
+            "answer needs a code change, say what you would change and why, and leave it to "
+            "the people on the thread."
+        )
+    return (
+        f"You were asked something on #{number} ('{title}').\n\n"
+        f"{conversation}\n\n"
+        f"Write your answer to `$LOGOS_ARTIFACT_DIR/{REPLY_FILE}` — the runner posts it in "
+        f"the thread for you, so write it as the reply itself: English, to the point, no "
+        f"preamble about being an agent. Answer what was actually asked; read the code "
+        f"before you claim anything about it, and say plainly when you do not know. "
+        f"{place}"
     )
 
 
@@ -165,11 +260,6 @@ class TriggerPoller:
     def __init__(self) -> None:
         self._task: asyncio.Task | None = None
         self._stopping = asyncio.Event()
-        # Only reactions to things that happened after this are queued. It
-        # starts one lookback window in the past and then follows the clock,
-        # so a long-running runner reacts to what is new rather than to
-        # everything the label has ever been on.
-        self._since = datetime.now(timezone.utc) - FIRST_PASS_LOOKBACK
         self._last_error: str = ""
         self._last_pass: datetime | None = None
         self._queued_total = 0
@@ -183,17 +273,17 @@ class TriggerPoller:
 
     async def start(self) -> None:
         if not settings.triggers_enabled:
-            logger.info("repository triggers are off (LOGOS_AGENT_TRIGGERS_ENABLED)")
+            logger.info("repository triggers are off (LOGOS_AGENT_TRIGGERS_ENABLED=false)")
             return
         if not settings.github_token:
             logger.warning("repository triggers are on but no GitHub token is configured; not polling")
             return
         self._task = asyncio.create_task(self._loop(), name="agent-triggers")
         logger.info(
-            "repository triggers on: polling %s every %.0fs for '%s' issues and reviews",
+            "watching %s as %s every %.0fs: assignments, reviews, and comments addressed to it",
             settings.repo_slug,
+            settings.github_login,
             POLL_INTERVAL_S,
-            LABEL,
         )
 
     async def stop(self) -> None:
@@ -215,7 +305,9 @@ class TriggerPoller:
             except Exception as exc:
                 # A failing poll is not a failing runner: sessions an
                 # operator queued keep running, and the next pass tries
-                # again.
+                # again. Nothing is lost by a failure either — a pass reads
+                # the repository's current state, it does not advance a
+                # cursor.
                 self._last_error = str(exc)
                 logger.warning("trigger poll failed: %s", exc)
             try:
@@ -230,61 +322,56 @@ class TriggerPoller:
         now = datetime.now(timezone.utc)
         room = max_active_sessions() - await db.count_active_trigger_sessions()
         if room <= 0:
-            # Nothing is dropped: the window only moves once the pass has
-            # actually looked, so what is skipped here is seen again when a
-            # session finishes.
             logger.debug("trigger poll skipped: already at %s self-queued sessions", max_active_sessions())
             self._last_pass = now
             return []
 
-        candidates = await self._candidates(since=self._since)
+        candidates = await self._candidates(now)
+        self._last_pass = now
+        self._last_error = ""
         if not candidates:
-            # Nothing was seen, so nothing can be left behind: the window
-            # may follow the clock.
-            self._since = now
-            self._last_pass = now
-            self._last_error = ""
             return []
 
-        handled = await db.handled_trigger_refs(
-            [candidate["ref"] for candidate in candidates],
-            since=now - DEDUP_WINDOW,
-        )
+        handled = await db.handled_trigger_refs([candidate["ref"] for candidate in candidates])
         queued: list[int] = []
-        # A candidate this pass could not take on — the ceiling was reached,
-        # no workspace was free, the model policy refused — must stay
-        # visible to the next pass. The window is what makes it visible: the
-        # listings filter by it, so moving it past an unqueued candidate
-        # drops that work for good rather than deferring it.
-        deferred = False
         for candidate in candidates:
-            if candidate["ref"] in handled:
-                continue
             if room <= 0:
-                deferred = True
+                # Left for the next pass: nothing here is consumed by being
+                # seen, so what does not fit now is found again.
+                break
+            if candidate["ref"] in handled:
                 continue
             session_id = await self._queue(candidate)
             if session_id is None:
-                deferred = True
                 continue
             queued.append(session_id)
             room -= 1
-        self._last_pass = now
-        self._last_error = ""
-        if not deferred:
-            # Only a pass that handled everything it saw may move on. A pass
-            # that raised earlier leaves the window untouched for the same
-            # reason.
-            self._since = now
+            await self._acknowledge(candidate)
         if queued and self.on_queued is not None:
             await self.on_queued()
         return queued
 
-    async def _candidates(self, *, since: datetime) -> list[dict[str, Any]]:
-        """What the repository is asking for, oldest signal first."""
+    async def _acknowledge(self, candidate: dict[str, Any]) -> None:
+        """React with 👀 so the person who asked can see it landed.
+
+        Best effort: a missing reaction is a cosmetic loss, and the work is
+        already queued. Anything else would make a failed reaction lose a
+        session.
+        """
+        target = candidate.get("reaction")
+        if not target:
+            return
+        try:
+            await github.react(target)
+        except Exception as exc:
+            logger.info("could not acknowledge %s: %s", candidate["ref"], exc)
+
+    async def _candidates(self, now: datetime) -> list[dict[str, Any]]:
+        """Everything the repository is currently asking this account for."""
+        login = settings.github_login
         found: list[dict[str, Any]] = []
 
-        for issue in await github.labelled_issues(LABEL, since=since):
+        for issue in await github.assigned_issues(login):
             number = issue.get("number")
             if not isinstance(number, int):
                 continue
@@ -293,56 +380,85 @@ class TriggerPoller:
                     "ref": f"issue-{number}",
                     "kind": "issue",
                     "task": issue_task(issue),
-                    "title": str(issue.get("title") or ""),
+                    "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
                 }
             )
 
-        for entry in await github.labelled_pull_requests(LABEL):
-            number = entry.get("number")
-            if not isinstance(number, int):
-                continue
-            title = str(entry.get("title") or "")
-            fresh = [
-                review
-                for review in await github.reviews_since(number, since)
-                # Only a review that asks for changes is work. An approval
-                # or a comment is a conversation, and answering it is a
-                # person's call.
-                if str(review.get("state") or "").upper() == "CHANGES_REQUESTED" and isinstance(review.get("id"), int)
-            ]
-            if not fresh:
-                continue
-            branch = await self._writable_head(number)
-            if branch is None:
-                continue
-            for review in fresh:
+        responsible = await self._responsible_pulls(login)
+        for number, pull in responsible.items():
+            branch = pull["branch"]
+            review = await github.latest_changes_requested_review(number)
+            if review is not None:
                 review_id = int(review["id"])
-                comments = await github.review_comments(number, review_id)
                 found.append(
                     {
                         "ref": f"pr-{number}-review-{review_id}",
                         "kind": "review",
-                        "task": review_task(number, title, review, comments),
-                        "title": title,
-                        # The branch the work belongs on. A review session
-                        # updates the pull request it answers; it does not
-                        # open a second one.
+                        "task": review_task(
+                            number, pull["title"], review, await github.review_comments(number, review_id)
+                        ),
                         "branch": branch,
                         "workspace": f"pr-{number}",
+                        "reaction": (
+                            f"/repos/{settings.repo_slug}/pulls/comments/{review_id}"
+                            if review.get("body")
+                            else f"/repos/{settings.repo_slug}/issues/{number}"
+                        ),
+                        "reply_target": f"issue:{number}",
                     }
                 )
+            elif pull["assigned"] and branch:
+                found.append(
+                    {
+                        "ref": f"pr-{number}-assigned",
+                        "kind": "takeover",
+                        "task": takeover_task(number, pull["title"], pull["body"], branch),
+                        "branch": branch,
+                        "workspace": f"pr-{number}",
+                        "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
+                    }
+                )
+
+        found.extend(await self._comment_candidates(now, responsible))
         return found
 
-    async def _writable_head(self, number: int) -> str | None:
-        """The branch a review session may push, or None if there is none.
+    async def _responsible_pulls(self, login: str) -> dict[int, dict[str, Any]]:
+        """The open pull requests this account has to answer for.
 
-        Two conditions, both about not writing where the runner has no
-        business writing. The head must live in this repository — a fork's
-        branch is not ours to push, and the token could not do it anyway —
-        and it must be under the agent branch prefix, which means the pull
-        request is one the runner opened. A human's branch is exactly what
-        `branch_for()` and the protected-branch rules exist to keep agent
-        pushes away from, and a review on it stays a person's job.
+        Its own, because their reviews are addressed to it, and the ones
+        somebody assigned to it. A head it may not push to is kept anyway,
+        with ``branch`` left None: a question on such a pull request is still
+        answerable, it just cannot be answered with a commit.
+        """
+        pulls: dict[int, dict[str, Any]] = {}
+
+        async def remember(entry: dict[str, Any], *, assigned: bool) -> None:
+            number = entry.get("number")
+            if not isinstance(number, int) or number in pulls:
+                return
+            pulls[number] = {
+                "title": str(entry.get("title") or ""),
+                "body": str(entry.get("body") or ""),
+                "assigned": assigned,
+                "branch": await self._writable_head(number),
+            }
+
+        for entry in await github.assigned_pull_requests(login):
+            await remember(entry, assigned=True)
+        for entry in await github.authored_pull_requests(login):
+            await remember(entry, assigned=False)
+        return pulls
+
+    async def _writable_head(self, number: int) -> str | None:
+        """The branch of a pull request the agent may push to, or None.
+
+        Two rules, and only two. The head has to live in this repository —
+        a fork's branch is not ours to push and the token could not do it
+        anyway — and it must not be a protected branch, which no session may
+        ever write to. The agent branch prefix is deliberately *not*
+        required: a pull request handed over by a person keeps its own
+        branch name, because renaming it would abandon the pull request it
+        belongs to.
         """
         try:
             pull = await github.pull_request(number)
@@ -351,19 +467,81 @@ class TriggerPoller:
             return None
         ref, repo = github.head_of(pull)
         if not ref:
-            logger.info("pull request %s has no usable head branch; skipping its review", number)
             return None
         if repo != settings.repo_slug:
             logger.info("pull request %s comes from '%s'; the runner does not push to forks", number, repo or "?")
             return None
-        if not ref.startswith(settings.branch_prefix):
-            logger.info(
-                "pull request %s is on '%s', which is not an agent branch; its review is a person's to answer",
-                number,
-                ref,
-            )
+        if ref in settings.protected_branches or ref.rsplit("/", 1)[-1] in settings.protected_branches:
+            logger.warning("pull request %s targets protected branch '%s'; refusing to work on it", number, ref)
             return None
         return ref
+
+    async def _comment_candidates(self, now: datetime, responsible: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+        """Comments the agent should answer, one candidate per thread.
+
+        Two kinds count: anything on a pull request it is responsible for,
+        and anything anywhere that mentions it by name. Its own comments and
+        those of bots are skipped — the first would be a conversation with
+        itself, the second a stampede.
+
+        Fresh comments on one thread become *one* task, keyed on the newest
+        of them: a person writing three notes in a row is asking one thing,
+        and three sessions writing to one branch would not be an answer.
+        """
+        since = now - COMMENT_LOOKBACK
+        threads: dict[int, dict[str, Any]] = {}
+
+        def consider(comment: dict[str, Any], number: int, *, review_comment: bool) -> None:
+            author = str((comment.get("user") or {}).get("login") or "")
+            if not author or author.lower() == settings.github_login.lower() or is_bot(author):
+                return
+            body = str(comment.get("body") or "")
+            if number not in responsible and not mentions_agent(body):
+                return
+            comment_id = comment.get("id")
+            if not isinstance(comment_id, int):
+                return
+            thread = threads.setdefault(number, {"comments": [], "newest": 0, "review_comment": review_comment})
+            thread["comments"].append(comment)
+            if comment_id > thread["newest"]:
+                thread["newest"] = comment_id
+                thread["review_comment"] = review_comment
+
+        for comment in await github.recent_issue_comments(since):
+            number = github.issue_number_of(comment)
+            if number is not None:
+                consider(comment, number, review_comment=False)
+        for comment in await github.recent_review_comments(since):
+            number = github.pull_number_of(comment)
+            if number is not None:
+                consider(comment, number, review_comment=True)
+
+        candidates: list[dict[str, Any]] = []
+        for number, thread in threads.items():
+            pull = responsible.get(number)
+            branch = pull["branch"] if pull else None
+            title = pull["title"] if pull else f"#{number}"
+            newest = thread["newest"]
+            candidates.append(
+                {
+                    "ref": f"thread-{number}-{newest}",
+                    "kind": "comment",
+                    "task": thread_task(number, title, thread["comments"], branch=branch),
+                    "branch": branch,
+                    "workspace": f"pr-{number}" if branch else None,
+                    "reaction": (
+                        f"/repos/{settings.repo_slug}/pulls/comments/{newest}"
+                        if thread["review_comment"]
+                        else f"/repos/{settings.repo_slug}/issues/comments/{newest}"
+                    ),
+                    "reply_target": (
+                        f"review_comment:{number}:{newest}" if thread["review_comment"] else f"issue:{number}"
+                    ),
+                }
+            )
+        return candidates
+
+    # --- queueing ---------------------------------------------------------
 
     async def _queue(self, candidate: dict[str, Any]) -> int | None:
         """Queue one session, making a workspace for it if none is free."""
@@ -377,9 +555,9 @@ class TriggerPoller:
             preferred_name=candidate.get("workspace"),
         )
         if workspace_id is None:
-            # Every workspace is busy and the ceiling is reached. The
-            # candidate is not recorded as handled, so the next pass — after
-            # a session has finished — picks it up again.
+            # Every workspace is busy and the ceiling is reached. Nothing is
+            # recorded, so the next pass — after a session has finished —
+            # finds this again.
             logger.info("not queueing %s: no free workspace", candidate["ref"])
             return None
         try:
@@ -388,12 +566,13 @@ class TriggerPoller:
                 task=candidate["task"],
                 model=None,
                 created_by=CREATED_BY,
-                # A review session pushes to the pull request's own branch,
-                # so the work lands where the review was written. Opening a
-                # second pull request for it would answer a review with a
-                # different pull request.
+                # Work on an existing branch updates its pull request, and a
+                # question is answered in words: only an assigned issue is
+                # fresh work that needs a pull request of its own. A comment
+                # session with no branch would otherwise open one for an
+                # answer nobody asked to be a pull request.
                 branch=branch,
-                open_pull_request=branch is None,
+                open_pull_request=candidate["kind"] == "issue",
                 # A session the runner queued by itself does not touch a
                 # shared environment: deploying is an operator's decision,
                 # made per session in the UI.
@@ -401,6 +580,7 @@ class TriggerPoller:
                 screenshot_paths=[],
                 trigger_kind=candidate["kind"],
                 trigger_ref=candidate["ref"],
+                reply_target=candidate.get("reply_target"),
             )
         except ValueError as exc:
             logger.warning("could not queue a session for %s: %s", candidate["ref"], exc)
@@ -436,7 +616,7 @@ class TriggerPoller:
             except ValueError:
                 # The name belongs to a workspace that is currently
                 # occupied — most often the one for this very pull request,
-                # already working on an earlier review.
+                # already working on an earlier request.
                 logger.info("workspace '%s' is taken; deferring", name)
                 return None
             logger.info("created workspace '%s' on '%s' for triggered work", name, base_branch)
@@ -454,7 +634,7 @@ class TriggerPoller:
         return {
             "enabled": settings.triggers_enabled,
             "polling": self._task is not None and not self._task.done(),
-            "label": LABEL,
+            "account": settings.github_login,
             "poll_interval_s": POLL_INTERVAL_S,
             "max_active_sessions": max_active_sessions(),
             "last_pass": self._last_pass.isoformat() if self._last_pass else None,
@@ -472,14 +652,17 @@ async def active_trigger_sessions() -> int:
 
 
 __all__ = [
-    "DEDUP_WINDOW",
-    "FIRST_PASS_LOOKBACK",
-    "LABEL",
+    "COMMENT_LOOKBACK",
     "POLL_INTERVAL_S",
+    "REPLY_FILE",
     "TriggerPoller",
     "active_trigger_sessions",
+    "is_bot",
     "issue_task",
     "max_active_sessions",
+    "mentions_agent",
     "poller",
     "review_task",
+    "takeover_task",
+    "thread_task",
 ]

--- a/logos/logos-agent/tests/test_github.py
+++ b/logos/logos-agent/tests/test_github.py
@@ -9,7 +9,6 @@ the wrong image tag.
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timezone
 
 import pytest
 from app import github
@@ -486,35 +485,46 @@ class TestListingPagination:
         monkeypatch.setattr(github, "settings", replace(github.settings, github_token="tok"))
         return requested
 
-    async def test_reviews_are_read_past_the_first_page(self, monkeypatch):
-        old = [{"id": i, "state": "COMMENTED", "submitted_at": "2020-01-01T00:00:00Z"} for i in range(100)]
-        newest = {"id": 999, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-02T10:00:00Z"}
+    async def test_the_newest_review_is_found_past_the_first_page(self, monkeypatch):
+        # The endpoint answers oldest-first and ignores a direction
+        # parameter, so on a long-running pull request the review that
+        # matters is on the last page, not the first.
+        old = [
+            {"id": i, "state": "CHANGES_REQUESTED", "submitted_at": "2020-01-01T00:00:00Z", "user": {"login": "a"}}
+            for i in range(100)
+        ]
+        newest = {
+            "id": 999,
+            "state": "CHANGES_REQUESTED",
+            "submitted_at": "2026-09-02T10:00:00Z",
+            "user": {"login": "a"},
+        }
         requested = self._paged_client(monkeypatch, [old, [newest]])
 
-        fresh = await github.reviews_since(772, datetime(2026, 9, 1, tzinfo=timezone.utc))
+        review = await github.latest_changes_requested_review(772)
 
-        assert [r["id"] for r in fresh] == [999]
+        assert review["id"] == 999
         assert [p["page"] for p in requested] == [1, 2]
         assert all(p["per_page"] == 100 for p in requested)
 
-    async def test_a_short_thread_costs_one_request(self, monkeypatch):
+    async def test_an_approval_is_not_a_request_for_changes(self, monkeypatch):
         requested = self._paged_client(
             monkeypatch, [[{"id": 1, "state": "APPROVED", "submitted_at": "2026-09-02T10:00:00Z"}]]
         )
 
-        await github.reviews_since(772, datetime(2026, 9, 1, tzinfo=timezone.utc))
-
+        assert await github.latest_changes_requested_review(772) is None
         assert len(requested) == 1
 
-    async def test_labelled_issues_are_paginated_too(self, monkeypatch):
+    async def test_assigned_listings_are_paginated_too(self, monkeypatch):
         first = [{"number": i, "title": "t"} for i in range(100)]
         second = [{"number": 500, "title": "the newest"}]
         requested = self._paged_client(monkeypatch, [first, second])
 
-        issues = await github.labelled_issues("logos-agent", since=datetime(2026, 9, 1, tzinfo=timezone.utc))
+        issues = await github.assigned_issues("LogosOSSAgent")
 
         assert len(issues) == 101
         assert [p["page"] for p in requested] == [1, 2]
+        assert requested[0]["assignee"] == "LogosOSSAgent"
 
     async def test_pagination_stops_at_the_page_ceiling(self, monkeypatch):
         # A pathological thread must not turn one poll into hundreds of
@@ -522,6 +532,70 @@ class TestListingPagination:
         full_page = [{"id": i, "state": "COMMENTED", "submitted_at": "2020-01-01T00:00:00Z"} for i in range(100)]
         requested = self._paged_client(monkeypatch, [full_page] * (github._MAX_PAGES + 5))
 
-        await github.reviews_since(772, datetime(2026, 9, 1, tzinfo=timezone.utc))
+        await github.latest_changes_requested_review(772)
 
         assert len(requested) == github._MAX_PAGES
+
+
+class TestReactionsAndReplies:
+    """Saying "seen" and saying the answer.
+
+    Both are the runner's job: the agent phase holds no GitHub credential,
+    so the acknowledgement and the reply are posted by the process that
+    does.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch, status=201, payload=None):
+        sent: list = []
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                sent.append({"url": url, "json": json})
+                return FakeResponse(status, payload or {"html_url": "https://github.com/x/y#c1"})
+
+        monkeypatch.setattr(github.httpx, "AsyncClient", FakeClient)
+        monkeypatch.setattr(github, "settings", replace(github.settings, github_token="tok"))
+        return sent
+
+    async def test_an_issue_is_acknowledged_with_eyes(self, monkeypatch):
+        sent = self._capture(monkeypatch)
+
+        assert await github.react("/repos/ls1intum/edutelligence/issues/812") is True
+
+        assert sent[0]["url"].endswith("/issues/812/reactions")
+        assert sent[0]["json"] == {"content": "eyes"}
+
+    async def test_an_existing_reaction_counts_as_acknowledged(self, monkeypatch):
+        # GitHub answers 200 when the reaction is already there; the point
+        # is the state, not who created it.
+        self._capture(monkeypatch, status=200)
+        assert await github.react("/repos/ls1intum/edutelligence/issues/812") is True
+
+    async def test_an_answer_goes_to_the_thread_it_was_asked_in(self, monkeypatch):
+        sent = self._capture(monkeypatch)
+
+        url = await github.post_issue_comment(772, "the answer")
+
+        assert sent[0]["url"].endswith("/issues/772/comments")
+        assert sent[0]["json"] == {"body": "the answer"}
+        assert url.startswith("https://github.com/")
+
+    async def test_an_inline_question_is_answered_inline(self, monkeypatch):
+        # A line-specific question answered as a top-level comment would be
+        # an answer nobody finds.
+        sent = self._capture(monkeypatch)
+
+        await github.reply_to_review_comment(772, 3910035243, "the answer")
+
+        assert sent[0]["url"].endswith("/pulls/772/comments/3910035243/replies")
+        assert sent[0]["json"] == {"body": "the answer"}

--- a/logos/logos-agent/tests/test_github.py
+++ b/logos/logos-agent/tests/test_github.py
@@ -627,8 +627,8 @@ class TestReviewSupersession:
         self._reviews(
             monkeypatch,
             [
-                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z"},
-                {"id": 2, "state": "APPROVED", "submitted_at": "2026-09-02T10:00:00Z"},
+                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z", "user": {"login": "a"}},
+                {"id": 2, "state": "APPROVED", "submitted_at": "2026-09-02T10:00:00Z", "user": {"login": "a"}},
             ],
         )
 
@@ -638,8 +638,8 @@ class TestReviewSupersession:
         self._reviews(
             monkeypatch,
             [
-                {"id": 1, "state": "APPROVED", "submitted_at": "2026-09-01T10:00:00Z"},
-                {"id": 2, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-02T10:00:00Z"},
+                {"id": 1, "state": "APPROVED", "submitted_at": "2026-09-01T10:00:00Z", "user": {"login": "a"}},
+                {"id": 2, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-02T10:00:00Z", "user": {"login": "a"}},
             ],
         )
 
@@ -647,18 +647,19 @@ class TestReviewSupersession:
 
         assert review["id"] == 2
 
-    async def test_a_plain_comment_after_a_change_request_also_withdraws_it(self, monkeypatch):
-        # Reviews are submitted deliberately; the newest one is what the
-        # reviewer currently says.
+    async def test_a_plain_comment_does_not_withdraw_a_change_request(self, monkeypatch):
+        # A COMMENTED review states no position, so the reviewer's earlier
+        # objection still stands.
         self._reviews(
             monkeypatch,
             [
-                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z"},
-                {"id": 2, "state": "COMMENTED", "submitted_at": "2026-09-02T10:00:00Z"},
+                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z", "user": {"login": "a"}},
+                {"id": 2, "state": "COMMENTED", "submitted_at": "2026-09-02T10:00:00Z", "user": {"login": "a"}},
             ],
         )
 
-        assert await github.latest_changes_requested_review(772) is None
+        review = await github.latest_changes_requested_review(772)
+        assert review is not None and review["id"] == 1
 
 
 class TestThreadIdentity:

--- a/logos/logos-agent/tests/test_github.py
+++ b/logos/logos-agent/tests/test_github.py
@@ -599,3 +599,78 @@ class TestReactionsAndReplies:
 
         assert sent[0]["url"].endswith("/pulls/772/comments/3910035243/replies")
         assert sent[0]["json"] == {"body": "the answer"}
+
+
+class TestReviewSupersession:
+    """A reviewer who approves has withdrawn their earlier objection."""
+
+    @staticmethod
+    def _reviews(monkeypatch, reviews):
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, headers=None, params=None):
+                page = int((params or {}).get("page", 1))
+                return FakeResponse(200, reviews if page == 1 else [])
+
+        monkeypatch.setattr(github.httpx, "AsyncClient", FakeClient)
+        monkeypatch.setattr(github, "settings", replace(github.settings, github_token="tok"))
+
+    async def test_an_approval_after_a_change_request_withdraws_it(self, monkeypatch):
+        self._reviews(
+            monkeypatch,
+            [
+                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z"},
+                {"id": 2, "state": "APPROVED", "submitted_at": "2026-09-02T10:00:00Z"},
+            ],
+        )
+
+        assert await github.latest_changes_requested_review(772) is None
+
+    async def test_a_change_request_after_an_approval_is_work(self, monkeypatch):
+        self._reviews(
+            monkeypatch,
+            [
+                {"id": 1, "state": "APPROVED", "submitted_at": "2026-09-01T10:00:00Z"},
+                {"id": 2, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-02T10:00:00Z"},
+            ],
+        )
+
+        review = await github.latest_changes_requested_review(772)
+
+        assert review["id"] == 2
+
+    async def test_a_plain_comment_after_a_change_request_also_withdraws_it(self, monkeypatch):
+        # Reviews are submitted deliberately; the newest one is what the
+        # reviewer currently says.
+        self._reviews(
+            monkeypatch,
+            [
+                {"id": 1, "state": "CHANGES_REQUESTED", "submitted_at": "2026-09-01T10:00:00Z"},
+                {"id": 2, "state": "COMMENTED", "submitted_at": "2026-09-02T10:00:00Z"},
+            ],
+        )
+
+        assert await github.latest_changes_requested_review(772) is None
+
+
+class TestThreadIdentity:
+    def test_a_reply_belongs_to_the_thread_it_answers(self):
+        assert github.thread_root_of({"id": 5, "in_reply_to_id": 1}) == 1
+
+    def test_a_thread_starter_is_its_own_root(self):
+        assert github.thread_root_of({"id": 5}) == 5
+
+    def test_a_comment_carries_its_time(self):
+        moment = github.created_at_of({"created_at": "2026-09-02T10:00:00Z"})
+        assert moment is not None and moment.year == 2026
+
+    def test_a_comment_without_a_time_says_so(self):
+        assert github.created_at_of({}) is None

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -2867,3 +2867,121 @@ class TestRestartReconciliation:
         assert stopped == ["cid-x"]
         assert removed == ["cid-x"]
         assert supervised == []
+
+
+class TestReplyDelivery:
+    """An answer that GitHub refused once is not an answer lost.
+
+    Delivery happens when a session settles, and its trigger counts as
+    handled from then on — so without a retry a single timeout would leave
+    somebody waiting on a thread forever.
+    """
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_a_failed_delivery_is_recorded_as_pending(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        (tmp_path / "7").mkdir()
+        (tmp_path / "7" / "reply.md").write_text("the answer")
+        attempts: list = []
+
+        async def failing_reply(_target, _body):
+            raise RuntimeError("502 from GitHub")
+
+        async def record(session_id, *, delivered):
+            attempts.append((session_id, delivered))
+
+        monkeypatch.setattr(sessions.db, "get_session", self._async_value({"reply_target": "issue:772"}))
+        monkeypatch.setattr(sessions.db, "record_reply_attempt", record)
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.SessionManager, "_send_reply", staticmethod(failing_reply))
+
+        await sessions.SessionManager()._post_reply(7)
+
+        assert attempts == [(7, False)]
+
+    async def test_a_pending_answer_is_tried_again(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        (tmp_path / "7").mkdir()
+        (tmp_path / "7" / "reply.md").write_text("the answer")
+        posted: list = []
+        attempts: list = []
+
+        async def owing(_max_attempts):
+            return [{"id": 7, "reply_target": "issue:772", "reply_attempts": 1}]
+
+        async def send(target, body):
+            posted.append((target, body))
+            return "https://github.com/x/y#c9"
+
+        async def record(session_id, *, delivered):
+            attempts.append((session_id, delivered))
+
+        monkeypatch.setattr(sessions.db, "sessions_owing_a_reply", owing)
+        monkeypatch.setattr(sessions.db, "get_session", self._async_value({"reply_target": "issue:772"}))
+        monkeypatch.setattr(sessions.db, "record_reply_attempt", record)
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.SessionManager, "_send_reply", staticmethod(send))
+
+        await sessions.SessionManager().deliver_pending_replies()
+
+        assert posted == [("issue:772", "the answer")]
+        assert attempts == [(7, True)]
+
+    async def test_a_delivered_answer_is_not_posted_twice(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        (tmp_path / "7").mkdir()
+        (tmp_path / "7" / "reply.md").write_text("the answer")
+        posted: list = []
+
+        async def send(target, body):
+            posted.append(target)
+            return "url"
+
+        monkeypatch.setattr(
+            sessions.db,
+            "get_session",
+            self._async_value({"reply_target": "issue:772", "reply_posted_at": "2026-09-02T18:00:00Z"}),
+        )
+        monkeypatch.setattr(sessions.db, "record_reply_attempt", self._async_value(None))
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.SessionManager, "_send_reply", staticmethod(send))
+
+        await sessions.SessionManager()._post_reply(7)
+
+        assert posted == []
+
+    async def test_an_oversized_answer_is_shortened_rather_than_refused(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        (tmp_path / "7").mkdir()
+        (tmp_path / "7" / "reply.md").write_text("x" * 80_000)
+        posted: list = []
+
+        async def send(_target, body):
+            posted.append(body)
+            return "url"
+
+        monkeypatch.setattr(sessions.db, "get_session", self._async_value({"reply_target": "issue:772"}))
+        monkeypatch.setattr(sessions.db, "record_reply_attempt", self._async_value(None))
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.SessionManager, "_send_reply", staticmethod(send))
+
+        await sessions.SessionManager()._post_reply(7)
+
+        # GitHub rejects a body over 65 536 characters outright, and a
+        # rejected answer is no answer.
+        assert len(posted[0]) < 65_000
+        assert posted[0].endswith("_[answer truncated]_")

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -75,6 +75,7 @@ class FakeRepo:
         review_comments=None,
         issue_comments=None,
         inline_comments=None,
+        writers=("wasnertobias",),
     ):
         self.assigned_issues = assigned_issues or []
         self.assigned_pulls = assigned_pulls or []
@@ -87,6 +88,9 @@ class FakeRepo:
         self.issue_comments = issue_comments or []
         self.inline_comments = inline_comments or []
         self.reactions: list = []
+        # Who may write to the repository. Anybody may comment on a public
+        # one; only these may direct a change to it.
+        self.writers = {w.lower() for w in writers}
 
     def install(self, monkeypatch):
         async def assigned_issues(_login):
@@ -118,6 +122,9 @@ class FakeRepo:
             self.reactions.append((path, content))
             return True
 
+        async def may_push(login):
+            return login.lower() in self.writers
+
         for name, fn in [
             ("assigned_issues", assigned_issues),
             ("assigned_pull_requests", assigned_pull_requests),
@@ -128,6 +135,7 @@ class FakeRepo:
             ("recent_issue_comments", recent_issue_comments),
             ("recent_review_comments", recent_review_comments),
             ("react", react),
+            ("may_push", may_push),
         ]:
             monkeypatch.setattr(triggers.github, name, fn)
 
@@ -671,3 +679,93 @@ class TestInlineThreads:
         await triggers.TriggerPoller().poll_once()
 
         assert fake_db.created[0]["trigger_ref"] == "thread-772-issue-10"
+
+
+class TestWhoMayDirectChanges:
+    """Anybody may ask; not everybody may have code written for them.
+
+    On a public repository the comment box is open to the world, and a
+    session that commits does so with the runner's credentials. What decides
+    is the repository's own permissions, not the ability to type.
+    """
+
+    async def test_an_outsider_gets_an_answer_but_no_branch(self, monkeypatch):
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[comment(9100, 772, f"@{AGENT} could you rewrite this?", "passer-by")],
+            writers=("wasnertobias",),
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["branch"] is None
+        assert created["reply_target"] == "issue:772"
+
+    async def test_a_collaborator_may_ask_for_a_change(self, monkeypatch):
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[comment(9101, 772, "please also handle the empty case", "wasnertobias")],
+            heads={772: ("logos/agent/x/session-1", REPO)},
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.created[0]["branch"] == "logos/agent/x/session-1"
+
+    async def test_one_writer_in_the_thread_is_enough(self, monkeypatch):
+        # A maintainer answering a passer-by is still a maintainer asking.
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[
+                comment(9102, 772, f"@{AGENT} what about X?", "passer-by", minutes_ago=30),
+                comment(9103, 772, "good point — please do that", "wasnertobias", minutes_ago=5),
+            ],
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.created[0]["branch"] is not None
+
+    async def test_a_review_from_outside_the_repository_is_left_to_a_person(self, monkeypatch):
+        # A review is a request to change code. From somebody who cannot
+        # push, acting on it would let a stranger direct what is committed.
+        outside = review(77)
+        outside["user"] = {"login": "passer-by"}
+        FakeRepo(authored_pulls=[pull(772)], reviews={772: outside}).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+    async def test_permissions_are_looked_up_once_per_pass(self, monkeypatch):
+        repo = FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[comment(9104 + i, 772, f"note {i}", "wasnertobias") for i in range(4)],
+        )
+        repo.install(monkeypatch)
+        looked_up: list = []
+        original = triggers.github.may_push
+
+        async def counting(login):
+            looked_up.append(login)
+            return await original(login)
+
+        monkeypatch.setattr(triggers.github, "may_push", counting)
+        FakeDb().install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert looked_up == ["wasnertobias"]

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -37,11 +37,22 @@ def review(review_id: int, state: str = "CHANGES_REQUESTED", body: str = "Please
     }
 
 
-def comment(comment_id: int, number: int, body: str, author: str = "wasnertobias", *, path: str | None = None) -> dict:
+def comment(
+    comment_id: int,
+    number: int,
+    body: str,
+    author: str = "wasnertobias",
+    *,
+    path: str | None = None,
+    root: int | None = None,
+    minutes_ago: int = 5,
+) -> dict:
     made = {
         "id": comment_id,
         "body": body,
         "user": {"login": author},
+        "created_at": (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z"),
+        "in_reply_to_id": root,
         "issue_url": f"https://api.github.com/repos/{REPO}/issues/{number}",
         "pull_request_url": f"https://api.github.com/repos/{REPO}/pulls/{number}",
     }
@@ -341,7 +352,7 @@ class TestConversation:
         await triggers.TriggerPoller().poll_once()
 
         created = fake_db.created[0]
-        assert created["trigger_ref"] == "thread-772-9001"
+        assert created["trigger_ref"] == "thread-772-issue-9001"
         assert created["trigger_kind"] == "comment"
         assert "Why does this need a lock?" in created["task"]
         assert created["reply_target"] == "issue:772"
@@ -359,7 +370,7 @@ class TestConversation:
         await triggers.TriggerPoller().poll_once()
 
         created = fake_db.created[0]
-        assert created["trigger_ref"] == "thread-864-9002"
+        assert created["trigger_ref"] == "thread-864-issue-9002"
         assert created["branch"] is None
         assert created["open_pull_request"] is False
         assert "Answer in words" in created["task"] or "answer in words" in created["task"].lower()
@@ -400,7 +411,7 @@ class TestConversation:
 
         assert len(queued) == 1
         created = fake_db.created[0]
-        assert created["trigger_ref"] == "thread-772-9003"
+        assert created["trigger_ref"] == "thread-772-issue-9003"
         for text in ("first thought", "and another", "and finally this"):
             assert text in created["task"]
 
@@ -543,3 +554,120 @@ class TestCommentWindow:
         # state; comments are a stream, and without a bound the first pass
         # after a restart would read years of them.
         assert timedelta(hours=12) <= triggers.COMMENT_LOOKBACK <= timedelta(days=2)
+
+
+class TestReviewRouting:
+    """What a review session is allowed to be queued as at all."""
+
+    async def test_a_review_without_a_writable_branch_is_left_to_a_person(self, monkeypatch):
+        # The fix belongs on that pull request's branch. Queued anyway, the
+        # session would start from the default branch on a branch of its own
+        # and could never update the pull request its task is about.
+        FakeRepo(
+            authored_pulls=[pull(900)],
+            reviews={900: review(1)},
+            heads={900: ("feature", "someone/edutelligence")},
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+    async def test_a_review_is_acknowledged_on_the_pull_request(self, monkeypatch):
+        # A submitted review is not a review *comment*: the two id sequences
+        # are independent, so reacting to the review id as though it were a
+        # comment id would fail silently.
+        repo = FakeRepo(authored_pulls=[pull(772)], reviews={772: review(5085681761)})
+        repo.install(monkeypatch)
+        FakeDb().install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert repo.reactions == [(f"/repos/{REPO}/issues/772", "eyes")]
+
+    async def test_the_reviews_own_comments_do_not_become_a_second_session(self, monkeypatch):
+        # The repository-wide comment scan sees the very comments the review
+        # task already carries.
+        inline = comment(7010, 772, "fix this", path="app/db.py")
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            reviews={772: review(55)},
+            review_comments={(772, 55): [inline]},
+            inline_comments=[inline],
+        ).install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in (1, 2)]
+        )
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        queued = await triggers.TriggerPoller().poll_once()
+
+        assert len(queued) == 1
+        assert fake_db.created[0]["trigger_ref"] == "pr-772-review-55"
+
+
+class TestInlineThreads:
+    async def test_each_inline_thread_is_answered_in_itself(self, monkeypatch):
+        # Two line-specific questions on one pull request are two
+        # conversations; merging them would answer one and leave the other
+        # without a reply.
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            inline_comments=[
+                comment(7001, 772, f"@{AGENT} why the lock?", path="app/db.py", root=None),
+                comment(7002, 772, f"@{AGENT} and here?", path="app/github.py", root=None),
+            ],
+        ).install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in (1, 2, 3)]
+        )
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        queued = await triggers.TriggerPoller().poll_once()
+
+        assert len(queued) == 2
+        targets = {c["reply_target"] for c in fake_db.created}
+        assert targets == {"review_comment:772:7001", "review_comment:772:7002"}
+
+    async def test_a_reply_joins_the_thread_it_answers(self, monkeypatch):
+        # A reply carries the root's id; both belong to one conversation.
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            inline_comments=[
+                comment(7001, 772, "why the lock?", path="app/db.py", root=None, minutes_ago=20),
+                comment(7005, 772, "…and does it cover restarts?", path="app/db.py", root=7001, minutes_ago=5),
+            ],
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        queued = await triggers.TriggerPoller().poll_once()
+
+        assert len(queued) == 1
+        created = fake_db.created[0]
+        assert created["reply_target"] == "review_comment:772:7001"
+        assert created["trigger_ref"] == "thread-772-inline-7001-7005"
+
+    async def test_the_newest_comment_is_the_newest_by_time(self, monkeypatch):
+        # Issue and review comments have independent id sequences, so a
+        # newer comment can carry a smaller id.
+        FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[
+                comment(9000, 772, "older, but a bigger number", minutes_ago=60),
+                comment(10, 772, "newer, with a smaller one", minutes_ago=1),
+            ],
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.created[0]["trigger_ref"] == "thread-772-issue-10"

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -1,8 +1,10 @@
-"""Tests for the sessions the runner queues by itself.
+"""Tests for using the agent's account the way you use a colleague's.
 
-The interesting property is not that a poll queues something — it is that a
-second poll over the same repository state queues nothing, that an approval
-is not mistaken for work, and that the automation cannot fill the platform.
+The interesting properties are not that a poll queues something. They are
+that assigning something twice does not produce two pull requests, that a
+question on somebody else's branch is answered rather than pushed to, that
+bots do not start a stampede, and that a taken-over pull request keeps its
+own branch name.
 """
 
 from __future__ import annotations
@@ -13,9 +15,16 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from app import triggers
 
+AGENT = "LogosOSSAgent"
+REPO = "ls1intum/edutelligence"
+
 
 def issue(number: int, title: str = "Something is wrong", body: str = "Details.") -> dict:
     return {"number": number, "title": title, "body": body}
+
+
+def pull(number: int, title: str = "A change", body: str = "What it does.") -> dict:
+    return {"number": number, "title": title, "body": body, "pull_request": {}}
 
 
 def review(review_id: int, state: str = "CHANGES_REQUESTED", body: str = "Please fix X.") -> dict:
@@ -28,42 +37,88 @@ def review(review_id: int, state: str = "CHANGES_REQUESTED", body: str = "Please
     }
 
 
-class FakeRepo:
-    """The GitHub reads a pass makes, with recorded results."""
+def comment(comment_id: int, number: int, body: str, author: str = "wasnertobias", *, path: str | None = None) -> dict:
+    made = {
+        "id": comment_id,
+        "body": body,
+        "user": {"login": author},
+        "issue_url": f"https://api.github.com/repos/{REPO}/issues/{number}",
+        "pull_request_url": f"https://api.github.com/repos/{REPO}/pulls/{number}",
+    }
+    if path:
+        made["path"] = path
+        made["line"] = 42
+    return made
 
-    def __init__(self, issues=None, pulls=None, reviews=None, heads=None, comments=None):
-        self.issues = issues or []
-        self.pulls = pulls or []
+
+class FakeRepo:
+    """The repository as the poller sees it."""
+
+    def __init__(
+        self,
+        assigned_issues=None,
+        assigned_pulls=None,
+        authored_pulls=None,
+        reviews=None,
+        heads=None,
+        review_comments=None,
+        issue_comments=None,
+        inline_comments=None,
+    ):
+        self.assigned_issues = assigned_issues or []
+        self.assigned_pulls = assigned_pulls or []
+        self.authored_pulls = authored_pulls or []
         self.reviews = reviews or {}
         # Per pull request: (head ref, head repository). Defaults to an agent
-        # branch in this repository, which is the case the runner acts on.
+        # branch in this repository.
         self.heads = heads or {}
-        self.comments = comments or {}
-        self.review_calls = 0
+        self.review_comments = review_comments or {}
+        self.issue_comments = issue_comments or []
+        self.inline_comments = inline_comments or []
+        self.reactions: list = []
 
     def install(self, monkeypatch):
-        async def labelled_issues(_label, *, since):
-            return self.issues
+        async def assigned_issues(_login):
+            return self.assigned_issues
 
-        async def labelled_pull_requests(_label):
-            return self.pulls
+        async def assigned_pull_requests(_login):
+            return self.assigned_pulls
 
-        async def reviews_since(number, _since):
-            self.review_calls += 1
-            return self.reviews.get(number, [])
+        async def authored_pull_requests(_login):
+            return self.authored_pulls
 
-        async def pull_request(number):
-            ref, repo = self.heads.get(number, (f"agent/pr/session-{number}", "ls1intum/edutelligence"))
-            return {"number": number, "head": {"ref": ref, "repo": {"full_name": repo}}}
+        async def latest_changes_requested_review(number):
+            return self.reviews.get(number)
 
         async def review_comments(number, review_id):
-            return self.comments.get((number, review_id), [])
+            return self.review_comments.get((number, review_id), [])
 
-        monkeypatch.setattr(triggers.github, "labelled_issues", labelled_issues)
-        monkeypatch.setattr(triggers.github, "labelled_pull_requests", labelled_pull_requests)
-        monkeypatch.setattr(triggers.github, "reviews_since", reviews_since)
-        monkeypatch.setattr(triggers.github, "pull_request", pull_request)
-        monkeypatch.setattr(triggers.github, "review_comments", review_comments)
+        async def pull_request(number):
+            ref, repo = self.heads.get(number, (f"logos/agent/pr/session-{number}", REPO))
+            return {"number": number, "head": {"ref": ref, "repo": {"full_name": repo}}}
+
+        async def recent_issue_comments(_since):
+            return self.issue_comments
+
+        async def recent_review_comments(_since):
+            return self.inline_comments
+
+        async def react(path, content="eyes"):
+            self.reactions.append((path, content))
+            return True
+
+        for name, fn in [
+            ("assigned_issues", assigned_issues),
+            ("assigned_pull_requests", assigned_pull_requests),
+            ("authored_pull_requests", authored_pull_requests),
+            ("latest_changes_requested_review", latest_changes_requested_review),
+            ("review_comments", review_comments),
+            ("pull_request", pull_request),
+            ("recent_issue_comments", recent_issue_comments),
+            ("recent_review_comments", recent_review_comments),
+            ("react", react),
+        ]:
+            monkeypatch.setattr(triggers.github, name, fn)
 
 
 class FakeDb:
@@ -71,7 +126,9 @@ class FakeDb:
 
     def __init__(self, *, workspaces=None, handled=(), active_triggers=0):
         self.workspaces = list(
-            workspaces if workspaces is not None else [{"id": 1, "active_sessions": 0, "base_branch": "main"}]
+            workspaces
+            if workspaces is not None
+            else [{"id": 1, "name": "auto-1", "active_sessions": 0, "base_branch": "main"}]
         )
         self.handled = set(handled)
         self.active_triggers = active_triggers
@@ -82,7 +139,7 @@ class FakeDb:
         async def count_active_trigger_sessions():
             return self.active_triggers
 
-        async def handled_trigger_refs(refs, since):
+        async def handled_trigger_refs(refs):
             return {ref for ref in refs if ref in self.handled}
 
         async def list_workspaces():
@@ -112,12 +169,15 @@ class FakeDb:
             self.next_id += 1
             return self.next_id
 
-        monkeypatch.setattr(triggers.db, "count_active_trigger_sessions", count_active_trigger_sessions)
-        monkeypatch.setattr(triggers.db, "handled_trigger_refs", handled_trigger_refs)
-        monkeypatch.setattr(triggers.db, "list_workspaces", list_workspaces)
-        monkeypatch.setattr(triggers.db, "create_workspace", create_workspace)
-        monkeypatch.setattr(triggers.db, "set_workspace_base_branch", set_workspace_base_branch)
-        monkeypatch.setattr(triggers.db, "create_session", create_session)
+        for name, fn in [
+            ("count_active_trigger_sessions", count_active_trigger_sessions),
+            ("handled_trigger_refs", handled_trigger_refs),
+            ("list_workspaces", list_workspaces),
+            ("create_workspace", create_workspace),
+            ("set_workspace_base_branch", set_workspace_base_branch),
+            ("create_session", create_session),
+        ]:
+            monkeypatch.setattr(triggers.db, name, fn)
 
 
 def allow_models(monkeypatch, ok: bool = True):
@@ -129,10 +189,19 @@ def allow_models(monkeypatch, ok: bool = True):
     monkeypatch.setattr(triggers.model_policy, "current", lambda: Policy())
 
 
-class TestPolling:
-    @pytest.mark.asyncio
-    async def test_an_opened_issue_becomes_a_session(self, monkeypatch):
-        FakeRepo(issues=[issue(812)]).install(monkeypatch)
+def agent_account(monkeypatch):
+    monkeypatch.setattr(triggers, "settings", replace(triggers.settings, github_login=AGENT, repo_slug=REPO))
+
+
+@pytest.fixture(autouse=True)
+def _account(monkeypatch):
+    agent_account(monkeypatch)
+
+
+class TestAssignment:
+    async def test_an_assigned_issue_becomes_work(self, monkeypatch):
+        repo = FakeRepo(assigned_issues=[issue(812)])
+        repo.install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
@@ -143,33 +212,186 @@ class TestPolling:
         created = fake_db.created[0]
         assert created["trigger_ref"] == "issue-812"
         assert created["trigger_kind"] == "issue"
-        assert "Issue #812" in created["task"]
-        # A self-queued session never touches a shared environment.
-        assert created["deploy_to_dev"] is False
+        assert "issue #812" in created["task"]
+        # New work: its own branch, and a pull request to show it in.
+        assert created["branch"] is None
         assert created["open_pull_request"] is True
+        # And the person who assigned it sees that it landed.
+        assert repo.reactions == [(f"/repos/{REPO}/issues/812", "eyes")]
 
-    @pytest.mark.asyncio
-    async def test_the_same_issue_is_not_queued_twice(self, monkeypatch):
-        FakeRepo(issues=[issue(812)]).install(monkeypatch)
+    async def test_an_assigned_pull_request_is_taken_over_on_its_own_branch(self, monkeypatch):
+        repo = FakeRepo(
+            assigned_pulls=[pull(864, title="Someone's work")],
+            heads={864: ("logos/issue-651-lacq-auto-set", REPO)},
+        )
+        repo.install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["trigger_ref"] == "pr-864-assigned"
+        assert created["trigger_kind"] == "takeover"
+        # A person's branch, kept as it is: renaming it would abandon the
+        # pull request it belongs to.
+        assert created["branch"] == "logos/issue-651-lacq-auto-set"
+        assert created["open_pull_request"] is False
+        workspace = next(w for w in fake_db.workspaces if w["id"] == created["workspace_id"])
+        assert workspace["base_branch"] == "logos/issue-651-lacq-auto-set"
+
+    async def test_the_same_assignment_is_not_worked_twice(self, monkeypatch):
+        # An issue that simply stays assigned must not produce a second pull
+        # request on the next pass, or next week.
+        FakeRepo(assigned_issues=[issue(812)]).install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
         poller = triggers.TriggerPoller()
 
         await poller.poll_once()
-        # The second pass sees the same repository state; the reference is
-        # what makes it a no-op, not the moving time window.
-        second = await poller.poll_once()
-
-        assert second == []
+        assert await poller.poll_once() == []
         assert len(fake_db.created) == 1
 
-    @pytest.mark.asyncio
-    async def test_a_review_asking_for_changes_becomes_a_session(self, monkeypatch):
-        FakeRepo(
-            pulls=[{"number": 772, "title": "Add an agent runner", "pull_request": {}}],
-            reviews={772: [review(5085681761)]},
-        ).install(monkeypatch)
+    async def test_a_fork_head_is_not_touched(self, monkeypatch):
+        FakeRepo(assigned_pulls=[pull(900)], heads={900: ("feature", "someone/edutelligence")}).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+    async def test_a_protected_branch_is_refused(self, monkeypatch):
+        FakeRepo(assigned_pulls=[pull(901)], heads={901: ("main", REPO)}).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+
+class TestReviews:
+    async def test_a_review_on_its_own_pull_request_is_addressed(self, monkeypatch):
+        repo = FakeRepo(
+            authored_pulls=[pull(772, title="Add an agent runner")],
+            reviews={772: review(5085681761)},
+            review_comments={(772, 5085681761): [{"path": "app/sessions.py", "line": 420, "body": "This strands."}]},
+            heads={772: ("logos/agent/agent-runner/session-3", REPO)},
+        )
+        repo.install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["trigger_ref"] == "pr-772-review-5085681761"
+        assert created["branch"] == "logos/agent/agent-runner/session-3"
+        assert created["open_pull_request"] is False
+        # The inline comments are where a changes-requested review keeps its
+        # substance.
+        assert "app/sessions.py:420" in created["task"]
+        assert "This strands." in created["task"]
+        # And the answer has somewhere to go.
+        assert created["reply_target"] == "issue:772"
+
+    async def test_an_approval_is_not_work(self, monkeypatch):
+        FakeRepo(authored_pulls=[pull(772)], reviews={}).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+
+    async def test_a_new_review_on_the_same_pull_request_is_new_work(self, monkeypatch):
+        repo = FakeRepo(authored_pulls=[pull(772)], reviews={772: review(1)})
+        repo.install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in (1, 2)]
+        )
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+        poller = triggers.TriggerPoller()
+
+        await poller.poll_once()
+        # The reviewer looked again and asked for more.
+        repo.reviews[772] = review(2)
+        fake_db.active_triggers = 0
+        await poller.poll_once()
+
+        assert [c["trigger_ref"] for c in fake_db.created] == ["pr-772-review-1", "pr-772-review-2"]
+
+
+class TestConversation:
+    async def test_a_comment_on_its_pull_request_is_answered(self, monkeypatch):
+        repo = FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[comment(9001, 772, "Why does this need a lock?")],
+            heads={772: ("logos/agent/x/session-1", REPO)},
+        )
+        repo.install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["trigger_ref"] == "thread-772-9001"
+        assert created["trigger_kind"] == "comment"
+        assert "Why does this need a lock?" in created["task"]
+        assert created["reply_target"] == "issue:772"
+        assert repo.reactions == [(f"/repos/{REPO}/issues/comments/9001", "eyes")]
+
+    async def test_a_mention_elsewhere_is_answered_without_pushing(self, monkeypatch):
+        # Somebody else's pull request: the agent may answer, it may not
+        # write to their branch.
+        repo = FakeRepo(issue_comments=[comment(9002, 864, f"@{AGENT} short question about this")])
+        repo.install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["trigger_ref"] == "thread-864-9002"
+        assert created["branch"] is None
+        assert created["open_pull_request"] is False
+        assert "Answer in words" in created["task"] or "answer in words" in created["task"].lower()
+
+    async def test_an_inline_question_is_answered_inline(self, monkeypatch):
+        repo = FakeRepo(
+            authored_pulls=[pull(772)],
+            inline_comments=[comment(7001, 772, f"@{AGENT} is this covered?", path="app/db.py")],
+        )
+        repo.install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = fake_db.created[0]
+        assert created["reply_target"] == "review_comment:772:7001"
+        assert repo.reactions == [(f"/repos/{REPO}/pulls/comments/7001", "eyes")]
+
+    async def test_several_comments_in_a_row_are_one_answer(self, monkeypatch):
+        # A person writing three notes is asking one thing; three sessions
+        # writing to one branch would not be an answer.
+        repo = FakeRepo(
+            authored_pulls=[pull(772)],
+            issue_comments=[
+                comment(9001, 772, "first thought"),
+                comment(9002, 772, "and another"),
+                comment(9003, 772, "and finally this"),
+            ],
+        )
+        repo.install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
@@ -178,34 +400,34 @@ class TestPolling:
 
         assert len(queued) == 1
         created = fake_db.created[0]
-        assert created["trigger_ref"] == "pr-772-review-5085681761"
-        assert created["trigger_kind"] == "review"
-        assert "#772" in created["task"]
-        assert "Please fix X." in created["task"]
-        # The work belongs on the pull request's own branch, and updating it
-        # is not opening another pull request.
-        assert created["branch"] == "agent/pr/session-772"
-        assert created["open_pull_request"] is False
+        assert created["trigger_ref"] == "thread-772-9003"
+        for text in ("first thought", "and another", "and finally this"):
+            assert text in created["task"]
 
-    @pytest.mark.asyncio
-    async def test_an_approval_is_not_work(self, monkeypatch):
+    async def test_its_own_comments_are_not_a_conversation_with_itself(self, monkeypatch):
+        FakeRepo(authored_pulls=[pull(772)], issue_comments=[comment(9004, 772, "Fixed on abc123.", AGENT)]).install(
+            monkeypatch
+        )
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+
+    async def test_bots_do_not_start_a_stampede(self, monkeypatch):
         FakeRepo(
-            pulls=[{"number": 772, "title": "Add an agent runner", "pull_request": {}}],
-            reviews={772: [review(1, state="APPROVED"), review(2, state="COMMENTED")]},
+            authored_pulls=[pull(772)],
+            issue_comments=[comment(9005, 772, "12 findings", "coderabbitai[bot]")],
+            inline_comments=[comment(7002, 772, "nitpick", "github-actions[bot]", path="x.py")],
         ).install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
 
         assert await triggers.TriggerPoller().poll_once() == []
-        assert fake_db.created == []
 
-    @pytest.mark.asyncio
-    async def test_a_pull_request_is_not_treated_as_an_issue(self, monkeypatch):
-        # The issues endpoint returns pull requests too; `labelled_issues`
-        # filters them, and this is the guard that keeps that filtering
-        # honest if the endpoint changes.
-        FakeRepo(issues=[], pulls=[{"number": 772, "title": "PR", "pull_request": {}}]).install(monkeypatch)
+    async def test_an_unrelated_comment_without_a_mention_is_none_of_its_business(self, monkeypatch):
+        FakeRepo(issue_comments=[comment(9006, 999, "two colleagues talking")]).install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
@@ -213,14 +435,35 @@ class TestPolling:
         assert await triggers.TriggerPoller().poll_once() == []
 
 
+class TestMentionMatching:
+    def test_the_account_is_matched_case_insensitively(self):
+        assert triggers.mentions_agent(f"hey @{AGENT.lower()} could you look")
+
+    def test_a_longer_name_is_not_this_account(self):
+        assert not triggers.mentions_agent(f"@{AGENT}Bot is a different account")
+
+    def test_no_mention_is_no_mention(self):
+        assert not triggers.mentions_agent("nothing to do with anyone")
+
+    def test_bots_are_recognised(self):
+        assert triggers.is_bot("coderabbitai[bot]")
+        assert triggers.is_bot("github-actions")
+        assert not triggers.is_bot("wasnertobias")
+
+
 class TestBounds:
-    @pytest.mark.asyncio
     async def test_the_automation_stops_at_its_own_ceiling(self, monkeypatch):
-        FakeRepo(issues=[issue(1), issue(2), issue(3)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": i, "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)])
+        FakeRepo(assigned_issues=[issue(1), issue(2), issue(3)]).install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)]
+        )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        monkeypatch.setattr(triggers, "settings", replace(triggers.settings, max_parallel_sessions=4))
+        monkeypatch.setattr(
+            triggers,
+            "settings",
+            replace(triggers.settings, github_login=AGENT, repo_slug=REPO, max_parallel_sessions=4),
+        )
 
         queued = await triggers.TriggerPoller().poll_once()
 
@@ -228,20 +471,16 @@ class TestBounds:
         assert triggers.max_active_sessions() == 2
         assert len(queued) == 2
 
-    @pytest.mark.asyncio
     async def test_nothing_is_queued_while_the_ceiling_is_full(self, monkeypatch):
-        repo = FakeRepo(issues=[issue(1)])
-        repo.install(monkeypatch)
+        FakeRepo(assigned_issues=[issue(1)]).install(monkeypatch)
         fake_db = FakeDb(active_triggers=99)
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
 
         assert await triggers.TriggerPoller().poll_once() == []
-        assert fake_db.created == []
 
-    @pytest.mark.asyncio
     async def test_a_cloud_capable_key_queues_nothing(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
+        FakeRepo(assigned_issues=[issue(1)]).install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch, ok=False)
@@ -249,199 +488,29 @@ class TestBounds:
         assert await triggers.TriggerPoller().poll_once() == []
         assert fake_db.created == []
 
-
-class TestWorkspaces:
-    @pytest.mark.asyncio
-    async def test_a_workspace_is_created_when_all_are_busy(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": 1, "active_sessions": 1, "base_branch": "main"}])
+    async def test_what_does_not_fit_now_is_found_again(self, monkeypatch):
+        # Nothing is consumed by being seen: a pass reads the repository's
+        # current state, so what it could not take on is still there.
+        repo = FakeRepo(assigned_issues=[issue(1), issue(2), issue(3)])
+        repo.install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)]
+        )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-
-        queued = await triggers.TriggerPoller().poll_once()
-
-        assert len(queued) == 1
-        assert len(fake_db.workspaces) == 2
-        assert fake_db.created[0]["workspace_id"] == 2
-
-    @pytest.mark.asyncio
-    async def test_no_workspace_beyond_the_parallel_ceiling(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": i, "active_sessions": 1, "base_branch": "main"} for i in range(1, 4)])
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-        monkeypatch.setattr(triggers, "settings", replace(triggers.settings, max_parallel_sessions=3))
-
-        assert await triggers.TriggerPoller().poll_once() == []
-        # A fourth workspace could never run anything, so it is not created.
-        assert len(fake_db.workspaces) == 3
-
-    @pytest.mark.asyncio
-    async def test_a_free_workspace_is_reused(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": 7, "active_sessions": 0, "base_branch": "main"}])
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        await triggers.TriggerPoller().poll_once()
-
-        assert len(fake_db.workspaces) == 1
-        assert fake_db.created[0]["workspace_id"] == 7
-
-
-class TestWindow:
-    @pytest.mark.asyncio
-    async def test_a_failing_pass_does_not_move_the_window(self, monkeypatch):
-        async def boom(*_args, **_kwargs):
-            raise RuntimeError("GitHub is down")
-
-        monkeypatch.setattr(triggers.github, "labelled_issues", boom)
-        FakeDb().install(monkeypatch)
-        allow_models(monkeypatch)
+        monkeypatch.setattr(
+            triggers,
+            "settings",
+            replace(triggers.settings, github_login=AGENT, repo_slug=REPO, max_parallel_sessions=4),
+        )
         poller = triggers.TriggerPoller()
-        before = poller._since
 
-        with pytest.raises(RuntimeError):
-            await poller.poll_once()
+        first = await poller.poll_once()
+        fake_db.active_triggers = 0  # the first two finished
+        second = await poller.poll_once()
 
-        # Otherwise the reviews submitted during the outage would fall out of
-        # the window and never be seen.
-        assert poller._since == before
-
-    @pytest.mark.asyncio
-    async def test_the_window_holds_while_a_candidate_is_deferred(self, monkeypatch):
-        # The ceiling stops the third issue from being queued. The listings
-        # filter by the window, so moving it past that issue would drop the
-        # work for good instead of deferring it to the next pass.
-        FakeRepo(issues=[issue(1), issue(2), issue(3)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": i, "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)])
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-        monkeypatch.setattr(triggers, "settings", replace(triggers.settings, max_parallel_sessions=4))
-        poller = triggers.TriggerPoller()
-        before = poller._since
-
-        queued = await poller.poll_once()
-
-        assert len(queued) == 2
-        assert poller._since == before
-
-    @pytest.mark.asyncio
-    async def test_the_window_holds_when_no_workspace_is_free(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        fake_db = FakeDb(workspaces=[{"id": i, "active_sessions": 1, "base_branch": "main"} for i in range(1, 4)])
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-        monkeypatch.setattr(triggers, "settings", replace(triggers.settings, max_parallel_sessions=3))
-        poller = triggers.TriggerPoller()
-        before = poller._since
-
-        assert await poller.poll_once() == []
-        assert poller._since == before
-
-    @pytest.mark.asyncio
-    async def test_the_window_advances_once_everything_was_handled(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        FakeDb().install(monkeypatch)
-        allow_models(monkeypatch)
-        poller = triggers.TriggerPoller()
-        before = poller._since
-
-        await poller.poll_once()
-
-        assert poller._since > before
-
-    @pytest.mark.asyncio
-    async def test_the_first_pass_looks_back_a_bounded_distance(self):
-        poller = triggers.TriggerPoller()
-        age = datetime.now(timezone.utc) - poller._since
-        assert timedelta(hours=5) < age < timedelta(hours=7)
-
-
-class TestReviewSessionsUpdateTheirPullRequest:
-    """A review is answered on the pull request it was written on.
-
-    Anything else — a second pull request, a push to somebody's branch —
-    is either useless or not the runner's to do.
-    """
-
-    @pytest.mark.asyncio
-    async def test_the_session_is_queued_on_the_pull_request_branch(self, monkeypatch):
-        FakeRepo(
-            pulls=[{"number": 772, "title": "Add an agent runner", "pull_request": {}}],
-            reviews={772: [review(11)]},
-            heads={772: ("agent/agent-runner/session-3", "ls1intum/edutelligence")},
-        ).install(monkeypatch)
-        fake_db = FakeDb()
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        await triggers.TriggerPoller().poll_once()
-
-        created = fake_db.created[0]
-        assert created["branch"] == "agent/agent-runner/session-3"
-        assert created["open_pull_request"] is False
-        # And the workspace it runs in starts from that branch, so the agent
-        # sees the pull request's current state rather than main.
-        workspace = next(w for w in fake_db.workspaces if w["id"] == created["workspace_id"])
-        assert workspace["base_branch"] == "agent/agent-runner/session-3"
-
-    @pytest.mark.asyncio
-    async def test_a_fork_head_is_not_touched(self, monkeypatch):
-        FakeRepo(
-            pulls=[{"number": 900, "title": "From a fork", "pull_request": {}}],
-            reviews={900: [review(12)]},
-            heads={900: ("feature", "someone/edutelligence")},
-        ).install(monkeypatch)
-        fake_db = FakeDb()
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        assert await triggers.TriggerPoller().poll_once() == []
-        assert fake_db.created == []
-
-    @pytest.mark.asyncio
-    async def test_a_human_branch_is_left_to_its_author(self, monkeypatch):
-        FakeRepo(
-            pulls=[{"number": 864, "title": "Someone's work", "pull_request": {}}],
-            reviews={864: [review(13)]},
-            heads={864: ("logos/issue-651-lacq-auto-set", "ls1intum/edutelligence")},
-        ).install(monkeypatch)
-        fake_db = FakeDb()
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        # The branch rules exist to keep agent pushes off human branches;
-        # answering such a review is a person's job.
-        assert await triggers.TriggerPoller().poll_once() == []
-        assert fake_db.created == []
-
-    @pytest.mark.asyncio
-    async def test_inline_comments_are_part_of_the_task(self, monkeypatch):
-        # Most changes-requested reviews say nothing in the body and
-        # everything inline; a task built from the body alone asks the agent
-        # to fix nothing in particular.
-        FakeRepo(
-            pulls=[{"number": 772, "title": "Add an agent runner", "pull_request": {}}],
-            reviews={772: [review(14, body="")]},
-            comments={
-                (772, 14): [
-                    {"path": "app/sessions.py", "line": 420, "body": "This can strand a session."},
-                    {"path": "app/github.py", "original_line": 350, "body": "Paginate this."},
-                ]
-            },
-        ).install(monkeypatch)
-        fake_db = FakeDb()
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        await triggers.TriggerPoller().poll_once()
-
-        task = fake_db.created[0]["task"]
-        assert "app/sessions.py:420" in task
-        assert "This can strand a session." in task
-        assert "app/github.py:350" in task
-        assert "Paginate this." in task
+        assert len(first) == 2 and len(second) == 1
+        assert {c["trigger_ref"] for c in fake_db.created} == {"issue-1", "issue-2", "issue-3"}
 
 
 class TestWorkspaceNaming:
@@ -450,42 +519,27 @@ class TestWorkspaceNaming:
         # later poll would hit the same conflict and defer work.
         assert triggers._next_auto_name(set()) == "auto-1"
         assert triggers._next_auto_name({"auto-1", "auto-3"}) == "auto-2"
-        assert triggers._next_auto_name({"auto-1", "auto-2"}) == "auto-3"
 
-    @pytest.mark.asyncio
-    async def test_a_deleted_workspace_does_not_block_the_next_poll(self, monkeypatch):
-        FakeRepo(issues=[issue(1)]).install(monkeypatch)
-        # 'auto-2' was deleted; the remaining names would make a counting
-        # scheme propose 'auto-3', which exists and is busy.
-        fake_db = FakeDb(
-            workspaces=[
-                {"id": 1, "name": "auto-1", "active_sessions": 1, "base_branch": "main"},
-                {"id": 3, "name": "auto-3", "active_sessions": 1, "base_branch": "main"},
-            ]
-        )
-        fake_db.install(monkeypatch)
-        allow_models(monkeypatch)
-
-        queued = await triggers.TriggerPoller().poll_once()
-
-        assert len(queued) == 1
-        assert any(w.get("name") == "auto-2" for w in fake_db.workspaces)
-
-    @pytest.mark.asyncio
     async def test_a_full_pool_repoints_a_free_workspace(self, monkeypatch):
-        FakeRepo(
-            pulls=[{"number": 772, "title": "Add an agent runner", "pull_request": {}}],
-            reviews={772: [review(15)]},
-            heads={772: ("agent/agent-runner/session-3", "ls1intum/edutelligence")},
-        ).install(monkeypatch)
+        FakeRepo(assigned_pulls=[pull(772)], heads={772: ("logos/agent/x/session-3", REPO)}).install(monkeypatch)
         fake_db = FakeDb(workspaces=[{"id": 1, "name": "auto-1", "active_sessions": 0, "base_branch": "main"}])
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        monkeypatch.setattr(triggers, "settings", replace(triggers.settings, max_parallel_sessions=1))
+        monkeypatch.setattr(
+            triggers,
+            "settings",
+            replace(triggers.settings, github_login=AGENT, repo_slug=REPO, max_parallel_sessions=1),
+        )
 
         queued = await triggers.TriggerPoller().poll_once()
 
-        # No room for another workspace, so the free one follows the branch
-        # instead of the work being deferred forever.
         assert len(queued) == 1
-        assert fake_db.workspaces[0]["base_branch"] == "agent/agent-runner/session-3"
+        assert fake_db.workspaces[0]["base_branch"] == "logos/agent/x/session-3"
+
+
+class TestCommentWindow:
+    def test_comments_are_read_from_a_bounded_window(self):
+        # Assignments and reviews are read from the repository's current
+        # state; comments are a stream, and without a bound the first pass
+        # after a restart would read years of them.
+        assert timedelta(hours=12) <= triggers.COMMENT_LOOKBACK <= timedelta(days=2)

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -48,8 +48,9 @@
     @if (trig.enabled) {
       <p class="page-subtitle">
         <i class="pi pi-bolt" aria-hidden="true"></i>
-        Reacting to the repository: issues and reviews labelled
-        <code>{{ trig.label }}</code> queue a session on their own ({{ trig.active_sessions }}/{{
+        Working as <code>{{ trig.account }}</code
+        >: assign it an issue or a pull request, review its work, or mention it in a comment, and it
+        queues a session on its own ({{ trig.active_sessions }}/{{
           trig.max_active_sessions
         }}
         active, {{ trig.queued_total }} queued since start).

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -49,8 +49,8 @@
       <p class="page-subtitle">
         <i class="pi pi-bolt" aria-hidden="true"></i>
         Working as <code>{{ trig.account }}</code
-        >: assign it an issue or a pull request, review its work, or mention it in a comment, and it
-        queues a session on its own ({{ trig.active_sessions }}/{{
+        >: assign it an issue or a pull request, request changes on its work, or mention it in a
+        comment from the last day, and it queues a session on its own ({{ trig.active_sessions }}/{{
           trig.max_active_sessions
         }}
         active, {{ trig.queued_total }} queued since start).

--- a/logos/logos-ui/src/app/features/agents/agents.spec.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.spec.ts
@@ -90,7 +90,7 @@ class FakeAgentService {
     return {
       enabled: false,
       polling: false,
-      label: 'logos-agent',
+      account: 'LogosOSSAgent',
       poll_interval_s: 120,
       max_active_sessions: 5,
       active_sessions: 0,

--- a/logos/logos-ui/src/app/shared/models/agent.model.ts
+++ b/logos/logos-ui/src/app/shared/models/agent.model.ts
@@ -79,11 +79,12 @@ export interface AgentModels {
   detail: string;
 }
 
-/** Whether the runner queues work of its own, and what it has queued. */
+/** Whether the runner reacts to the repository, and what it has queued. */
 export interface AgentTriggers {
   enabled: boolean;
   polling: boolean;
-  label: string;
+  /** The GitHub account whose assignments and mentions it answers. */
+  account: string;
   poll_interval_s: number;
   max_active_sessions: number;
   active_sessions: number;

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/020_agent_sessions.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/020_agent_sessions.xml
@@ -195,4 +195,33 @@
         </rollback>
     </changeSet>
 
+    <!-- Whether a session's answer actually reached GitHub. The reply is
+         posted once the session has settled, and a timeout or a 5xx at that
+         moment used to lose it for good: the trigger reference counts as
+         handled, so nothing ever looked at it again. With the delivery
+         recorded separately, a later scheduler pass — or a restart — can
+         try again, and stops trying once it succeeded or the attempts run
+         out. -->
+    <changeSet id="020-agent-session-reply-delivery" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_sessions" columnName="reply_posted_at"/></not>
+        </preConditions>
+        <sql><![CDATA[
+            ALTER TABLE agent_sessions ADD COLUMN reply_posted_at TIMESTAMPTZ;
+            ALTER TABLE agent_sessions ADD COLUMN reply_attempts INTEGER NOT NULL DEFAULT 0;
+
+            -- The retry sweep asks for the few sessions that owe an answer.
+            CREATE INDEX idx_agent_sessions_reply_pending
+                ON agent_sessions(reply_posted_at)
+             WHERE reply_target IS NOT NULL AND reply_posted_at IS NULL;
+        ]]></sql>
+        <rollback>
+            <sql><![CDATA[
+                DROP INDEX IF EXISTS idx_agent_sessions_reply_pending;
+                ALTER TABLE agent_sessions DROP COLUMN IF EXISTS reply_attempts;
+                ALTER TABLE agent_sessions DROP COLUMN IF EXISTS reply_posted_at;
+            ]]></sql>
+        </rollback>
+    </changeSet>
+
 </databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/020_agent_sessions.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/020_agent_sessions.xml
@@ -175,4 +175,24 @@
         </rollback>
     </changeSet>
 
+    <!-- Where a session's answer is posted when it finishes. The agent
+         phase holds no GitHub credential, so it writes its reply into its
+         artefact directory and the runner posts it — this column is what
+         tells the runner where: 'issue:772' for a thread, or
+         'review_comment:772:3910035243' to answer inside an inline review
+         thread. Null for sessions nobody asked a question. -->
+    <changeSet id="020-agent-session-reply-target" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_sessions" columnName="reply_target"/></not>
+        </preConditions>
+        <sql><![CDATA[
+            ALTER TABLE agent_sessions ADD COLUMN reply_target TEXT;
+        ]]></sql>
+        <rollback>
+            <sql><![CDATA[
+                ALTER TABLE agent_sessions DROP COLUMN IF EXISTS reply_target;
+            ]]></sql>
+        </rollback>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Assigning an issue to `LogosOSSAgent` did nothing. That is the wrong answer to a reasonable gesture: work was opted in by a label nobody had created, on a feature that needed a second environment variable to be on at all, on a service that already lives behind its own compose profile.

The signal is now the account itself.

| What you do on GitHub | What the agent does |
|---|---|
| assign it an issue | works on it and opens a draft pull request |
| assign it a pull request | takes it over, on that pull request's own branch |
| ask one of its pull requests for changes | addresses the review on that branch |
| comment on a pull request it is responsible for | reads the thread and answers |
| mention it anywhere by name | answers there; changes code only if that is what was asked |

## It acknowledges immediately

Queueing a session leaves a 👀 reaction on whatever triggered it — the issue, the comment, the inline comment. A question is then visibly picked up instead of apparently ignored while the platform waits for idle GPUs.

## It can answer at all

The agent phase holds no GitHub credential by design, so it could not have replied to anything. It now writes its answer into its artefact directory and the **runner** posts it when the session settles — in the thread the question was asked in, and inline when the question was inline. The answer is produced by the untrusted phase; posting it is the trusted phase's job, with the token that never enters a session container.

## Branches

Work the agent starts itself goes on `logos/agent/…`, matching this repository's convention. A pull request **handed to it keeps its own branch name** — renaming it would abandon the pull request it belongs to — so the agent-prefix rule now binds only branches the runner creates. Forks (not ours to push) and protected branches stay refused for every session.

## Triggers default to on

Starting this service is already the deliberate step, and the per-item consent is the assignment or the mention. A second, invisible switch could only mean the feature is deployed and quietly doing nothing. `LOGOS_AGENT_TRIGGERS_ENABLED` remains, as a kill switch.

## Idempotence, simplified

References are remembered **forever** rather than for a week: an issue that stays assigned must not produce a second pull request next week, and an answered question must not be answered twice. Only the *newest* changes-requested review of a pull request counts as work — the older ones were answered by it — which also removes the poll cursor and the whole class of bug that came with advancing it. Bots are skipped, so a review bot's dozen notes are not a dozen sessions; their findings reach the agent through the next review.

Comments are the one stream that still needs a bound: a 24-hour window, so the first pass after a restart does not read years of them.

## Verification

216 agent tests (33 of them new, covering assignment, takeover, reviews, mentions, bot suppression, the 👀 acknowledgement, reply targets, and the branch rules), 107 UI tests, pre-commit clean, UI production build clean.

Depends on nothing in #884, but both touch the runner; merging #884 first avoids a trivial conflict in the compose comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLK1R5FwY2LnG5LeHnnWAb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now be queued by assigning issues or pull requests, requesting changes, commenting, or mentioning the agent.
  * Agents can respond to questions and inline review comments, with visible acknowledgment reactions.
  * Agent-created branches now use the `logos/agent/` path.
* **Changes**
  * Repository-triggered agent sessions are enabled by default.
  * Agent activity is managed per GitHub item, with safeguards for protected branches, duplicate requests, and comment volume.
* **UI Updates**
  * The Agents page now displays the configured agent account and explains the available interaction methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->