### PR TITLE
`Logos`: Give the runner a stop, a dial, a queue order, and a memory

### DIFF
--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -81,8 +81,12 @@ from having several workspaces; the ceiling across all of them is
 Workspaces the runner creates for triggered work are named after it —
 `issue-812-oom-on-startup`, `pr-772-add-an-agent-runner` — which is also what
 appears in the branch (`logos/agent/issue-812-oom-on-startup/session-42`) and
-in the workspace list. They are removed once their work is finished, together
-with their volume; an operator's own workspaces are never touched.
+in the workspace list. Once their work is finished their volume is reclaimed and the workspace is
+retired — the row stays, because every finished session hangs off it, and
+deleting it would take their history, the trigger references that keep
+assigned work from being done twice, and any answer still waiting to be
+delivered. An operator's own workspaces are never touched, and a retired one
+is revived if the same issue comes back.
 
 This is enforced twice: the admission query skips workspaces that are occupied,
 and a partial unique index in the schema rejects a second active session for a

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -78,6 +78,12 @@ a workspace at a time** — two would write over each other. Parallelism comes
 from having several workspaces; the ceiling across all of them is
 `MAX_PARALLEL_SESSIONS`.
 
+Workspaces the runner creates for triggered work are named after it —
+`issue-812-oom-on-startup`, `pr-772-add-an-agent-runner` — which is also what
+appears in the branch (`logos/agent/issue-812-oom-on-startup/session-42`) and
+in the workspace list. They are removed once their work is finished, together
+with their volume; an operator's own workspaces are never touched.
+
 This is enforced twice: the admission query skips workspaces that are occupied,
 and a partial unique index in the schema rejects a second active session for a
 workspace outright. The second exists because a scheduler bug should raise
@@ -128,6 +134,33 @@ Branch names are derived from the session id, not chosen by the agent, so two
 sessions cannot collide and no workspace name can steer a push at a protected
 branch. The exception is a pull request handed to it, which keeps its own
 branch — checked against the protected list all the same.
+
+## Stopping it, and slowing it down
+
+Two controls live in the database rather than in the environment, because
+they are needed *during* something — an incident, a deploy, a surprise — and
+editing an `.env` on a host to restart a service that is mid-session is not
+what anybody wants to be doing then. Both are on the Agents page, both
+survive a restart, and both are visible to whoever finds the runner stopped.
+
+| Control | What it does |
+|---|---|
+| **Stop new sessions** (draining) | Nothing new starts. What is running finishes, and a paused session may still resume. |
+| **Pause everything** | Running sessions are paused on the next pass and the capacity goes back to the platform. Nothing is cancelled: resuming picks the work up mid-task. |
+| **Sessions at once** | A ceiling for now, overriding the configured one. Zero drains without pausing. |
+
+## What gets worked on first
+
+A session is admitted per capacity reading, so the order of the queue is what
+the platform actually works on while it is busy. That order is urgency, not
+arrival: a review (which holds a pull request shut) outranks a question,
+which outranks new work, and the repository's own labels move it — a
+`security fix` to the top, `documentation` down. `blocked`, `wontfix`,
+`invalid`, `duplicate` and `stale` are not urgency but an answer: the runner
+does not pick that work up at all, and says which label stopped it.
+
+The mapping is in `app/priority.py`, in one table, for a repository that
+labels things differently.
 
 ## Configuration
 

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -278,13 +278,26 @@ anyway: GitHub only assigns collaborators.
 
 Only a **changes-requested** review is work — an approval or a plain comment
 is not, and an approval submitted after a change request withdraws it.
-Comments are read from the last 24 hours: assignments and reviews are read
-from the repository's current state, but comments are a stream, and without a
-bound the first pass after a restart would read years of them.
+Comments are read from where the last complete pass stopped — a mark kept in
+the database, so a question asked while the runner was paused is still found
+when it comes back. Assignments and reviews are read from the repository's
+current state and need no window; comments are a stream, so a fresh
+deployment starts with the last 24 hours and no pass ever reaches back
+further than a week.
 
-**It says it heard you.** The moment a session is queued it reacts with 👀 on
-what triggered it, so a question does not sit there looking ignored while the
-platform waits for idle GPUs.
+**It says where your request is.** Three reactions, on the comment you
+wrote:
+
+| | |
+|---|---|
+| 👀 | accepted and in the queue |
+| 🚀 | being worked on right now |
+| 😕 | it did not work out — the session failed |
+
+👀 is posted *after* the session row exists, so it is never a promise of work
+that is not queued; and because the row is what the queue is, a restart
+changes nothing about it. GitHub's reaction palette is fixed and has no
+hourglass, so these three are the states it can show.
 
 **It can answer.** The agent phase holds no GitHub credential, so it writes
 its answer into its artefact directory and the runner posts it when the

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -138,14 +138,23 @@ def parse_scheduler_state(payload: dict) -> Reading:
     )
 
 
-def start_decision(reading: Reading, *, running: int, paused: int) -> tuple[bool, str]:
-    """Whether another session may start now, and why."""
+def start_decision(reading: Reading, *, running: int, paused: int, max_parallel: int | None = None) -> tuple[bool, str]:
+    """Whether another session may start now, and why.
+
+    ``max_parallel`` is the ceiling in force at this moment: an operator can
+    lower it while the runner is running (see :mod:`controls`), so the
+    decision takes it as an argument rather than reading the configured
+    value here.
+    """
+    ceiling = settings.max_parallel_sessions if max_parallel is None else max_parallel
     if not reading.ok:
         return False, f"capacity unknown ({reading.detail})"
     if not reading.reclaimable:
         return False, f"nothing to reclaim ({reading.detail})"
-    if running + paused >= settings.max_parallel_sessions:
-        return False, (f"at the parallel-session ceiling " f"({running + paused}/{settings.max_parallel_sessions})")
+    if ceiling <= 0:
+        return False, "the parallel ceiling is set to zero"
+    if running + paused >= ceiling:
+        return False, (f"at the parallel-session ceiling " f"({running + paused}/{ceiling})")
     if reading.queue_total > 0:
         return False, f"users are queueing ({reading.queue_total} waiting)"
     if reading.load >= settings.start_below_load:

--- a/logos/logos-agent/app/controls.py
+++ b/logos/logos-agent/app/controls.py
@@ -90,8 +90,16 @@ class Controls:
 
 DEFAULT = Controls()
 
-_cached: Controls = DEFAULT
+# What the runner assumes before it has ever managed to read its controls:
+# nothing may start, and nothing resumes. A process restarted during a
+# database outage must not decide that the persisted `paused` it cannot see
+# means `running` — the whole point of persisting the switch is that a
+# restart does not release it.
+UNREAD = Controls(mode=PAUSED, mode_reason="the runner has not read its controls yet")
+
+_cached: Controls = UNREAD
 _read_at: float = 0.0
+_ever_read: bool = False
 
 
 def cached() -> Controls:
@@ -106,16 +114,19 @@ async def current() -> Controls:
     controls are an operator's intent, and forgetting a pause because of a
     transient error would be the wrong way to fail.
     """
-    global _cached, _read_at
+    global _cached, _read_at, _ever_read
     now = time.monotonic()
-    if now - _read_at < _CACHE_S:
+    if _ever_read and now - _read_at < _CACHE_S:
         return _cached
     try:
         row = await db.get_controls()
     except Exception as exc:
+        # Keep whatever was last known — which, before the first successful
+        # read, is the state that blocks everything.
         logger.warning("could not read the runner controls; keeping the previous reading: %s", exc)
         return _cached
     _read_at = now
+    _ever_read = True
     if row is None:
         _cached = DEFAULT
         return _cached
@@ -159,13 +170,14 @@ async def _refresh() -> Controls:
 
 
 def forget() -> None:
-    """Drop the cache. For tests, and for a restart's first read."""
-    global _cached, _read_at
-    _cached, _read_at = DEFAULT, 0.0
+    """Drop the cache, back to the state that has read nothing."""
+    global _cached, _read_at, _ever_read
+    _cached, _read_at, _ever_read = UNREAD, 0.0, False
 
 
 __all__ = [
     "DRAINING",
+    "UNREAD",
     "MODES",
     "PAUSED",
     "RUNNING",

--- a/logos/logos-agent/app/controls.py
+++ b/logos/logos-agent/app/controls.py
@@ -1,0 +1,180 @@
+"""What an operator can change about the runner while it is running.
+
+The environment configures a deployment. This configures a moment: stopping
+the automation and lowering the parallel ceiling are things somebody needs
+*during* something, from the page they are already looking at — not by
+editing an `.env` on a host and restarting a service that is in the middle of
+ten sessions.
+
+The kill switch has two halves, because "stop" means two different things
+depending on what is wrong:
+
+* **draining** — start nothing new. What is already running runs to the end,
+  and a paused session may still resume. This is what you want when the
+  agent's *work* is fine but you need the fleet to go quiet, or before a
+  deploy.
+* **paused** — hand everything back now. Running sessions are paused on the
+  next pass and nothing resumes until the switch is released. Paused, not
+  cancelled: the work survives and picks up mid-task.
+
+Alongside it, a ceiling for now, overriding the configured one.
+
+All of it is persisted, because a runner that forgets it was stopped is not
+stopped, and read through a short-lived cache so the scheduler can consult it
+on every decision without a query each time.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, replace
+
+from . import db
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# How long a reading is reused. Short enough that pressing the switch takes
+# effect on the next pass, long enough that the scheduler does not query per
+# decision.
+_CACHE_S = 2.0
+
+RUNNING = "running"
+DRAINING = "draining"
+PAUSED = "paused"
+MODES = (RUNNING, DRAINING, PAUSED)
+
+
+@dataclass(frozen=True)
+class Controls:
+    """The runtime state of the operator controls."""
+
+    mode: str = RUNNING
+    mode_reason: str = ""
+    # None means "whatever the environment configured".
+    max_parallel_override: int | None = None
+    updated_by: str = ""
+
+    @property
+    def paused(self) -> bool:
+        """Whether running sessions must be handed back to the platform."""
+        return self.mode == PAUSED
+
+    @property
+    def max_parallel(self) -> int:
+        return settings.max_parallel_sessions if self.max_parallel_override is None else self.max_parallel_override
+
+    @property
+    def _reason_suffix(self) -> str:
+        return f" ({self.mode_reason})" if self.mode_reason else ""
+
+    def admission_block(self) -> str:
+        """Why nothing new may start right now, or an empty string."""
+        if self.mode == PAUSED:
+            return f"the runner is paused{self._reason_suffix}"
+        if self.mode == DRAINING:
+            return f"the runner is draining: no new sessions{self._reason_suffix}"
+        if self.max_parallel <= 0:
+            return "the parallel ceiling is set to zero"
+        return ""
+
+    def may_resume(self) -> bool:
+        """Whether a paused session may be resumed at all.
+
+        Draining does not hold work back that is already under way — that is
+        the difference between it and a pause.
+        """
+        return self.mode != PAUSED
+
+
+DEFAULT = Controls()
+
+_cached: Controls = DEFAULT
+_read_at: float = 0.0
+
+
+def cached() -> Controls:
+    """The last reading, without touching the database."""
+    return _cached
+
+
+async def current() -> Controls:
+    """The controls as they are now, from a cache of a couple of seconds.
+
+    A database that cannot be read leaves the previous reading in place: the
+    controls are an operator's intent, and forgetting a pause because of a
+    transient error would be the wrong way to fail.
+    """
+    global _cached, _read_at
+    now = time.monotonic()
+    if now - _read_at < _CACHE_S:
+        return _cached
+    try:
+        row = await db.get_controls()
+    except Exception as exc:
+        logger.warning("could not read the runner controls; keeping the previous reading: %s", exc)
+        return _cached
+    _read_at = now
+    if row is None:
+        _cached = DEFAULT
+        return _cached
+    override = row.get("max_parallel")
+    mode = str(row.get("mode") or RUNNING)
+    fresh = Controls(
+        mode=mode if mode in MODES else RUNNING,
+        mode_reason=str(row.get("mode_reason") or ""),
+        max_parallel_override=int(override) if override is not None else None,
+        updated_by=str(row.get("updated_by") or ""),
+    )
+    if fresh != _cached:
+        logger.info(
+            "runner controls: %s, max parallel=%s%s",
+            fresh.mode,
+            fresh.max_parallel,
+            f" (set by {fresh.updated_by})" if fresh.updated_by else "",
+        )
+    _cached = fresh
+    return _cached
+
+
+async def set_mode(*, mode: str, reason: str, by: str) -> Controls:
+    """Run, drain, or pause."""
+    if mode not in MODES:
+        raise ValueError(f"unknown mode '{mode}' (expected one of {', '.join(MODES)})")
+    await db.set_controls(mode=mode, mode_reason=reason if mode != RUNNING else "", updated_by=by)
+    return await _refresh()
+
+
+async def set_max_parallel(*, limit: int | None, by: str) -> Controls:
+    """Set or clear the runtime ceiling on concurrent sessions."""
+    await db.set_controls(max_parallel=limit, clear_max_parallel=limit is None, updated_by=by)
+    return await _refresh()
+
+
+async def _refresh() -> Controls:
+    global _read_at
+    _read_at = 0.0
+    return await current()
+
+
+def forget() -> None:
+    """Drop the cache. For tests, and for a restart's first read."""
+    global _cached, _read_at
+    _cached, _read_at = DEFAULT, 0.0
+
+
+__all__ = [
+    "DRAINING",
+    "MODES",
+    "PAUSED",
+    "RUNNING",
+    "Controls",
+    "DEFAULT",
+    "cached",
+    "current",
+    "forget",
+    "replace",
+    "set_max_parallel",
+    "set_mode",
+]

--- a/logos/logos-agent/app/conventions.py
+++ b/logos/logos-agent/app/conventions.py
@@ -57,29 +57,6 @@ Working within the sandbox:
 """.strip()
 
 
-# Traps in GitHub's API that cost real time when they are met for the first
-# time. Only added to tasks that will read the API.
-GITHUB_API_NOTES = """
---- Reading GitHub's API ---
-
-- Comment and review listings answer OLDEST FIRST and ignore a `direction`
-  parameter. `per_page=5` gives you the five oldest, not the newest: page
-  through to the end, or filter by time, when you want what is recent.
-- A review's id is not a review-comment id, and issue-comment ids and
-  review-comment ids are separate sequences. Never use one where the other
-  is expected — the request fails, or worse, hits something else.
-- A freshly created comment can answer 404 on a direct read for a minute or
-  two. Check the listing rather than concluding it was not created.
-- When posting a body from a file, pass it as a value, not as a file
-  reference: `-f "body=$(cat file)"`. `-f body=@file` posts the literal
-  string "@file". Read the comment back afterwards and check it starts with
-  your text.
-""".strip()
-
-
-def for_task(task: str, *, reads_github_api: bool = False) -> str:
+def for_task(task: str) -> str:
     """One task, followed by the conventions it has to hold to."""
-    parts = [task.strip(), HOUSE_RULES]
-    if reads_github_api:
-        parts.append(GITHUB_API_NOTES)
-    return "\n\n".join(parts)
+    return f"{task.strip()}\n\n{HOUSE_RULES}"

--- a/logos/logos-agent/app/conventions.py
+++ b/logos/logos-agent/app/conventions.py
@@ -1,0 +1,85 @@
+"""What this repository expects, told to the agent before it starts.
+
+Every line here was learned the expensive way — a review round spent on
+something a sentence could have prevented. An unattended agent cannot ask,
+so the things a new colleague would be told in their first week are told to
+it in its task instead.
+
+Kept in one place because it is one contract, and appended to every task so
+none of them can quietly drift from it.
+"""
+
+from __future__ import annotations
+
+# Conventions every session is held to, whatever kind of work it is.
+HOUSE_RULES = """
+--- How work is done here ---
+
+Commits and pull requests:
+- Commit messages start with the component in backticks, then an imperative
+  summary of what changed: `Logos`: Close the session before its volume is
+  removed. The body explains why the change is right, not what the diff
+  already shows.
+- Never merge a pull request, and never force-push over somebody else's
+  commits.
+- Do not reference issue or pull-request numbers in code comments,
+  docstrings, or test names. They are noise in a file that outlives them;
+  put the reference in the commit message or the pull request instead.
+
+Verifying before you claim:
+- Check every review point against the CURRENT code before you change
+  anything. Lines move, and some of what a review asks for has often been
+  addressed already — say so instead of changing it twice.
+- A regression test that passes before your fix is not a regression test.
+  Confirm it fails on the unfixed code, then make it pass.
+- Run the tests and linters of the part of the repository you touched, and
+  the repository's pre-commit hooks. Report what you ran.
+- Before you finish, check that the pull request's checks are green and that
+  it is mergeable. If a check is red for a reason your change did not cause,
+  say which and why rather than leaving it unexplained.
+
+Writing on GitHub:
+- Everything you write on GitHub is in English, whatever language the task
+  was given in.
+- Answer the point that was made. State what you changed and how you
+  verified it, or why it needed no change — not a summary of your process.
+
+Working within the sandbox:
+- You have no network beyond the model gateway, and no GitHub credential.
+  Do not attempt to push, open pull requests, or post comments yourself:
+  write your work into the checkout and your answer into the reply file, and
+  the runner does the rest with a credential you never see.
+- Your time is capped. If the task is larger than the budget, do the part
+  you are confident about, leave the rest untouched, and say plainly in your
+  final message what you left out and why. A partial change that is honest
+  about being partial is useful; a half-finished one that claims to be done
+  is not.
+""".strip()
+
+
+# Traps in GitHub's API that cost real time when they are met for the first
+# time. Only added to tasks that will read the API.
+GITHUB_API_NOTES = """
+--- Reading GitHub's API ---
+
+- Comment and review listings answer OLDEST FIRST and ignore a `direction`
+  parameter. `per_page=5` gives you the five oldest, not the newest: page
+  through to the end, or filter by time, when you want what is recent.
+- A review's id is not a review-comment id, and issue-comment ids and
+  review-comment ids are separate sequences. Never use one where the other
+  is expected — the request fails, or worse, hits something else.
+- A freshly created comment can answer 404 on a direct read for a minute or
+  two. Check the listing rather than concluding it was not created.
+- When posting a body from a file, pass it as a value, not as a file
+  reference: `-f "body=$(cat file)"`. `-f body=@file` posts the literal
+  string "@file". Read the comment back afterwards and check it starts with
+  your text.
+""".strip()
+
+
+def for_task(task: str, *, reads_github_api: bool = False) -> str:
+    """One task, followed by the conventions it has to hold to."""
+    parts = [task.strip(), HOUSE_RULES]
+    if reads_github_api:
+        parts.append(GITHUB_API_NOTES)
+    return "\n\n".join(parts)

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -142,7 +142,8 @@ async def get_controls() -> dict[str, Any] | None:
                 await db.execute(
                     text(
                         """
-                    SELECT mode, mode_reason, max_parallel, updated_by, updated_at
+                    SELECT mode, mode_reason, max_parallel, comments_scanned_at,
+                           updated_by, updated_at
                       FROM agent_controls WHERE id = 1
                     """
                     )
@@ -340,6 +341,30 @@ async def get_workspace(workspace_id: int) -> dict[str, Any] | None:
     return dict(row) if row else None
 
 
+async def comments_scanned_at() -> datetime | None:
+    """How far the comment scan has got, across restarts."""
+    async with sessionmaker()() as db:
+        return (
+            await db.execute(text("SELECT comments_scanned_at FROM agent_controls WHERE id = 1"))
+        ).scalar_one_or_none()
+
+
+async def mark_comments_scanned(moment: datetime) -> None:
+    """Remember that comments up to this point have been dealt with."""
+    async with sessionmaker()() as db:
+        await db.execute(
+            text(
+                """
+                INSERT INTO agent_controls (id, comments_scanned_at, updated_at)
+                VALUES (1, :moment, :now)
+                ON CONFLICT (id) DO UPDATE SET comments_scanned_at = :moment
+                """
+            ),
+            {"moment": moment, "now": _now()},
+        )
+        await db.commit()
+
+
 async def disposable_workspaces(idle_before: datetime) -> list[dict[str, Any]]:
     """Ephemeral workspaces whose work is done and whose volume can go.
 
@@ -487,6 +512,7 @@ async def create_session(
     trigger_ref: str | None = None,
     branch: str | None = None,
     reply_target: str | None = None,
+    reaction_target: str | None = None,
     priority: int = 50,
     priority_reason: str | None = None,
 ) -> int:
@@ -515,11 +541,12 @@ async def create_session(
                         (workspace_id, task, model, status, created_by,
                          open_pull_request, deploy_to_dev, screenshot_paths,
                          trigger_kind, trigger_ref, branch_name, reply_target,
-                         priority, priority_reason)
+                         reaction_target, priority, priority_reason)
                     VALUES
                         (:workspace_id, :task, :model, 'queued', :created_by,
                          :open_pr, :deploy, CAST(:paths AS jsonb),
                          :trigger_kind, :trigger_ref, :branch, :reply_target,
+                         :reaction_target,
                          :priority, :priority_reason)
                     RETURNING id
                     """
@@ -540,6 +567,7 @@ async def create_session(
                     # the session id.
                     "branch": branch,
                     "reply_target": reply_target,
+                    "reaction_target": reaction_target,
                     "priority": priority,
                     "priority_reason": priority_reason,
                 },
@@ -663,6 +691,7 @@ _SESSION_SELECT = """
            s.started_at, s.finished_at, s.exit_code, s.error,
            s.container_id, s.open_pull_request, s.deploy_to_dev,
            s.screenshot_paths, s.trigger_kind, s.trigger_ref, s.reply_target,
+           s.reaction_target,
            s.priority, s.priority_reason,
            COALESCE(s.tokens_in, 0) AS tokens_in,
            COALESCE(s.tokens_out, 0) AS tokens_out,

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -131,10 +131,81 @@ async def reachable_deployments(key_value: str) -> list[dict[str, Any]]:
     return [dict(row) for row in rows]
 
 
+# --- what an operator changed while the runner was running ----------------
+
+
+async def get_controls() -> dict[str, Any] | None:
+    """The one row of runtime controls, or None if it is missing."""
+    async with sessionmaker()() as db:
+        row = (
+            (
+                await db.execute(
+                    text(
+                        """
+                    SELECT mode, mode_reason, max_parallel, updated_by, updated_at
+                      FROM agent_controls WHERE id = 1
+                    """
+                    )
+                )
+            )
+            .mappings()
+            .first()
+        )
+    return dict(row) if row else None
+
+
+async def set_controls(
+    *,
+    mode: str | None = None,
+    mode_reason: str | None = None,
+    max_parallel: int | None = None,
+    clear_max_parallel: bool = False,
+    updated_by: str,
+) -> None:
+    """Change the runtime controls, leaving untouched what was not named.
+
+    ``clear_max_parallel`` is how the override goes back to "whatever the
+    environment configured": null is a value here, not an absence, so it
+    cannot be expressed by omitting the argument.
+    """
+    async with sessionmaker()() as db:
+        await db.execute(
+            text(
+                """
+                INSERT INTO agent_controls (id, mode, mode_reason, max_parallel, updated_by, updated_at)
+                VALUES (1, COALESCE(:mode, 'running'), :mode_reason,
+                        CASE WHEN :clear THEN NULL ELSE :max_parallel END, :updated_by, :now)
+                ON CONFLICT (id) DO UPDATE SET
+                    mode = COALESCE(:mode, agent_controls.mode),
+                    mode_reason = CASE
+                        WHEN :mode IS NULL THEN agent_controls.mode_reason
+                        ELSE :mode_reason
+                    END,
+                    max_parallel = CASE
+                        WHEN :clear THEN NULL
+                        WHEN :max_parallel IS NULL THEN agent_controls.max_parallel
+                        ELSE :max_parallel
+                    END,
+                    updated_by = :updated_by,
+                    updated_at = :now
+                """
+            ),
+            {
+                "mode": mode,
+                "mode_reason": mode_reason,
+                "max_parallel": max_parallel,
+                "clear": clear_max_parallel,
+                "updated_by": updated_by,
+                "now": _now(),
+            },
+        )
+        await db.commit()
+
+
 # --- workspaces -----------------------------------------------------------
 
 
-async def create_workspace(name: str, base_branch: str, created_by: str) -> dict[str, Any]:
+async def create_workspace(name: str, base_branch: str, created_by: str, *, ephemeral: bool = False) -> dict[str, Any]:
     volume = f"logos_agent_ws_{name}"
     async with sessionmaker()() as db:
         row = (
@@ -142,10 +213,12 @@ async def create_workspace(name: str, base_branch: str, created_by: str) -> dict
                 await db.execute(
                     text(
                         """
-                    INSERT INTO agent_workspaces (name, base_branch, volume_name, created_by)
-                    VALUES (:name, :base_branch, :volume, :created_by)
+                    INSERT INTO agent_workspaces
+                        (name, base_branch, volume_name, created_by, ephemeral)
+                    VALUES (:name, :base_branch, :volume, :created_by, :ephemeral)
                     ON CONFLICT (name) DO NOTHING
-                    RETURNING id, name, base_branch, volume_name, created_by, created_at
+                    RETURNING id, name, base_branch, volume_name, created_by,
+                              created_at, ephemeral
                     """
                     ),
                     {
@@ -153,6 +226,7 @@ async def create_workspace(name: str, base_branch: str, created_by: str) -> dict
                         "base_branch": base_branch,
                         "volume": volume,
                         "created_by": created_by,
+                        "ephemeral": ephemeral,
                     },
                 )
             )
@@ -173,7 +247,7 @@ async def list_workspaces() -> list[dict[str, Any]]:
                     text(
                         """
                     SELECT w.id, w.name, w.base_branch, w.volume_name, w.created_by,
-                           w.created_at,
+                           w.created_at, w.ephemeral,
                            COUNT(s.id) FILTER (WHERE s.status = ANY(:active)) AS active_sessions
                       FROM agent_workspaces w
                       LEFT JOIN agent_sessions s ON s.workspace_id = w.id
@@ -256,6 +330,46 @@ async def get_workspace(workspace_id: int) -> dict[str, Any] | None:
     return dict(row) if row else None
 
 
+async def disposable_workspaces(idle_before: datetime) -> list[dict[str, Any]]:
+    """Ephemeral workspaces whose work is done.
+
+    A workspace the runner made for one piece of triggered work has no
+    meaning once that work has finished, and left behind they fill the
+    parallel ceiling with checkouts nobody is using. An operator's
+    workspace is never in this list: they made it, they keep it.
+
+    ``idle_before`` guards the moment between a session being queued and
+    being claimed: a workspace created seconds ago has no active session
+    yet either, and removing it would delete the working copy out from
+    under the session it was made for.
+    """
+    async with sessionmaker()() as db:
+        rows = (
+            (
+                await db.execute(
+                    text(
+                        """
+                    SELECT w.id, w.name, w.volume_name
+                      FROM agent_workspaces w
+                     WHERE w.ephemeral = TRUE
+                       AND w.created_at < :idle_before
+                       AND NOT EXISTS (
+                             SELECT 1 FROM agent_sessions s
+                              WHERE s.workspace_id = w.id
+                                AND s.status = ANY(:active)
+                           )
+                     ORDER BY w.id
+                    """
+                    ),
+                    {"idle_before": idle_before, "active": [s.value for s in ACTIVE_STATUSES]},
+                )
+            )
+            .mappings()
+            .all()
+        )
+    return [dict(row) for row in rows]
+
+
 async def delete_workspace(workspace_id: int) -> bool:
     """Delete a workspace. Refuses while it still has non-terminal sessions.
 
@@ -309,6 +423,8 @@ async def create_session(
     trigger_ref: str | None = None,
     branch: str | None = None,
     reply_target: str | None = None,
+    priority: int = 50,
+    priority_reason: str | None = None,
 ) -> int:
     async with sessionmaker()() as db:
         # Lock the workspace row before inserting. delete_workspace takes
@@ -334,11 +450,13 @@ async def create_session(
                     INSERT INTO agent_sessions
                         (workspace_id, task, model, status, created_by,
                          open_pull_request, deploy_to_dev, screenshot_paths,
-                         trigger_kind, trigger_ref, branch_name, reply_target)
+                         trigger_kind, trigger_ref, branch_name, reply_target,
+                         priority, priority_reason)
                     VALUES
                         (:workspace_id, :task, :model, 'queued', :created_by,
                          :open_pr, :deploy, CAST(:paths AS jsonb),
-                         :trigger_kind, :trigger_ref, :branch, :reply_target)
+                         :trigger_kind, :trigger_ref, :branch, :reply_target,
+                         :priority, :priority_reason)
                     RETURNING id
                     """
                 ),
@@ -358,6 +476,8 @@ async def create_session(
                     # the session id.
                     "branch": branch,
                     "reply_target": reply_target,
+                    "priority": priority,
+                    "priority_reason": priority_reason,
                 },
             )
         ).scalar_one()
@@ -479,6 +599,7 @@ _SESSION_SELECT = """
            s.started_at, s.finished_at, s.exit_code, s.error,
            s.container_id, s.open_pull_request, s.deploy_to_dev,
            s.screenshot_paths, s.trigger_kind, s.trigger_ref, s.reply_target,
+           s.priority, s.priority_reason,
            COALESCE(s.tokens_in, 0) AS tokens_in,
            COALESCE(s.tokens_out, 0) AS tokens_out,
            COALESCE(s.cost_usd, 0) AS cost_usd,
@@ -554,7 +675,10 @@ async def claim_queued_sessions(limit: int) -> list[dict[str, Any]]:
                               WHERE peer.workspace_id = s.workspace_id
                                 AND peer.status = 'queued'
                            )
-                     ORDER BY s.created_at
+                     -- Most urgent first, oldest among equals: sessions are
+                     -- admitted one per capacity reading, so this order is
+                     -- what the platform works on while it is busy.
+                     ORDER BY s.priority DESC, s.created_at
                      LIMIT :limit
                      FOR UPDATE OF s SKIP LOCKED
                     """

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -216,7 +216,16 @@ async def create_workspace(name: str, base_branch: str, created_by: str, *, ephe
                     INSERT INTO agent_workspaces
                         (name, base_branch, volume_name, created_by, ephemeral)
                     VALUES (:name, :base_branch, :volume, :created_by, :ephemeral)
-                    ON CONFLICT (name) DO NOTHING
+                    -- An archived workspace of the same name is revived
+                    -- rather than collided with: the name identifies the
+                    -- work (an issue, a pull request), and its history is
+                    -- worth keeping across the gap. A live one is left
+                    -- alone, which is what makes the name unique.
+                    ON CONFLICT (name) DO UPDATE
+                       SET archived_at = NULL,
+                           base_branch = EXCLUDED.base_branch,
+                           ephemeral = EXCLUDED.ephemeral
+                     WHERE agent_workspaces.archived_at IS NOT NULL
                     RETURNING id, name, base_branch, volume_name, created_by,
                               created_at, ephemeral
                     """
@@ -251,6 +260,7 @@ async def list_workspaces() -> list[dict[str, Any]]:
                            COUNT(s.id) FILTER (WHERE s.status = ANY(:active)) AS active_sessions
                       FROM agent_workspaces w
                       LEFT JOIN agent_sessions s ON s.workspace_id = w.id
+                     WHERE w.archived_at IS NULL
                      GROUP BY w.id
                      ORDER BY w.created_at DESC
                     """
@@ -331,17 +341,20 @@ async def get_workspace(workspace_id: int) -> dict[str, Any] | None:
 
 
 async def disposable_workspaces(idle_before: datetime) -> list[dict[str, Any]]:
-    """Ephemeral workspaces whose work is done.
+    """Ephemeral workspaces whose work is done and whose volume can go.
 
     A workspace the runner made for one piece of triggered work has no
     meaning once that work has finished, and left behind they fill the
     parallel ceiling with checkouts nobody is using. An operator's
     workspace is never in this list: they made it, they keep it.
 
-    ``idle_before`` guards the moment between a session being queued and
-    being claimed: a workspace created seconds ago has no active session
-    yet either, and removing it would delete the working copy out from
-    under the session it was made for.
+    Idle is measured from when the last session in it *finished*, not from
+    when the workspace was created — a workspace made an hour ago whose
+    session ended a minute ago is not idle. A workspace that never ran
+    anything falls back to its creation time, which also covers the gap
+    between a session being queued into a fresh workspace and being
+    claimed: neither is active yet, and sweeping then would delete the
+    working copy out from under the session it was made for.
     """
     async with sessionmaker()() as db:
         rows = (
@@ -352,12 +365,17 @@ async def disposable_workspaces(idle_before: datetime) -> list[dict[str, Any]]:
                     SELECT w.id, w.name, w.volume_name
                       FROM agent_workspaces w
                      WHERE w.ephemeral = TRUE
-                       AND w.created_at < :idle_before
+                       AND w.archived_at IS NULL
                        AND NOT EXISTS (
                              SELECT 1 FROM agent_sessions s
                               WHERE s.workspace_id = w.id
                                 AND s.status = ANY(:active)
                            )
+                       AND COALESCE(
+                             (SELECT MAX(s.finished_at) FROM agent_sessions s
+                               WHERE s.workspace_id = w.id),
+                             w.created_at
+                           ) < :idle_before
                      ORDER BY w.id
                     """
                     ),
@@ -368,6 +386,52 @@ async def disposable_workspaces(idle_before: datetime) -> list[dict[str, Any]]:
             .all()
         )
     return [dict(row) for row in rows]
+
+
+async def archive_workspace(workspace_id: int) -> bool:
+    """Retire a workspace without deleting anything that happened in it.
+
+    The row stays: `agent_sessions.workspace_id` cascades, so deleting it
+    would take every finished session in it — their events, their trigger
+    references, their pending replies — and with the references gone, work
+    that is still assigned would be queued all over again. Archiving keeps
+    the history and the name while giving back the only thing worth
+    reclaiming, which is the volume.
+
+    Refuses while the workspace is occupied, under the same row lock
+    :func:`create_session` takes, so a session accepted a moment ago is
+    never archived out from under itself.
+    """
+    async with sessionmaker()() as db:
+        existing = (
+            await db.execute(
+                text("SELECT id FROM agent_workspaces WHERE id = :id AND archived_at IS NULL FOR UPDATE"),
+                {"id": workspace_id},
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            await db.rollback()
+            return False
+        active = (
+            await db.execute(
+                text(
+                    """
+                    SELECT COUNT(*) FROM agent_sessions
+                     WHERE workspace_id = :id AND status = ANY(:active)
+                    """
+                ),
+                {"id": workspace_id, "active": [s.value for s in ACTIVE_STATUSES]},
+            )
+        ).scalar_one()
+        if active:
+            await db.rollback()
+            return False
+        await db.execute(
+            text("UPDATE agent_workspaces SET archived_at = :now WHERE id = :id"),
+            {"id": workspace_id, "now": _now()},
+        )
+        await db.commit()
+    return True
 
 
 async def delete_workspace(workspace_id: int) -> bool:
@@ -667,13 +731,20 @@ async def claim_queued_sessions(limit: int) -> list[dict[str, Any]]:
                               WHERE busy.workspace_id = s.workspace_id
                                 AND busy.status = ANY(:occupying)
                            )
-                       -- Only the oldest queued session of each workspace is a
-                       -- candidate, so one workspace cannot take several slots
-                       -- in a single pass and then collide with itself.
+                       -- One candidate per workspace, so a workspace cannot
+                       -- take several slots in a pass and then collide with
+                       -- itself — and it is that workspace's most urgent
+                       -- queued session, oldest among equals. Picking the
+                       -- oldest outright would hide a security fix behind a
+                       -- typo that happened to be queued into the same
+                       -- checkout first, and the global order below could
+                       -- never correct it.
                        AND s.id = (
-                             SELECT min(peer.id) FROM agent_sessions peer
+                             SELECT peer.id FROM agent_sessions peer
                               WHERE peer.workspace_id = s.workspace_id
                                 AND peer.status = 'queued'
+                              ORDER BY peer.priority DESC, peer.created_at, peer.id
+                              LIMIT 1
                            )
                      -- Most urgent first, oldest among equals: sessions are
                      -- admitted one per capacity reading, so this order is

--- a/logos/logos-agent/app/docker_engine.py
+++ b/logos/logos-agent/app/docker_engine.py
@@ -139,6 +139,24 @@ async def ensure_network(name: str, *, internal: bool = False) -> None:
     )
 
 
+async def image_present(image: str) -> bool:
+    """Whether an image is on this host already.
+
+    Sessions run an image the registry publishes on every build of the
+    default branch. Between a merge and that build finishing — or when a
+    deployment has never pulled it — the first session dies with a bare
+    `404: No such image`, which reads like a bug in the runner rather than
+    a missing artefact. Asking first turns that into a sentence.
+    """
+    try:
+        await _request("GET", f"/images/{image}/json")
+        return True
+    except DockerError as exc:
+        if exc.status == 404:
+            return False
+        raise
+
+
 async def create_session_container(
     *,
     name: str,

--- a/logos/logos-agent/app/github.py
+++ b/logos/logos-agent/app/github.py
@@ -556,7 +556,18 @@ async def may_push(login: str) -> bool:
     return str(payload.get("permission") or "").lower() in _WRITE_PERMISSIONS
 
 
-async def react(path: str, content: str = "eyes") -> bool:
+# What a session's stage looks like on a thread. GitHub's palette is fixed
+# — +1, -1, laugh, confused, heart, hooray, rocket, eyes — so there is no
+# hourglass to wait with: eyes means seen and in the queue, a rocket means
+# it is being worked on now, and a shrug means it did not work out. Three
+# reactions, no notifications, and a person can see where their request is
+# without asking.
+REACTION_QUEUED = "eyes"
+REACTION_RUNNING = "rocket"
+REACTION_FAILED = "confused"
+
+
+async def react(path: str, content: str = REACTION_QUEUED) -> bool:
     """Leave a reaction, so a person can see their request was picked up.
 
     ``path`` is the API path of the thing reacted to — an issue, an issue

--- a/logos/logos-agent/app/main.py
+++ b/logos/logos-agent/app/main.py
@@ -217,7 +217,8 @@ async def get_models(_: Principal = Depends(require_agent_operator)) -> dict[str
 @app.get("/triggers", tags=["capacity"])
 async def get_triggers(_: Principal = Depends(require_agent_operator)) -> dict[str, object]:
     """Whether the runner reacts to the repository, and what it has done."""
-    status = triggers.poller.status()
+    control = await controls.current()
+    status = triggers.poller.status(control.max_parallel)
     status["active_sessions"] = await triggers.active_trigger_sessions()
     return status
 

--- a/logos/logos-agent/app/main.py
+++ b/logos/logos-agent/app/main.py
@@ -19,11 +19,13 @@ from pathlib import Path
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from fastapi.responses import Response, StreamingResponse
 
-from . import capacity, db, docker_engine, github, model_policy, triggers
+from . import capacity, controls, db, docker_engine, github, model_policy, triggers
 from .auth import Principal, require_agent_operator
 from .config import settings
 from .schemas import (
     CapacityState,
+    ControlState,
+    ControlUpdate,
     SessionCreate,
     SessionEvent,
     SessionStatus,
@@ -120,7 +122,13 @@ async def get_capacity(_: Principal = Depends(require_agent_operator)) -> Capaci
     counts = await db.count_sessions_by_status()
     running = counts.get(SessionStatus.RUNNING.value, 0)
     paused = counts.get(SessionStatus.PAUSED.value, 0)
-    may_start, reason = capacity.start_decision(reading, running=running, paused=paused)
+    control = await controls.current()
+    may_start, reason = capacity.start_decision(
+        reading, running=running, paused=paused, max_parallel=control.max_parallel
+    )
+    blocked = control.admission_block()
+    if blocked:
+        may_start, reason = False, blocked
     # The local-only model policy gates admission as hard as load does, so
     # the page that explains why nothing starts has to show it too — an
     # operator staring at an idle platform should not have to read the logs
@@ -137,10 +145,56 @@ async def get_capacity(_: Principal = Depends(require_agent_operator)) -> Capaci
         sessions_running=running,
         sessions_queued=counts.get(SessionStatus.QUEUED.value, 0),
         sessions_paused=paused,
-        max_parallel=settings.max_parallel_sessions,
+        max_parallel=control.max_parallel,
         may_start=may_start,
         reason=reason,
     )
+
+
+def _control_state(state: controls.Controls) -> ControlState:
+    return ControlState(
+        mode=state.mode,
+        mode_reason=state.mode_reason,
+        paused=state.paused,
+        admits_new_sessions=not state.admission_block(),
+        max_parallel=state.max_parallel,
+        max_parallel_override=state.max_parallel_override,
+        max_parallel_configured=settings.max_parallel_sessions,
+        updated_by=state.updated_by,
+    )
+
+
+@app.get("/controls", response_model=ControlState, tags=["capacity"])
+async def get_controls(_: Principal = Depends(require_agent_operator)) -> ControlState:
+    """The kill switch and the ceiling, as they stand."""
+    return _control_state(await controls.current())
+
+
+@app.post("/controls", response_model=ControlState, tags=["capacity"])
+async def update_controls(body: ControlUpdate, principal: Principal = Depends(require_agent_operator)) -> ControlState:
+    """Stop the runner, drain it, or change how much of the platform it uses.
+
+    `draining` starts nothing new and lets what is running finish;
+    `paused` hands everything back on the next scheduler pass. Neither
+    cancels anything, so going back to `running` resumes the work mid-task.
+    """
+    state = await controls.current()
+    if body.mode is not None:
+        state = await controls.set_mode(mode=body.mode, reason=body.reason, by=principal.username)
+        logger.info(
+            "%s set the agent runner to %s%s",
+            principal.username,
+            body.mode,
+            f": {body.reason}" if body.reason else "",
+        )
+    if body.clear_max_parallel or body.max_parallel is not None:
+        limit = None if body.clear_max_parallel else body.max_parallel
+        state = await controls.set_max_parallel(limit=limit, by=principal.username)
+        logger.info("%s set the parallel ceiling to %s", principal.username, limit if limit is not None else "default")
+    # A pause takes effect on the next pass anyway; running one now means the
+    # operator sees it happen instead of waiting a tick for it.
+    asyncio.create_task(manager.scheduler_pass())
+    return _control_state(state)
 
 
 @app.get("/models", tags=["capacity"])

--- a/logos/logos-agent/app/priority.py
+++ b/logos/logos-agent/app/priority.py
@@ -1,0 +1,120 @@
+"""How urgent a piece of work is, read from the labels already on it.
+
+Sessions are admitted one per capacity reading, so the order they are
+admitted in *is* what the platform works on first while it is busy. Arrival
+order is the wrong answer to that: a security fix waiting behind a
+documentation typo is exactly the failure this module exists to prevent.
+
+Nothing new is invented for it. The repository already labels its issues, and
+those labels already say what kind of work something is; this maps them onto
+one number. Where a repository uses different words, the mapping is the one
+place to change.
+
+Two decisions are worth naming:
+
+* **Answering beats starting.** A question has somebody waiting on it and
+  costs one short session; a fresh issue has nobody waiting and costs an
+  hour. So conversation outranks new work, and a review — which blocks a
+  pull request from landing — outranks both.
+* **Some labels mean "not now".** `blocked`, `wontfix`, `invalid`,
+  `duplicate` and `stale` are not urgency, they are an answer: the runner
+  does not pick that work up at all, and says which label stopped it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+# What each kind of trigger is worth before labels are taken into account.
+# The numbers are only meaningful relative to each other.
+BASE = {
+    # A review holds a pull request shut; somebody is waiting for the
+    # branch to move.
+    "review": 80,
+    # A question, with a person on the other end of it.
+    "comment": 70,
+    # Somebody handed over a pull request: work in progress, not a new idea.
+    "takeover": 60,
+    # A fresh issue.
+    "issue": 50,
+}
+
+# Labels that raise or lower urgency, most urgent first. A thread carrying
+# several of them takes the strongest.
+LABEL_PRIORITY: tuple[tuple[str, int, str], ...] = (
+    ("security fix", 40, "a security fix"),
+    ("security", 40, "a security fix"),
+    ("critical", 35, "labelled critical"),
+    ("urgent", 30, "labelled urgent"),
+    ("deployment-error", 30, "a broken deployment"),
+    ("bug", 20, "a bug"),
+    ("enhancement", 0, "an enhancement"),
+    ("documentation", -10, "documentation"),
+    ("question", -10, "a question"),
+    ("good first issue", -15, "a good first issue"),
+)
+
+# Labels that mean the work is not the runner's to start, whatever else the
+# thread says.
+REFUSING_LABELS: tuple[str, ...] = ("blocked", "wontfix", "invalid", "duplicate", "stale")
+
+# The floor and ceiling the database column allows.
+MIN, MAX = 0, 100
+
+
+@dataclass(frozen=True)
+class Urgency:
+    """What a candidate is worth, and the sentence explaining it."""
+
+    value: int
+    reason: str
+    # Set when a label says the work should not be started at all.
+    refused_by: str | None = None
+
+    @property
+    def refused(self) -> bool:
+        return self.refused_by is not None
+
+
+def _names(labels: Iterable[Any]) -> list[str]:
+    """Label names from GitHub's shape, lowercased.
+
+    Issues carry objects; some listings carry plain strings.
+    """
+    found: list[str] = []
+    for label in labels or ():
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if isinstance(name, str) and name.strip():
+            found.append(name.strip().lower())
+    return found
+
+
+def of(kind: str, labels: Iterable[Any] = ()) -> Urgency:
+    """The urgency of one candidate.
+
+    ``kind`` is the trigger kind ('issue', 'review', 'comment',
+    'takeover'); ``labels`` are the labels on the issue or pull request it
+    came from.
+    """
+    names = set(_names(labels))
+    for refusing in REFUSING_LABELS:
+        if refusing in names:
+            return Urgency(value=BASE.get(kind, 50), reason=f"labelled {refusing}", refused_by=refusing)
+
+    base = BASE.get(kind, 50)
+    adjustment, why = 0, None
+    for label, delta, description in LABEL_PRIORITY:
+        if label in names:
+            adjustment, why = delta, description
+            break
+
+    value = max(MIN, min(MAX, base + adjustment))
+    if why is None:
+        reason = f"{kind} work"
+    else:
+        reason = f"{kind} work on {why}"
+    return Urgency(value=value, reason=reason)

--- a/logos/logos-agent/app/schemas.py
+++ b/logos/logos-agent/app/schemas.py
@@ -158,6 +158,9 @@ class SessionSummary(BaseModel):
     # ('issue-812'). Null for sessions a person created.
     trigger_kind: str | None = None
     trigger_ref: str | None = None
+    # How urgent this work is, and the sentence explaining it.
+    priority: int = 50
+    priority_reason: str | None = None
 
 
 class SessionEvent(BaseModel):
@@ -166,6 +169,37 @@ class SessionEvent(BaseModel):
     ts: datetime
     kind: EventKind
     payload: dict
+
+
+class ControlState(BaseModel):
+    """What an operator has changed about the runner while it runs."""
+
+    # 'running', 'draining' (start nothing new), or 'paused' (hand
+    # everything back now).
+    mode: str = "running"
+    mode_reason: str = ""
+    paused: bool = False
+    admits_new_sessions: bool = True
+    # The ceiling in force. `max_parallel_override` is null when the
+    # environment's configured value stands.
+    max_parallel: int
+    max_parallel_override: int | None = None
+    max_parallel_configured: int
+    updated_by: str = ""
+
+
+class ControlUpdate(BaseModel):
+    """A change to the runtime controls. Omitted fields stay as they are."""
+
+    # 'running' works as configured, 'draining' starts nothing new while
+    # what runs finishes, 'paused' hands everything back now.
+    mode: str | None = Field(default=None, pattern="^(running|draining|paused)$")
+    # Why it was stopped, for the people who find it stopped.
+    reason: str = Field(default="", max_length=200)
+    # 0 drains without pausing: nothing new starts, what runs keeps running.
+    # Null clears the override and the configured ceiling applies again.
+    max_parallel: int | None = Field(default=None, ge=0, le=100)
+    clear_max_parallel: bool = False
 
 
 class CapacityState(BaseModel):

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -729,6 +729,10 @@ class SessionManager:
 
         await db.add_event(sid, EventKind.STATUS, {"status": "running", "branch": branch})
         self._supervise(sid, container_id)
+        # The queue acknowledged the request; this says it is being worked
+        # on now — the difference a person on the other end of a comment
+        # actually wants to know.
+        await self._react(session, github.REACTION_RUNNING)
 
     async def _workspace_image_present(self) -> bool:
         """Whether the session image is on this host, remembered once it is.
@@ -1030,6 +1034,21 @@ class SessionManager:
 
     # --- settlement -------------------------------------------------------
 
+    async def _react(self, session: dict[str, Any] | None, content: str) -> None:
+        """Show on the thread how far this session's work has got.
+
+        Best effort in both directions: a reaction that does not appear
+        costs nothing, and one that is already there is answered with a 200,
+        so a resumed or re-settled session leaves no duplicates.
+        """
+        target = str((session or {}).get("reaction_target") or "")
+        if not target:
+            return
+        try:
+            await github.react(target, content)
+        except Exception as exc:
+            logger.info("could not react on %s: %s", target, exc)
+
     async def _settle(self, session_id: int, *, exit_code: int | None, error: str | None) -> None:
         """Record the outcome of a finished session and clean up after it."""
         if exit_code == 0 and not error:
@@ -1119,6 +1138,12 @@ class SessionManager:
 
         if result.get("pr_url"):
             await db.add_event(session_id, EventKind.PULL_REQUEST, {"url": result["pr_url"]})
+
+        if not succeeded:
+            # Somebody is looking at a thread that has been marked as picked
+            # up and started. Saying that it did not work out belongs there
+            # too — an answer that never comes is the worst of the three.
+            await self._react(await db.get_session(session_id), github.REACTION_FAILED)
 
         # Somebody asked this session a question. The agent phase holds no
         # GitHub credential, so it wrote the answer into its artefact

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -417,11 +417,22 @@ class SessionManager:
             may_resume, why = capacity.resume_decision(reading)
             if may_resume and not control.may_resume():
                 may_resume, why = False, control.admission_block()
-            elif may_resume and control.max_parallel < len(running) + 1:
-                may_resume, why = False, "the parallel ceiling was lowered"
             if may_resume:
+                # Room is counted per session, not once for the batch: with
+                # four paused sessions and a ceiling of two, checking only
+                # before the loop would resume all four and put the runner
+                # over the ceiling an operator just set.
+                live = len(running)
                 for session in paused:
+                    if live >= control.max_parallel:
+                        logger.info(
+                            "not resuming session %s: %s sessions is the ceiling in force",
+                            session["id"],
+                            control.max_parallel,
+                        )
+                        break
                     await self._resume(session, why)
+                    live += 1
                     reading = await capacity.read_load()
                     self._last_reading = reading
                     if not capacity.resume_decision(reading)[0]:
@@ -1157,15 +1168,17 @@ class SessionManager:
             return
         for workspace in disposable:
             name, volume = workspace.get("name"), workspace.get("volume_name")
-            if not await db.delete_workspace(int(workspace["id"])):
-                # A session was accepted into it between the query and here.
-                continue
+            # The volume goes first, the row is retired second: a failure in
+            # between leaves the workspace un-archived, so the next sweep
+            # finds it again and tries the volume once more. Retiring first
+            # would leave a volume nothing knows about.
             try:
                 await docker_engine.remove_volume(str(volume), force=True)
             except Exception as exc:
-                logger.warning("workspace '%s' is gone but its volume %s is not: %s", name, volume, exc)
+                logger.warning("could not remove the volume of finished workspace '%s': %s", name, exc)
                 continue
-            logger.info("removed finished workspace '%s' and its volume", name)
+            if await db.archive_workspace(int(workspace["id"])):
+                logger.info("retired finished workspace '%s' and reclaimed its volume", name)
 
     async def deliver_pending_replies(self) -> None:
         """Try again for answers that did not reach GitHub the first time.

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -24,13 +24,13 @@ import json
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import httpx
 
-from . import capacity, db, docker_engine, github, model_policy
+from . import capacity, controls, db, docker_engine, github, model_policy
 from .config import REPLY_FILE, settings
 from .schemas import EventKind, SessionStatus
 
@@ -57,6 +57,11 @@ _MAX_REPLY_CHARS = 60000
 
 # How often an undelivered answer is retried before it is left alone.
 _MAX_REPLY_ATTEMPTS = 5
+
+# How long a workspace the runner created must have existed before it may be
+# swept away. It covers the gap between a session being queued into a fresh
+# workspace and being claimed, in which neither is active yet.
+_WORKSPACE_IDLE_GRACE = timedelta(minutes=10)
 
 
 def container_name(session_id: int) -> str:
@@ -162,6 +167,8 @@ class SessionManager:
         # other's run and photograph the other's revision.
         self._deploy_screenshot_lock = asyncio.Lock()
         self._last_reading: capacity.Reading = capacity.UNKNOWN
+        # Set once the session image has been seen on this host.
+        self._image_present = False
 
     # --- lifecycle --------------------------------------------------------
 
@@ -366,6 +373,12 @@ class SessionManager:
             except Exception:
                 logger.exception("retrying undelivered answers failed")
             try:
+                await self.sweep_workspaces()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("removing finished workspaces failed")
+            try:
                 await asyncio.wait_for(self._stopping.wait(), timeout=settings.scheduler_interval_s)
             except asyncio.TimeoutError:
                 pass
@@ -373,9 +386,22 @@ class SessionManager:
     async def scheduler_pass(self) -> None:
         reading = await capacity.read_load()
         self._last_reading = reading
+        # What an operator has asked for right now — the kill switch and the
+        # ceiling they set — read before anything is decided.
+        control = await controls.current()
 
         running = await db.sessions_in_status(SessionStatus.RUNNING)
         paused = await db.sessions_in_status(SessionStatus.PAUSED)
+
+        if control.paused:
+            # The hard half of the kill switch: hand the platform back
+            # everything the runner holds. Paused, not cancelled — the work
+            # survives, and releasing the switch resumes it mid-task.
+            # Draining is the other half and deliberately does none of this:
+            # it lets what is running finish and only stops admission.
+            for session in running:
+                await self._pause(session, control.admission_block())
+            return
 
         # 1. Give capacity back first. Yielding always takes precedence over
         #    admitting, so a burst of user traffic is never met by the runner
@@ -389,6 +415,10 @@ class SessionManager:
         # 2. Resume what was paused, oldest first.
         if paused:
             may_resume, why = capacity.resume_decision(reading)
+            if may_resume and not control.may_resume():
+                may_resume, why = False, control.admission_block()
+            elif may_resume and control.max_parallel < len(running) + 1:
+                may_resume, why = False, "the parallel ceiling was lowered"
             if may_resume:
                 for session in paused:
                     await self._resume(session, why)
@@ -420,7 +450,16 @@ class SessionManager:
                 return
             running = await db.sessions_in_status(SessionStatus.RUNNING)
             paused = await db.sessions_in_status(SessionStatus.PAUSED)
-            may_start, why = capacity.start_decision(reading, running=len(running), paused=len(paused))
+            blocked = control.admission_block()
+            if blocked:
+                # Draining, paused, or a ceiling of zero: nothing new starts.
+                return
+            may_start, why = capacity.start_decision(
+                reading,
+                running=len(running),
+                paused=len(paused),
+                max_parallel=control.max_parallel,
+            )
             if not may_start:
                 return
             claimed = await db.claim_queued_sessions(1)
@@ -550,6 +589,23 @@ class SessionManager:
             await self._settle(sid, exit_code=None, error=f"refusing branch '{branch}'")
             return
 
+        # The image every phase of this session runs. It is published by the
+        # build of the default branch, so a deployment can be a few minutes
+        # ahead of its registry — and a session that dies with a bare
+        # `404: No such image` looks like a broken runner rather than an
+        # artefact that is not there yet.
+        if not await self._workspace_image_present():
+            await self._settle(
+                sid,
+                exit_code=None,
+                error=(
+                    f"the session image '{settings.workspace_image}' is not available on this host. "
+                    f"It is published by the build of the default branch — wait for that build, or "
+                    f"pull the image — and queue the session again."
+                ),
+            )
+            return
+
         # The model is checked again here, against the policy this pass
         # established: a session queued while its model was local must not
         # start after that model gained a cloud deployment. This is the last
@@ -662,6 +718,23 @@ class SessionManager:
 
         await db.add_event(sid, EventKind.STATUS, {"status": "running", "branch": branch})
         self._supervise(sid, container_id)
+
+    async def _workspace_image_present(self) -> bool:
+        """Whether the session image is on this host, remembered once it is.
+
+        Checked per launch until it succeeds: an image does not vanish, so
+        one positive answer stands for the life of the process, while a
+        negative one is worth re-asking every time — that is the state that
+        changes when the registry catches up.
+        """
+        if self._image_present:
+            return True
+        try:
+            self._image_present = await docker_engine.image_present(settings.workspace_image)
+        except Exception as exc:
+            logger.warning("could not check for the session image: %s", exc)
+            return True  # let the launch try and report the real error
+        return self._image_present
 
     async def _still_ours(self, session_id: int) -> bool:
         """Whether the row is still the 'starting' one this launch claimed."""
@@ -1062,6 +1135,37 @@ class SessionManager:
                 await self._capture_screenshots(session_id, deploy, after_run_id)
         else:
             await self._cleanup_container(session_id)
+
+    async def sweep_workspaces(self) -> None:
+        """Remove the workspaces the runner made for work that is finished.
+
+        A workspace is a Docker volume holding a working copy. One created
+        for a piece of triggered work has no meaning once that work is done,
+        and left behind they fill the parallel ceiling with checkouts nobody
+        is using — the ceiling counts workspaces, not sessions. Operators'
+        workspaces are never touched: they made them, they keep them.
+
+        The idle grace is what keeps this from deleting a workspace out from
+        under the session it was just created for: between queueing and
+        claiming, that session is not active yet either.
+        """
+        cutoff = datetime.now(timezone.utc) - _WORKSPACE_IDLE_GRACE
+        try:
+            disposable = await db.disposable_workspaces(cutoff)
+        except Exception as exc:
+            logger.warning("could not look for finished workspaces: %s", exc)
+            return
+        for workspace in disposable:
+            name, volume = workspace.get("name"), workspace.get("volume_name")
+            if not await db.delete_workspace(int(workspace["id"])):
+                # A session was accepted into it between the query and here.
+                continue
+            try:
+                await docker_engine.remove_volume(str(volume), force=True)
+            except Exception as exc:
+                logger.warning("workspace '%s' is gone but its volume %s is not: %s", name, volume, exc)
+                continue
+            logger.info("removed finished workspace '%s' and its volume", name)
 
     async def deliver_pending_replies(self) -> None:
         """Try again for answers that did not reach GitHub the first time.

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -115,15 +115,19 @@ def _next_auto_name(existing: set[str]) -> str:
     return f"auto-{index}"
 
 
-def max_active_sessions() -> int:
+def max_active_sessions(ceiling: int | None = None) -> int:
     """How many self-queued sessions may be active at once.
 
-    Derived rather than configured: half the parallel ceiling, at least one.
-    The runner is a guest on this platform even when it is idle, and an
-    operator who queues work by hand should always find room next to the
-    automation.
+    Derived rather than configured: half the ceiling in force, at least
+    one. The runner is a guest on this platform even when it is idle, and
+    an operator who queues work by hand should always find room next to the
+    automation — which is why it follows the *current* ceiling and not the
+    configured one. Lowering the limit to two and still letting five
+    triggered sessions through would take that room away, and their higher
+    priorities would win it.
     """
-    return max(1, settings.max_parallel_sessions // 2)
+    limit = settings.max_parallel_sessions if ceiling is None else ceiling
+    return max(1, limit // 2)
 
 
 def mentions_agent(body: str) -> bool:
@@ -347,14 +351,16 @@ class TriggerPoller:
         # Nothing to queue into: the runner is paused, draining, or its
         # ceiling is zero. The repository is read again next pass, and
         # nothing is lost by not looking now.
-        blocked = (await controls.current()).admission_block()
+        control = await controls.current()
+        blocked = control.admission_block()
         if blocked:
             logger.debug("trigger poll skipped: %s", blocked)
             self._last_pass = now
             return []
-        room = max_active_sessions() - await db.count_active_trigger_sessions()
+        quota = max_active_sessions(control.max_parallel)
+        room = quota - await db.count_active_trigger_sessions()
         if room <= 0:
-            logger.debug("trigger poll skipped: already at %s self-queued sessions", max_active_sessions())
+            logger.debug("trigger poll skipped: already at %s self-queued sessions", quota)
             self._last_pass = now
             return []
 
@@ -673,6 +679,13 @@ class TriggerPoller:
             logger.info("not queueing %s: %s", candidate["ref"], policy.detail)
             return None
         urgency = candidate.get("urgency") or priority.of(candidate["kind"])
+        if urgency.refused:
+            # Checked here rather than per source: a review, a handover and
+            # a question can all carry `blocked` or `wontfix` just as an
+            # issue can, and this is the one place every kind passes
+            # through.
+            logger.info("not queueing %s: %s", candidate["ref"], urgency.reason)
+            return None
         branch = candidate.get("branch")
         workspace_id = await self._free_workspace(
             base_branch=branch or "main",

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -15,9 +15,11 @@ No labels, no separate vocabulary. **Consent is per item:** nothing is picked
 up because it exists, only because somebody assigned it, reviewed its work,
 or asked it something by name.
 
-**It says it heard you.** The moment a session is queued, the runner reacts
-with 👀 on the thing that triggered it — so a question does not sit there
-looking ignored while the platform waits for idle GPUs.
+**It says where your request is.** The moment a session is queued — after the
+row exists, never before — the runner reacts with 👀 on what triggered it. A
+🚀 follows when the session actually starts, and a 😕 if it fails, so a
+thread never sits there looking either ignored or eternally in progress.
+GitHub's palette has no hourglass; these are the three states it can say.
 
 **It can answer.** The agent phase holds no GitHub credential, so it writes
 its answer to a file in its artefact directory and the runner posts it when
@@ -61,12 +63,16 @@ logger = logging.getLogger(__name__)
 # to stay far inside GitHub's rate limits (a pass is a handful of requests).
 POLL_INTERVAL_S = 120.0
 
-# How far back a pass looks for comments. Assignments and reviews need no
-# window — they are read from the current state of the repository — but
-# comments are a stream, and without a bound the first pass after a restart
-# would read years of them. A day is generous for "somebody asked something
-# and is waiting"; anything older is not a live question.
+# How far back a pass looks for comments when it has no mark of its own —
+# the first pass on a fresh deployment. Assignments and reviews need no
+# window (they are read from the repository's current state), but comments
+# are a stream, and without a bound the first pass would read years of them.
 COMMENT_LOOKBACK = timedelta(hours=24)
+
+# How far back the scan will ever reach, even with a mark that old. A runner
+# stopped for a week should answer what it missed; one that was gone for a
+# month should not wake up and reply to a month of conversations.
+MAX_COMMENT_LOOKBACK = timedelta(days=7)
 
 # At most this many comments are carried into one task, and this much of each.
 MAX_THREAD_COMMENTS = 20
@@ -354,6 +360,10 @@ class TriggerPoller:
         control = await controls.current()
         blocked = control.admission_block()
         if blocked:
+            # Nothing is queued while the runner is stopped — and nothing is
+            # forgotten either: the comment mark is only moved by a pass
+            # that handled what it saw, so a question asked during a pause is
+            # still in the window when the runner comes back.
             logger.debug("trigger poll skipped: %s", blocked)
             self._last_pass = now
             return []
@@ -371,6 +381,9 @@ class TriggerPoller:
         self._last_pass = now
         self._last_error = ""
         if not candidates:
+            # Everything up to now has been looked at, so the comment scan
+            # may move on.
+            await self._mark_comments_scanned(now)
             return []
 
         # Most urgent first: a pass may only have room for some of them, and
@@ -378,35 +391,68 @@ class TriggerPoller:
         candidates.sort(key=lambda candidate: -(candidate.get("urgency").value if candidate.get("urgency") else 50))
         handled = await db.handled_trigger_refs([candidate["ref"] for candidate in candidates])
         queued: list[int] = []
+        # A candidate this pass could not take on is not recorded anywhere,
+        # so the mark must not move past it — assignments and reviews would
+        # be found again from the repository's state, but a comment would
+        # simply fall out of the window.
+        deferred = False
         for candidate in candidates:
-            if room <= 0:
-                # Left for the next pass: nothing here is consumed by being
-                # seen, so what does not fit now is found again.
-                break
             if candidate["ref"] in handled:
+                continue
+            if room <= 0:
+                deferred = True
                 continue
             session_id = await self._queue(candidate)
             if session_id is None:
+                deferred = True
                 continue
             queued.append(session_id)
             room -= 1
             await self._acknowledge(candidate)
+        if not deferred:
+            await self._mark_comments_scanned(now)
         if queued and self.on_queued is not None:
             await self.on_queued()
         return queued
 
-    async def _acknowledge(self, candidate: dict[str, Any]) -> None:
-        """React with 👀 so the person who asked can see it landed.
+    async def _comment_window(self, now: datetime) -> datetime:
+        """How far back this pass reads comments.
 
-        Best effort: a missing reaction is a cosmetic loss, and the work is
-        already queued. Anything else would make a failed reaction lose a
-        session.
+        From the mark the last complete pass left, so a question asked while
+        the runner was paused is still there when it comes back — bounded,
+        because a runner that was gone for a month should not answer a
+        month of conversations at once.
+        """
+        try:
+            mark = await db.comments_scanned_at()
+        except Exception as exc:
+            logger.warning("could not read the comment mark; using the default window: %s", exc)
+            mark = None
+        floor = now - MAX_COMMENT_LOOKBACK
+        if mark is None:
+            return now - COMMENT_LOOKBACK
+        if mark.tzinfo is None:
+            mark = mark.replace(tzinfo=timezone.utc)
+        return max(mark, floor)
+
+    async def _mark_comments_scanned(self, moment: datetime) -> None:
+        try:
+            await db.mark_comments_scanned(moment)
+        except Exception as exc:
+            logger.warning("could not record how far the comment scan got: %s", exc)
+
+    async def _acknowledge(self, candidate: dict[str, Any]) -> None:
+        """React so the person who asked can see their request landed.
+
+        Posted after the session row exists, so the reaction never promises
+        work that is not queued — and best effort, so a reaction GitHub
+        refuses never loses a session that is.
         """
         target = candidate.get("reaction")
         if not target:
             return
         try:
-            await github.react(target)
+            await github.react(target, github.REACTION_QUEUED)
         except Exception as exc:
             logger.info("could not acknowledge %s: %s", candidate["ref"], exc)
 
@@ -591,7 +637,7 @@ class TriggerPoller:
         Comments already carried by a review task are skipped: they are being
         worked on, and answering them twice is not answering them better.
         """
-        since = now - COMMENT_LOOKBACK
+        since = await self._comment_window(now)
         threads: dict[tuple[str, int], dict[str, Any]] = {}
 
         def consider(comment: dict[str, Any], number: int, *, root: int | None) -> None:
@@ -718,6 +764,10 @@ class TriggerPoller:
                 trigger_kind=candidate["kind"],
                 trigger_ref=candidate["ref"],
                 reply_target=candidate.get("reply_target"),
+                # Kept on the row because the stages that follow — started,
+                # and possibly failed — are reacted to by the launcher,
+                # minutes later and across a restart.
+                reaction_target=candidate.get("reaction"),
                 priority=urgency.value,
                 priority_reason=urgency.reason,
             )
@@ -771,13 +821,19 @@ class TriggerPoller:
 
     # --- what the UI shows ------------------------------------------------
 
-    def status(self) -> dict[str, Any]:
+    def status(self, ceiling: int | None = None) -> dict[str, Any]:
+        """What the UI shows about the automation.
+
+        ``ceiling`` is the parallel ceiling in force; without it the quota
+        shown would be the configured one, which is not the number that
+        decides anything once an operator has lowered it.
+        """
         return {
             "enabled": settings.triggers_enabled,
             "polling": self._task is not None and not self._task.done(),
             "account": settings.github_login,
             "poll_interval_s": POLL_INTERVAL_S,
-            "max_active_sessions": max_active_sessions(),
+            "max_active_sessions": max_active_sessions(ceiling),
             "last_pass": self._last_pass.isoformat() if self._last_pass else None,
             "queued_total": self._queued_total,
             "last_error": self._last_error,

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -50,8 +50,9 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from . import db, github, model_policy
+from . import controls, db, github, model_policy, priority
 from .config import settings
+from .conventions import for_task
 
 logger = logging.getLogger(__name__)
 
@@ -78,12 +79,35 @@ CREATED_BY = "logos-agent (trigger)"
 REPLY_FILE = "reply.md"
 
 
+_NAME_SAFE = re.compile(r"[^a-z0-9]+")
+
+
+def workspace_name(kind: str, number: int, title: str) -> str:
+    """A workspace name that says what is in it.
+
+    The name is not decoration: it becomes part of the branch a session
+    pushes (`logos/agent/<workspace>/session-42`) and the first column of
+    the workspace list. `auto-2` tells nobody anything; `issue-812-oom-on-
+    startup` says what the checkout is for, in the branch as well as in the
+    UI.
+
+    Trimmed to keep branch names readable, and reduced to characters that
+    are safe in both a Docker volume name and a git ref.
+    """
+    slug = _NAME_SAFE.sub("-", (title or "").strip().lower()).strip("-")
+    words = [word for word in slug.split("-") if word][:5]
+    tail = "-".join(words)[:40].strip("-")
+    prefix = "issue" if kind == "issue" else "pr"
+    return f"{prefix}-{number}-{tail}" if tail else f"{prefix}-{number}"
+
+
 def _next_auto_name(existing: set[str]) -> str:
     """The lowest ``auto-N`` no workspace carries.
 
-    Counting workspaces would repeat a name after a deletion — with `auto-1`
-    and `auto-3` left, the count says `auto-3` — and every later poll would
-    hit the same conflict and defer work while the ceiling still had room.
+    The fallback for work that names nothing. Counting workspaces would
+    repeat a name after a deletion — with `auto-1` and `auto-3` left, the
+    count says `auto-3` — and every later poll would hit the same conflict
+    and defer work while the ceiling still had room.
     """
     index = 1
     while f"auto-{index}" in existing:
@@ -132,17 +156,15 @@ def issue_task(issue: dict[str, Any]) -> str:
     body = str(issue.get("body") or "").strip()
     if len(body) > 6000:
         body = body[:6000] + "\n\n[issue body truncated]"
-    return (
+    return for_task(
         f"You have been assigned issue #{number}. Work on it and open a draft pull "
         f"request with your result.\n\n"
         f"Issue #{number}: {title}\n\n"
         f"{body}\n\n"
-        f"Scope your change to what the issue asks for. Add or adjust tests for what you "
-        f"change, and run the test suite and linters of the part of the repository you "
-        f"touched before you finish. If the issue is unclear or turns out to be larger "
-        f"than it looks, do the part you are confident about and say plainly in your "
-        f"final message what you left out and why. Do not reference the issue number in "
-        f"code comments, docstrings, or test names."
+        f"Scope your change to what the issue asks for: the smallest change that "
+        f"answers it, with tests for what you changed. If the issue is unclear or turns "
+        f"out to be larger than it looks, do the part you are confident about and say "
+        f"plainly in your final message what you left out and why."
     )
 
 
@@ -151,7 +173,7 @@ def takeover_task(number: int, title: str, body: str, branch: str) -> str:
     text = (body or "").strip()
     if len(text) > 6000:
         text = text[:6000] + "\n\n[description truncated]"
-    return (
+    return for_task(
         f"Pull request #{number} ('{title}') has been assigned to you: somebody wants you "
         f"to carry it the rest of the way. You are working in a checkout of its own "
         f"branch `{branch}`, and your commit updates that pull request — do not open a "
@@ -196,7 +218,7 @@ def review_task(number: int, title: str, review: dict[str, Any], comments: list[
     if len(body) > 6000:
         body = body[:6000] + "\n\n[review body truncated]"
     inline = _inline_block(comments or [])
-    return (
+    return for_task(
         f"A review on pull request #{number} ('{title}') asked for changes. You are working "
         f"in a checkout of that pull request's own branch, and your commit updates it — "
         f"there is no new pull request to open.\n\n"
@@ -243,7 +265,7 @@ def thread_task(number: int, title: str, comments: list[dict[str, Any]], *, bran
             "answer needs a code change, say what you would change and why, and leave it to "
             "the people on the thread."
         )
-    return (
+    return for_task(
         f"You were asked something on #{number} ('{title}').\n\n"
         f"{conversation}\n\n"
         f"Write your answer to `$LOGOS_ARTIFACT_DIR/{REPLY_FILE}` — the runner posts it in "
@@ -322,6 +344,14 @@ class TriggerPoller:
     async def poll_once(self) -> list[int]:
         """One look at the repository. Returns the sessions queued, if any."""
         now = datetime.now(timezone.utc)
+        # Nothing to queue into: the runner is paused, draining, or its
+        # ceiling is zero. The repository is read again next pass, and
+        # nothing is lost by not looking now.
+        blocked = (await controls.current()).admission_block()
+        if blocked:
+            logger.debug("trigger poll skipped: %s", blocked)
+            self._last_pass = now
+            return []
         room = max_active_sessions() - await db.count_active_trigger_sessions()
         if room <= 0:
             logger.debug("trigger poll skipped: already at %s self-queued sessions", max_active_sessions())
@@ -337,6 +367,9 @@ class TriggerPoller:
         if not candidates:
             return []
 
+        # Most urgent first: a pass may only have room for some of them, and
+        # what it takes should be what matters most.
+        candidates.sort(key=lambda candidate: -(candidate.get("urgency").value if candidate.get("urgency") else 50))
         handled = await db.handled_trigger_refs([candidate["ref"] for candidate in candidates])
         queued: list[int] = []
         for candidate in candidates:
@@ -380,12 +413,19 @@ class TriggerPoller:
             number = issue.get("number")
             if not isinstance(number, int):
                 continue
+            urgency = priority.of("issue", issue.get("labels"))
+            if urgency.refused:
+                logger.info("issue %s is %s; not starting work on it", number, urgency.reason)
+                continue
+            title = str(issue.get("title") or "")
             found.append(
                 {
                     "ref": f"issue-{number}",
                     "kind": "issue",
                     "task": issue_task(issue),
+                    "workspace": workspace_name("issue", number, title),
                     "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
+                    "urgency": urgency,
                 }
             )
 
@@ -427,12 +467,13 @@ class TriggerPoller:
                         "kind": "review",
                         "task": review_task(number, pull["title"], review, comments),
                         "branch": branch,
-                        "workspace": f"pr-{number}",
+                        "workspace": workspace_name("pr", number, pull["title"]),
                         # A submitted review is not a review *comment*: the
                         # two have independent id sequences, so the
                         # acknowledgement goes on the pull request itself.
                         "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
                         "reply_target": f"issue:{number}",
+                        "urgency": priority.of("review", pull["labels"]),
                     }
                 )
             elif pull["assigned"] and branch:
@@ -442,8 +483,9 @@ class TriggerPoller:
                         "kind": "takeover",
                         "task": takeover_task(number, pull["title"], pull["body"], branch),
                         "branch": branch,
-                        "workspace": f"pr-{number}",
+                        "workspace": workspace_name("pr", number, pull["title"]),
                         "reaction": f"/repos/{settings.repo_slug}/issues/{number}",
+                        "urgency": priority.of("takeover", pull["labels"]),
                     }
                 )
 
@@ -467,6 +509,7 @@ class TriggerPoller:
             pulls[number] = {
                 "title": str(entry.get("title") or ""),
                 "body": str(entry.get("body") or ""),
+                "labels": entry.get("labels") or (),
                 "assigned": assigned,
                 "branch": await self._writable_head(number),
             }
@@ -607,7 +650,8 @@ class TriggerPoller:
                     "kind": "comment",
                     "task": thread_task(number, title, thread["comments"], branch=branch),
                     "branch": branch,
-                    "workspace": f"pr-{number}" if branch else None,
+                    "workspace": workspace_name("pr", number, title) if branch else None,
+                    "urgency": priority.of("comment", pull["labels"] if pull else ()),
                     "reaction": (
                         f"/repos/{settings.repo_slug}/pulls/comments/{newest}"
                         if inline
@@ -628,6 +672,7 @@ class TriggerPoller:
         if not policy.ok:
             logger.info("not queueing %s: %s", candidate["ref"], policy.detail)
             return None
+        urgency = candidate.get("urgency") or priority.of(candidate["kind"])
         branch = candidate.get("branch")
         workspace_id = await self._free_workspace(
             base_branch=branch or "main",
@@ -660,6 +705,8 @@ class TriggerPoller:
                 trigger_kind=candidate["kind"],
                 trigger_ref=candidate["ref"],
                 reply_target=candidate.get("reply_target"),
+                priority=urgency.value,
+                priority_reason=urgency.reason,
             )
         except ValueError as exc:
             logger.warning("could not queue a session for %s: %s", candidate["ref"], exc)
@@ -691,7 +738,9 @@ class TriggerPoller:
         if len(workspaces) < settings.max_parallel_sessions:
             name = preferred_name or _next_auto_name({str(w.get("name") or "") for w in workspaces})
             try:
-                created = await db.create_workspace(name=name, base_branch=base_branch, created_by=CREATED_BY)
+                created = await db.create_workspace(
+                    name=name, base_branch=base_branch, created_by=CREATED_BY, ephemeral=True
+                )
             except ValueError:
                 # The name belongs to a workspace that is currently
                 # occupied — most often the one for this very pull request,

--- a/logos/logos-agent/tests/conftest.py
+++ b/logos/logos-agent/tests/conftest.py
@@ -10,7 +10,7 @@ the policy build their own.
 from __future__ import annotations
 
 import pytest
-from app import db, model_policy
+from app import controls, db, model_policy
 
 
 @pytest.fixture(autouse=True)
@@ -47,3 +47,21 @@ def local_model_policy(monkeypatch):
     # underlying `load` is left alone so its own tests still exercise it.
     monkeypatch.setattr(model_policy, "_current", policy)
     monkeypatch.setattr(model_policy, "refresh", evaluated)
+
+
+@pytest.fixture(autouse=True)
+def unpaused_runner(monkeypatch):
+    """No operator has touched the controls, unless a test says otherwise.
+
+    The real reader runs — it is the code under test elsewhere — but against
+    an answer that needs no database. Tests about the controls give their
+    own `get_controls`.
+    """
+
+    async def untouched():
+        return None
+
+    monkeypatch.setattr(db, "get_controls", untouched)
+    controls.forget()
+    yield
+    controls.forget()

--- a/logos/logos-agent/tests/test_controls.py
+++ b/logos/logos-agent/tests/test_controls.py
@@ -208,3 +208,41 @@ class TestAdmission:
 
         assert capacity.start_decision(reading, running=3, paused=0)[0] is False
         assert capacity.start_decision(reading, running=2, paused=0)[0] is True
+
+
+class TestBeforeAnythingIsKnown:
+    """A runner that has not read its controls does not assume it may work.
+
+    Persisting the switch is pointless if a restart during a database
+    outage quietly releases it.
+    """
+
+    async def test_an_unread_runner_blocks_everything(self, monkeypatch):
+        async def broken():
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(controls.db, "get_controls", broken)
+        controls.forget()
+
+        state = await controls.current()
+
+        assert state.admission_block()
+        assert state.may_resume() is False
+
+    async def test_the_first_successful_read_takes_over(self, monkeypatch):
+        answers = [
+            RuntimeError("connection refused"),
+            {"mode": "running", "mode_reason": "", "max_parallel": None, "updated_by": ""},
+        ]
+
+        async def flaky():
+            answer = answers.pop(0)
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+
+        monkeypatch.setattr(controls.db, "get_controls", flaky)
+        controls.forget()
+
+        assert (await controls.current()).admission_block()
+        assert (await controls.current()).admission_block() == ""

--- a/logos/logos-agent/tests/test_controls.py
+++ b/logos/logos-agent/tests/test_controls.py
@@ -1,0 +1,210 @@
+"""Tests for the two things an operator can change while the runner runs.
+
+Both matter during an incident, which is exactly when nobody wants to edit
+an `.env` on a host and restart a service that is in the middle of ten
+sessions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from app import capacity, controls
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    controls.forget()
+    yield
+    controls.forget()
+
+
+def stored(monkeypatch, **row):
+    async def get_controls():
+        return {"mode": "running", "mode_reason": "", "max_parallel": None, "updated_by": "", **row}
+
+    monkeypatch.setattr(controls.db, "get_controls", get_controls)
+
+
+class TestReading:
+    async def test_an_untouched_runner_uses_its_configuration(self, monkeypatch):
+        async def nothing():
+            return None
+
+        monkeypatch.setattr(controls.db, "get_controls", nothing)
+
+        state = await controls.current()
+
+        assert not state.paused
+        assert state.max_parallel == controls.settings.max_parallel_sessions
+        assert state.admission_block() == ""
+
+    async def test_a_pause_is_read_with_its_reason(self, monkeypatch):
+        stored(monkeypatch, mode="paused", mode_reason="incident 4711", updated_by="tobias")
+
+        state = await controls.current()
+
+        assert state.paused
+        assert "incident 4711" in state.admission_block()
+
+    async def test_a_lowered_ceiling_wins_over_the_configuration(self, monkeypatch):
+        stored(monkeypatch, max_parallel=2)
+
+        state = await controls.current()
+
+        assert state.max_parallel == 2
+        assert state.max_parallel_override == 2
+
+    async def test_a_ceiling_of_zero_blocks_admission_without_pausing(self, monkeypatch):
+        # Draining: nothing new starts, what runs keeps running.
+        stored(monkeypatch, max_parallel=0)
+
+        state = await controls.current()
+
+        assert not state.paused
+        assert "zero" in state.admission_block()
+
+    async def test_a_reading_is_reused_for_a_moment(self, monkeypatch):
+        calls: list = []
+
+        async def counting():
+            calls.append(1)
+            return {"mode": "running", "mode_reason": "", "max_parallel": None, "updated_by": ""}
+
+        monkeypatch.setattr(controls.db, "get_controls", counting)
+
+        await controls.current()
+        await controls.current()
+
+        # The scheduler asks on every pass and every decision; one query per
+        # couple of seconds is the point of the cache.
+        assert len(calls) == 1
+
+    async def test_an_unreadable_database_does_not_forget_a_pause(self, monkeypatch):
+        stored(monkeypatch, mode="paused", mode_reason="incident")
+        await controls.current()
+
+        async def broken():
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(controls.db, "get_controls", broken)
+        controls._read_at = 0.0  # force a re-read
+
+        state = await controls.current()
+
+        # A pause is an operator's intent; forgetting it because of a
+        # transient error is the wrong way to fail.
+        assert state.paused
+
+
+class TestTheTwoHalvesOfTheSwitch:
+    async def test_draining_stops_new_work_but_not_the_running_kind(self, monkeypatch):
+        stored(monkeypatch, mode="draining", mode_reason="before a deploy")
+
+        state = await controls.current()
+
+        # Nothing new starts…
+        assert "no new sessions" in state.admission_block()
+        # …and what is under way is left alone, which is the whole
+        # difference between draining and pausing.
+        assert state.may_resume() is True
+        assert state.paused is False
+
+    async def test_pausing_also_takes_back_what_is_running(self, monkeypatch):
+        stored(monkeypatch, mode="paused", mode_reason="incident")
+
+        state = await controls.current()
+
+        assert state.paused is True
+        assert state.may_resume() is False
+
+    async def test_an_unknown_mode_is_read_as_running(self, monkeypatch):
+        # A value the database should not hold must not silently stop the
+        # runner, nor silently un-stop it: 'running' is what the schema's
+        # own default says.
+        stored(monkeypatch, mode="halted")
+
+        assert (await controls.current()).mode == "running"
+
+
+class TestWriting:
+    async def test_stopping_stores_the_reason_and_the_person(self, monkeypatch):
+        written: list = []
+
+        async def set_controls(**kwargs):
+            written.append(kwargs)
+
+        async def get_controls():
+            return {"mode": "paused", "mode_reason": "incident", "max_parallel": None, "updated_by": "tobias"}
+
+        monkeypatch.setattr(controls.db, "set_controls", set_controls)
+        monkeypatch.setattr(controls.db, "get_controls", get_controls)
+
+        state = await controls.set_mode(mode="paused", reason="incident", by="tobias")
+
+        assert written[0]["mode"] == "paused"
+        assert written[0]["mode_reason"] == "incident"
+        assert written[0]["updated_by"] == "tobias"
+        assert state.paused
+
+    async def test_running_again_clears_the_reason(self, monkeypatch):
+        written: list = []
+
+        async def set_controls(**kwargs):
+            written.append(kwargs)
+
+        async def get_controls():
+            return {"mode": "running", "mode_reason": "", "max_parallel": None, "updated_by": "tobias"}
+
+        monkeypatch.setattr(controls.db, "set_controls", set_controls)
+        monkeypatch.setattr(controls.db, "get_controls", get_controls)
+
+        await controls.set_mode(mode="running", reason="", by="tobias")
+
+        assert written[0]["mode_reason"] == ""
+
+    async def test_an_unknown_mode_is_refused(self, monkeypatch):
+        with pytest.raises(ValueError, match="unknown mode"):
+            await controls.set_mode(mode="halted", reason="", by="tobias")
+
+    async def test_clearing_the_ceiling_is_not_the_same_as_zero(self, monkeypatch):
+        written: list = []
+
+        async def set_controls(**kwargs):
+            written.append(kwargs)
+
+        async def get_controls():
+            return {"mode": "running", "mode_reason": "", "max_parallel": None, "updated_by": ""}
+
+        monkeypatch.setattr(controls.db, "set_controls", set_controls)
+        monkeypatch.setattr(controls.db, "get_controls", get_controls)
+
+        await controls.set_max_parallel(limit=None, by="tobias")
+        await controls.set_max_parallel(limit=0, by="tobias")
+
+        assert written[0]["clear_max_parallel"] is True
+        assert written[1]["clear_max_parallel"] is False and written[1]["max_parallel"] == 0
+
+
+class TestAdmission:
+    def test_the_ceiling_in_force_is_the_one_that_decides(self):
+        reading = capacity.Reading(load=0.0, busy_slots=0, total_slots=10, queue_total=0, ok=True)
+
+        may_start, why = capacity.start_decision(reading, running=2, paused=0, max_parallel=2)
+
+        assert not may_start and "2/2" in why
+
+    def test_a_ceiling_of_zero_says_so(self):
+        reading = capacity.Reading(load=0.0, busy_slots=0, total_slots=10, queue_total=0, ok=True)
+
+        may_start, why = capacity.start_decision(reading, running=0, paused=0, max_parallel=0)
+
+        assert not may_start and "zero" in why
+
+    def test_without_an_override_the_configuration_applies(self, monkeypatch):
+        monkeypatch.setattr(capacity, "settings", replace(capacity.settings, max_parallel_sessions=3))
+        reading = capacity.Reading(load=0.0, busy_slots=0, total_slots=10, queue_total=0, ok=True)
+
+        assert capacity.start_decision(reading, running=3, paused=0)[0] is False
+        assert capacity.start_decision(reading, running=2, paused=0)[0] is True

--- a/logos/logos-agent/tests/test_priority.py
+++ b/logos/logos-agent/tests/test_priority.py
@@ -1,0 +1,82 @@
+"""Tests for what the platform works on first while it is busy.
+
+Sessions are admitted one per capacity reading, so ordering is not a
+nicety: whatever sorts first is what gets the idle GPU, and everything else
+waits for the next one.
+"""
+
+from __future__ import annotations
+
+from app import priority
+
+
+def labels(*names: str) -> list[dict]:
+    return [{"name": name} for name in names]
+
+
+class TestKinds:
+    def test_a_review_outranks_new_work(self):
+        # A review holds a pull request shut; an issue has nobody waiting.
+        assert priority.of("review").value > priority.of("issue").value
+
+    def test_a_question_outranks_new_work(self):
+        # Somebody is on the other end of it, and answering is short.
+        assert priority.of("comment").value > priority.of("issue").value
+
+    def test_a_handover_outranks_a_fresh_issue(self):
+        assert priority.of("takeover").value > priority.of("issue").value
+
+    def test_an_unknown_kind_lands_in_the_middle(self):
+        assert 0 < priority.of("something-new").value < 100
+
+
+class TestLabels:
+    def test_a_security_fix_outranks_everything_of_its_kind(self):
+        assert priority.of("issue", labels("security fix")).value > priority.of("issue", labels("bug")).value
+
+    def test_a_bug_outranks_an_enhancement(self):
+        assert priority.of("issue", labels("bug")).value > priority.of("issue", labels("enhancement")).value
+
+    def test_documentation_sinks_below_plain_work(self):
+        assert priority.of("issue", labels("documentation")).value < priority.of("issue").value
+
+    def test_the_strongest_label_decides(self):
+        both = priority.of("issue", labels("documentation", "security fix"))
+        assert both.value == priority.of("issue", labels("security fix")).value
+
+    def test_a_security_issue_outranks_an_ordinary_review(self):
+        # Across kinds too: the ordering is one scale, not one per kind.
+        assert priority.of("issue", labels("security fix")).value > priority.of("review").value
+
+    def test_labels_may_be_plain_strings(self):
+        assert priority.of("issue", ["bug"]).value == priority.of("issue", labels("bug")).value
+
+    def test_the_reason_says_why(self):
+        assert "security" in priority.of("issue", labels("security fix")).reason
+        assert "review" in priority.of("review").reason
+
+
+class TestRefusal:
+    def test_blocked_work_is_not_picked_up(self):
+        urgency = priority.of("issue", labels("blocked"))
+        assert urgency.refused and urgency.refused_by == "blocked"
+
+    def test_the_other_closing_labels_refuse_too(self):
+        for label in ("wontfix", "invalid", "duplicate", "stale"):
+            assert priority.of("issue", labels(label)).refused, label
+
+    def test_a_refusal_beats_urgency(self):
+        # "Blocked and critical" is blocked: the label is an answer, not a
+        # measure of how much somebody wants it.
+        assert priority.of("issue", labels("critical", "blocked")).refused
+
+    def test_ordinary_work_is_not_refused(self):
+        assert not priority.of("issue", labels("bug")).refused
+
+
+class TestBounds:
+    def test_nothing_leaves_the_column_range(self):
+        for kind in ("issue", "review", "comment", "takeover"):
+            for label in ("security fix", "documentation", "good first issue", "critical"):
+                value = priority.of(kind, labels(label)).value
+                assert priority.MIN <= value <= priority.MAX

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -447,6 +447,92 @@ class TestLaunchAndSupervision:
         assert removed.count("cid-7") >= 1
 
 
+class TestReactionsOnAThread:
+    """What a person watching their own comment gets to see.
+
+    Three states, and GitHub's fixed palette to say them in: the queueing
+    pass leaves an eye when the work is accepted, the launch adds a rocket
+    when it actually starts, and a session that fails says so rather than
+    leaving a thread that looks like it is still being worked on.
+    """
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_a_starting_session_says_so_on_its_thread(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        monkeypatch.setattr(sessions.os, "chown", lambda *args, **kwargs: None)
+        reactions: list = []
+        starts: list = []
+        container_ids = iter(["cid-prepare", "cid-7"])
+
+        async def fake_create(**_kwargs):
+            return next(container_ids)
+
+        async def fake_start(cid):
+            starts.append(cid)
+
+        async def fake_react(path, content="eyes"):
+            reactions.append((path, content))
+            return True
+
+        async def noop(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(sessions.docker_engine, "ensure_volume", noop)
+        monkeypatch.setattr(
+            sessions.docker_engine,
+            "volume_mountpoint",
+            self._async_value("/var/lib/docker/volumes/logos_agent_artifacts/_data"),
+        )
+        monkeypatch.setattr(sessions.docker_engine, "create_session_container", fake_create)
+        monkeypatch.setattr(sessions.docker_engine, "start_container", fake_start)
+        monkeypatch.setattr(sessions.docker_engine, "wait_container", self._async_value(0))
+        monkeypatch.setattr(sessions.docker_engine, "remove_container", noop)
+        monkeypatch.setattr(sessions.db, "get_workspace", self._async_value(TestLaunchAndSupervision.WORKSPACE))
+        monkeypatch.setattr(sessions.db, "transition_session", self._async_value(True))
+        monkeypatch.setattr(sessions.db, "add_event", noop)
+        monkeypatch.setattr(sessions.github, "react", fake_react)
+        # On the class: an instance attribute would outlive the test and
+        # shadow the patches other tests make on the class.
+        monkeypatch.setattr(sessions.SessionManager, "_supervise", lambda *_args, **_kwargs: None)
+
+        session = dict(TestLaunchAndSupervision.SESSION)
+        session["reaction_target"] = "/repos/ls1intum/edutelligence/issues/comments/9001"
+
+        await sessions.manager._launch(session)
+
+        assert reactions == [(session["reaction_target"], sessions.github.REACTION_RUNNING)]
+
+    async def test_a_session_nobody_asked_for_reacts_nowhere(self, monkeypatch):
+        # Sessions started from the page have no thread behind them.
+        from app import sessions
+
+        async def refuse(*_args, **_kwargs):
+            raise AssertionError("a session with no target must not react")
+
+        monkeypatch.setattr(sessions.github, "react", refuse)
+
+        await sessions.manager._react({"id": 7}, sessions.github.REACTION_RUNNING)
+
+    async def test_a_reaction_github_refuses_does_not_fail_the_session(self, monkeypatch):
+        from app import sessions
+
+        async def broken(*_args, **_kwargs):
+            raise RuntimeError("403")
+
+        monkeypatch.setattr(sessions.github, "react", broken)
+
+        # No exception: the work is what matters, the emoji is not.
+        await sessions.manager._react({"reaction_target": "/x"}, sessions.github.REACTION_FAILED)
+
+
 class TestAgentPhaseIsolation:
     """What the untrusted agent phase may hold and reach.
 

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -3087,14 +3087,19 @@ class TestWorkspaceHousekeeping:
 
         return fake
 
-    async def test_a_finished_workspace_and_its_volume_are_removed(self, monkeypatch):
+    async def test_a_finished_workspace_gives_back_its_volume_and_keeps_its_history(self, monkeypatch):
         from app import sessions
 
         removed_volumes: list = []
+        archived: list = []
         deleted: list = []
 
         async def disposable(_cutoff):
             return [{"id": 3, "name": "issue-812-oom", "volume_name": "logos_agent_ws_issue-812-oom"}]
+
+        async def archive(workspace_id):
+            archived.append(workspace_id)
+            return True
 
         async def delete(workspace_id):
             deleted.append(workspace_id)
@@ -3104,18 +3109,46 @@ class TestWorkspaceHousekeeping:
             removed_volumes.append(name)
 
         monkeypatch.setattr(sessions.db, "disposable_workspaces", disposable)
+        monkeypatch.setattr(sessions.db, "archive_workspace", archive)
         monkeypatch.setattr(sessions.db, "delete_workspace", delete)
         monkeypatch.setattr(sessions.docker_engine, "remove_volume", remove_volume)
 
         await sessions.SessionManager().sweep_workspaces()
 
-        assert deleted == [3]
         assert removed_volumes == ["logos_agent_ws_issue-812-oom"]
+        assert archived == [3]
+        # Deleting the row would cascade into every finished session in it:
+        # the history, the trigger references that keep assignments from
+        # being worked twice, and any answer still waiting to be delivered.
+        assert deleted == []
+
+    async def test_a_volume_that_could_not_be_removed_is_tried_again(self, monkeypatch):
+        from app import sessions
+
+        archived: list = []
+
+        async def disposable(_cutoff):
+            return [{"id": 3, "name": "issue-812", "volume_name": "vol"}]
+
+        async def archive(workspace_id):
+            archived.append(workspace_id)
+            return True
+
+        async def failing_remove(_name, **_kwargs):
+            raise RuntimeError("volume is in use")
+
+        monkeypatch.setattr(sessions.db, "disposable_workspaces", disposable)
+        monkeypatch.setattr(sessions.db, "archive_workspace", archive)
+        monkeypatch.setattr(sessions.docker_engine, "remove_volume", failing_remove)
+
+        await sessions.SessionManager().sweep_workspaces()
+
+        # Not archived, so the next sweep finds it and tries the volume
+        # again — archiving first would leave a volume nothing tracks.
+        assert archived == []
 
     async def test_a_workspace_that_just_took_work_is_left_alone(self, monkeypatch):
         from app import sessions
-
-        removed: list = []
 
         async def disposable(_cutoff):
             return [{"id": 3, "name": "issue-812", "volume_name": "vol"}]
@@ -3124,16 +3157,17 @@ class TestWorkspaceHousekeeping:
             # A session was accepted into it between the query and here.
             return False
 
-        async def remove_volume(name, **_kwargs):
-            removed.append(name)
+        async def remove_volume(_name, **_kwargs):
+            return None
 
         monkeypatch.setattr(sessions.db, "disposable_workspaces", disposable)
-        monkeypatch.setattr(sessions.db, "delete_workspace", refuses)
+        monkeypatch.setattr(sessions.db, "archive_workspace", refuses)
         monkeypatch.setattr(sessions.docker_engine, "remove_volume", remove_volume)
 
+        # The archive refuses under the same row lock a session creation
+        # takes, so nothing is lost by the volume already being gone: the
+        # next preparation clones it again.
         await sessions.SessionManager().sweep_workspaces()
-
-        assert removed == []
 
 
 class TestMissingSessionImage:
@@ -3183,3 +3217,55 @@ class TestMissingSessionImage:
         assert len(settled) == 1
         message = settled[0][1]
         assert "not available on this host" in message and "build of the default branch" in message
+
+
+class TestResumeCeiling:
+    """An operator's ceiling holds for resumed sessions too.
+
+    Resuming is where it is easiest to overshoot: the check is naturally
+    written once, before a loop that then resumes everything.
+    """
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_only_as_many_are_resumed_as_the_ceiling_allows(self, monkeypatch, tmp_path):
+        from app import capacity, controls, sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        resumed: list = []
+
+        async def ceiling_of_two():
+            return {"mode": "running", "mode_reason": "", "max_parallel": 2, "updated_by": "tobias"}
+
+        async def in_status(status):
+            if status is SessionStatus.PAUSED:
+                return [{"id": i, "container_id": f"cid-{i}"} for i in (1, 2, 3, 4)]
+            return []
+
+        async def fake_unpause(cid, **_kwargs):
+            resumed.append(cid)
+            return True
+
+        monkeypatch.setattr(controls.db, "get_controls", ceiling_of_two)
+        controls.forget()
+        monkeypatch.setattr(
+            sessions.capacity,
+            "read_load",
+            self._async_value(capacity.Reading(load=0.0, busy_slots=0, total_slots=10, queue_total=0, ok=True)),
+        )
+        monkeypatch.setattr(sessions.db, "sessions_in_status", in_status)
+        monkeypatch.setattr(sessions.db, "transition_session", self._async_value(True))
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.docker_engine, "connect_network", self._async_value(True))
+        monkeypatch.setattr(sessions.docker_engine, "unpause_container", fake_unpause)
+
+        await sessions.SessionManager().scheduler_pass()
+
+        # Four were paused and the platform is idle; the ceiling is what
+        # stops the fourth, third and — here — everything past the second.
+        assert resumed == ["cid-1", "cid-2"]

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -2985,3 +2985,201 @@ class TestReplyDelivery:
         # rejected answer is no answer.
         assert len(posted[0]) < 65_000
         assert posted[0].endswith("_[answer truncated]_")
+
+
+class TestOperatorControls:
+    """The kill switch, from the scheduler's side."""
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_pausing_hands_back_what_the_runner_holds(self, monkeypatch, tmp_path):
+        from app import capacity, controls, sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        paused: list = []
+        claimed: list = []
+
+        async def stopped():
+            return {"mode": "paused", "mode_reason": "incident", "max_parallel": None, "updated_by": "tobias"}
+
+        async def fake_pause(cid, **_kwargs):
+            paused.append(cid)
+            return True
+
+        async def fake_claim(_limit):
+            claimed.append(1)
+            return []
+
+        monkeypatch.setattr(controls.db, "get_controls", stopped)
+        controls.forget()
+        monkeypatch.setattr(
+            sessions.capacity,
+            "read_load",
+            self._async_value(capacity.Reading(load=0.0, busy_slots=0, total_slots=4, queue_total=0, ok=True)),
+        )
+        monkeypatch.setattr(sessions.db, "sessions_in_status", self._async_value([{"id": 7, "container_id": "cid-7"}]))
+        monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "transition_session", self._async_value(True))
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+        monkeypatch.setattr(sessions.docker_engine, "pause_container", fake_pause)
+        monkeypatch.setattr(sessions.docker_engine, "disconnect_network", self._async_value(True))
+
+        await sessions.SessionManager().scheduler_pass()
+
+        # Running work is handed back, and nothing is admitted — but nothing
+        # is cancelled either, so releasing the switch resumes it.
+        assert paused == ["cid-7"]
+        assert claimed == []
+
+    async def test_draining_stops_admission_without_pausing_anything(self, monkeypatch, tmp_path):
+        from app import capacity, controls, sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        claimed: list = []
+
+        async def drained():
+            return {"mode": "draining", "mode_reason": "before a deploy", "max_parallel": None, "updated_by": "t"}
+
+        async def fake_claim(_limit):
+            claimed.append(1)
+            return []
+
+        monkeypatch.setattr(controls.db, "get_controls", drained)
+        controls.forget()
+        monkeypatch.setattr(
+            sessions.capacity,
+            "read_load",
+            self._async_value(capacity.Reading(load=0.0, busy_slots=0, total_slots=4, queue_total=0, ok=True)),
+        )
+        paused: list = []
+
+        async def fake_pause(cid, **_kwargs):
+            paused.append(cid)
+            return True
+
+        monkeypatch.setattr(sessions.db, "sessions_in_status", self._async_value([{"id": 7, "container_id": "cid-7"}]))
+        monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.docker_engine, "pause_container", fake_pause)
+        monkeypatch.setattr(sessions.docker_engine, "disconnect_network", self._async_value(True))
+        monkeypatch.setattr(sessions.db, "transition_session", self._async_value(True))
+        monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
+
+        await sessions.SessionManager().scheduler_pass()
+
+        # Nothing new is admitted, and the session already running is left
+        # alone — that is what separates draining from pausing.
+        assert claimed == []
+        assert paused == []
+
+
+class TestWorkspaceHousekeeping:
+    """Workspaces the runner made for itself do not accumulate."""
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_a_finished_workspace_and_its_volume_are_removed(self, monkeypatch):
+        from app import sessions
+
+        removed_volumes: list = []
+        deleted: list = []
+
+        async def disposable(_cutoff):
+            return [{"id": 3, "name": "issue-812-oom", "volume_name": "logos_agent_ws_issue-812-oom"}]
+
+        async def delete(workspace_id):
+            deleted.append(workspace_id)
+            return True
+
+        async def remove_volume(name, **_kwargs):
+            removed_volumes.append(name)
+
+        monkeypatch.setattr(sessions.db, "disposable_workspaces", disposable)
+        monkeypatch.setattr(sessions.db, "delete_workspace", delete)
+        monkeypatch.setattr(sessions.docker_engine, "remove_volume", remove_volume)
+
+        await sessions.SessionManager().sweep_workspaces()
+
+        assert deleted == [3]
+        assert removed_volumes == ["logos_agent_ws_issue-812-oom"]
+
+    async def test_a_workspace_that_just_took_work_is_left_alone(self, monkeypatch):
+        from app import sessions
+
+        removed: list = []
+
+        async def disposable(_cutoff):
+            return [{"id": 3, "name": "issue-812", "volume_name": "vol"}]
+
+        async def refuses(_workspace_id):
+            # A session was accepted into it between the query and here.
+            return False
+
+        async def remove_volume(name, **_kwargs):
+            removed.append(name)
+
+        monkeypatch.setattr(sessions.db, "disposable_workspaces", disposable)
+        monkeypatch.setattr(sessions.db, "delete_workspace", refuses)
+        monkeypatch.setattr(sessions.docker_engine, "remove_volume", remove_volume)
+
+        await sessions.SessionManager().sweep_workspaces()
+
+        assert removed == []
+
+
+class TestMissingSessionImage:
+    """A missing image is an artefact that is not there, not a runner bug."""
+
+    @staticmethod
+    def _async_value(value):
+        async def fake(*_args, **_kwargs):
+            return value
+
+        return fake
+
+    async def test_the_session_says_what_is_missing(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        monkeypatch.setattr(sessions.os, "chown", lambda *args, **kwargs: None)
+        settled: list = []
+        created: list = []
+
+        async def no_image(_image):
+            return False
+
+        async def fake_create(**kwargs):
+            created.append(kwargs)
+            return "cid"
+
+        async def fake_settle(_self, sid, *, exit_code, error):
+            settled.append((sid, error))
+
+        monkeypatch.setattr(sessions.docker_engine, "image_present", no_image)
+        monkeypatch.setattr(sessions.docker_engine, "ensure_volume", self._async_value(None))
+        monkeypatch.setattr(sessions.docker_engine, "volume_mountpoint", self._async_value("/vol"))
+        monkeypatch.setattr(sessions.docker_engine, "create_session_container", fake_create)
+        monkeypatch.setattr(
+            sessions.db,
+            "get_workspace",
+            self._async_value({"id": 1, "name": "issue-812", "base_branch": "main", "volume_name": "vol"}),
+        )
+        monkeypatch.setattr(sessions.SessionManager, "_settle", fake_settle)
+
+        await sessions.SessionManager()._launch(
+            {"id": 7, "workspace_id": 1, "task": "a task", "model": None, "screenshot_paths": []}
+        )
+
+        assert created == []
+        assert len(settled) == 1
+        message = settled[0][1]
+        assert "not available on this host" in message and "build of the default branch" in message

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -164,7 +164,7 @@ class FakeDb:
         async def list_workspaces():
             return list(self.workspaces)
 
-        async def create_workspace(*, name, base_branch, created_by):
+        async def create_workspace(*, name, base_branch, created_by, ephemeral=False):
             if any(w.get("name") == name for w in self.workspaces):
                 raise ValueError(f"workspace '{name}' already exists")
             entry = {
@@ -172,6 +172,7 @@ class FakeDb:
                 "name": name,
                 "active_sessions": 0,
                 "base_branch": base_branch,
+                "ephemeral": ephemeral,
             }
             self.workspaces.append(entry)
             return entry
@@ -769,3 +770,101 @@ class TestWhoMayDirectChanges:
         await triggers.TriggerPoller().poll_once()
 
         assert looked_up == ["wasnertobias"]
+
+
+class TestWorkspaceNames:
+    """A workspace name is read by people, and lands in the branch."""
+
+    def test_an_issue_workspace_says_which_issue(self):
+        assert triggers.workspace_name("issue", 812, "OOM on startup") == "issue-812-oom-on-startup"
+
+    def test_a_long_title_is_trimmed_rather_than_dumped(self):
+        name = triggers.workspace_name("issue", 5, "Refactor the whole scheduling pipeline for clarity and speed")
+        # It becomes part of `logos/agent/<name>/session-42`, so it stays
+        # readable rather than complete.
+        assert len(name) < 60
+        assert name.startswith("issue-5-refactor")
+
+    def test_punctuation_does_not_reach_a_volume_or_a_branch_name(self):
+        name = triggers.workspace_name("issue", 9, "Fix: don't crash (again)!")
+        assert all(c.isalnum() or c == "-" for c in name)
+
+    def test_a_titleless_thread_still_names_its_number(self):
+        assert triggers.workspace_name("pr", 772, "") == "pr-772"
+
+    async def test_a_triggered_workspace_is_named_after_its_work(self, monkeypatch):
+        FakeRepo(assigned_issues=[issue(812, title="OOM on startup")]).install(monkeypatch)
+        fake_db = FakeDb(workspaces=[{"id": 1, "name": "taken", "active_sessions": 1, "base_branch": "main"}])
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        created = [w for w in fake_db.workspaces if w["name"] != "taken"]
+        assert created[0]["name"] == "issue-812-oom-on-startup"
+        # And it is the runner's to clean up when the work is done.
+        assert created[0]["ephemeral"] is True
+
+
+class TestUrgency:
+    async def test_a_security_issue_is_queued_above_a_documentation_one(self, monkeypatch):
+        FakeRepo(
+            assigned_issues=[
+                dict(issue(1, title="typo"), labels=[{"name": "documentation"}]),
+                dict(issue(2, title="token leak"), labels=[{"name": "security fix"}]),
+            ]
+        ).install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in (1, 2, 3)]
+        )
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        # Both fit here; what matters is which one the queue offers first,
+        # since a busy platform only admits one per capacity reading.
+        assert [c["trigger_ref"] for c in fake_db.created] == ["issue-2", "issue-1"]
+        assert fake_db.created[0]["priority"] > fake_db.created[1]["priority"]
+        assert "security" in fake_db.created[0]["priority_reason"]
+
+    async def test_blocked_work_is_not_started(self, monkeypatch):
+        FakeRepo(assigned_issues=[dict(issue(3), labels=[{"name": "blocked"}])]).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+    async def test_a_review_carries_more_urgency_than_a_fresh_issue(self, monkeypatch):
+        FakeRepo(
+            assigned_issues=[issue(1)],
+            authored_pulls=[pull(772)],
+            reviews={772: review(9)},
+        ).install(monkeypatch)
+        fake_db = FakeDb(
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in (1, 2, 3)]
+        )
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.created[0]["trigger_ref"] == "pr-772-review-9"
+
+
+class TestTaskConventions:
+    """Every task carries what a new colleague would be told."""
+
+    def test_each_kind_of_task_carries_the_house_rules(self):
+        tasks = [
+            triggers.issue_task(issue(1)),
+            triggers.takeover_task(2, "t", "b", "logos/agent/x"),
+            triggers.review_task(3, "t", review(1), []),
+            triggers.thread_task(4, "t", [{"body": "q", "user": {"login": "a"}}], branch=None),
+        ]
+        for task in tasks:
+            assert "How work is done here" in task
+            assert "Never merge a pull request" in task
+            assert "fails on the unfixed code" in task

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -13,7 +13,7 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from app import triggers
+from app import controls, triggers
 
 AGENT = "LogosOSSAgent"
 REPO = "ls1intum/edutelligence"
@@ -207,6 +207,16 @@ def allow_models(monkeypatch, ok: bool = True):
             self.detail = "test policy"
 
     monkeypatch.setattr(triggers.model_policy, "current", lambda: Policy())
+
+
+def ceiling(monkeypatch, limit: int):
+    """Set the ceiling an operator would have set, at runtime."""
+
+    async def stored():
+        return {"mode": "running", "mode_reason": "", "max_parallel": limit, "updated_by": "tobias"}
+
+    monkeypatch.setattr(controls.db, "get_controls", stored)
+    controls.forget()
 
 
 def agent_account(monkeypatch):
@@ -479,16 +489,14 @@ class TestBounds:
         )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        monkeypatch.setattr(
-            triggers,
-            "settings",
-            replace(triggers.settings, github_login=AGENT, repo_slug=REPO, max_parallel_sessions=4),
-        )
+        ceiling(monkeypatch, 4)
 
         queued = await triggers.TriggerPoller().poll_once()
 
-        # Half the parallel ceiling, so an operator always has room.
-        assert triggers.max_active_sessions() == 2
+        # Half the ceiling *in force*, so an operator always has room — and
+        # it follows what they set at runtime, not what the environment
+        # configured.
+        assert triggers.max_active_sessions(4) == 2
         assert len(queued) == 2
 
     async def test_nothing_is_queued_while_the_ceiling_is_full(self, monkeypatch):
@@ -518,11 +526,7 @@ class TestBounds:
         )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        monkeypatch.setattr(
-            triggers,
-            "settings",
-            replace(triggers.settings, github_login=AGENT, repo_slug=REPO, max_parallel_sessions=4),
-        )
+        ceiling(monkeypatch, 4)
         poller = triggers.TriggerPoller()
 
         first = await poller.poll_once()
@@ -868,3 +872,38 @@ class TestTaskConventions:
             assert "How work is done here" in task
             assert "Never merge a pull request" in task
             assert "fails on the unfixed code" in task
+
+
+class TestRefusalAppliesToEveryKind:
+    """`blocked` is an answer, whatever kind of work carries it."""
+
+    async def test_a_blocked_pull_request_is_not_taken_over(self, monkeypatch):
+        FakeRepo(assigned_pulls=[dict(pull(864), labels=[{"name": "blocked"}])]).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert fake_db.created == []
+
+    async def test_a_review_on_a_blocked_pull_request_is_not_worked(self, monkeypatch):
+        FakeRepo(
+            authored_pulls=[dict(pull(772), labels=[{"name": "wontfix"}])],
+            reviews={772: review(5)},
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+
+    async def test_a_question_on_a_stale_thread_is_left_alone(self, monkeypatch):
+        FakeRepo(
+            authored_pulls=[dict(pull(772), labels=[{"name": "stale"}])],
+            issue_comments=[comment(9200, 772, f"@{AGENT} still relevant?")],
+        ).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        assert await triggers.TriggerPoller().poll_once() == []

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -153,6 +153,7 @@ class FakeDb:
         self.active_triggers = active_triggers
         self.created: list[dict] = []
         self.next_id = 100
+        self.comment_mark = None
 
     def install(self, monkeypatch):
         async def count_active_trigger_sessions():
@@ -189,7 +190,15 @@ class FakeDb:
             self.next_id += 1
             return self.next_id
 
+        async def comments_scanned_at():
+            return self.comment_mark
+
+        async def mark_comments_scanned(moment):
+            self.comment_mark = moment
+
         for name, fn in [
+            ("comments_scanned_at", comments_scanned_at),
+            ("mark_comments_scanned", mark_comments_scanned),
             ("count_active_trigger_sessions", count_active_trigger_sessions),
             ("handled_trigger_refs", handled_trigger_refs),
             ("list_workspaces", list_workspaces),
@@ -567,6 +576,132 @@ class TestCommentWindow:
         # state; comments are a stream, and without a bound the first pass
         # after a restart would read years of them.
         assert timedelta(hours=12) <= triggers.COMMENT_LOOKBACK <= timedelta(days=2)
+
+
+class TestTheCommentMark:
+    """Where the comment scan got to, kept across stops.
+
+    A question asked while the runner is paused has to still be there when
+    it comes back: nothing else remembers it. An assignment or a review is
+    read from the repository's current state on every pass, but a comment
+    older than the window is simply gone.
+    """
+
+    async def test_a_finished_pass_records_how_far_it_got(self, monkeypatch):
+        FakeRepo().install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.comment_mark is not None
+
+    async def test_a_stopped_runner_forgets_nothing(self, monkeypatch):
+        FakeRepo(assigned_issues=[issue(812)]).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        async def paused():
+            return {"mode": "paused", "mode_reason": "incident", "max_parallel": None, "updated_by": "tobias"}
+
+        monkeypatch.setattr(controls.db, "get_controls", paused)
+        controls.forget()
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        # Moving the mark here would drop every question asked during the
+        # pause out of the window before anyone could answer it.
+        assert fake_db.comment_mark is None
+
+    async def test_work_left_for_the_next_pass_holds_the_mark(self, monkeypatch):
+        FakeRepo(assigned_issues=[issue(812), issue(813)]).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+        ceiling(monkeypatch, 1)
+
+        queued = await triggers.TriggerPoller().poll_once()
+
+        assert len(queued) == 1
+        assert fake_db.comment_mark is None
+
+    async def test_the_window_starts_where_the_last_pass_stopped(self, monkeypatch):
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        now = datetime.now(timezone.utc)
+        fake_db.comment_mark = now - timedelta(days=3)
+
+        window = await triggers.TriggerPoller()._comment_window(now)
+
+        # Three days beyond the ordinary lookback, because that is how long
+        # the runner was down and those questions are still unanswered.
+        assert window == fake_db.comment_mark
+
+    async def test_a_long_absence_does_not_wake_up_to_a_month_of_talk(self, monkeypatch):
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        now = datetime.now(timezone.utc)
+        fake_db.comment_mark = now - timedelta(days=90)
+
+        window = await triggers.TriggerPoller()._comment_window(now)
+
+        assert window == now - triggers.MAX_COMMENT_LOOKBACK
+
+    async def test_without_a_mark_the_ordinary_window_applies(self, monkeypatch):
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        now = datetime.now(timezone.utc)
+
+        assert await triggers.TriggerPoller()._comment_window(now) == now - triggers.COMMENT_LOOKBACK
+
+
+class TestWhatTheUiIsTold:
+    def test_the_quota_shown_is_the_one_in_force(self):
+        # An operator who lowers the ceiling to 2 and still reads "up to 6"
+        # on the page has been told a number that decides nothing.
+        lowered = triggers.poller.status(2)["max_active_sessions"]
+        configured = triggers.poller.status()["max_active_sessions"]
+
+        assert lowered <= 2
+        assert lowered <= configured
+
+
+class TestReactions:
+    """What a person sees on the thread they wrote in."""
+
+    async def test_a_queued_request_is_acknowledged(self, monkeypatch):
+        repo = FakeRepo(assigned_issues=[issue(812)])
+        repo.install(monkeypatch)
+        FakeDb().install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert repo.reactions == [(f"/repos/{REPO}/issues/812", triggers.github.REACTION_QUEUED)]
+
+    async def test_nothing_is_acknowledged_that_was_not_queued(self, monkeypatch):
+        # The reaction is a promise that the work is in the queue: a refused
+        # session must not leave one behind.
+        repo = FakeRepo(assigned_issues=[issue(812)])
+        repo.install(monkeypatch)
+        FakeDb().install(monkeypatch)
+        allow_models(monkeypatch, ok=False)
+
+        assert await triggers.TriggerPoller().poll_once() == []
+        assert repo.reactions == []
+
+    async def test_the_session_carries_where_to_react_next(self, monkeypatch):
+        # The later stages are reacted to by the launcher, in another
+        # process and possibly after a restart.
+        FakeRepo(assigned_issues=[issue(812)]).install(monkeypatch)
+        fake_db = FakeDb()
+        fake_db.install(monkeypatch)
+        allow_models(monkeypatch)
+
+        await triggers.TriggerPoller().poll_once()
+
+        assert fake_db.created[0]["reaction_target"] == f"/repos/{REPO}/issues/812"
 
 
 class TestReviewRouting:

--- a/logos/logos-ui/src/app/core/services/agent.service.ts
+++ b/logos/logos-ui/src/app/core/services/agent.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import {
   AgentCapacity,
+  AgentControls,
   AgentEvent,
   AgentModels,
   AgentSession,
@@ -89,5 +90,20 @@ export class AgentService {
   /** Whether the runner reacts to the repository on its own. */
   getTriggers(): Promise<AgentTriggers> {
     return firstValueFrom(this.http.get<AgentTriggers>(`${AgentService.BASE}/triggers`));
+  }
+
+  /** The kill switch and the parallel ceiling, as they stand. */
+  getControls(): Promise<AgentControls> {
+    return firstValueFrom(this.http.get<AgentControls>(`${AgentService.BASE}/controls`));
+  }
+
+  /** Stop the runner, release it, or change how much of the platform it uses. */
+  setControls(body: {
+    mode?: 'running' | 'draining' | 'paused';
+    reason?: string;
+    max_parallel?: number | null;
+    clear_max_parallel?: boolean;
+  }): Promise<AgentControls> {
+    return firstValueFrom(this.http.post<AgentControls>(`${AgentService.BASE}/controls`, body));
   }
 }

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -128,13 +128,16 @@
           min="0"
           max="100"
           [placeholder]="String(ctl.max_parallel_configured)"
-          [ngModel]="ctl.max_parallel_override"
-          (ngModelChange)="applyLimit($event === null ? '' : String($event))"
+          [ngModel]="limitDraft()"
+          (ngModelChange)="limitDraft.set($event === null ? '' : String($event))"
+          (blur)="applyLimit(limitDraft())"
+          (keydown.enter)="applyLimit(limitDraft())"
           [disabled]="controlBusy()"
           aria-label="How many sessions may run at once"
         />
         <span class="field__hint">
-          Empty uses the configured {{ ctl.max_parallel_configured }}. Zero drains without pausing.
+          Applied when you leave the field. Empty uses the configured
+          {{ ctl.max_parallel_configured }}; zero drains without pausing.
         </span>
       </label>
     </section>

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -61,6 +61,85 @@
     }
   }
 
+  <!-- ── Runner controls ───────────────────────────────────────────────────── -->
+  @if (controls(); as ctl) {
+    <section class="controls" [class.controls--stopped]="ctl.mode !== 'running'">
+      <div class="controls__state">
+        <i
+          class="pi"
+          [class.pi-play-circle]="ctl.mode === 'running'"
+          [class.pi-hourglass]="ctl.mode === 'draining'"
+          [class.pi-pause-circle]="ctl.mode === 'paused'"
+          aria-hidden="true"
+        ></i>
+        <span>{{ modeLabel() }}</span>
+        @if (ctl.mode_reason) {
+          <span class="field__hint"
+            >{{ ctl.mode_reason }}{{ ctl.updated_by ? ' — ' + ctl.updated_by : '' }}</span
+          >
+        }
+      </div>
+
+      <div class="controls__actions">
+        @if (ctl.mode !== 'running') {
+          <button class="btn" (click)="setMode('running')" [disabled]="controlBusy()">
+            Resume
+          </button>
+        }
+        @if (ctl.mode !== 'draining') {
+          <button
+            class="btn"
+            (click)="setMode('draining')"
+            [disabled]="controlBusy()"
+            title="Start nothing new; let what is running finish"
+          >
+            Stop new sessions
+          </button>
+        }
+        @if (ctl.mode !== 'paused') {
+          <button
+            class="btn btn--danger"
+            (click)="setMode('paused')"
+            [disabled]="controlBusy()"
+            title="Pause everything and hand the capacity back now"
+          >
+            Pause everything
+          </button>
+        }
+      </div>
+
+      <label class="controls__field">
+        <span class="field__label">Reason <span class="field__optional">(optional)</span></span>
+        <input
+          class="input"
+          type="text"
+          placeholder="what is going on"
+          [ngModel]="pauseReason()"
+          (ngModelChange)="pauseReason.set($event)"
+          aria-label="Reason for stopping the runner"
+        />
+      </label>
+
+      <label class="controls__field">
+        <span class="field__label">Sessions at once</span>
+        <input
+          class="input input--narrow"
+          type="number"
+          min="0"
+          max="100"
+          [placeholder]="String(ctl.max_parallel_configured)"
+          [ngModel]="ctl.max_parallel_override"
+          (ngModelChange)="applyLimit($event === null ? '' : String($event))"
+          [disabled]="controlBusy()"
+          aria-label="How many sessions may run at once"
+        />
+        <span class="field__hint">
+          Empty uses the configured {{ ctl.max_parallel_configured }}. Zero drains without pausing.
+        </span>
+      </label>
+    </section>
+  }
+
   @if (error(); as message) {
     <div class="alert alert--error" role="alert">{{ message }}</div>
   }
@@ -253,6 +332,15 @@
             <div>
               <dt>Model</dt>
               <dd>{{ session.model ?? 'runner default' }}</dd>
+            </div>
+            <div>
+              <dt>Priority</dt>
+              <dd>
+                {{ session.priority }}
+                @if (session.priority_reason) {
+                  <span class="field__hint">{{ session.priority_reason }}</span>
+                }
+              </dd>
             </div>
             <div>
               <dt>Branch</dt>

--- a/logos/logos-ui/src/app/features/agents/agents.scss
+++ b/logos/logos-ui/src/app/features/agents/agents.scss
@@ -440,3 +440,45 @@
     padding: 0.5rem 0;
   }
 }
+
+/* ── Runner controls ──────────────────────────────────────────────────────── */
+.controls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  border: 1px solid rgb(var(--color-outline-200));
+  border-radius: 10px;
+  padding: 1rem;
+  background: rgb(var(--color-background-50));
+  margin-bottom: 1.25rem;
+
+  &--stopped {
+    border-color: rgb(var(--color-warning));
+  }
+
+  &__state {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: var(--font-weight-semibold);
+    color: rgb(var(--color-typography-700));
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    grid-column: 1 / -1;
+  }
+}
+
+.input--narrow {
+  max-width: 8rem;
+}

--- a/logos/logos-ui/src/app/features/agents/agents.spec.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.spec.ts
@@ -4,6 +4,7 @@ import { AgentService } from '../../core/services/agent.service';
 import {
   ACTIVE_SESSION_STATUSES,
   AgentCapacity,
+  AgentControls,
   AgentModels,
   AgentSession,
   AgentTriggers,
@@ -41,6 +42,8 @@ const makeSession = (overrides: Partial<AgentSession> = {}): AgentSession => ({
   screenshot_count: 0,
   trigger_kind: null,
   trigger_ref: null,
+  priority: 50,
+  priority_reason: null,
   ...overrides,
 });
 
@@ -83,6 +86,19 @@ class FakeAgentService {
       default: 'local-model',
       local_only: true,
       detail: 'one local model',
+    };
+  }
+
+  async getControls(): Promise<AgentControls> {
+    return {
+      mode: 'running',
+      mode_reason: '',
+      paused: false,
+      admits_new_sessions: true,
+      max_parallel: 10,
+      max_parallel_override: null,
+      max_parallel_configured: 10,
+      updated_by: '',
     };
   }
 

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -12,6 +12,8 @@ import { FormsModule } from '@angular/forms';
 import { AgentService } from '../../core/services/agent.service';
 import {
   AgentCapacity,
+  AgentControls,
+  AgentRunnerMode,
   AgentEvent,
   AgentModels,
   AgentSession,
@@ -46,6 +48,8 @@ export class Agents implements OnInit {
   capacity = signal<AgentCapacity | null>(null);
   models = signal<AgentModels | null>(null);
   triggers = signal<AgentTriggers | null>(null);
+  controls = signal<AgentControls | null>(null);
+  controlBusy = signal(false);
   loading = signal(true);
   error = signal<string | null>(null);
 
@@ -71,6 +75,7 @@ export class Agents implements OnInit {
   formError = signal<string | null>(null);
 
   newWorkspaceName = signal('');
+  pauseReason = signal('');
   creatingWorkspace = signal(false);
 
   readonly workspaceOptions = computed<AppSelectOption[]>(() =>
@@ -156,6 +161,58 @@ export class Agents implements OnInit {
       this.capacity.set(await this.agentService.getCapacity());
     } catch {
       this.capacity.set(null);
+    }
+    // Read with the capacity, not with the list: an operator who paused the
+    // runner wants to see it paused on the next tick, not on the next
+    // manual refresh.
+    try {
+      this.controls.set(await this.agentService.getControls());
+    } catch {
+      this.controls.set(null);
+    }
+  }
+
+  /**
+   * Run, drain, or pause. Draining starts nothing new and lets what is
+   * running finish; pausing hands everything back at once.
+   */
+  async setMode(mode: AgentRunnerMode): Promise<void> {
+    if (this.controlBusy()) return;
+    this.controlBusy.set(true);
+    try {
+      const reason = mode === 'running' ? '' : this.pauseReason().trim();
+      this.controls.set(await this.agentService.setControls({ mode, reason }));
+      await this.refresh({ quiet: true });
+    } catch (err: unknown) {
+      this.error.set(this.messageOf(err, 'Could not change the runner controls.'));
+    } finally {
+      this.controlBusy.set(false);
+    }
+  }
+
+  readonly modeLabel = computed(() => {
+    const mode = this.controls()?.mode;
+    if (mode === 'paused') return 'Paused — everything handed back';
+    if (mode === 'draining') return 'Draining — no new sessions';
+    return 'Running';
+  });
+
+  /** Change how many sessions may run at once, from now on. */
+  async applyLimit(value: string): Promise<void> {
+    if (this.controlBusy()) return;
+    const trimmed = value.trim();
+    this.controlBusy.set(true);
+    try {
+      const body =
+        trimmed === ''
+          ? { clear_max_parallel: true }
+          : { max_parallel: Math.max(0, Math.min(100, Number(trimmed))) };
+      this.controls.set(await this.agentService.setControls(body));
+      await this.refresh({ quiet: true });
+    } catch (err: unknown) {
+      this.error.set(this.messageOf(err, 'Could not change the session limit.'));
+    } finally {
+      this.controlBusy.set(false);
     }
   }
 

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -76,6 +76,8 @@ export class Agents implements OnInit {
 
   newWorkspaceName = signal('');
   pauseReason = signal('');
+  /** What is typed in the limit field, until it is applied. */
+  limitDraft = signal('');
   creatingWorkspace = signal(false);
 
   readonly workspaceOptions = computed<AppSelectOption[]>(() =>
@@ -166,7 +168,12 @@ export class Agents implements OnInit {
     // runner wants to see it paused on the next tick, not on the next
     // manual refresh.
     try {
-      this.controls.set(await this.agentService.getControls());
+      const state = await this.agentService.getControls();
+      this.controls.set(state);
+      if (!this.controlBusy()) {
+        this.limitDraft.set(String(state.max_parallel_override ?? ''));
+        this.pauseReason.set(state.mode_reason);
+      }
     } catch {
       this.controls.set(null);
     }
@@ -181,7 +188,11 @@ export class Agents implements OnInit {
     this.controlBusy.set(true);
     try {
       const reason = mode === 'running' ? '' : this.pauseReason().trim();
-      this.controls.set(await this.agentService.setControls({ mode, reason }));
+      const state = await this.agentService.setControls({ mode, reason });
+      this.controls.set(state);
+      // Follow the server: after a resume the reason is gone, and a later
+      // pause must not silently send the old one again.
+      this.pauseReason.set(state.mode_reason);
       await this.refresh({ quiet: true });
     } catch (err: unknown) {
       this.error.set(this.messageOf(err, 'Could not change the runner controls.'));
@@ -197,17 +208,34 @@ export class Agents implements OnInit {
     return 'Running';
   });
 
-  /** Change how many sessions may run at once, from now on. */
+  /**
+   * Change how many sessions may run at once, from now on.
+   *
+   * Called when the field is left or Enter is pressed, never on each
+   * keystroke: submitting per character disables the input mid-number, so
+   * "25" could not be typed at all.
+   */
   async applyLimit(value: string): Promise<void> {
     if (this.controlBusy()) return;
     const trimmed = value.trim();
+    let body: { max_parallel?: number; clear_max_parallel?: boolean };
+    if (trimmed === '') {
+      body = { clear_max_parallel: true };
+    } else {
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed)) {
+        // Nothing to send: an unparseable field is a typo, not an
+        // instruction, and null would silently mean "no change".
+        this.limitDraft.set(String(this.controls()?.max_parallel_override ?? ''));
+        return;
+      }
+      body = { max_parallel: Math.max(0, Math.min(100, Math.round(parsed))) };
+    }
     this.controlBusy.set(true);
     try {
-      const body =
-        trimmed === ''
-          ? { clear_max_parallel: true }
-          : { max_parallel: Math.max(0, Math.min(100, Number(trimmed))) };
-      this.controls.set(await this.agentService.setControls(body));
+      const state = await this.agentService.setControls(body);
+      this.controls.set(state);
+      this.limitDraft.set(String(state.max_parallel_override ?? ''));
       await this.refresh({ quiet: true });
     } catch (err: unknown) {
       this.error.set(this.messageOf(err, 'Could not change the session limit.'));

--- a/logos/logos-ui/src/app/shared/models/agent.model.ts
+++ b/logos/logos-ui/src/app/shared/models/agent.model.ts
@@ -45,6 +45,9 @@ export interface AgentSession {
   trigger_kind: string | null;
   /** Which event it reacted to, e.g. 'issue-812'. */
   trigger_ref: string | null;
+  /** How urgent the work is (higher runs first), and why. */
+  priority: number;
+  priority_reason: string | null;
 }
 
 export interface AgentEvent {
@@ -69,6 +72,23 @@ export interface AgentCapacity {
   /** False when the agent key could reach a cloud model: nothing starts. */
   models_local_only: boolean;
   models_detail: string;
+}
+
+/** What an operator has changed about the runner while it runs. */
+export type AgentRunnerMode = 'running' | 'draining' | 'paused';
+
+export interface AgentControls {
+  /** running: as configured · draining: nothing new · paused: hand it all back. */
+  mode: AgentRunnerMode;
+  mode_reason: string;
+  paused: boolean;
+  admits_new_sessions: boolean;
+  /** The ceiling in force right now. */
+  max_parallel: number;
+  /** Null when the deployment's configured ceiling applies. */
+  max_parallel_override: number | null;
+  max_parallel_configured: number;
+  updated_by: string;
 }
 
 /** The locally served models a session may be driven by. */

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- What an operator can change about the agent runner while it runs.
+
+         The environment configures a deployment; this configures a moment.
+         Stopping the automation and lowering the parallel ceiling are things
+         somebody needs during an incident, from the page they are already
+         looking at — not by editing an `.env` on a host and restarting a
+         service that is in the middle of ten sessions.
+
+         One row, because there is one runner per deployment. The mode is
+         the kill switch, and it has two halves that are genuinely
+         different: `draining` stops new sessions while the ones already
+         running finish, `paused` hands everything back to the platform at
+         once. `max_parallel` is null when the environment's value stands.
+         All of it survives a restart, which is the point: a runner that
+         forgets it was stopped is not stopped. -->
+    <changeSet id="021-agent-controls" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="agent_controls"/></not>
+        </preConditions>
+        <sql><![CDATA[
+            CREATE TABLE agent_controls (
+                id SMALLINT PRIMARY KEY DEFAULT 1,
+                -- running:  work as configured
+                -- draining: start nothing new; what runs, runs to the end
+                -- paused:   hand everything back to the platform now
+                mode TEXT NOT NULL DEFAULT 'running',
+                mode_reason TEXT,
+                max_parallel INTEGER,
+                updated_by TEXT,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+                CONSTRAINT agent_controls_single_row CHECK (id = 1),
+                CONSTRAINT agent_controls_mode_known
+                    CHECK (mode IN ('running', 'draining', 'paused')),
+                CONSTRAINT agent_controls_max_parallel_sane
+                    CHECK (max_parallel IS NULL OR (max_parallel >= 0 AND max_parallel <= 100))
+            );
+
+            INSERT INTO agent_controls (id) VALUES (1) ON CONFLICT DO NOTHING;
+        ]]></sql>
+        <rollback>
+            <sql>DROP TABLE IF EXISTS agent_controls;</sql>
+        </rollback>
+    </changeSet>
+
+    <!-- How urgent a session's work is, and where it came from.
+
+         Sessions are admitted one per capacity reading, so the order they
+         are admitted in is the only thing that decides what the platform
+         works on first while it is busy. A security fix waiting behind a
+         documentation typo is the whole problem: priority is read from the
+         labels the repository already uses and kept on the row, so the
+         admission query can order by it instead of by arrival. -->
+    <changeSet id="021-agent-session-priority" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_sessions" columnName="priority"/></not>
+        </preConditions>
+        <sql><![CDATA[
+            ALTER TABLE agent_sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 50;
+            ALTER TABLE agent_sessions ADD COLUMN priority_reason TEXT;
+
+            -- The admission query asks for the most urgent queued session,
+            -- oldest first among equals.
+            DROP INDEX IF EXISTS idx_agent_sessions_status_created;
+            CREATE INDEX idx_agent_sessions_queue_order
+                ON agent_sessions(status, priority DESC, created_at);
+        ]]></sql>
+        <rollback>
+            <sql><![CDATA[
+                DROP INDEX IF EXISTS idx_agent_sessions_queue_order;
+                CREATE INDEX idx_agent_sessions_status_created
+                    ON agent_sessions(status, created_at);
+                ALTER TABLE agent_sessions DROP COLUMN IF EXISTS priority_reason;
+                ALTER TABLE agent_sessions DROP COLUMN IF EXISTS priority;
+            ]]></sql>
+        </rollback>
+    </changeSet>
+
+    <!-- Workspaces the runner made for itself, and may therefore remove.
+
+         A workspace is a Docker volume holding a working copy. One created
+         for a piece of triggered work has no meaning once that work is
+         done, and left behind they accumulate until the parallel ceiling is
+         full of checkouts nobody is using. An operator's workspace is
+         different: they made it, they keep it. -->
+    <changeSet id="021-agent-workspace-ephemeral" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_workspaces" columnName="ephemeral"/></not>
+        </preConditions>
+        <sql><![CDATA[
+            ALTER TABLE agent_workspaces ADD COLUMN ephemeral BOOLEAN NOT NULL DEFAULT FALSE;
+        ]]></sql>
+        <rollback>
+            <sql>ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS ephemeral;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
@@ -83,22 +83,40 @@
         </rollback>
     </changeSet>
 
-    <!-- Workspaces the runner made for itself, and may therefore remove.
+    <!-- Workspaces the runner made for itself, and the resource it reclaims.
 
-         A workspace is a Docker volume holding a working copy. One created
-         for a piece of triggered work has no meaning once that work is
-         done, and left behind they accumulate until the parallel ceiling is
-         full of checkouts nobody is using. An operator's workspace is
-         different: they made it, they keep it. -->
+         A workspace is two things: a row, and a Docker volume holding a
+         working copy. Only the volume is worth reclaiming — the row is what
+         the finished sessions hang off (`agent_sessions.workspace_id` is ON
+         DELETE CASCADE), and deleting it would take their events, their
+         trigger references and their pending replies with it. The history
+         would go, and with the trigger references gone, work that is still
+         assigned would be queued all over again.
+
+         So a swept workspace is *archived*: its volume is removed, its row
+         stays, and it stops counting towards the parallel ceiling. The name
+         stays reserved, which is what lets the same issue revive its
+         workspace later instead of colliding with it. -->
     <changeSet id="021-agent-workspace-ephemeral" author="logos">
         <preConditions onFail="MARK_RAN">
             <not><columnExists tableName="agent_workspaces" columnName="ephemeral"/></not>
         </preConditions>
         <sql><![CDATA[
             ALTER TABLE agent_workspaces ADD COLUMN ephemeral BOOLEAN NOT NULL DEFAULT FALSE;
+            ALTER TABLE agent_workspaces ADD COLUMN archived_at TIMESTAMPTZ;
+
+            -- The sweep asks for ephemeral workspaces that are not archived
+            -- yet; the admission side asks for the ones that still exist.
+            CREATE INDEX idx_agent_workspaces_live
+                ON agent_workspaces(archived_at)
+             WHERE archived_at IS NULL;
         ]]></sql>
         <rollback>
-            <sql>ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS ephemeral;</sql>
+            <sql><![CDATA[
+                DROP INDEX IF EXISTS idx_agent_workspaces_live;
+                ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS archived_at;
+                ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS ephemeral;
+            ]]></sql>
         </rollback>
     </changeSet>
 

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/021_agent_controls.xml
@@ -33,6 +33,12 @@
                 mode TEXT NOT NULL DEFAULT 'running',
                 mode_reason TEXT,
                 max_parallel INTEGER,
+                -- How far the comment scan has got. Assignments and reviews
+                -- are read from the repository's current state, but comments
+                -- are a stream: without a mark, a question asked while the
+                -- runner was stopped would fall out of the lookback window
+                -- and never be answered.
+                comments_scanned_at TIMESTAMPTZ,
                 updated_by TEXT,
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -117,6 +123,24 @@
                 ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS archived_at;
                 ALTER TABLE agent_workspaces DROP COLUMN IF EXISTS ephemeral;
             ]]></sql>
+        </rollback>
+    </changeSet>
+
+    <!-- Where a session reacts, so a person can see where their request is.
+
+         A reaction is the cheapest status there is: it appears on the
+         comment somebody wrote, needs no notification, and says whether the
+         request is waiting or being worked on. The queueing pass knows the
+         thing that was reacted to, but the launch happens minutes later in
+         another process — so the target is kept on the row rather than in
+         the poller's memory, and survives a restart with it. -->
+    <changeSet id="021-agent-session-reaction-target" author="logos">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="agent_sessions" columnName="reaction_target"/></not>
+        </preConditions>
+        <sql>ALTER TABLE agent_sessions ADD COLUMN reaction_target TEXT;</sql>
+        <rollback>
+            <sql>ALTER TABLE agent_sessions DROP COLUMN IF EXISTS reaction_target;</sql>
         </rollback>
     </changeSet>
 

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -23,5 +23,6 @@
     <include file="liquibase/changelog/017_provider_performance.xml"/>
     <include file="liquibase/changelog/018_model_aliases.xml"/>
     <include file="liquibase/changelog/020_agent_sessions.xml"/>
+    <include file="liquibase/changelog/021_agent_controls.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Five things an operator needs from a service that works on its own, and one error message that was a Docker status code.

## A stop with two halves

"Stop" means two different things depending on what is wrong, so the kill switch has both:

| Control | What it does |
|---|---|
| **Stop new sessions** (draining) | Nothing new starts. What is running finishes, and a paused session may still resume. |
| **Pause everything** | Running sessions are paused on the next pass and the capacity goes back to the platform. |
| **Sessions at once** | A ceiling for now, overriding the configured one. Zero drains without pausing. |

Neither stop cancels anything: going back to running resumes the work mid-task. All of it lives in the database rather than the environment, because these are needed *during* something — an incident, a deploy — and editing an `.env` on a host to restart a service that is mid-session is not what anybody wants to be doing then. It survives a restart, since a runner that forgets it was stopped is not stopped, and the reason and the person who set it are shown to whoever finds it stopped.

## A queue ordered by urgency

A session is admitted per capacity reading, so queue order *is* what the platform works on while it is busy. Arrival order was the wrong answer to that — a security fix waiting behind a documentation typo is the failure this prevents.

Urgency comes from what kind of work it is (a review holds a pull request shut, a question has somebody waiting, a fresh issue has neither) and from the labels the repository already uses: `security fix` to the top, `documentation` down. `blocked`, `wontfix`, `invalid`, `duplicate` and `stale` are not urgency but an answer — that work is not picked up at all, and the log says which label stopped it. The mapping is one table in `app/priority.py`.

## Workspaces that say what they hold, and then go away

`auto-2` told nobody anything, and stayed forever. Workspaces the runner creates are now named after their work — `issue-812-oom-on-startup`, which is also what appears in the branch (`logos/agent/issue-812-oom-on-startup/session-42`) — and are removed together with their Docker volumes once that work is finished. An operator's own workspaces are never touched. A ten-minute grace covers the gap between a session being queued into a fresh workspace and being claimed.

## A missing image, said in words

A session died with `launch failed: docker api 404: No such image: …/logos-agent-workspace:latest`, which reads like a broken runner rather than an artefact the registry has not published yet. The launch now checks first and says which image is missing, where it comes from, and what to do about it.

## What a new colleague would be told

Every generated task now carries the conventions this repository actually holds work to — commit style, no issue numbers in code comments or test names, check each review point against the *current* code, a regression test must fail before the fix, run the tests and linters you touched, write on GitHub in English, never merge, never force-push over somebody else's commits, and say plainly what you left out when the budget runs short.

Each of those lines is a review round somebody already spent. There is a second block, added only to tasks that read the GitHub API, for the traps that cost the most time: listings answer oldest-first and ignore `direction`, review ids and comment ids are separate sequences, a fresh comment can 404 for a minute, and `-f body=@file` posts the literal string `@file`.

## Verification

284 agent tests (46 new: the two stop modes, the ceiling, urgency and refusal labels, workspace naming and sweeping, the image check, and that every task carries the conventions), 107 UI tests, pre-commit clean, UI production build clean.

Schema: `021_agent_controls.xml` — the controls row, the priority columns with the queue-order index, and the ephemeral flag on workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLK1R5FwY2LnG5LeHnnWAb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runner controls to stop new sessions, pause active work, and set a maximum number of parallel sessions.
  - Added session urgency indicators and queue ordering based on work type and labels.
  - Added descriptive, automatically managed workspaces for runner-created tasks.
  - Added clear reporting when the required session image is unavailable.

- **Documentation**
  - Documented runner controls, workspace behavior, and work-priority rules, including labels that prevent work from being picked up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->