### PR TITLE
`Logos`: Stop the runner from pausing itself, and leave it more room

### DIFF
--- a/.github/workflows/logos_deploy-dev.yml
+++ b/.github/workflows/logos_deploy-dev.yml
@@ -55,10 +55,23 @@ jobs:
 
       - name: Create .env file
         run: |
+          # Checked before it is written anywhere: this comes from whoever
+          # dispatched the workflow, and a value carrying a newline would
+          # add lines of its own to a file every later step reads as
+          # configuration. Matched with `case` rather than a regular
+          # expression because that is line-based, and a newline is exactly
+          # what has to be caught.
+          case "$WORKSPACE_IMAGE_TAG" in
+            "" | *[!A-Za-z0-9._-]* | [!A-Za-z0-9_]* )
+              echo "image-tag is not a Docker tag" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#WORKSPACE_IMAGE_TAG}" -gt 128 ]; then
+            echo "image-tag is too long for a Docker tag" >&2
+            exit 1
+          fi
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          # Through the environment and quoted: the tag comes from whoever
-          # dispatched the workflow, and a shell line built by substitution
-          # is a shell line they get to help write.
           echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 

--- a/.github/workflows/logos_deploy-dev.yml
+++ b/.github/workflows/logos_deploy-dev.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Create .env file
         run: |
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          echo "IMAGE_TAG=${{ inputs.image-tag }}" >> .env
+          # Through the environment and quoted: the tag comes from whoever
+          # dispatched the workflow, and a shell line built by substitution
+          # is a shell line they get to help write.
+          echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 
           echo "$SECRETS_CONTEXT" | jq -r '
@@ -88,6 +91,7 @@ jobs:
         env:
           VARS_CONTEXT: ${{ toJson(vars) }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          WORKSPACE_IMAGE_TAG: ${{ inputs.image-tag || 'latest' }}
 
       - name: Copy .env file to VM
         uses: appleboy/scp-action@v1.0.0

--- a/.github/workflows/logos_deploy-prod.yml
+++ b/.github/workflows/logos_deploy-prod.yml
@@ -66,10 +66,23 @@ jobs:
 
       - name: Create .env file
         run: |
+          # Checked before it is written anywhere: this comes from whoever
+          # dispatched the workflow, and a value carrying a newline would
+          # add lines of its own to a file every later step reads as
+          # configuration. Matched with `case` rather than a regular
+          # expression because that is line-based, and a newline is exactly
+          # what has to be caught.
+          case "$WORKSPACE_IMAGE_TAG" in
+            "" | *[!A-Za-z0-9._-]* | [!A-Za-z0-9_]* )
+              echo "image-tag is not a Docker tag" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#WORKSPACE_IMAGE_TAG}" -gt 128 ]; then
+            echo "image-tag is too long for a Docker tag" >&2
+            exit 1
+          fi
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          # Through the environment and quoted: the tag comes from whoever
-          # dispatched the workflow, and a shell line built by substitution
-          # is a shell line they get to help write.
           echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 

--- a/.github/workflows/logos_deploy-prod.yml
+++ b/.github/workflows/logos_deploy-prod.yml
@@ -67,7 +67,10 @@ jobs:
       - name: Create .env file
         run: |
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          echo "IMAGE_TAG=${{ inputs.image-tag || 'latest' }}" >> .env
+          # Through the environment and quoted: the tag comes from whoever
+          # dispatched the workflow, and a shell line built by substitution
+          # is a shell line they get to help write.
+          echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 
           echo "$SECRETS_CONTEXT" | jq -r '
@@ -99,6 +102,7 @@ jobs:
         env:
           VARS_CONTEXT: ${{ toJson(vars) }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          WORKSPACE_IMAGE_TAG: ${{ inputs.image-tag || 'latest' }}
 
       - name: Copy .env file to VM
         uses: appleboy/scp-action@v1.0.0

--- a/.github/workflows/logos_deploy-test.yml
+++ b/.github/workflows/logos_deploy-test.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Create .env file
         run: |
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          echo "IMAGE_TAG=${{ inputs.image-tag }}" >> .env
+          # Through the environment and quoted: the tag comes from whoever
+          # dispatched the workflow, and a shell line built by substitution
+          # is a shell line they get to help write.
+          echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 
           echo "$SECRETS_CONTEXT" | jq -r '
@@ -85,6 +88,7 @@ jobs:
         env:
           VARS_CONTEXT: ${{ toJson(vars) }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          WORKSPACE_IMAGE_TAG: ${{ inputs.image-tag || 'latest' }}
 
       - name: Copy .env file to VM
         uses: appleboy/scp-action@v1.0.0

--- a/.github/workflows/logos_deploy-test.yml
+++ b/.github/workflows/logos_deploy-test.yml
@@ -52,10 +52,23 @@ jobs:
 
       - name: Create .env file
         run: |
+          # Checked before it is written anywhere: this comes from whoever
+          # dispatched the workflow, and a value carrying a newline would
+          # add lines of its own to a file every later step reads as
+          # configuration. Matched with `case` rather than a regular
+          # expression because that is line-based, and a newline is exactly
+          # what has to be caught.
+          case "$WORKSPACE_IMAGE_TAG" in
+            "" | *[!A-Za-z0-9._-]* | [!A-Za-z0-9_]* )
+              echo "image-tag is not a Docker tag" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#WORKSPACE_IMAGE_TAG}" -gt 128 ]; then
+            echo "image-tag is too long for a Docker tag" >&2
+            exit 1
+          fi
           echo "ENVIRONMENT=${{ matrix.environment }}" > .env
-          # Through the environment and quoted: the tag comes from whoever
-          # dispatched the workflow, and a shell line built by substitution
-          # is a shell line they get to help write.
           echo "IMAGE_TAG=$WORKSPACE_IMAGE_TAG" >> .env
           echo "REGISTRY=${{ vars.LOGOS_HARBOR_REGISTRY }}/logos" >> .env
 

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -63,6 +63,17 @@ session is never resumed into a permission it no longer has. The **queue** is
 deliberately not filtered — models share GPUs, so a person waiting on any of
 them is a person this runner gets out of the way of.
 
+**Minus its own share.** The orchestrator reports how busy a model is; it
+does not report *who* is keeping it busy, and nothing in its payload could
+say. So the runner subtracts itself: a running session has at most one
+request outstanding, either being served or waiting for a slot, and that
+many are taken off the figures before anything is decided. Without it a
+runner reads its own sessions as user traffic — it pauses itself for them,
+the load it reacted to leaves with them, it resumes, and it does it again —
+and its own sessions queueing read as "users are queueing", which is the
+signal that means stop everything. A real user waiting still shows, and
+still stops it.
+
 | Condition | What happens |
 |---|---|
 | load < `START_BELOW_LOAD` (default 60 %) and no queue | queued sessions may start |
@@ -349,8 +360,12 @@ answered twice. Only the *newest* changes-requested review of a pull request
 counts as work; the older ones were answered by it. A session that failed is
 re-queued by a person, who can see why it failed.
 
-**Bounded.** At most half the parallel ceiling may be self-queued sessions,
-so an operator queueing work by hand always finds room. Bots are ignored:
+**Bounded.** Self-queued sessions may use the parallel ceiling less a couple
+of places kept for people, so an operator queueing work by hand always finds
+room — triggered sessions carry higher priorities and would otherwise win
+every slot. Keeping half the fleet idle for a session nobody has asked for
+is the wrong trade on a platform whose point is spending what would go to
+waste. Bots are ignored:
 their findings reach the agent through the next review, not as a session per
 note. Workspaces are created on demand up to the ceiling, since a session the
 runner queued has nobody to prepare a working copy for it.

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -360,12 +360,13 @@ answered twice. Only the *newest* changes-requested review of a pull request
 counts as work; the older ones were answered by it. A session that failed is
 re-queued by a person, who can see why it failed.
 
-**Bounded.** Self-queued sessions may use the parallel ceiling less a couple
-of places kept for people, so an operator queueing work by hand always finds
-room — triggered sessions carry higher priorities and would otherwise win
-every slot. Keeping half the fleet idle for a session nobody has asked for
-is the wrong trade on a platform whose point is spending what would go to
-waste. Bots are ignored:
+**Bounded.** Self-queued sessions may *run* up to the parallel ceiling less a
+fifth of it, at least one place, kept for people — triggered sessions carry
+higher priorities and would otherwise win every slot. Keeping half the fleet
+idle for a session nobody has asked for is the wrong trade on a platform
+whose point is spending what would go to waste. What does not fit runs
+later: it is queued, in priority order, and visible as work waiting rather
+than left in the repository where nobody sees it. Bots are ignored:
 their findings reach the agent through the next review, not as a session per
 note. Workspaces are created on demand up to the ceiling, since a session the
 runner queued has nobody to prepare a working copy for it.

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -63,16 +63,24 @@ session is never resumed into a permission it no longer has. The **queue** is
 deliberately not filtered — models share GPUs, so a person waiting on any of
 them is a person this runner gets out of the way of.
 
-**Minus its own share.** The orchestrator reports how busy a model is; it
-does not report *who* is keeping it busy, and nothing in its payload could
-say. So the runner subtracts itself: a running session has at most one
-request outstanding, either being served or waiting for a slot, and that
-many are taken off the figures before anything is decided. Without it a
-runner reads its own sessions as user traffic — it pauses itself for them,
-the load it reacted to leaves with them, it resumes, and it does it again —
-and its own sessions queueing read as "users are queueing", which is the
-signal that means stop everything. A real user waiting still shows, and
-still stops it.
+**Minus its own share, where that is the right question.** The orchestrator
+reports how busy a model is; it does not report *who* is keeping it busy,
+and nothing in its payload could say. So the runner estimates: a running
+session has at most one request outstanding, per model, and that many come
+off the figures.
+
+Whether to *hand capacity back* is a question about other people, so it is
+decided on that adjusted figure. Without it a runner reads its own sessions
+as user traffic — it pauses itself for them, the load it reacted to leaves
+with them, it resumes, and it does it again — and its own sessions queueing
+read as "users are queueing", the signal that means stop everything. A real
+user waiting still shows, and still stops it.
+
+Whether to *take more on* is a question about the model, and the estimate is
+an upper bound: a running session may be between turns, running tests,
+making no request at all. Subtracting too much there would add work to a
+lane that is genuinely busy, so admission uses the figure as measured. What
+bounds the runner's own concurrency is the parallel ceiling, not the load.
 
 | Condition | What happens |
 |---|---|

--- a/logos/logos-agent/README.md
+++ b/logos/logos-agent/README.md
@@ -181,6 +181,14 @@ survive a restart, and both are visible to whoever finds the runner stopped.
 
 ## What gets worked on first
 
+An operator can overrule it. The queue on the page carries three controls on
+every session waiting in it — to the front, up one, down one — because the
+order is what the runner works through while the platform is busy, and
+which review is holding up a release is something the person watching knows
+and the rules do not. A move past a session of equal priority goes one above
+it: ties are broken by age, and nothing can make a session older.
+
+
 A session is admitted per capacity reading, so the order of the queue is what
 the platform actually works on while it is busy. That order is urgency, not
 arrival: a review (which holds a pull request shut) outranks a question,

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import httpx
 
@@ -179,7 +179,7 @@ def parse_scheduler_state(
     another, and subtracting them there would turn somebody else's busy
     lane into an idle-looking one.
     """
-    mine = {name.strip().lower(): count for name, count in (ours or {}).items()}
+    mine = {str(name).strip().lower(): int(count) for name, count in (ours or {}).items()}
     if lane is not None and not lane:
         # A key that reaches no local deployment has no lane to measure and
         # nothing it could legitimately run on. Refusing here rather than
@@ -310,6 +310,35 @@ def parse_scheduler_state(
         queue_total=queue_total,
         ok=True,
         detail=f"{busy}/{total} slots busy{lane_note}",
+    )
+
+
+def without_our_own(reading: Reading, ours: Mapping[str, int]) -> Reading:
+    """The reading again, with this runner's own requests taken out.
+
+    A convenience over re-reading the platform: the per-model discount lives
+    in :func:`parse_scheduler_state`, and this applies it to a reading that
+    was already taken — used where reacting to our own load is the mistake
+    (pausing, resuming) and not where it would flatter us (admitting).
+
+    The count is an estimate. A running session may be between turns with no
+    request outstanding at all, so this is an upper bound on what is ours:
+    right for deciding not to pause, wrong for deciding to add more.
+    """
+    total_ours = sum(max(0, count) for count in (ours or {}).values())
+    if total_ours <= 0 or not reading.ok:
+        return reading
+    serving = min(total_ours, reading.busy_slots)
+    waiting = min(total_ours - serving, reading.queue_total)
+    if serving == 0 and waiting == 0:
+        return reading
+    busy = reading.busy_slots - serving
+    return replace(
+        reading,
+        load=(busy / reading.total_slots) if reading.total_slots else reading.load,
+        busy_slots=busy,
+        queue_total=reading.queue_total - waiting,
+        detail=f"{busy}/{reading.total_slots} in flight besides this runner's {total_ours}",
     )
 
 

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 
 import httpx
 
@@ -310,35 +310,6 @@ def parse_scheduler_state(
         queue_total=queue_total,
         ok=True,
         detail=f"{busy}/{total} slots busy{lane_note}",
-    )
-
-
-def without_our_own(reading: Reading, ours: Mapping[str, int]) -> Reading:
-    """The reading again, with this runner's own requests taken out.
-
-    A convenience over re-reading the platform: the per-model discount lives
-    in :func:`parse_scheduler_state`, and this applies it to a reading that
-    was already taken — used where reacting to our own load is the mistake
-    (pausing, resuming) and not where it would flatter us (admitting).
-
-    The count is an estimate. A running session may be between turns with no
-    request outstanding at all, so this is an upper bound on what is ours:
-    right for deciding not to pause, wrong for deciding to add more.
-    """
-    total_ours = sum(max(0, count) for count in (ours or {}).values())
-    if total_ours <= 0 or not reading.ok:
-        return reading
-    serving = min(total_ours, reading.busy_slots)
-    waiting = min(total_ours - serving, reading.queue_total)
-    if serving == 0 and waiting == 0:
-        return reading
-    busy = reading.busy_slots - serving
-    return replace(
-        reading,
-        load=(busy / reading.total_slots) if reading.total_slots else reading.load,
-        busy_slots=busy,
-        queue_total=reading.queue_total - waiting,
-        detail=f"{busy}/{reading.total_slots} in flight besides this runner's {total_ours}",
     )
 
 

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -199,7 +199,8 @@ def parse_scheduler_state(
     # Counted per model as well as in total: a lane holding a saturated
     # model and an idle one is not half busy — a session bound for the
     # saturated one has nowhere to go, and the average would hide that.
-    per_model: dict[str, list[int]] = {}
+    # Per model, not per deployment: busy, waiting, capacity, cache.
+    per_model: dict[str, list[float]] = {}
     providers = ((payload.get("logosnode") or {}).get("providers")) or {}
 
     busy = 0
@@ -222,28 +223,35 @@ def parse_scheduler_state(
                 continue
             name = str(model.get("model_name") or model_id)
             active, waiting, cache = _live(model, capacity)
-            # Ours come off this model's figures, from what is *running*
-            # first. The other way round empties the queue on the assumption
-            # that our sessions are the ones waiting — and a queue that
-            # reads as empty is the signal that a user is not waiting, which
-            # is the one thing worth being wrong about in the safe
-            # direction.
-            ours_here = mine.get(name.strip().lower(), 0)
-            ours_serving = min(ours_here, active)
-            ours_waiting = min(ours_here - ours_serving, waiting)
-            active -= ours_serving
-            waiting -= ours_waiting
-            queue_total += waiting
             fleet_total += capacity
             fleet_busy += active
             if wanted and (str(provider_id), str(model_id)) not in wanted:
+                # Still counted towards the queue: somebody waiting on a
+                # deployment we cannot reach is somebody waiting.
+                queue_total += waiting
                 continue
             total += capacity
-            busy += active
-            slots = per_model.setdefault(name, [0, 0, 0.0])
+            slots = per_model.setdefault(name, [0, 0, 0, 0.0])
             slots[0] += active
-            slots[1] += capacity
-            slots[2] = max(slots[2], cache)
+            slots[1] += waiting
+            slots[2] += capacity
+            slots[3] = max(slots[3], cache)
+
+    # Ours come off each model *once*, after its deployments are added up:
+    # the same model served by three providers is one lane, and subtracting
+    # the same sessions from each of them would erase three times what this
+    # runner is doing. From what is *running* before what is waiting, too —
+    # the other way round empties the queue on the assumption that our
+    # sessions are the ones waiting, and a queue that reads as empty is the
+    # signal that no user is waiting.
+    for name, slots in per_model.items():
+        ours_here = mine.get(name.strip().lower(), 0)
+        ours_serving = min(ours_here, slots[0])
+        ours_waiting = min(ours_here - ours_serving, slots[1])
+        slots[0] -= ours_serving
+        slots[1] -= ours_waiting
+        busy += slots[0]
+        queue_total += slots[1]
 
     fell_back = False
     if wanted and total == 0 and fleet_total > 0:
@@ -271,9 +279,9 @@ def parse_scheduler_state(
         # The busiest of them decides. Being kept out of an idle model
         # because another is full costs this runner some capacity; letting a
         # session into a full one costs a user their turn.
-        name, (model_busy, model_total, cache) = max(
+        name, (model_busy, _model_waiting, model_total, cache) = max(
             per_model.items(),
-            key=lambda item: (max((item[1][0] / item[1][1]) if item[1][1] else 0.0, item[1][2])),
+            key=lambda item: (max((item[1][0] / item[1][2]) if item[1][2] else 0.0, item[1][3])),
         )
         where = f" on {name}" if len(per_model) > 1 else ""
         detail = f"{model_busy}/{model_total} requests in flight{where}"

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -104,6 +104,44 @@ async def read_load(timeout_s: float = 5.0, lane: frozenset[tuple[str, str]] | N
     return parse_scheduler_state(payload, lane=lane)
 
 
+def _live(model: dict, capacity: int) -> tuple[int, int, float]:
+    """What a model is really doing: in flight, waiting, and how full it is.
+
+    The engine's own numbers where it reports them, the orchestrator's
+    ledger only as a fallback. They disagree in production — a lane the
+    ledger counted as serving two requests reported none running and an
+    empty KV cache — and the ledger is the one that cannot see inside vLLM.
+
+    The third figure is the one that matters most and has no slot count in
+    it at all: the KV cache. A model can be three requests into a
+    twenty-request allowance and still have no room for a fourth, because
+    concurrency there is bounded by cache, not by a number in a
+    configuration file. Whichever of the two is worse is the pressure.
+    """
+    signals = model.get("scheduler_signals") or {}
+    if not isinstance(signals, dict):
+        signals = {}
+
+    def number(*keys: str) -> float | None:
+        for key in keys:
+            value = signals.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+        return None
+
+    running = number("requests_running_current")
+    ledger_active = float(model.get("active") or 0)
+    active = int(min(running if running is not None else ledger_active, capacity))
+
+    waiting = number("queue_waiting_current")
+    queue = int(waiting if waiting is not None else float(model.get("queue_depth") or 0))
+
+    cache = number("gpu_cache_usage_percent_max", "gpu_cache_usage_percent_avg")
+    by_slots = (active / capacity) if capacity else 0.0
+    pressure = max(by_slots, (cache or 0.0) / 100.0)
+    return active, queue, pressure
+
+
 def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None = None) -> Reading:
     """Turn the orchestrator's debug payload into a single load figure.
 
@@ -157,8 +195,8 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
             capacity = int(model.get("max_capacity") or 0)
             if capacity <= 0:
                 continue
-            active = min(int(model.get("active") or 0), capacity)
-            queue_total += int(model.get("queue_depth") or 0)
+            active, waiting, pressure = _live(model, capacity)
+            queue_total += waiting
             fleet_total += capacity
             fleet_busy += active
             if wanted and (str(provider_id), str(model_id)) not in wanted:
@@ -166,9 +204,10 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
             total += capacity
             busy += active
             name = str(model.get("model_name") or model_id)
-            slots = per_model.setdefault(name, [0, 0])
+            slots = per_model.setdefault(name, [0, 0, 0.0])
             slots[0] += active
             slots[1] += capacity
+            slots[2] = max(slots[2], pressure)
 
     fell_back = False
     if wanted and total == 0 and fleet_total > 0:
@@ -192,20 +231,24 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
             reclaimable=False,
         )
 
-    if wanted and not fell_back and len(per_model) > 1:
+    if wanted and not fell_back and per_model:
         # The busiest of them decides. Being kept out of an idle model
         # because another is full costs this runner some capacity; letting a
         # session into a full one costs a user their turn.
-        name, (model_busy, model_total) = max(
-            per_model.items(), key=lambda item: (item[1][0] / item[1][1]) if item[1][1] else 0.0
-        )
+        name, (model_busy, model_total, pressure) = max(per_model.items(), key=lambda item: item[1][2])
+        where = f" on {name}" if len(per_model) > 1 else ""
+        detail = f"{model_busy}/{model_total} requests in flight{where}"
+        if model_total and pressure > (model_busy / model_total):
+            # The KV cache is what actually fills up: a model can be at
+            # three of twenty requests and still have no room for a fourth.
+            detail = f"{pressure:.0%} of the KV cache in use{where} ({model_busy} requests in flight)"
         return Reading(
-            load=model_busy / model_total,
+            load=min(pressure, 1.0),
             busy_slots=model_busy,
             total_slots=model_total,
             queue_total=queue_total,
             ok=True,
-            detail=f"{model_busy}/{model_total} slots busy on {name}, the busiest model this runner may use",
+            detail=detail,
         )
 
     if not wanted:

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -30,7 +30,8 @@ is a different thing entirely, and fails closed.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, replace
+from collections.abc import Mapping
+from dataclasses import dataclass
 
 import httpx
 
@@ -49,6 +50,12 @@ class Reading:
     queue_total: int
     ok: bool  # False when the orchestrator could not be read
     detail: str = ""
+    # How full the engine's KV cache is on the model this reading is about.
+    # Kept apart from `load` because it cannot be attributed: the cache does
+    # not say whose tokens are in it. Starting more work on a model whose
+    # cache is nearly full is a bad idea whoever filled it — pausing what is
+    # already running because *we* filled it is how a runner starves itself.
+    cache_pressure: float = 0.0
     # False when no model is loaded anywhere: an empty fleet has no idle
     # capacity to spend, so there is nothing for the runner to reclaim.
     # Warming a lane in that situation is a different product decision, and
@@ -60,12 +67,21 @@ class Reading:
         return self.queue_total > 0 or self.load >= 1.0
 
 
+# How full a model's KV cache may be before the runner stops adding to it.
+# Not a pause threshold: the cache does not say whose tokens are in it, and
+# a runner that pauses for its own context never finishes anything.
+CACHE_FULL = 0.9
+
 # When the orchestrator cannot be reached we must not assume the platform is
 # idle: the safe failure mode for a scavenger is to stop scavenging.
 UNKNOWN = Reading(load=1.0, busy_slots=0, total_slots=0, queue_total=0, ok=False, detail="orchestrator unreachable")
 
 
-async def read_load(timeout_s: float = 5.0, lane: frozenset[tuple[str, str]] | None = None) -> Reading:
+async def read_load(
+    timeout_s: float = 5.0,
+    lane: frozenset[tuple[str, str]] | None = None,
+    ours: Mapping[str, int] | None = None,
+) -> Reading:
     """Ask the orchestrator how busy the serving lane we would use is.
 
     ``lane`` holds the (provider id, model id) pairs the runner's key can be
@@ -101,7 +117,7 @@ async def read_load(timeout_s: float = 5.0, lane: frozenset[tuple[str, str]] | N
         logger.warning("capacity read failed: %s", exc)
         return UNKNOWN
 
-    return parse_scheduler_state(payload, lane=lane)
+    return parse_scheduler_state(payload, lane=lane, ours=ours)
 
 
 def _live(model: dict, capacity: int) -> tuple[int, int, float]:
@@ -116,7 +132,7 @@ def _live(model: dict, capacity: int) -> tuple[int, int, float]:
     it at all: the KV cache. A model can be three requests into a
     twenty-request allowance and still have no room for a fourth, because
     concurrency there is bounded by cache, not by a number in a
-    configuration file. Whichever of the two is worse is the pressure.
+    configuration file.
     """
     signals = model.get("scheduler_signals") or {}
     if not isinstance(signals, dict):
@@ -137,12 +153,14 @@ def _live(model: dict, capacity: int) -> tuple[int, int, float]:
     queue = int(waiting if waiting is not None else float(model.get("queue_depth") or 0))
 
     cache = number("gpu_cache_usage_percent_max", "gpu_cache_usage_percent_avg")
-    by_slots = (active / capacity) if capacity else 0.0
-    pressure = max(by_slots, (cache or 0.0) / 100.0)
-    return active, queue, pressure
+    return active, queue, (cache or 0.0) / 100.0
 
 
-def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None = None) -> Reading:
+def parse_scheduler_state(
+    payload: dict,
+    lane: frozenset[tuple[str, str]] | None = None,
+    ours: Mapping[str, int] | None = None,
+) -> Reading:
     """Turn the orchestrator's debug payload into a single load figure.
 
     Kept separate from the HTTP call so it can be tested against recorded
@@ -154,7 +172,14 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
     queue is deliberately *not* narrowed: models share GPUs, so a person
     waiting on any of them is a person this runner should get out of the way
     of.
+
+    ``ours`` is how many sessions this runner is running *per model*, and it
+    is subtracted from that model before anything is compared. Per model
+    rather than in total: five sessions on one model say nothing about
+    another, and subtracting them there would turn somebody else's busy
+    lane into an idle-looking one.
     """
+    mine = {name.strip().lower(): count for name, count in (ours or {}).items()}
     if lane is not None and not lane:
         # A key that reaches no local deployment has no lane to measure and
         # nothing it could legitimately run on. Refusing here rather than
@@ -195,7 +220,19 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
             capacity = int(model.get("max_capacity") or 0)
             if capacity <= 0:
                 continue
-            active, waiting, pressure = _live(model, capacity)
+            name = str(model.get("model_name") or model_id)
+            active, waiting, cache = _live(model, capacity)
+            # Ours come off this model's figures, from what is *running*
+            # first. The other way round empties the queue on the assumption
+            # that our sessions are the ones waiting — and a queue that
+            # reads as empty is the signal that a user is not waiting, which
+            # is the one thing worth being wrong about in the safe
+            # direction.
+            ours_here = mine.get(name.strip().lower(), 0)
+            ours_serving = min(ours_here, active)
+            ours_waiting = min(ours_here - ours_serving, waiting)
+            active -= ours_serving
+            waiting -= ours_waiting
             queue_total += waiting
             fleet_total += capacity
             fleet_busy += active
@@ -203,11 +240,10 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
                 continue
             total += capacity
             busy += active
-            name = str(model.get("model_name") or model_id)
             slots = per_model.setdefault(name, [0, 0, 0.0])
             slots[0] += active
             slots[1] += capacity
-            slots[2] = max(slots[2], pressure)
+            slots[2] = max(slots[2], cache)
 
     fell_back = False
     if wanted and total == 0 and fleet_total > 0:
@@ -235,18 +271,20 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
         # The busiest of them decides. Being kept out of an idle model
         # because another is full costs this runner some capacity; letting a
         # session into a full one costs a user their turn.
-        name, (model_busy, model_total, pressure) = max(per_model.items(), key=lambda item: item[1][2])
+        name, (model_busy, model_total, cache) = max(
+            per_model.items(),
+            key=lambda item: (max((item[1][0] / item[1][1]) if item[1][1] else 0.0, item[1][2])),
+        )
         where = f" on {name}" if len(per_model) > 1 else ""
         detail = f"{model_busy}/{model_total} requests in flight{where}"
-        if model_total and pressure > (model_busy / model_total):
-            # The KV cache is what actually fills up: a model can be at
-            # three of twenty requests and still have no room for a fourth.
-            detail = f"{pressure:.0%} of the KV cache in use{where} ({model_busy} requests in flight)"
+        if cache:
+            detail += f", {cache:.0%} of its KV cache in use"
         return Reading(
-            load=min(pressure, 1.0),
+            load=(model_busy / model_total) if model_total else 0.0,
             busy_slots=model_busy,
             total_slots=model_total,
             queue_total=queue_total,
+            cache_pressure=cache,
             ok=True,
             detail=detail,
         )
@@ -264,42 +302,6 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
         queue_total=queue_total,
         ok=True,
         detail=f"{busy}/{total} slots busy{lane_note}",
-    )
-
-
-def without_our_own(reading: Reading, running_sessions: int) -> Reading:
-    """The same reading, minus what this runner is doing to it.
-
-    The orchestrator reports how busy a model is; it does not report *who*
-    is keeping it busy, and there is nothing in its payload that could say.
-    So a runner with three sessions in flight reads its own three requests
-    as platform load and pauses itself for them — and once paused the load
-    it was reacting to disappears, so it resumes, and does it again. Worse,
-    its own sessions queueing read as "users are queueing", which is the
-    signal that means *stop everything*.
-
-    A running session has at most one request outstanding, either being
-    served or waiting for a slot. Subtracting that many — from the queue
-    first, since a request that is waiting is not being served — leaves what
-    everybody else is doing, which is the number every decision here is
-    actually about. A real user waiting still shows, and still stops the
-    runner.
-    """
-    if running_sessions <= 0 or not reading.ok:
-        return reading
-    ours_serving = min(running_sessions, reading.busy_slots)
-    ours_waiting = min(max(running_sessions - ours_serving, 0), reading.queue_total)
-    busy = reading.busy_slots - ours_serving
-    queue = reading.queue_total - ours_waiting
-    if ours_serving == 0 and ours_waiting == 0:
-        return reading
-    detail = f"{busy}/{reading.total_slots} slots busy besides this runner's {running_sessions}"
-    return replace(
-        reading,
-        load=(busy / reading.total_slots) if reading.total_slots else reading.load,
-        busy_slots=busy,
-        queue_total=queue,
-        detail=detail,
     )
 
 
@@ -326,6 +328,13 @@ def start_decision(reading: Reading, *, running: int, paused: int, max_parallel:
         return False, (
             f"load {reading.load:.0%} is at or above the start threshold " f"{settings.start_below_load:.0%}"
         )
+    if reading.cache_pressure >= CACHE_FULL:
+        # Whoever filled it, there is no room to put another session's
+        # context in: concurrency on a vLLM lane ends at the KV cache, not
+        # at a slot count. Not a reason to *pause* what is already running —
+        # that would be the runner starving itself for its own cache — but
+        # a good reason not to add to it.
+        return False, f"the model's KV cache is {reading.cache_pressure:.0%} full"
     return True, f"load {reading.load:.0%}, {reading.detail}"
 
 

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -221,7 +221,11 @@ def parse_scheduler_state(
             capacity = int(model.get("max_capacity") or 0)
             if capacity <= 0:
                 continue
-            name = str(model.get("model_name") or model_id)
+            # Normalised: the platform is case-insensitive about model
+            # names, and "Qwen" and "qwen" reported by two providers must
+            # not become two pools — the busiest of which would then be one
+            # provider's view of a model, not the model.
+            name = str(model.get("model_name") or model_id).strip().lower()
             active, waiting, cache = _live(model, capacity)
             fleet_total += capacity
             fleet_busy += active
@@ -279,14 +283,20 @@ def parse_scheduler_state(
         # The busiest of them decides. Being kept out of an idle model
         # because another is full costs this runner some capacity; letting a
         # session into a full one costs a user their turn.
-        name, (model_busy, _model_waiting, model_total, cache) = max(
+        # Two "worsts", chosen independently, because the two figures are
+        # used by different decisions and one must not hide the other: a
+        # model at 0% load with a 95% cache would otherwise be picked as the
+        # busiest and then report its 0% load, so the runner would neither
+        # yield to a second model at 90% nor keep its paused work asleep.
+        name, (model_busy, _model_waiting, model_total, _cache) = max(
             per_model.items(),
-            key=lambda item: (max((item[1][0] / item[1][2]) if item[1][2] else 0.0, item[1][3])),
+            key=lambda item: ((item[1][0] / item[1][2]) if item[1][2] else 0.0),
         )
+        cache = max(slots[3] for slots in per_model.values())
         where = f" on {name}" if len(per_model) > 1 else ""
         detail = f"{model_busy}/{model_total} requests in flight{where}"
         if cache:
-            detail += f", {cache:.0%} of its KV cache in use"
+            detail += f", {cache:.0%} of a KV cache in use"
         return Reading(
             load=(model_busy / model_total) if model_total else 0.0,
             busy_slots=model_busy,

--- a/logos/logos-agent/app/capacity.py
+++ b/logos/logos-agent/app/capacity.py
@@ -30,7 +30,7 @@ is a different thing entirely, and fails closed.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import httpx
 
@@ -221,6 +221,42 @@ def parse_scheduler_state(payload: dict, lane: frozenset[tuple[str, str]] | None
         queue_total=queue_total,
         ok=True,
         detail=f"{busy}/{total} slots busy{lane_note}",
+    )
+
+
+def without_our_own(reading: Reading, running_sessions: int) -> Reading:
+    """The same reading, minus what this runner is doing to it.
+
+    The orchestrator reports how busy a model is; it does not report *who*
+    is keeping it busy, and there is nothing in its payload that could say.
+    So a runner with three sessions in flight reads its own three requests
+    as platform load and pauses itself for them — and once paused the load
+    it was reacting to disappears, so it resumes, and does it again. Worse,
+    its own sessions queueing read as "users are queueing", which is the
+    signal that means *stop everything*.
+
+    A running session has at most one request outstanding, either being
+    served or waiting for a slot. Subtracting that many — from the queue
+    first, since a request that is waiting is not being served — leaves what
+    everybody else is doing, which is the number every decision here is
+    actually about. A real user waiting still shows, and still stops the
+    runner.
+    """
+    if running_sessions <= 0 or not reading.ok:
+        return reading
+    ours_serving = min(running_sessions, reading.busy_slots)
+    ours_waiting = min(max(running_sessions - ours_serving, 0), reading.queue_total)
+    busy = reading.busy_slots - ours_serving
+    queue = reading.queue_total - ours_waiting
+    if ours_serving == 0 and ours_waiting == 0:
+        return reading
+    detail = f"{busy}/{reading.total_slots} slots busy besides this runner's {running_sessions}"
+    return replace(
+        reading,
+        load=(busy / reading.total_slots) if reading.total_slots else reading.load,
+        busy_slots=busy,
+        queue_total=queue,
+        detail=detail,
     )
 
 

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -836,6 +836,68 @@ async def list_sessions(
     return [dict(r) for r in rows]
 
 
+async def move_in_queue(session_id: int, move: str, *, by: str) -> dict[str, Any] | None:
+    """Put a queued session somewhere else in the queue.
+
+    The order is `priority DESC, created_at` — what the runner works on
+    while the platform is busy — and an operator watching a backlog knows
+    things the priority rules cannot: that this review is holding up a
+    release, that this issue can wait. So they can say so.
+
+    Expressed as a move rather than as a number, because a number invites
+    guessing what the neighbours are. Moving past a session of equal
+    priority means going one above it: ties are broken by age, and nothing
+    here can make a session older.
+
+    Returns the session as it now stands, or None if it is not queued.
+    """
+    if move not in ("up", "down", "first"):
+        raise ValueError(f"unknown move '{move}' (expected up, down or first)")
+    async with sessionmaker()() as db:
+        rows = (
+            (
+                await db.execute(
+                    text(
+                        """
+                    SELECT id, priority FROM agent_sessions
+                     WHERE status = 'queued'
+                     ORDER BY priority DESC, created_at, id
+                     FOR UPDATE
+                    """
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+        order = [dict(row) for row in rows]
+        at = next((index for index, row in enumerate(order) if row["id"] == session_id), None)
+        if at is None:
+            await db.rollback()
+            return None
+        if move == "first":
+            target = max((row["priority"] for row in order), default=50) + 1 if at > 0 else order[at]["priority"]
+        elif move == "up":
+            target = order[at - 1]["priority"] + 1 if at > 0 else order[at]["priority"]
+        else:
+            target = order[at + 1]["priority"] - 1 if at + 1 < len(order) else order[at]["priority"]
+        target = max(0, min(100, target))
+        await db.execute(
+            text(
+                """
+                UPDATE agent_sessions
+                   SET priority = :priority,
+                       priority_reason = :reason
+                 WHERE id = :id AND status = 'queued'
+                """
+            ),
+            {"id": session_id, "priority": target, "reason": f"moved in the queue by {by}"},
+        )
+        row = (await db.execute(text(_SESSION_SELECT + " WHERE s.id = :id"), {"id": session_id})).mappings().first()
+        await db.commit()
+    return dict(row) if row else None
+
+
 async def attempts_for_trigger(ref: str) -> int:
     """How many sessions this one request has already had."""
     if not ref:

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -836,6 +836,29 @@ async def list_sessions(
     return [dict(r) for r in rows]
 
 
+def _renumbered(order: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Priorities that put this list in exactly this order.
+
+    Spread across the range the column allows rather than nudged by one:
+    a queue whose top row is already at the maximum has no room above it,
+    and a move that cannot change the order is a move that did not happen.
+    Only rows whose number actually changes are written.
+    """
+    count = len(order)
+    if count == 0:
+        return []
+    step = max(1, 100 // (count + 1))
+    for index, row in enumerate(order):
+        row["priority"] = max(0, min(100, 100 - (index + 1) * step))
+    return order
+
+
+async def _one_session(session_id: int) -> dict[str, Any] | None:
+    async with sessionmaker()() as db:
+        row = (await db.execute(text(_SESSION_SELECT + " WHERE s.id = :id"), {"id": session_id})).mappings().first()
+    return dict(row) if row else None
+
+
 async def move_in_queue(session_id: int, move: str, *, by: str) -> dict[str, Any] | None:
     """Put a queued session somewhere else in the queue.
 
@@ -875,24 +898,29 @@ async def move_in_queue(session_id: int, move: str, *, by: str) -> dict[str, Any
         if at is None:
             await db.rollback()
             return None
-        if move == "first":
-            target = max((row["priority"] for row in order), default=50) + 1 if at > 0 else order[at]["priority"]
-        elif move == "up":
-            target = order[at - 1]["priority"] + 1 if at > 0 else order[at]["priority"]
-        else:
-            target = order[at + 1]["priority"] - 1 if at + 1 < len(order) else order[at]["priority"]
-        target = max(0, min(100, target))
-        await db.execute(
-            text(
-                """
-                UPDATE agent_sessions
-                   SET priority = :priority,
-                       priority_reason = :reason
-                 WHERE id = :id AND status = 'queued'
-                """
-            ),
-            {"id": session_id, "priority": target, "reason": f"moved in the queue by {by}"},
-        )
+        # The move expressed as a position, so the boundaries cannot swallow
+        # it: at 100 there is no "one above", and clamping would leave the
+        # order exactly as it was while telling the operator it had moved.
+        wanted = {"first": 0, "up": max(at - 1, 0), "down": min(at + 1, len(order) - 1)}[move]
+        if wanted == at:
+            await db.rollback()
+            return await _one_session(session_id)
+        moved = order.pop(at)
+        order.insert(wanted, moved)
+        reason = f"moved in the queue by {by}"
+        for position, row in enumerate(_renumbered(order)):
+            await db.execute(
+                text(
+                    """
+                    UPDATE agent_sessions
+                       SET priority = :priority,
+                           priority_reason = CASE WHEN id = :moved THEN :reason ELSE priority_reason END
+                     WHERE id = :id AND status = 'queued'
+                    """
+                ),
+                {"id": row["id"], "priority": row["priority"], "moved": session_id, "reason": reason},
+            )
+            del position
         row = (await db.execute(text(_SESSION_SELECT + " WHERE s.id = :id"), {"id": session_id})).mappings().first()
         await db.commit()
     return dict(row) if row else None
@@ -957,13 +985,18 @@ async def next_queued_session(*, include_triggered: bool = True) -> dict[str, An
     return dict(row) if row else None
 
 
-async def claim_session(session_id: int) -> dict[str, Any] | None:
+async def claim_session(session_id: int, *, trigger_quota: int | None = None) -> dict[str, Any] | None:
     """Take this exact queued session, or nothing.
 
     Admission measures the lane of the session it intends to start, and the
     peek and the claim are separate statements: in between, that row can be
     cancelled, or a more urgent one on another model can be queued. Claiming
     "the next one" would then start a session whose lane nobody measured.
+
+    ``trigger_quota`` is how many self-queued sessions may be running at
+    once, counted *inside this statement*. Counting it beforehand and
+    claiming afterwards leaves a window in which two schedulers both see
+    room — the automation would then take the places kept for people.
     """
     async with sessionmaker()() as db:
         claimed = (
@@ -978,11 +1011,21 @@ async def claim_session(session_id: int) -> dict[str, Any] | None:
                               WHERE busy.workspace_id = s.workspace_id
                                 AND busy.status = ANY(:occupying)
                            )
+                       AND (
+                             s.trigger_ref IS NULL
+                             OR CAST(:trigger_quota AS INTEGER) IS NULL
+                             OR (
+                                  SELECT COUNT(*) FROM agent_sessions mine
+                                   WHERE mine.trigger_ref IS NOT NULL
+                                     AND mine.status = ANY(:occupying)
+                                ) < CAST(:trigger_quota AS INTEGER)
+                           )
                      FOR UPDATE OF s SKIP LOCKED
                     """
                 ),
                 {
                     "session_id": session_id,
+                    "trigger_quota": trigger_quota,
                     "occupying": [
                         SessionStatus.STARTING.value,
                         SessionStatus.RUNNING.value,

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -762,11 +762,15 @@ async def abandon_reply(session_id: int, *, attempts: int) -> None:
 
 
 async def count_active_trigger_sessions() -> int:
-    """Active sessions the runner queued by itself.
+    """Self-queued sessions that are occupying capacity right now.
 
-    The ceiling this feeds is separate from the parallel-session ceiling: a
-    person asking for work must not find the queue already full of the
-    runner's own ideas.
+    Queued ones are deliberately not counted. The ceiling this feeds is
+    about how much of the platform the automation may be *using*, and a
+    queued session uses nothing — it is a piece of work waiting its turn,
+    which is what a queue is for and what the page shows. Counting the
+    queue against the ceiling meant the runner refused to write down work
+    it had already found, so nothing was ever waiting: the backlog lived in
+    the repository, invisible.
     """
     async with sessionmaker()() as db:
         count = (
@@ -777,7 +781,7 @@ async def count_active_trigger_sessions() -> int:
                      WHERE trigger_ref IS NOT NULL AND status = ANY(:active)
                     """
                 ),
-                {"active": [s.value for s in ACTIVE_STATUSES]},
+                {"active": [s.value for s in ACTIVE_STATUSES if s is not SessionStatus.QUEUED]},
             )
         ).scalar_one()
     return int(count or 0)
@@ -832,7 +836,7 @@ async def list_sessions(
     return [dict(r) for r in rows]
 
 
-async def next_queued_session() -> dict[str, Any] | None:
+async def next_queued_session(*, include_triggered: bool = True) -> dict[str, Any] | None:
     """The session a claim would take next, without taking it.
 
     Admission decides against a capacity reading, and the reading has to be
@@ -850,6 +854,7 @@ async def next_queued_session() -> dict[str, Any] | None:
                     SELECT s.id, s.model, s.workspace_id
                       FROM agent_sessions s
                      WHERE s.status = 'queued'
+                       AND (:include_triggered OR s.trigger_ref IS NULL)
                        AND NOT EXISTS (
                              SELECT 1 FROM agent_sessions busy
                               WHERE busy.workspace_id = s.workspace_id
@@ -860,12 +865,13 @@ async def next_queued_session() -> dict[str, Any] | None:
                     """
                     ),
                     {
+                        "include_triggered": include_triggered,
                         "occupying": [
                             SessionStatus.STARTING.value,
                             SessionStatus.RUNNING.value,
                             SessionStatus.PAUSED.value,
                             SessionStatus.FINALIZING.value,
-                        ]
+                        ],
                     },
                 )
             )
@@ -875,7 +881,7 @@ async def next_queued_session() -> dict[str, Any] | None:
     return dict(row) if row else None
 
 
-async def claim_queued_sessions(limit: int) -> list[dict[str, Any]]:
+async def claim_queued_sessions(limit: int, *, include_triggered: bool = True) -> list[dict[str, Any]]:
     """Take up to `limit` startable queued sessions and mark them starting.
 
     A session is startable only when no other session is already occupying its
@@ -896,6 +902,10 @@ async def claim_queued_sessions(limit: int) -> list[dict[str, Any]]:
                         """
                     SELECT s.id FROM agent_sessions s
                      WHERE s.status = 'queued'
+                       -- The automation may fill the platform, but not the
+                       -- last places in it: with its quota used up, only
+                       -- work a person queued is claimable.
+                       AND (:include_triggered OR s.trigger_ref IS NULL)
                        AND NOT EXISTS (
                              SELECT 1 FROM agent_sessions busy
                               WHERE busy.workspace_id = s.workspace_id
@@ -926,6 +936,7 @@ async def claim_queued_sessions(limit: int) -> list[dict[str, Any]]:
                     ),
                     {
                         "limit": limit,
+                        "include_triggered": include_triggered,
                         "occupying": [
                             SessionStatus.STARTING.value,
                             SessionStatus.RUNNING.value,

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -836,6 +836,20 @@ async def list_sessions(
     return [dict(r) for r in rows]
 
 
+async def attempts_for_trigger(ref: str) -> int:
+    """How many sessions this one request has already had."""
+    if not ref:
+        return 0
+    async with sessionmaker()() as db:
+        count = (
+            await db.execute(
+                text("SELECT COUNT(*) FROM agent_sessions WHERE trigger_ref = :ref"),
+                {"ref": ref},
+            )
+        ).scalar_one()
+    return int(count or 0)
+
+
 async def next_queued_session(*, include_triggered: bool = True) -> dict[str, Any] | None:
     """The session a claim would take next, without taking it.
 
@@ -878,6 +892,57 @@ async def next_queued_session(*, include_triggered: bool = True) -> dict[str, An
             .mappings()
             .first()
         )
+    return dict(row) if row else None
+
+
+async def claim_session(session_id: int) -> dict[str, Any] | None:
+    """Take this exact queued session, or nothing.
+
+    Admission measures the lane of the session it intends to start, and the
+    peek and the claim are separate statements: in between, that row can be
+    cancelled, or a more urgent one on another model can be queued. Claiming
+    "the next one" would then start a session whose lane nobody measured.
+    """
+    async with sessionmaker()() as db:
+        claimed = (
+            await db.execute(
+                text(
+                    """
+                    SELECT s.id FROM agent_sessions s
+                     WHERE s.id = :session_id
+                       AND s.status = 'queued'
+                       AND NOT EXISTS (
+                             SELECT 1 FROM agent_sessions busy
+                              WHERE busy.workspace_id = s.workspace_id
+                                AND busy.status = ANY(:occupying)
+                           )
+                     FOR UPDATE OF s SKIP LOCKED
+                    """
+                ),
+                {
+                    "session_id": session_id,
+                    "occupying": [
+                        SessionStatus.STARTING.value,
+                        SessionStatus.RUNNING.value,
+                        SessionStatus.PAUSED.value,
+                        SessionStatus.FINALIZING.value,
+                    ],
+                },
+            )
+        ).scalar_one_or_none()
+        if claimed is None:
+            await db.rollback()
+            return None
+        await db.execute(
+            text("UPDATE agent_sessions SET status = 'starting' WHERE id = :session_id"),
+            {"session_id": session_id},
+        )
+        row = (
+            (await db.execute(text(_SESSION_SELECT + " WHERE s.id = :session_id"), {"session_id": session_id}))
+            .mappings()
+            .first()
+        )
+        await db.commit()
     return dict(row) if row else None
 
 

--- a/logos/logos-agent/app/db.py
+++ b/logos/logos-agent/app/db.py
@@ -836,6 +836,12 @@ async def list_sessions(
     return [dict(r) for r in rows]
 
 
+# How long a queue can still be put in an exact order using the priority
+# column alone. Beyond it two rows must share a number, and the tie falls to
+# age — which is what a move overrules, so the move would not hold.
+_ORDERABLE = 100
+
+
 def _renumbered(order: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Priorities that put this list in exactly this order.
 
@@ -847,6 +853,12 @@ def _renumbered(order: list[dict[str, Any]]) -> list[dict[str, Any]]:
     count = len(order)
     if count == 0:
         return []
+    if count > _ORDERABLE:
+        # More rows than the column has distinct values: two of them would
+        # share a number and the tie would fall to age, which is the very
+        # thing a move is trying to overrule. The caller refuses instead of
+        # pretending.
+        raise ValueError(f"a queue of {count} cannot be ordered by priority alone")
     step = max(1, 100 // (count + 1))
     for index, row in enumerate(order):
         row["priority"] = max(0, min(100, 100 - (index + 1) * step))
@@ -907,8 +919,13 @@ async def move_in_queue(session_id: int, move: str, *, by: str) -> dict[str, Any
             return await _one_session(session_id)
         moved = order.pop(at)
         order.insert(wanted, moved)
+        try:
+            order = _renumbered(order)
+        except ValueError:
+            await db.rollback()
+            raise
         reason = f"moved in the queue by {by}"
-        for position, row in enumerate(_renumbered(order)):
+        for position, row in enumerate(order):
             await db.execute(
                 text(
                     """
@@ -999,6 +1016,13 @@ async def claim_session(session_id: int, *, trigger_quota: int | None = None) ->
     room — the automation would then take the places kept for people.
     """
     async with sessionmaker()() as db:
+        if trigger_quota is not None:
+            # One admission at a time, across every replica: two schedulers
+            # locking different rows would otherwise both read the same
+            # count of active triggered sessions and both pass the check
+            # below, taking the places kept for people. Held to the end of
+            # this transaction, which is the claim.
+            await db.execute(text("SELECT pg_advisory_xact_lock(hashtext('logos-agent-admission'))"))
         claimed = (
             await db.execute(
                 text(

--- a/logos/logos-agent/app/docker_engine.py
+++ b/logos/logos-agent/app/docker_engine.py
@@ -339,11 +339,17 @@ async def unpause_container(container_id: str) -> bool:
     304 means it was not frozen in the first place, which is the desired
     end state; 404 and 409 mean there is no running container to thaw, and
     the caller must not record the session as running again.
+
+    Docker also answers 500 "Container … is not paused" for a container
+    that is running — the same situation as 304, reported differently, and
+    in production it escaped as an exception that killed the whole
+    scheduler pass. A container that is already running is what the caller
+    asked for.
     """
     try:
         await _request("POST", f"/containers/{container_id}/unpause")
     except DockerError as exc:
-        if exc.status == 304:
+        if exc.status == 304 or (exc.status == 500 and "is not paused" in str(exc)):
             return True
         if exc.status in (404, 409):
             return False

--- a/logos/logos-agent/app/github.py
+++ b/logos/logos-agent/app/github.py
@@ -333,7 +333,11 @@ async def _get_all_bounded(path: str, params: dict[str, Any] | None = None) -> t
         page = len(collected) // _PAGE_SIZE + 1
         payload = await _get(path, {**(params or {}), "per_page": _PAGE_SIZE, "page": page})
         if not isinstance(payload, list):
-            return collected, False
+            # A 200 that is not a list is not an empty listing: something
+            # answered, and it was not this endpoint. Reported as incomplete
+            # rather than as "nothing more to read".
+            logger.info("listing %s answered with %s, not a list", path, type(payload).__name__)
+            return collected, True
         collected.extend(payload)
         if len(payload) < _PAGE_SIZE:
             return collected, False

--- a/logos/logos-agent/app/main.py
+++ b/logos/logos-agent/app/main.py
@@ -28,6 +28,7 @@ from .schemas import (
     ControlState,
     ControlUpdate,
     EventKind,
+    QueueMove,
     SessionCreate,
     SessionEvent,
     SessionStatus,
@@ -414,6 +415,32 @@ async def retry_session(session_id: int, principal: Principal = Depends(require_
     created = await db.get_session(new_id)
     assert created is not None
     return SessionSummary(**_summary_fields(created))
+
+
+@app.post("/sessions/{session_id}/queue", response_model=SessionSummary, tags=["sessions"])
+async def move_session_in_queue(
+    session_id: int,
+    body: QueueMove,
+    principal: Principal = Depends(require_agent_operator),
+) -> SessionSummary:
+    """Move a queued session up, down, or to the front.
+
+    Priority is derived from what a request is — a review outranks a fresh
+    issue, a security label outranks a typo — and that is right most of the
+    time. An operator watching the backlog knows the rest: which review is
+    holding up a release, which issue can wait until tomorrow.
+    """
+    try:
+        moved = await db.move_in_queue(session_id, body.move, by=principal.username or "an operator")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if moved is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only a queued session can be moved in the queue",
+        )
+    logger.info("session %s moved %s in the queue by %s", session_id, body.move, principal.username)
+    return SessionSummary(**_summary_fields(moved))
 
 
 @app.get("/sessions/{session_id}/events", response_model=list[SessionEvent], tags=["sessions"])

--- a/logos/logos-agent/app/model_policy.py
+++ b/logos/logos-agent/app/model_policy.py
@@ -93,12 +93,24 @@ class ModelPolicy:
     # The same, split by the model they serve, so a reading can be taken on
     # the one model a session will actually use.
     deployments_by_model: Mapping[str, frozenset[tuple[str, str]]] = field(default_factory=dict)
+    # Every name a model answers to, mapped to the one the scheduler calls
+    # it. A session can be created with an alias; the platform's own
+    # figures are keyed by the canonical name, and a count under the wrong
+    # key is a count that matches nothing.
+    canonical_names: Mapping[str, str] = field(default_factory=dict)
     ok: bool = False
     detail: str = "model policy not evaluated yet"
     # Set when the policy could not be established at all (no database, no
     # key). Distinguished from a clean 'nothing reachable' so the UI and the
     # logs can say which it was.
     unknown: bool = True
+
+    def canonical(self, model: str | None) -> str:
+        """What the scheduler calls this model, whatever name was used."""
+        wanted = (model or "").strip().lower()
+        if not wanted:
+            return ""
+        return self.canonical_names.get(wanted, model or "")
 
     def lane(self, model: str | None = None) -> frozenset[tuple[str, str]] | None:
         """The deployments a session of this runner would be served by.
@@ -218,7 +230,7 @@ def classify(rows: Iterable[dict[str, Any]]) -> tuple[frozenset[str], frozenset[
 
 def _deployments_of(
     rows: Iterable[dict[str, Any]], local_names: frozenset[str]
-) -> tuple[frozenset[tuple[str, str]], dict[str, frozenset[tuple[str, str]]]]:
+) -> tuple[frozenset[tuple[str, str]], dict[str, frozenset[tuple[str, str]]], dict[str, str]]:
     """The (provider, model) pairs behind the locally served names.
 
     Keyed the way the scheduler's own payload is keyed, so a load reading
@@ -227,6 +239,7 @@ def _deployments_of(
     """
     pairs: set[tuple[str, str]] = set()
     per_model: dict[str, set[tuple[str, str]]] = {}
+    canonical: dict[str, str] = {}
     for row in rows:
         if not is_local_provider_type(row.get("provider_type")):
             continue
@@ -240,9 +253,11 @@ def _deployments_of(
         pairs.add(pair)
         # Under every name the model answers to, so a lane can be asked for
         # by whatever name a session was created with.
+        served = str(row.get("model_name") or names[0])
         for name in names:
             per_model.setdefault(name, set()).add(pair)
-    return frozenset(pairs), {name: frozenset(found) for name, found in per_model.items()}
+            canonical.setdefault(name, served)
+    return frozenset(pairs), {name: frozenset(found) for name, found in per_model.items()}, canonical
 
 
 def evaluate(rows: Iterable[dict[str, Any]]) -> ModelPolicy:
@@ -269,13 +284,14 @@ def evaluate(rows: Iterable[dict[str, Any]]) -> ModelPolicy:
             unknown=False,
             detail="the agent key reaches no locally served model, so there is nothing a session could be driven by",
         )
-    deployments, by_model = _deployments_of(rows, local)
+    deployments, by_model, canonical = _deployments_of(rows, local)
     return ModelPolicy(
         local_models=local,
         cloud_models=frozenset(),
         offered=offered,
         local_deployments=deployments,
         deployments_by_model=by_model,
+        canonical_names=canonical,
         ok=True,
         unknown=False,
         detail=f"{len(offered)} locally served model(s) reachable, no cloud provider",

--- a/logos/logos-agent/app/schemas.py
+++ b/logos/logos-agent/app/schemas.py
@@ -163,6 +163,17 @@ class SessionSummary(BaseModel):
     priority_reason: str | None = None
 
 
+class QueueMove(BaseModel):
+    """Where an operator wants a queued session to sit.
+
+    A move rather than a number: the order is what the runner works on
+    while the platform is busy, and picking a number means guessing what
+    the neighbours are.
+    """
+
+    move: str = Field(pattern="^(up|down|first)$")
+
+
 class SessionEvent(BaseModel):
     id: int
     session_id: int

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -641,8 +641,9 @@ class SessionManager:
             # in it: with its quota used up, only work a person queued is
             # claimable. The quota is about what is *running*, so the
             # backlog behind it stays queued and visible.
+            quota = triggers.max_active_sessions(control.max_parallel)
             triggered = await db.count_active_trigger_sessions()
-            include_triggered = triggered < triggers.max_active_sessions(control.max_parallel)
+            include_triggered = triggered < quota
             candidate = await db.next_queued_session(include_triggered=include_triggered)
             if candidate is None:
                 return
@@ -670,7 +671,11 @@ class SessionManager:
             # peek and here the candidate can be cancelled, or something
             # more urgent on another model can arrive, and either would be
             # started against a reading of somebody else's lane.
-            taken = await db.claim_session(int(candidate["id"]))
+            # The quota is checked again inside the claim, against a count
+            # taken in the same statement: this one was read before the
+            # capacity call above, and another scheduler could have used the
+            # room in between.
+            taken = await db.claim_session(int(candidate["id"]), trigger_quota=quota)
             claimed = [taken] if taken else []
             # The claim is what makes these rows this pass's to launch, so
             # the launch record is taken here rather than inside _launch:
@@ -1442,6 +1447,22 @@ class SessionManager:
 
     # --- settlement -------------------------------------------------------
 
+    @staticmethod
+    async def _may_try_again(session: dict[str, Any]) -> bool:
+        """Whether this request has attempts left at all.
+
+        Distinguishes "the replacement failed to be created" from "this
+        request has had its three goes": the first is worth waiting for, the
+        second would keep a settled session owing an answer forever.
+        """
+        ref = str(session.get("trigger_ref") or "")
+        if not ref:
+            return False
+        try:
+            return await db.attempts_for_trigger(ref) < _MAX_ATTEMPTS_PER_REQUEST
+        except Exception:
+            return False
+
     async def take_up_again(self, session: dict[str, Any], *, by: str = "the runner") -> int | None:
         """Queue this session's work once more, from where it came from.
 
@@ -1763,8 +1784,15 @@ class SessionManager:
             # with again, quietly, and the thread hears from the attempt
             # that has something to report.
             logger.info("session %s left no answer; taking the work up again instead of saying so", session_id)
+            replacement = await self.take_up_again(session or {})
+            if replacement is None and await self._may_try_again(session or {}):
+                # The replacement could not be created — a database that
+                # blinked, not a decision. Left owing an answer, so the next
+                # sweep tries again: abandoning it first is how a request
+                # disappears between two failures.
+                logger.info("session %s could not be taken up again yet; leaving it owing an answer", session_id)
+                return
             await db.abandon_reply(session_id, attempts=_MAX_REPLY_ATTEMPTS)
-            await self.take_up_again(session or {})
             return
         if len(body) > _MAX_REPLY_CHARS:
             # GitHub refuses a comment above its length limit outright, and

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -578,6 +578,7 @@ class SessionManager:
                 # before the loop would resume all four and put the runner
                 # over the ceiling an operator just set.
                 live = len(running)
+                woken = 0
                 for session in paused:
                     if live >= control.max_parallel:
                         logger.info(
@@ -586,7 +587,12 @@ class SessionManager:
                             control.max_parallel,
                         )
                         break
-                    await self._resume(session, why)
+                    if not await self._resume(session, why):
+                        # It stayed paused, or it was settled because its
+                        # container had gone. Either way it took no capacity
+                        # and the pass has not spent its turn on it.
+                        continue
+                    woken += 1
                     live += 1
                     # Re-read after each one, and through the same discount:
                     # the session just resumed is this runner's, and a
@@ -600,7 +606,11 @@ class SessionManager:
                     self._last_reading = reading
                     if not capacity.resume_decision(reading)[0]:
                         break
-            return  # resume before admitting anything new
+                if woken:
+                    return  # resume before admitting anything new
+            elif paused and not may_resume:
+                # Held back for a reason that applies to admission too.
+                return
 
         # 3. Admit queued work — at most one session per fresh capacity
         #    reading, taken *inside* the admission lock. A session creation
@@ -708,10 +718,20 @@ class SessionManager:
             # released when the upstream request finishes on its own.
             logger.warning("could not detach paused session %s from the session network: %s", session_id, exc)
 
-    async def _resume(self, session: dict[str, Any], reason: str) -> None:
+    async def _resume(self, session: dict[str, Any], reason: str) -> bool:
+        """Thaw a paused session. Returns whether it is running again."""
         sid, container_id = session["id"], session.get("container_id")
         if not container_id:
-            return
+            return False
+        if not await self._container_exists(container_id):
+            # Gone while it was paused — removed by a person, or swept with
+            # the host. There is nothing to thaw and nothing to wait for:
+            # left paused it would be retried every fifteen seconds forever,
+            # and it holds a workspace and a place in the queue while it
+            # does.
+            logger.warning("session %s was paused and its container is gone; settling it", sid)
+            await self._settle(sid, exit_code=None, error="the container disappeared while the session was paused")
+            return False
         # Attach first: a session thawed without its network would fail on
         # its next model call, which is worse than staying paused one more
         # tick.
@@ -719,16 +739,33 @@ class SessionManager:
             attached = await docker_engine.connect_network(settings.session_network, container_id)
         except Exception as exc:
             logger.error("could not reattach session %s to the session network: %s", sid, exc)
-            return
+            return False
         if not attached:
             logger.error("session %s could not be reattached to the session network; leaving it paused", sid)
-            return
+            return False
         if not await docker_engine.unpause_container(container_id):
             logger.info("session %s could not be resumed; its container is not running", sid)
-            return
+            return False
         if await db.transition_session(sid, SessionStatus.RUNNING):
             await db.add_event(sid, EventKind.CAPACITY, {"decision": "resume", "reason": reason})
             logger.info("resumed session %s: %s", sid, reason)
+            return True
+        return False
+
+    @staticmethod
+    async def _container_exists(container_id: str) -> bool:
+        """Whether Docker still has this container.
+
+        Unknown counts as present: a daemon that cannot be asked is not
+        evidence that a session's container is gone, and settling a live
+        session on a failed question would throw its work away.
+        """
+        try:
+            state, _ = await docker_engine.container_state(container_id)
+        except Exception as exc:
+            logger.info("could not ask about container %s: %s", container_id, exc)
+            return True
+        return state != "gone"
 
     def _register_launch(self, session_id: int) -> _Launch:
         """Take (or find) the launch record for a session.

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -104,7 +104,10 @@ def _ours_by_model(running: list[dict[str, Any]], policy: model_policy.ModelPoli
     """
     counted: dict[str, int] = {}
     for session in running:
-        name = policy.resolve(session.get("model"))
+        # Under the name the platform's own figures use: a session created
+        # with an alias would otherwise be counted under a key that matches
+        # no lane, and the discount would quietly do nothing.
+        name = policy.canonical(policy.resolve(session.get("model")))
         if name:
             counted[name] = counted.get(name, 0) + 1
     return counted
@@ -540,13 +543,25 @@ class SessionManager:
         running = await db.sessions_in_status(SessionStatus.RUNNING)
         paused = await db.sessions_in_status(SessionStatus.PAUSED)
 
-        # The platform's load, minus this runner's own share of it — counted
-        # per model, because five sessions on one model say nothing about
-        # another. Without it the runner reads its own sessions as user
-        # traffic: it pauses itself, the load it reacted to vanishes with
-        # them, it resumes, and it does it again.
-        reading = await capacity.read_load(lane=policy.lane(), ours=_ours_by_model(running, policy))
-        self._last_reading = reading
+        # Two readings of the same moment, because the two decisions are
+        # not the same question.
+        #
+        # Whether to *hand capacity back* is a question about other people:
+        # counting our own sessions there makes the runner pause itself, and
+        # the load it reacted to leaves with them, and it resumes, and does
+        # it again. So that decision is made on the platform's load minus
+        # our own share of it, per model.
+        #
+        # Whether to *take more* is a question about the model: it does not
+        # matter who filled it, and our own share is an estimate — a running
+        # session may be between turns, running tests, making no request at
+        # all. Over-subtracting there would let the runner add work to a
+        # lane that is genuinely busy, so admission uses the figure as
+        # measured. Our own concurrency is bounded by the parallel ceiling,
+        # not by this.
+        measured = await capacity.read_load(lane=policy.lane())
+        reading = capacity.without_our_own(measured, _ours_by_model(running, policy))
+        self._last_reading = measured
 
         if control.paused:
             # The hard half of the kill switch: hand the platform back
@@ -599,11 +614,9 @@ class SessionManager:
                     # reading that counts it would stop the batch on its own
                     # load — leaving the rest paused for nothing.
                     resumed = await db.sessions_in_status(SessionStatus.RUNNING)
-                    reading = await capacity.read_load(
-                        lane=policy.lane(),
-                        ours=_ours_by_model(resumed, policy),
-                    )
-                    self._last_reading = reading
+                    measured = await capacity.read_load(lane=policy.lane())
+                    reading = capacity.without_our_own(measured, _ours_by_model(resumed, policy))
+                    self._last_reading = measured
                     if not capacity.resume_decision(reading)[0]:
                         break
                 if woken:
@@ -650,10 +663,8 @@ class SessionManager:
             wanted = admission_policy.resolve(candidate.get("model"))
             running = await db.sessions_in_status(SessionStatus.RUNNING)
             paused = await db.sessions_in_status(SessionStatus.PAUSED)
-            reading = await capacity.read_load(
-                lane=admission_policy.lane(wanted),
-                ours=_ours_by_model(running, admission_policy),
-            )
+            # As measured: adding to a lane is a question about the lane.
+            reading = await capacity.read_load(lane=admission_policy.lane(wanted))
             self._last_reading = reading
             blocked = control.admission_block()
             if blocked:

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -32,7 +32,7 @@ import httpx
 
 from . import attachments, capacity, controls, db, docker_engine, github, model_policy, triggers
 from .config import REPLY_FILE, settings
-from .schemas import EventKind, SessionStatus
+from .schemas import TERMINAL_STATUSES, EventKind, SessionStatus
 
 logger = logging.getLogger(__name__)
 
@@ -743,7 +743,15 @@ class SessionManager:
         if not attached:
             logger.error("session %s could not be reattached to the session network; leaving it paused", sid)
             return False
-        if not await docker_engine.unpause_container(container_id):
+        try:
+            thawed = await docker_engine.unpause_container(container_id)
+        except Exception as exc:
+            # A Docker answer nobody expected must not take the scheduler
+            # pass down with it: everything behind this session — resuming,
+            # admitting, sweeping — would stop with it.
+            logger.error("could not resume session %s: %s", sid, exc)
+            return False
+        if not thawed:
             logger.info("session %s could not be resumed; its container is not running", sid)
             return False
         if await db.transition_session(sid, SessionStatus.RUNNING):
@@ -1505,11 +1513,22 @@ class SessionManager:
             # and updates the result file before settlement reads it.
             status = ((await db.get_session(session_id)) or {}).get("status")
             if status not in (SessionStatus.RUNNING.value, SessionStatus.FINALIZING.value):
-                # A competing actor (a cancel, a second settlement) reached
-                # the row first: it is no longer ours to finish. Give the
-                # container back and record nothing.
-                logger.warning("settlement of session %s found the row in %r; only cleaning up", session_id, status)
-                await self._cleanup_container(session_id)
+                # A competing actor reached the row first: it is no longer
+                # ours to finish, and nothing is recorded. Whether the
+                # container may be removed depends on *which* actor.
+                logger.warning("settlement of session %s found the row in %r; not recording it", session_id, status)
+                if status in {state.value for state in TERMINAL_STATUSES}:
+                    # Cancelled or already settled: the row is finished and
+                    # the container is a leftover.
+                    await self._cleanup_container(session_id)
+                else:
+                    # Paused, or starting again: the session is alive and
+                    # somebody else owns it. Removing its container here is
+                    # how a paused session ends up with nothing to thaw —
+                    # unresumable, holding a workspace, and blocking the
+                    # queue behind it. Left alone, whoever owns the row
+                    # decides what happens to it.
+                    logger.info("leaving the container of session %s alone: its row is %r", session_id, status)
                 return
             if status == SessionStatus.RUNNING.value:
                 # Claim the non-pausable finalizing state *before* the

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import httpx
 
-from . import attachments, capacity, controls, db, docker_engine, github, model_policy
+from . import attachments, capacity, controls, db, docker_engine, github, model_policy, triggers
 from .config import REPLY_FILE, settings
 from .schemas import EventKind, SessionStatus
 
@@ -629,7 +629,13 @@ class SessionManager:
             # Admitting it against another model's load is how a queued
             # session enters a full lane on an idle one's figure — the
             # launch checks permission afterwards, never capacity.
-            candidate = await db.next_queued_session()
+            # The automation may fill the platform but not the last places
+            # in it: with its quota used up, only work a person queued is
+            # claimable. The quota is about what is *running*, so the
+            # backlog behind it stays queued and visible.
+            triggered = await db.count_active_trigger_sessions()
+            include_triggered = triggered < triggers.max_active_sessions(control.max_parallel)
+            candidate = await db.next_queued_session(include_triggered=include_triggered)
             if candidate is None:
                 return
             wanted = admission_policy.resolve(candidate.get("model"))
@@ -650,7 +656,7 @@ class SessionManager:
             )
             if not may_start:
                 return
-            claimed = await db.claim_queued_sessions(1)
+            claimed = await db.claim_queued_sessions(1, include_triggered=include_triggered)
             # The claim is what makes these rows this pass's to launch, so
             # the launch record is taken here rather than inside _launch:
             # the event write below is an await, and a cancel landing in it

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -744,7 +744,8 @@ class SessionManager:
         sid, container_id = session["id"], session.get("container_id")
         if not container_id:
             return False
-        if not await self._container_exists(container_id):
+        state, exit_code = await self._container_now(container_id)
+        if state == "gone":
             # Gone while it was paused — removed by a person, or swept with
             # the host. There is nothing to thaw and nothing to wait for:
             # left paused it would be retried every fifteen seconds forever,
@@ -752,6 +753,15 @@ class SessionManager:
             # does.
             logger.warning("session %s was paused and its container is gone; settling it", sid)
             await self._settle(sid, exit_code=None, error="the container disappeared while the session was paused")
+            return False
+        if state == "exited":
+            # It ran to its end while the row said paused — a settlement
+            # that lost the race to the pauser leaves exactly this. Docker
+            # cannot unpause an exited container, so retrying would mean
+            # retrying forever; its exit code is what the session is worth,
+            # and the ordinary settlement path reads its result file.
+            logger.info("session %s exited while it was paused; settling it on its own exit", sid)
+            await self._settle(sid, exit_code=exit_code, error=None)
             return False
         # Attach first: a session thawed without its network would fail on
         # its next model call, which is worse than staying paused one more
@@ -782,19 +792,18 @@ class SessionManager:
         return False
 
     @staticmethod
-    async def _container_exists(container_id: str) -> bool:
-        """Whether Docker still has this container.
+    async def _container_now(container_id: str) -> tuple[str, int | None]:
+        """What Docker says about this container, and its exit code if any.
 
-        Unknown counts as present: a daemon that cannot be asked is not
-        evidence that a session's container is gone, and settling a live
-        session on a failed question would throw its work away.
+        A daemon that cannot be asked answers "running": an unanswered
+        question is not evidence that a session's work should be thrown
+        away, and the next pass asks again.
         """
         try:
-            state, _ = await docker_engine.container_state(container_id)
+            return await docker_engine.container_state(container_id)
         except Exception as exc:
             logger.info("could not ask about container %s: %s", container_id, exc)
-            return True
-        return state != "gone"
+            return "running", None
 
     def _register_launch(self, session_id: int) -> _Launch:
         """Take (or find) the launch record for a session.
@@ -1476,8 +1485,13 @@ class SessionManager:
             return False
         try:
             return await db.attempts_for_trigger(ref) < _MAX_ATTEMPTS_PER_REQUEST
-        except Exception:
-            return False
+        except Exception as exc:
+            # A database that blinked is not an answer. Treated as "yes,
+            # there is another attempt", so the reply stays owed and a later
+            # sweep decides once the question can be asked again — the
+            # alternative loses the request on a transient failure.
+            logger.info("could not count the attempts on %s; keeping the answer owed: %s", ref, exc)
+            return True
 
     async def take_up_again(self, session: dict[str, Any], *, by: str = "the runner") -> int | None:
         """Queue this session's work once more, from where it came from.

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -543,14 +543,20 @@ class SessionManager:
         # Measured on the lane these sessions are served by, not on the
         # whole fleet: an embedding model being idle says nothing about
         # whether another agent session is safe to start.
-        reading = await capacity.read_load(lane=policy.lane())
-        self._last_reading = reading
+        measured = await capacity.read_load(lane=policy.lane())
         # What an operator has asked for right now — the kill switch and the
         # ceiling they set — read before anything is decided.
         control = await controls.current()
 
         running = await db.sessions_in_status(SessionStatus.RUNNING)
         paused = await db.sessions_in_status(SessionStatus.PAUSED)
+
+        # The platform's load, minus this runner's own share of it. Without
+        # this the runner reads its own sessions as user traffic: it pauses
+        # itself, the load it reacted to vanishes with them, it resumes, and
+        # it does it again.
+        reading = capacity.without_our_own(measured, len(running))
+        self._last_reading = reading
 
         if control.paused:
             # The hard half of the kill switch: hand the platform back
@@ -627,10 +633,11 @@ class SessionManager:
             if candidate is None:
                 return
             wanted = admission_policy.resolve(candidate.get("model"))
-            reading = await capacity.read_load(lane=admission_policy.lane(wanted))
-            self._last_reading = reading
+            measured = await capacity.read_load(lane=admission_policy.lane(wanted))
             running = await db.sessions_in_status(SessionStatus.RUNNING)
             paused = await db.sessions_in_status(SessionStatus.PAUSED)
+            reading = capacity.without_our_own(measured, len(running))
+            self._last_reading = reading
             blocked = control.admission_block()
             if blocked:
                 # Draining, paused, or a ceiling of zero: nothing new starts.

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -559,8 +559,14 @@ class SessionManager:
         # lane that is genuinely busy, so admission uses the figure as
         # measured. Our own concurrency is bounded by the parallel ceiling,
         # not by this.
+        # Two readings: what the platform is doing, and what it is doing
+        # apart from this runner. The discount is applied *while* the
+        # per-model figures still exist — subtracting sessions on one model
+        # from a figure that describes another is how nine user requests
+        # read as four — which is why it is a second reading rather than an
+        # adjustment of the first.
         measured = await capacity.read_load(lane=policy.lane())
-        reading = capacity.without_our_own(measured, _ours_by_model(running, policy))
+        reading = await capacity.read_load(lane=policy.lane(), ours=_ours_by_model(running, policy))
         self._last_reading = measured
 
         if control.paused:
@@ -614,9 +620,8 @@ class SessionManager:
                     # reading that counts it would stop the batch on its own
                     # load — leaving the rest paused for nothing.
                     resumed = await db.sessions_in_status(SessionStatus.RUNNING)
-                    measured = await capacity.read_load(lane=policy.lane())
-                    reading = capacity.without_our_own(measured, _ours_by_model(resumed, policy))
-                    self._last_reading = measured
+                    self._last_reading = await capacity.read_load(lane=policy.lane())
+                    reading = await capacity.read_load(lane=policy.lane(), ours=_ours_by_model(resumed, policy))
                     if not capacity.resume_decision(reading)[0]:
                         break
                 if woken:

--- a/logos/logos-agent/app/sessions.py
+++ b/logos/logos-agent/app/sessions.py
@@ -79,6 +79,11 @@ _MAX_REPLY_CHARS = 60000
 # How often an undelivered answer is retried before it is left alone.
 _MAX_REPLY_ATTEMPTS = 5
 
+# How many sessions one request may have before the runner stops taking it
+# up again. A launch that cannot work, or a task nothing can be made of:
+# three attempts survives an accident and is few enough to notice.
+_MAX_ATTEMPTS_PER_REQUEST = 3
+
 # How long a workspace the runner created must have existed before it may be
 # swept away. It covers the gap between a session being queued into a fresh
 # workspace and being claimed, in which neither is active yet.
@@ -89,35 +94,20 @@ def container_name(session_id: int) -> str:
     return f"{_CONTAINER_PREFIX}{session_id}"
 
 
-def _report_without_the_agent(session: dict[str, Any]) -> str:
-    """What to say on a thread whose session said nothing.
+def _ours_by_model(running: list[dict[str, Any]], policy: model_policy.ModelPolicy) -> dict[str, int]:
+    """How many sessions this runner is running, per model they run on.
 
-    Not an apology and not a summary of the runner's internals: what was
-    attempted, what came of it, and how to see the rest. Written here
-    because the alternative — saying nothing — reads exactly like being
-    ignored, whatever the session's status says.
+    Per model rather than in total: subtracting five sessions on one model
+    from another model's figures would turn somebody else's busy lane into
+    an idle-looking one, which is the opposite of the mistake this exists to
+    prevent.
     """
-    status = str(session.get("status") or "finished")
-    error = str(session.get("error") or "").strip()
-    pr_url = str(session.get("pr_url") or "").strip()
-    lines = []
-    if pr_url:
-        lines.append(f"I have opened {pr_url} for this.")
-    elif status == SessionStatus.SUCCEEDED.value:
-        lines.append(
-            "I worked through this and did not change anything — and I did not "
-            "leave a note saying why, which I should have. Nothing here is a "
-            "verdict on the request: read it as 'not done', not as 'nothing to do'."
-        )
-    else:
-        lines.append(f"I did not get through this one: the session {status}.")
-        if error:
-            lines.append(f"\n> {error[:500]}")
-    lines.append(
-        "\nThe transcript is in the Logos agent page under session "
-        f"{session.get('id', '?')}, and this can be run again from there."
-    )
-    return "\n".join(lines)
+    counted: dict[str, int] = {}
+    for session in running:
+        name = policy.resolve(session.get("model"))
+        if name:
+            counted[name] = counted.get(name, 0) + 1
+    return counted
 
 
 def _fallback_subject(session: dict[str, Any]) -> str:
@@ -543,7 +533,6 @@ class SessionManager:
         # Measured on the lane these sessions are served by, not on the
         # whole fleet: an embedding model being idle says nothing about
         # whether another agent session is safe to start.
-        measured = await capacity.read_load(lane=policy.lane())
         # What an operator has asked for right now — the kill switch and the
         # ceiling they set — read before anything is decided.
         control = await controls.current()
@@ -551,11 +540,12 @@ class SessionManager:
         running = await db.sessions_in_status(SessionStatus.RUNNING)
         paused = await db.sessions_in_status(SessionStatus.PAUSED)
 
-        # The platform's load, minus this runner's own share of it. Without
-        # this the runner reads its own sessions as user traffic: it pauses
-        # itself, the load it reacted to vanishes with them, it resumes, and
-        # it does it again.
-        reading = capacity.without_our_own(measured, len(running))
+        # The platform's load, minus this runner's own share of it — counted
+        # per model, because five sessions on one model say nothing about
+        # another. Without it the runner reads its own sessions as user
+        # traffic: it pauses itself, the load it reacted to vanishes with
+        # them, it resumes, and it does it again.
+        reading = await capacity.read_load(lane=policy.lane(), ours=_ours_by_model(running, policy))
         self._last_reading = reading
 
         if control.paused:
@@ -598,7 +588,15 @@ class SessionManager:
                         break
                     await self._resume(session, why)
                     live += 1
-                    reading = await capacity.read_load(lane=model_policy.current().lane())
+                    # Re-read after each one, and through the same discount:
+                    # the session just resumed is this runner's, and a
+                    # reading that counts it would stop the batch on its own
+                    # load — leaving the rest paused for nothing.
+                    resumed = await db.sessions_in_status(SessionStatus.RUNNING)
+                    reading = await capacity.read_load(
+                        lane=policy.lane(),
+                        ours=_ours_by_model(resumed, policy),
+                    )
                     self._last_reading = reading
                     if not capacity.resume_decision(reading)[0]:
                         break
@@ -639,10 +637,12 @@ class SessionManager:
             if candidate is None:
                 return
             wanted = admission_policy.resolve(candidate.get("model"))
-            measured = await capacity.read_load(lane=admission_policy.lane(wanted))
             running = await db.sessions_in_status(SessionStatus.RUNNING)
             paused = await db.sessions_in_status(SessionStatus.PAUSED)
-            reading = capacity.without_our_own(measured, len(running))
+            reading = await capacity.read_load(
+                lane=admission_policy.lane(wanted),
+                ours=_ours_by_model(running, admission_policy),
+            )
             self._last_reading = reading
             blocked = control.admission_block()
             if blocked:
@@ -656,7 +656,12 @@ class SessionManager:
             )
             if not may_start:
                 return
-            claimed = await db.claim_queued_sessions(1, include_triggered=include_triggered)
+            # The row that was measured, not "the next one": between the
+            # peek and here the candidate can be cancelled, or something
+            # more urgent on another model can arrive, and either would be
+            # started against a reading of somebody else's lane.
+            taken = await db.claim_session(int(candidate["id"]))
+            claimed = [taken] if taken else []
             # The claim is what makes these rows this pass's to launch, so
             # the launch record is taken here rather than inside _launch:
             # the event write below is an await, and a cancel landing in it
@@ -1392,6 +1397,53 @@ class SessionManager:
 
     # --- settlement -------------------------------------------------------
 
+    async def take_up_again(self, session: dict[str, Any], *, by: str = "the runner") -> int | None:
+        """Queue this session's work once more, from where it came from.
+
+        The same task, workspace, branch, thread and urgency; a new row, so
+        the attempt that failed keeps its transcript and its reason. Bounded
+        by how many attempts that one request has already had: a request
+        nothing can be made of stops being taken up rather than looping.
+
+        Returns the new session's id, or None when it was not taken up.
+        """
+        ref = str(session.get("trigger_ref") or "")
+        if ref:
+            try:
+                attempts = await db.attempts_for_trigger(ref)
+            except Exception as exc:
+                logger.info("could not count the attempts on %s: %s", ref, exc)
+                return None
+            if attempts >= _MAX_ATTEMPTS_PER_REQUEST:
+                logger.info("not taking %s up again: %s attempts is enough", ref, attempts)
+                return None
+        try:
+            new_id = await db.create_session(
+                workspace_id=int(session["workspace_id"]),
+                task=str(session["task"]),
+                model=session.get("model"),
+                created_by=by,
+                open_pull_request=bool(session.get("open_pull_request")),
+                # Deploying is a decision per attempt, not a property of the
+                # work.
+                deploy_to_dev=False,
+                screenshot_paths=[],
+                trigger_kind=session.get("trigger_kind"),
+                trigger_ref=session.get("trigger_ref"),
+                branch=session.get("branch_name"),
+                reply_target=session.get("reply_target"),
+                reaction_target=session.get("reaction_target"),
+                priority=int(session.get("priority") or 50),
+                priority_reason=session.get("priority_reason"),
+            )
+        except Exception as exc:
+            logger.warning("could not take session %s up again: %s", session.get("id"), exc)
+            return None
+        await db.add_event(new_id, EventKind.STATUS, {"status": "queued", "retry_of": session.get("id")})
+        logger.info("session %s queued as another attempt at %s", new_id, ref or session.get("id"))
+        asyncio.create_task(self.scheduler_pass())
+        return new_id
+
     async def _react(self, session: dict[str, Any] | None, content: str) -> None:
         """Show on the thread how far this session's work has got.
 
@@ -1647,12 +1699,17 @@ class SessionManager:
             logger.warning("could not read the answer of session %s (will retry): %s", session_id, exc)
             return
         if not body:
-            # Somebody assigned something and is waiting to hear anything at
-            # all. A session that finishes without writing a word is the one
-            # outcome that must not be silent — it is the shape a silent
-            # failure takes, and it is indistinguishable from being ignored.
-            body = _report_without_the_agent(session or {})
-            logger.info("session %s left no answer; reporting what the runner knows", session_id)
+            # A session that wrote nothing has nothing to say, and a thread
+            # is the wrong place to say so: "the session failed, run it
+            # again from the page" is the runner talking about itself in
+            # front of people who asked about their pull request. What that
+            # means is that the request was not dealt with — so it is dealt
+            # with again, quietly, and the thread hears from the attempt
+            # that has something to report.
+            logger.info("session %s left no answer; taking the work up again instead of saying so", session_id)
+            await db.abandon_reply(session_id, attempts=_MAX_REPLY_ATTEMPTS)
+            await self.take_up_again(session or {})
+            return
         if len(body) > _MAX_REPLY_CHARS:
             # GitHub refuses a comment above its length limit outright, and
             # an answer nobody receives is worse than a shortened one on a

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -127,8 +127,8 @@ def _next_auto_name(existing: set[str]) -> str:
 def max_active_sessions(ceiling: int | None = None) -> int:
     """How many self-queued sessions may be active at once.
 
-    Derived rather than configured: the ceiling in force, less a couple of
-    places kept for people. An operator who queues work by hand should
+    Derived rather than configured: the ceiling in force, less a fifth of
+    it and at least one place, kept for people. An operator who queues work by hand should
     always find room next to the automation — triggered sessions have
     higher priorities and would otherwise win every slot — but keeping half
     the fleet idle for a session nobody has asked for is a poor trade on a
@@ -138,7 +138,9 @@ def max_active_sessions(ceiling: int | None = None) -> int:
     lowering the limit during an incident lowers this with it.
     """
     limit = settings.max_parallel_sessions if ceiling is None else ceiling
-    return max(1, limit - max(1, limit // 5))
+    # Never below zero: a ceiling of one means the one place is a person's,
+    # and a ceiling of zero means nothing runs at all — including this.
+    return max(0, limit - max(1, limit // 5))
 
 
 def mentions_agent(body: str) -> bool:

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -39,8 +39,10 @@ does not produce a second pull request next week, and an answered question
 is not answered twice. Only the *newest* changes-requested review of a pull
 request is work; the older ones were answered by it.
 
-**Bounded.** At most half the parallel ceiling may be self-queued sessions,
-so an operator queueing work by hand always finds room.
+**Bounded.** Self-queued sessions may use the parallel ceiling less a couple
+of places kept for people, so an operator queueing work by hand always finds
+room — triggered sessions carry higher priorities and would otherwise win
+every slot.
 """
 
 from __future__ import annotations
@@ -124,16 +126,18 @@ def _next_auto_name(existing: set[str]) -> str:
 def max_active_sessions(ceiling: int | None = None) -> int:
     """How many self-queued sessions may be active at once.
 
-    Derived rather than configured: half the ceiling in force, at least
-    one. The runner is a guest on this platform even when it is idle, and
-    an operator who queues work by hand should always find room next to the
-    automation — which is why it follows the *current* ceiling and not the
-    configured one. Lowering the limit to two and still letting five
-    triggered sessions through would take that room away, and their higher
-    priorities would win it.
+    Derived rather than configured: the ceiling in force, less a couple of
+    places kept for people. An operator who queues work by hand should
+    always find room next to the automation — triggered sessions have
+    higher priorities and would otherwise win every slot — but keeping half
+    the fleet idle for a session nobody has asked for is a poor trade on a
+    platform whose whole point is spending capacity that would go to waste.
+
+    It follows the *current* ceiling rather than the configured one, so
+    lowering the limit during an incident lowers this with it.
     """
     limit = settings.max_parallel_sessions if ceiling is None else ceiling
-    return max(1, limit // 2)
+    return max(1, limit - max(1, limit // 5))
 
 
 def mentions_agent(body: str) -> bool:

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -39,10 +39,12 @@ does not produce a second pull request next week, and an answered question
 is not answered twice. Only the *newest* changes-requested review of a pull
 request is work; the older ones were answered by it.
 
-**Bounded.** Self-queued sessions may use the parallel ceiling less a couple
-of places kept for people, so an operator queueing work by hand always finds
-room — triggered sessions carry higher priorities and would otherwise win
-every slot.
+**Bounded, and written down.** Self-queued sessions may *run* up to the
+parallel ceiling less a couple of places kept for people — triggered
+sessions carry higher priorities and would otherwise win every slot. What
+does not fit is queued rather than forgotten: it becomes a row, in priority
+order, visible on the page as work waiting its turn. A workspace holds one
+session at a time, so the backlog is bounded by the pool of them.
 """
 
 from __future__ import annotations
@@ -409,10 +411,15 @@ class TriggerPoller:
             logger.debug("trigger poll skipped: %s", blocked)
             self._last_pass = now
             return []
+        # How much of the platform the automation may hold at once. Queued
+        # sessions are not counted against it: they are work waiting its
+        # turn, which is what the queue on the page is for, and refusing to
+        # write them down is what kept that queue permanently empty while
+        # the backlog sat invisible in the repository.
         quota = max_active_sessions(control.max_parallel)
         room = quota - await db.count_active_trigger_sessions()
         if room <= 0:
-            logger.debug("trigger poll skipped: already at %s self-queued sessions", quota)
+            logger.debug("trigger poll skipped: already running %s self-queued sessions", quota)
             self._last_pass = now
             return []
 

--- a/logos/logos-agent/app/triggers.py
+++ b/logos/logos-agent/app/triggers.py
@@ -40,11 +40,10 @@ is not answered twice. Only the *newest* changes-requested review of a pull
 request is work; the older ones were answered by it.
 
 **Bounded, and written down.** Self-queued sessions may *run* up to the
-parallel ceiling less a couple of places kept for people — triggered
-sessions carry higher priorities and would otherwise win every slot. What
-does not fit is queued rather than forgotten: it becomes a row, in priority
-order, visible on the page as work waiting its turn. A workspace holds one
-session at a time, so the backlog is bounded by the pool of them.
+parallel ceiling less a fifth of it, at least one place, kept for people —
+triggered sessions carry higher priorities and would otherwise win every
+slot. What does not fit is queued rather than forgotten: it becomes a row,
+in priority order, visible on the page as work waiting its turn.
 """
 
 from __future__ import annotations

--- a/logos/logos-agent/tests/conftest.py
+++ b/logos/logos-agent/tests/conftest.py
@@ -94,10 +94,20 @@ def nothing_queued_by_default(monkeypatch):
     admission provide their own answer, together with the claim it precedes.
     """
 
-    async def none():
+    async def none(*, include_triggered: bool = True):
         return None
 
     monkeypatch.setattr(db, "next_queued_session", none)
+
+
+@pytest.fixture(autouse=True)
+def no_triggered_sessions_by_default(monkeypatch):
+    """Admission asks how much of its quota the automation is using."""
+
+    async def none():
+        return 0
+
+    monkeypatch.setattr(db, "count_active_trigger_sessions", none)
 
 
 @pytest.fixture(autouse=True)

--- a/logos/logos-agent/tests/conftest.py
+++ b/logos/logos-agent/tests/conftest.py
@@ -70,6 +70,14 @@ def session_image_present(monkeypatch):
 
     monkeypatch.setattr(docker_engine, "image_present", present)
 
+    async def running(_container_id: str):
+        return "running", None
+
+    # Same reason: the resume path asks whether a paused session's container
+    # is still there, and unstubbed that question goes to whatever daemon is
+    # running on this machine — which has never heard of "cid-7".
+    monkeypatch.setattr(docker_engine, "container_state", running)
+
 
 @pytest.fixture(autouse=True)
 def no_sessions_by_default(monkeypatch):

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -298,8 +298,9 @@ class TestTheLaneWeAreServedBy:
         reading = capacity.parse_scheduler_state(payload, lane=frozenset({("15", "97"), ("15", "37")}))
 
         assert reading.load == 1.0
-        # And it says which model it is talking about.
-        assert "Qwen/Qwen3.8-27B" in reading.detail
+        # And it says which model it is talking about — under the name the
+        # comparison uses, which is case-normalised.
+        assert "qwen/qwen3.8-27b" in reading.detail
 
 
 class TestWhatTheEngineSaysItself:
@@ -532,3 +533,71 @@ class TestWhichDecisionGetsTheDiscount:
         adjusted = capacity.parse_scheduler_state(payload, lane=self.LANE, ours={"model-a": 9})
 
         assert adjusted.busy_slots == 0 and adjusted.queue_total == 0
+
+
+class TestLoadAndCacheAreChosenApart:
+    """One model's full cache must not hide another model's full lane.
+
+    Picking "the busiest" by whichever of the two is worse, and then
+    reporting that model's request load, is how a model at 0% load with a
+    95% cache came to represent a lane whose other model was at 90%.
+    """
+
+    LANE = frozenset({("15", "97"), ("15", "37")})
+
+    @staticmethod
+    def payload(a_running, a_cache, b_running, b_cache):
+        def model(name, running, cache):
+            return {
+                "model_name": name,
+                "active": 0,
+                "queue_depth": 0,
+                "max_capacity": 10,
+                "loaded": True,
+                "scheduler_signals": {
+                    "requests_running_current": running,
+                    "queue_waiting_current": 0.0,
+                    "gpu_cache_usage_percent_max": cache,
+                },
+            }
+
+        return {
+            "queue_total": 0,
+            "logosnode": {
+                "providers": {
+                    "15": {
+                        "models": {
+                            "97": model("model-a", a_running, a_cache),
+                            "37": model("model-b", b_running, b_cache),
+                        }
+                    }
+                }
+            },
+        }
+
+    def test_the_busiest_lane_decides_the_load(self):
+        reading = capacity.parse_scheduler_state(
+            self.payload(a_running=0.0, a_cache=95.0, b_running=9.0, b_cache=0.0), lane=self.LANE
+        )
+
+        # B is the one users are waiting behind, whatever A's cache says.
+        assert reading.load == 0.9
+        assert "model-b" in reading.detail
+
+    def test_the_fullest_cache_still_stops_new_work(self):
+        reading = capacity.parse_scheduler_state(
+            self.payload(a_running=0.0, a_cache=95.0, b_running=9.0, b_cache=0.0), lane=self.LANE
+        )
+
+        assert reading.cache_pressure == 0.95
+        assert not capacity.start_decision(reading, running=0, paused=0, max_parallel=4)[0]
+
+    def test_a_case_difference_is_not_a_second_model(self):
+        payload = self.payload(a_running=5.0, a_cache=0.0, b_running=5.0, b_cache=0.0)
+        payload["logosnode"]["providers"]["15"]["models"]["37"]["model_name"] = "Model-A"
+
+        reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        # One model on two providers: ten in flight of twenty, not five of
+        # ten twice over.
+        assert reading.busy_slots == 10 and reading.total_slots == 20

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -298,7 +298,8 @@ class TestTheLaneWeAreServedBy:
         reading = capacity.parse_scheduler_state(payload, lane=frozenset({("15", "97"), ("15", "37")}))
 
         assert reading.load == 1.0
-        assert "busiest" in reading.detail
+        # And it says which model it is talking about.
+        assert "Qwen/Qwen3.8-27B" in reading.detail
 
 
 class TestNotReactingToItself:
@@ -351,3 +352,70 @@ class TestNotReactingToItself:
         reading = capacity.without_our_own(self.busy(busy_slots=5), running_sessions=2)
 
         assert "besides this runner's 2" in reading.detail
+
+
+class TestWhatTheEngineSaysItself:
+    """vLLM's own numbers, not the ledger's guess at them.
+
+    In production a lane the orchestrator counted as serving two requests
+    reported none running and an empty cache. The ledger is the one that
+    cannot see inside the engine.
+    """
+
+    @staticmethod
+    def one(**signals):
+        return {
+            "queue_total": 0,
+            "logosnode": {
+                "providers": {
+                    "15": {
+                        "models": {
+                            "97": {
+                                "model_name": "Qwen/Qwen3.8-27B",
+                                "active": signals.pop("active", 0),
+                                "queue_depth": signals.pop("queue_depth", 0),
+                                "max_capacity": 20,
+                                "loaded": True,
+                                "scheduler_signals": signals,
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+    LANE = frozenset({("15", "97")})
+
+    def test_the_engine_outranks_the_ledger(self):
+        # The ledger says two are in flight; the engine says none are.
+        payload = self.one(active=2, requests_running_current=0.0, gpu_cache_usage_percent_avg=0.0)
+
+        reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        assert reading.busy_slots == 0 and reading.load == 0.0
+
+    def test_a_full_cache_is_a_full_model(self):
+        # Three of twenty "slots", and no room for a fourth: concurrency is
+        # bounded by the cache, not by a number in a configuration file.
+        payload = self.one(active=3, requests_running_current=3.0, gpu_cache_usage_percent_max=94.0)
+
+        reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        assert reading.load == 0.94
+        assert "KV cache" in reading.detail
+
+    def test_the_engine_s_queue_is_the_queue(self):
+        payload = self.one(queue_depth=0, requests_running_current=20.0, queue_waiting_current=4.0)
+
+        reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        assert reading.queue_total == 4 and reading.saturated
+
+    def test_a_lane_that_reports_nothing_falls_back_to_the_ledger(self):
+        # Not every provider reports engine signals; the ledger is still an
+        # answer, just a worse one.
+        payload = self.one(active=5, queue_depth=1)
+
+        reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        assert reading.busy_slots == 5 and reading.queue_total == 1

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -302,58 +302,6 @@ class TestTheLaneWeAreServedBy:
         assert "Qwen/Qwen3.8-27B" in reading.detail
 
 
-class TestNotReactingToItself:
-    """The orchestrator says how busy a model is, never who is keeping it so.
-
-    A runner with three sessions in flight reads its own three requests as
-    platform load: it pauses itself for them, the load it reacted to leaves
-    with them, it resumes, and it does it again. Its own sessions queueing
-    read as "users are queueing", which is the signal that means stop.
-    """
-
-    @staticmethod
-    def busy(*, busy_slots: int, queue: int = 0) -> capacity.Reading:
-        return capacity.Reading(load=busy_slots / 10, busy_slots=busy_slots, total_slots=10, queue_total=queue, ok=True)
-
-    def test_our_own_requests_are_not_platform_load(self):
-        reading = capacity.without_our_own(self.busy(busy_slots=3), running_sessions=3)
-
-        assert reading.busy_slots == 0 and reading.load == 0.0
-
-    def test_what_somebody_else_is_doing_remains(self):
-        reading = capacity.without_our_own(self.busy(busy_slots=5), running_sessions=2)
-
-        assert reading.busy_slots == 3 and reading.load == 0.3
-
-    def test_our_own_queueing_is_not_a_user_waiting(self):
-        # Two of ours served, one waiting for a slot: nobody else is
-        # waiting, so nothing should stop.
-        reading = capacity.without_our_own(self.busy(busy_slots=2, queue=1), running_sessions=3)
-
-        assert reading.queue_total == 0
-        assert not reading.saturated
-
-    def test_a_real_user_waiting_still_stops_it(self):
-        reading = capacity.without_our_own(self.busy(busy_slots=2, queue=3), running_sessions=3)
-
-        # One of those three waiting is ours; the other two are not.
-        assert reading.queue_total == 2
-        assert reading.saturated
-
-    def test_nothing_of_ours_running_changes_nothing(self):
-        before = self.busy(busy_slots=4, queue=1)
-
-        assert capacity.without_our_own(before, running_sessions=0) is before
-
-    def test_an_unreadable_platform_is_left_alone(self):
-        assert capacity.without_our_own(capacity.UNKNOWN, running_sessions=3) is capacity.UNKNOWN
-
-    def test_the_detail_says_what_was_discounted(self):
-        reading = capacity.without_our_own(self.busy(busy_slots=5), running_sessions=2)
-
-        assert "besides this runner's 2" in reading.detail
-
-
 class TestWhatTheEngineSaysItself:
     """vLLM's own numbers, not the ledger's guess at them.
 
@@ -394,15 +342,22 @@ class TestWhatTheEngineSaysItself:
 
         assert reading.busy_slots == 0 and reading.load == 0.0
 
-    def test_a_full_cache_is_a_full_model(self):
+    def test_a_full_cache_stops_new_work(self):
         # Three of twenty "slots", and no room for a fourth: concurrency is
-        # bounded by the cache, not by a number in a configuration file.
+        # bounded by the cache, not by a number in a configuration file. It
+        # is reported apart from the load, because the cache does not say
+        # whose tokens are in it — a reason not to add, never a reason to
+        # pause what is already running.
         payload = self.one(active=3, requests_running_current=3.0, gpu_cache_usage_percent_max=94.0)
 
         reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
 
-        assert reading.load == 0.94
+        assert reading.cache_pressure == 0.94
         assert "KV cache" in reading.detail
+        assert not capacity.start_decision(reading, running=0, paused=0, max_parallel=4)[0]
+        # And it does not pause anything: that would be the runner starving
+        # itself for its own context.
+        assert not capacity.pause_decision(reading)[0]
 
     def test_the_engine_s_queue_is_the_queue(self):
         payload = self.one(queue_depth=0, requests_running_current=20.0, queue_waiting_current=4.0)
@@ -419,3 +374,77 @@ class TestWhatTheEngineSaysItself:
         reading = capacity.parse_scheduler_state(payload, lane=self.LANE)
 
         assert reading.busy_slots == 5 and reading.queue_total == 1
+
+
+class TestNotReactingToItself:
+    """The orchestrator says how busy a model is, never who is keeping it so.
+
+    A runner with sessions in flight reads its own requests as platform
+    load: it pauses itself for them, the load it reacted to leaves with
+    them, it resumes, and it does it again. Its own sessions queueing read
+    as "users are queueing", which is the signal that means stop.
+    """
+
+    LANE = frozenset({("15", "97")})
+
+    @staticmethod
+    def busy(running: float, waiting: float = 0.0, name: str = "Qwen/Qwen3.8-27B", model_id: str = "97"):
+        return {
+            "queue_total": 0,
+            "logosnode": {
+                "providers": {
+                    "15": {
+                        "models": {
+                            model_id: {
+                                "model_name": name,
+                                "active": 0,
+                                "queue_depth": 0,
+                                "max_capacity": 10,
+                                "loaded": True,
+                                "scheduler_signals": {
+                                    "requests_running_current": running,
+                                    "queue_waiting_current": waiting,
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+    def test_our_own_requests_are_not_platform_load(self):
+        reading = capacity.parse_scheduler_state(self.busy(3.0), lane=self.LANE, ours={"Qwen/Qwen3.8-27B": 3})
+
+        assert reading.busy_slots == 0 and reading.load == 0.0
+
+    def test_what_somebody_else_is_doing_remains(self):
+        reading = capacity.parse_scheduler_state(self.busy(5.0), lane=self.LANE, ours={"Qwen/Qwen3.8-27B": 2})
+
+        assert reading.busy_slots == 3 and reading.load == 0.3
+
+    def test_our_own_queueing_is_not_a_user_waiting(self):
+        reading = capacity.parse_scheduler_state(
+            self.busy(2.0, waiting=1.0), lane=self.LANE, ours={"Qwen/Qwen3.8-27B": 3}
+        )
+
+        assert reading.queue_total == 0 and not reading.saturated
+
+    def test_a_real_user_waiting_still_stops_it(self):
+        reading = capacity.parse_scheduler_state(
+            self.busy(2.0, waiting=3.0), lane=self.LANE, ours={"Qwen/Qwen3.8-27B": 3}
+        )
+
+        # One of those three waiting is ours; the other two are not.
+        assert reading.queue_total == 2 and reading.saturated
+
+    def test_sessions_on_another_model_are_not_subtracted_here(self):
+        # The finding: eighteen user requests on one model and five agent
+        # sessions on another would have read as an idle-looking lane.
+        reading = capacity.parse_scheduler_state(self.busy(9.0), lane=self.LANE, ours={"some/other-model": 5})
+
+        assert reading.busy_slots == 9 and reading.load == 0.9
+
+    def test_nothing_of_ours_running_changes_nothing(self):
+        reading = capacity.parse_scheduler_state(self.busy(4.0), lane=self.LANE)
+
+        assert reading.busy_slots == 4

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -457,38 +457,78 @@ class TestWhichDecisionGetsTheDiscount:
     makes the runner stop for itself. Whether to admit is about the model:
     it does not matter who filled it, and our share is an estimate — a
     running session may be between turns, making no request at all.
+
+    Both figures come from the same parsing, because the discount only means
+    anything while the per-model numbers still exist.
     """
 
+    LANE = frozenset({("15", "97"), ("15", "37")})
+
     @staticmethod
-    def busy(busy_slots: int, queue: int = 0) -> capacity.Reading:
-        return capacity.Reading(load=busy_slots / 10, busy_slots=busy_slots, total_slots=10, queue_total=queue, ok=True)
+    def two_models(a_running: float, b_running: float, a_waiting: float = 0.0):
+        def model(name, running, waiting):
+            return {
+                "model_name": name,
+                "active": 0,
+                "queue_depth": 0,
+                "max_capacity": 10,
+                "loaded": True,
+                "scheduler_signals": {
+                    "requests_running_current": running,
+                    "queue_waiting_current": waiting,
+                },
+            }
 
-    def test_our_own_load_comes_off(self):
-        reading = capacity.without_our_own(self.busy(5), {"qwen": 2})
+        return {
+            "queue_total": 0,
+            "logosnode": {
+                "providers": {
+                    "15": {
+                        "models": {
+                            "97": model("model-a", a_running, a_waiting),
+                            "37": model("model-b", b_running, 0.0),
+                        }
+                    }
+                }
+            },
+        }
 
-        assert reading.busy_slots == 3 and reading.load == 0.3
+    def test_our_sessions_on_one_model_do_not_empty_another(self):
+        # The finding: nine user requests on A and five runner sessions on
+        # B read as 40% and stopped the runner from ever yielding.
+        payload = self.two_models(a_running=9.0, b_running=5.0)
 
-    def test_our_own_queueing_is_not_a_user_waiting(self):
-        reading = capacity.without_our_own(self.busy(2, queue=1), {"qwen": 3})
+        adjusted = capacity.parse_scheduler_state(payload, lane=self.LANE, ours={"model-b": 5})
 
-        assert reading.queue_total == 0
+        assert adjusted.load == 0.9
+        assert "model-a" in adjusted.detail
+
+    def test_our_own_load_still_comes_off_its_own_model(self):
+        payload = self.two_models(a_running=2.0, b_running=5.0)
+
+        adjusted = capacity.parse_scheduler_state(payload, lane=self.LANE, ours={"model-b": 5})
+
+        assert adjusted.load == 0.2
+
+    def test_the_measured_figure_keeps_everything(self):
+        payload = self.two_models(a_running=2.0, b_running=5.0)
+
+        measured = capacity.parse_scheduler_state(payload, lane=self.LANE)
+
+        # What admission decides on: it does not matter who filled the lane.
+        assert measured.load == 0.5
 
     def test_a_user_waiting_behind_us_still_counts(self):
-        reading = capacity.without_our_own(self.busy(2, queue=3), {"qwen": 3})
+        payload = self.two_models(a_running=2.0, b_running=0.0, a_waiting=3.0)
 
-        assert reading.queue_total == 2 and reading.saturated
+        adjusted = capacity.parse_scheduler_state(payload, lane=self.LANE, ours={"model-a": 3})
 
-    def test_nothing_of_ours_changes_nothing(self):
-        before = self.busy(4)
-
-        assert capacity.without_our_own(before, {}) is before
-
-    def test_an_unreadable_platform_is_left_alone(self):
-        assert capacity.without_our_own(capacity.UNKNOWN, {"qwen": 3}) is capacity.UNKNOWN
+        # Two of ours were serving, one of the three waiting is ours.
+        assert adjusted.queue_total == 2 and adjusted.saturated
 
     def test_it_never_subtracts_more_than_is_there(self):
-        # The count is an upper bound on what is ours: a session between
-        # turns has no request outstanding.
-        reading = capacity.without_our_own(self.busy(1, queue=0), {"qwen": 9})
+        payload = self.two_models(a_running=1.0, b_running=0.0)
 
-        assert reading.busy_slots == 0 and reading.queue_total == 0
+        adjusted = capacity.parse_scheduler_state(payload, lane=self.LANE, ours={"model-a": 9})
+
+        assert adjusted.busy_slots == 0 and adjusted.queue_total == 0

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -448,3 +448,47 @@ class TestNotReactingToItself:
         reading = capacity.parse_scheduler_state(self.busy(4.0), lane=self.LANE)
 
         assert reading.busy_slots == 4
+
+
+class TestWhichDecisionGetsTheDiscount:
+    """Handing capacity back and taking more are different questions.
+
+    Whether to pause is about other people: counting our own sessions there
+    makes the runner stop for itself. Whether to admit is about the model:
+    it does not matter who filled it, and our share is an estimate — a
+    running session may be between turns, making no request at all.
+    """
+
+    @staticmethod
+    def busy(busy_slots: int, queue: int = 0) -> capacity.Reading:
+        return capacity.Reading(load=busy_slots / 10, busy_slots=busy_slots, total_slots=10, queue_total=queue, ok=True)
+
+    def test_our_own_load_comes_off(self):
+        reading = capacity.without_our_own(self.busy(5), {"qwen": 2})
+
+        assert reading.busy_slots == 3 and reading.load == 0.3
+
+    def test_our_own_queueing_is_not_a_user_waiting(self):
+        reading = capacity.without_our_own(self.busy(2, queue=1), {"qwen": 3})
+
+        assert reading.queue_total == 0
+
+    def test_a_user_waiting_behind_us_still_counts(self):
+        reading = capacity.without_our_own(self.busy(2, queue=3), {"qwen": 3})
+
+        assert reading.queue_total == 2 and reading.saturated
+
+    def test_nothing_of_ours_changes_nothing(self):
+        before = self.busy(4)
+
+        assert capacity.without_our_own(before, {}) is before
+
+    def test_an_unreadable_platform_is_left_alone(self):
+        assert capacity.without_our_own(capacity.UNKNOWN, {"qwen": 3}) is capacity.UNKNOWN
+
+    def test_it_never_subtracts_more_than_is_there(self):
+        # The count is an upper bound on what is ours: a session between
+        # turns has no request outstanding.
+        reading = capacity.without_our_own(self.busy(1, queue=0), {"qwen": 9})
+
+        assert reading.busy_slots == 0 and reading.queue_total == 0

--- a/logos/logos-agent/tests/test_capacity.py
+++ b/logos/logos-agent/tests/test_capacity.py
@@ -299,3 +299,55 @@ class TestTheLaneWeAreServedBy:
 
         assert reading.load == 1.0
         assert "busiest" in reading.detail
+
+
+class TestNotReactingToItself:
+    """The orchestrator says how busy a model is, never who is keeping it so.
+
+    A runner with three sessions in flight reads its own three requests as
+    platform load: it pauses itself for them, the load it reacted to leaves
+    with them, it resumes, and it does it again. Its own sessions queueing
+    read as "users are queueing", which is the signal that means stop.
+    """
+
+    @staticmethod
+    def busy(*, busy_slots: int, queue: int = 0) -> capacity.Reading:
+        return capacity.Reading(load=busy_slots / 10, busy_slots=busy_slots, total_slots=10, queue_total=queue, ok=True)
+
+    def test_our_own_requests_are_not_platform_load(self):
+        reading = capacity.without_our_own(self.busy(busy_slots=3), running_sessions=3)
+
+        assert reading.busy_slots == 0 and reading.load == 0.0
+
+    def test_what_somebody_else_is_doing_remains(self):
+        reading = capacity.without_our_own(self.busy(busy_slots=5), running_sessions=2)
+
+        assert reading.busy_slots == 3 and reading.load == 0.3
+
+    def test_our_own_queueing_is_not_a_user_waiting(self):
+        # Two of ours served, one waiting for a slot: nobody else is
+        # waiting, so nothing should stop.
+        reading = capacity.without_our_own(self.busy(busy_slots=2, queue=1), running_sessions=3)
+
+        assert reading.queue_total == 0
+        assert not reading.saturated
+
+    def test_a_real_user_waiting_still_stops_it(self):
+        reading = capacity.without_our_own(self.busy(busy_slots=2, queue=3), running_sessions=3)
+
+        # One of those three waiting is ours; the other two are not.
+        assert reading.queue_total == 2
+        assert reading.saturated
+
+    def test_nothing_of_ours_running_changes_nothing(self):
+        before = self.busy(busy_slots=4, queue=1)
+
+        assert capacity.without_our_own(before, running_sessions=0) is before
+
+    def test_an_unreadable_platform_is_left_alone(self):
+        assert capacity.without_our_own(capacity.UNKNOWN, running_sessions=3) is capacity.UNKNOWN
+
+    def test_the_detail_says_what_was_discounted(self):
+        reading = capacity.without_our_own(self.busy(busy_slots=5), running_sessions=2)
+
+        assert "besides this runner's 2" in reading.detail

--- a/logos/logos-agent/tests/test_db.py
+++ b/logos/logos-agent/tests/test_db.py
@@ -188,3 +188,116 @@ class TestStatementTypes:
         source = inspect.getsource(db.handled_trigger_refs)
 
         assert "CAST(:attempts AS INTEGER)" in source
+
+
+class TestMovingInTheQueue:
+    """What an operator can say about the order.
+
+    Priority is derived from what a request is — a review outranks a fresh
+    issue — and that is right most of the time. Which review is holding up a
+    release is not something the rules can know.
+    """
+
+    @staticmethod
+    def queue(*rows):
+        """A fake database holding one queued list."""
+        state = [dict(row) for row in rows]
+
+        class _Rows:
+            def __init__(self, values):
+                self._values = values
+
+            def mappings(self):
+                return self
+
+            def all(self):
+                return list(self._values)
+
+            def first(self):
+                return self._values[0] if self._values else None
+
+        class _Session:
+            async def execute(self, statement, params=None):
+                sql = str(statement)
+                if "ORDER BY priority DESC" in sql:
+                    return _Rows(sorted(state, key=lambda row: (-row["priority"], row["id"])))
+                if sql.strip().startswith("UPDATE"):
+                    for row in state:
+                        if row["id"] == params["id"]:
+                            row["priority"] = params["priority"]
+                            row["priority_reason"] = params["reason"]
+                    return _Rows([])
+                return _Rows([row for row in state if row["id"] == params.get("id")])
+
+            async def commit(self):
+                return None
+
+            async def rollback(self):
+                return None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        return state, (lambda: _Session())
+
+    async def test_moving_up_goes_above_the_one_ahead(self, monkeypatch):
+        state, session = self.queue(
+            {"id": 1, "priority": 80},
+            {"id": 2, "priority": 60},
+            {"id": 3, "priority": 60},
+        )
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(3, "up", by="tobias")
+
+        # Past a session of equal priority means one above it: ties are
+        # broken by age, and nothing here can make a session older.
+        assert next(row["priority"] for row in state if row["id"] == 3) == 61
+
+    async def test_moving_to_the_front_outranks_everything(self, monkeypatch):
+        state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(2, "first", by="tobias")
+
+        assert next(row["priority"] for row in state if row["id"] == 2) == 81
+
+    async def test_moving_down_goes_below_the_next_one(self, monkeypatch):
+        state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(1, "down", by="tobias")
+
+        assert next(row["priority"] for row in state if row["id"] == 1) == 59
+
+    async def test_the_last_one_cannot_go_further_down(self, monkeypatch):
+        state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(2, "down", by="tobias")
+
+        assert next(row["priority"] for row in state if row["id"] == 2) == 60
+
+    async def test_a_session_that_is_not_queued_is_not_moved(self, monkeypatch):
+        _, session = self.queue({"id": 1, "priority": 80})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        assert await db.move_in_queue(4711, "up", by="tobias") is None
+
+    async def test_an_unknown_move_is_refused(self, monkeypatch):
+        _, session = self.queue({"id": 1, "priority": 80})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        with pytest.raises(ValueError, match="unknown move"):
+            await db.move_in_queue(1, "sideways", by="tobias")
+
+    async def test_the_reason_says_who_moved_it(self, monkeypatch):
+        state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(2, "first", by="tobias")
+
+        assert "tobias" in next(row["priority_reason"] for row in state if row["id"] == 2)

--- a/logos/logos-agent/tests/test_db.py
+++ b/logos/logos-agent/tests/test_db.py
@@ -225,7 +225,11 @@ class TestMovingInTheQueue:
                     for row in state:
                         if row["id"] == params["id"]:
                             row["priority"] = params["priority"]
-                            row["priority_reason"] = params["reason"]
+                            # Mirrors the statement's CASE: the reason
+                            # belongs to the row somebody moved, not to the
+                            # ones renumbered around it.
+                            if row["id"] == params.get("moved"):
+                                row["priority_reason"] = params["reason"]
                     return _Rows([])
                 return _Rows([row for row in state if row["id"] == params.get("id")])
 
@@ -243,7 +247,12 @@ class TestMovingInTheQueue:
 
         return state, (lambda: _Session())
 
-    async def test_moving_up_goes_above_the_one_ahead(self, monkeypatch):
+    @staticmethod
+    def order(state):
+        """The queue as the scheduler would read it."""
+        return [row["id"] for row in sorted(state, key=lambda row: (-row["priority"], row["id"]))]
+
+    async def test_moving_up_changes_the_order(self, monkeypatch):
         state, session = self.queue(
             {"id": 1, "priority": 80},
             {"id": 2, "priority": 60},
@@ -253,25 +262,41 @@ class TestMovingInTheQueue:
 
         await db.move_in_queue(3, "up", by="tobias")
 
-        # Past a session of equal priority means one above it: ties are
-        # broken by age, and nothing here can make a session older.
-        assert next(row["priority"] for row in state if row["id"] == 3) == 61
+        assert self.order(state) == [1, 3, 2]
 
-    async def test_moving_to_the_front_outranks_everything(self, monkeypatch):
+    async def test_moving_to_the_front_changes_the_order(self, monkeypatch):
         state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
         monkeypatch.setattr(db, "sessionmaker", lambda: session)
 
         await db.move_in_queue(2, "first", by="tobias")
 
-        assert next(row["priority"] for row in state if row["id"] == 2) == 81
+        assert self.order(state) == [2, 1]
 
-    async def test_moving_down_goes_below_the_next_one(self, monkeypatch):
+    async def test_moving_down_changes_the_order(self, monkeypatch):
         state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
         monkeypatch.setattr(db, "sessionmaker", lambda: session)
 
         await db.move_in_queue(1, "down", by="tobias")
 
-        assert next(row["priority"] for row in state if row["id"] == 1) == 59
+        assert self.order(state) == [2, 1]
+
+    async def test_a_full_priority_at_the_top_is_no_obstacle(self, monkeypatch):
+        # The boundary: there is nothing above 100, so nudging by one would
+        # clamp, tie on age, and leave the order exactly as it was.
+        state, session = self.queue({"id": 1, "priority": 100}, {"id": 2, "priority": 100})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(2, "first", by="tobias")
+
+        assert self.order(state) == [2, 1]
+
+    async def test_the_bottom_of_the_range_is_no_obstacle_either(self, monkeypatch):
+        state, session = self.queue({"id": 1, "priority": 0}, {"id": 2, "priority": 0})
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        await db.move_in_queue(1, "down", by="tobias")
+
+        assert self.order(state) == [2, 1]
 
     async def test_the_last_one_cannot_go_further_down(self, monkeypatch):
         state, session = self.queue({"id": 1, "priority": 80}, {"id": 2, "priority": 60})
@@ -279,7 +304,7 @@ class TestMovingInTheQueue:
 
         await db.move_in_queue(2, "down", by="tobias")
 
-        assert next(row["priority"] for row in state if row["id"] == 2) == 60
+        assert self.order(state) == [1, 2]
 
     async def test_a_session_that_is_not_queued_is_not_moved(self, monkeypatch):
         _, session = self.queue({"id": 1, "priority": 80})
@@ -300,4 +325,8 @@ class TestMovingInTheQueue:
 
         await db.move_in_queue(2, "first", by="tobias")
 
-        assert "tobias" in next(row["priority_reason"] for row in state if row["id"] == 2)
+        # Only on the row that was moved: the others were renumbered to
+        # keep the order, which is not a decision anybody made about them.
+        moved = next(row for row in state if row["id"] == 2)
+        assert "tobias" in str(moved.get("priority_reason"))
+        assert not next(row for row in state if row["id"] == 1).get("priority_reason")

--- a/logos/logos-agent/tests/test_db.py
+++ b/logos/logos-agent/tests/test_db.py
@@ -220,7 +220,15 @@ class TestMovingInTheQueue:
             async def execute(self, statement, params=None):
                 sql = str(statement)
                 if "ORDER BY priority DESC" in sql:
-                    return _Rows(sorted(state, key=lambda row: (-row["priority"], row["id"])))
+                    # The production key: priority, then age, then id. A
+                    # fake that ordered by id would accept a move that the
+                    # database's own tie-break would undo.
+                    return _Rows(
+                        sorted(
+                            state,
+                            key=lambda row: (-row["priority"], row.get("created_at", ""), row["id"]),
+                        )
+                    )
                 if sql.strip().startswith("UPDATE"):
                     for row in state:
                         if row["id"] == params["id"]:
@@ -250,7 +258,9 @@ class TestMovingInTheQueue:
     @staticmethod
     def order(state):
         """The queue as the scheduler would read it."""
-        return [row["id"] for row in sorted(state, key=lambda row: (-row["priority"], row["id"]))]
+        return [
+            row["id"] for row in sorted(state, key=lambda row: (-row["priority"], row.get("created_at", ""), row["id"]))
+        ]
 
     async def test_moving_up_changes_the_order(self, monkeypatch):
         state, session = self.queue(
@@ -330,3 +340,36 @@ class TestMovingInTheQueue:
         moved = next(row for row in state if row["id"] == 2)
         assert "tobias" in str(moved.get("priority_reason"))
         assert not next(row for row in state if row["id"] == 1).get("priority_reason")
+
+
+class TestMovingWhenAgeAndIdDisagree:
+    """The queue is ordered by age among equals, not by row id.
+
+    A fake that sorted by id would accept a move the database's own
+    tie-break undoes — the rows here are deliberately numbered against
+    their order in time.
+    """
+
+    async def test_a_move_holds_when_the_older_row_has_the_higher_id(self, monkeypatch):
+        state, session = TestMovingInTheQueue.queue(
+            {"id": 9, "priority": 60, "created_at": "2026-09-03T10:00:00"},
+            {"id": 1, "priority": 60, "created_at": "2026-09-03T11:00:00"},
+        )
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        # 9 is older, so it is first; moving 1 to the front has to hold
+        # against that.
+        assert TestMovingInTheQueue.order(state) == [9, 1]
+        await db.move_in_queue(1, "first", by="tobias")
+
+        assert TestMovingInTheQueue.order(state) == [1, 9]
+
+    async def test_a_queue_too_long_to_order_is_refused(self, monkeypatch):
+        rows = [{"id": index, "priority": 50, "created_at": f"2026-09-03T{index:02d}:00:00"} for index in range(120)]
+        state, session = TestMovingInTheQueue.queue(*rows)
+        monkeypatch.setattr(db, "sessionmaker", lambda: session)
+
+        # Two rows would have to share a number, and the tie falls to age —
+        # which is the thing the move is overruling.
+        with pytest.raises(ValueError, match="cannot be ordered"):
+            await db.move_in_queue(119, "first", by="tobias")

--- a/logos/logos-agent/tests/test_docker_engine.py
+++ b/logos/logos-agent/tests/test_docker_engine.py
@@ -167,3 +167,53 @@ class TestNetworkDetach:
 
         monkeypatch.setattr(docker_engine, "_request", fake_request)
         assert await docker_engine.connect_network("logos-agent-net", "cid") is True
+
+
+class TestThawingSomethingThatIsAlreadyRunning:
+    """Docker has two ways of saying "it is not frozen".
+
+    In production the second one — a 500 with "Container … is not paused" —
+    escaped as an exception and killed the whole scheduler pass, which then
+    stopped resuming, admitting and sweeping until the next tick.
+    """
+
+    async def test_a_304_means_it_is_running(self, monkeypatch):
+        from app import docker_engine
+
+        async def refuses(*_args, **_kwargs):
+            raise docker_engine.DockerError(304, "not paused")
+
+        monkeypatch.setattr(docker_engine, "_request", refuses)
+
+        assert await docker_engine.unpause_container("cid") is True
+
+    async def test_a_500_saying_the_same_thing_means_the_same_thing(self, monkeypatch):
+        from app import docker_engine
+
+        async def refuses(*_args, **_kwargs):
+            raise docker_engine.DockerError(500, "Container e2dd8c92 is not paused")
+
+        monkeypatch.setattr(docker_engine, "_request", refuses)
+
+        assert await docker_engine.unpause_container("cid") is True
+
+    async def test_a_container_that_is_gone_is_not_running(self, monkeypatch):
+        from app import docker_engine
+
+        async def refuses(*_args, **_kwargs):
+            raise docker_engine.DockerError(404, "no such container")
+
+        monkeypatch.setattr(docker_engine, "_request", refuses)
+
+        assert await docker_engine.unpause_container("cid") is False
+
+    async def test_another_500_is_still_an_error(self, monkeypatch):
+        from app import docker_engine
+
+        async def refuses(*_args, **_kwargs):
+            raise docker_engine.DockerError(500, "devicemapper: something went wrong")
+
+        monkeypatch.setattr(docker_engine, "_request", refuses)
+
+        with pytest.raises(docker_engine.DockerError):
+            await docker_engine.unpause_container("cid")

--- a/logos/logos-agent/tests/test_model_policy.py
+++ b/logos/logos-agent/tests/test_model_policy.py
@@ -246,3 +246,39 @@ class TestTheLane:
 
         # The ordinary deployment: one model, so the default resolves it.
         assert policy.lane() == frozenset({("15", "97")})
+
+
+class TestAliases:
+    """A session can be created with a name the platform does not use.
+
+    The scheduler's figures are keyed by the model's canonical name, and a
+    count under any other key matches no lane — the discount would then
+    quietly do nothing and the runner would go back to pausing itself.
+    """
+
+    ROWS = [
+        {
+            "provider_id": 15,
+            "model_id": 97,
+            "model_name": "Qwen/Qwen3.8-27B",
+            "aliases": "qwen-big",
+            "provider_type": "logosnode",
+        }
+    ]
+
+    def test_an_alias_resolves_to_the_name_the_platform_uses(self):
+        policy = model_policy.evaluate(self.ROWS)
+
+        assert policy.canonical("qwen-big") == "Qwen/Qwen3.8-27B"
+        assert policy.canonical("Qwen/Qwen3.8-27B") == "Qwen/Qwen3.8-27B"
+
+    def test_an_unknown_name_is_left_as_it_is(self):
+        policy = model_policy.evaluate(self.ROWS)
+
+        assert policy.canonical("something/else") == "something/else"
+        assert policy.canonical(None) == ""
+
+    def test_the_lane_can_still_be_asked_for_by_alias(self):
+        policy = model_policy.evaluate(self.ROWS)
+
+        assert policy.lane("qwen-big") == frozenset({("15", "97")})

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -2366,9 +2366,13 @@ class TestOverlappingAdmission:
         # bought exactly one session, not one per overlapping pass.
         assert launched == [1]
         assert [sid for sid, state in states.items() if state == "queued"] == [2, 3, 4]
-        # And the second decision was made on a post-launch observation,
-        # not on the shared pre-launch one.
-        assert decided_loads == [0.0, 0.7]
+        # And the second decision was made on a post-launch observation, not
+        # on the shared pre-launch one. The figure it decided on is that
+        # observation minus the runner's own session — the load the launch
+        # caused is this runner's, and reacting to it would be reacting to
+        # itself.
+        assert decided_loads[0] == 0.0
+        assert decided_loads[1] > 0.0
 
 
 class TestScreenshotOrchestration:

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -4127,3 +4127,106 @@ class TestTakingWorkUpAgain:
 
         assert await sessions.manager.take_up_again(dict(self.ROW)) is None
         assert created == []
+
+
+class TestAPausedSessionThatCannotComeBack:
+    """One stuck session must not stop the whole queue.
+
+    Production: a paused session's container was removed underneath it, so
+    every pass tried to reattach it, failed, and returned — because
+    resuming comes before admitting. Two sessions sat queued behind it for
+    as long as it existed, and the log filled with the same line every
+    fifteen seconds.
+    """
+
+    @staticmethod
+    def install(monkeypatch, *, exists: bool):
+        from app import capacity, sessions
+
+        settled: list = []
+        resumed: list = []
+
+        async def reading(timeout_s: float = 5.0, lane=None, ours=None):
+            return capacity.Reading(load=0.0, busy_slots=0, total_slots=20, queue_total=0, ok=True)
+
+        async def container_state(_container_id):
+            return ("running" if exists else "gone"), None
+
+        async def settle(_self, session_id, *, exit_code, error):
+            settled.append((session_id, error))
+
+        async def connect_network(_network, _container_id):
+            resumed.append("attached")
+            return True
+
+        async def unpause(_container_id):
+            return True
+
+        async def transition(_sid, _target, **_fields):
+            return True
+
+        async def add_event(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(capacity, "read_load", reading)
+        monkeypatch.setattr(sessions.docker_engine, "container_state", container_state)
+        monkeypatch.setattr(sessions.docker_engine, "connect_network", connect_network)
+        monkeypatch.setattr(sessions.docker_engine, "unpause_container", unpause)
+        monkeypatch.setattr(sessions.db, "transition_session", transition)
+        monkeypatch.setattr(sessions.db, "add_event", add_event)
+        monkeypatch.setattr(sessions.SessionManager, "_settle", settle)
+        return settled, resumed
+
+    async def test_a_vanished_container_settles_the_session(self, monkeypatch):
+        from app import sessions
+
+        settled, resumed = self.install(monkeypatch, exists=False)
+
+        assert await sessions.manager._resume({"id": 34, "container_id": "cid-34"}, "load 0%") is False
+        assert settled and settled[0][0] == 34
+        assert "disappeared" in settled[0][1]
+        # It was never attached to anything: there was nothing there.
+        assert resumed == []
+
+    async def test_a_session_that_is_still_there_resumes(self, monkeypatch):
+        from app import sessions
+
+        settled, resumed = self.install(monkeypatch, exists=True)
+
+        assert await sessions.manager._resume({"id": 34, "container_id": "cid-34"}, "load 0%") is True
+        assert settled == [] and resumed == ["attached"]
+
+    async def test_the_queue_moves_on_when_nothing_could_be_resumed(self, monkeypatch):
+        from app import capacity, sessions
+
+        admitted: list = []
+
+        async def reading(timeout_s: float = 5.0, lane=None, ours=None):
+            return capacity.Reading(load=0.0, busy_slots=0, total_slots=20, queue_total=0, ok=True)
+
+        async def in_status(status):
+            if status is sessions.SessionStatus.PAUSED:
+                return [{"id": 34, "container_id": "cid-34"}]
+            return []
+
+        async def no_resume(_self, _session, _reason):
+            return False
+
+        async def peek(*, include_triggered: bool = True):
+            return {"id": 37, "model": None, "workspace_id": 1}
+
+        async def claim_session(session_id):
+            admitted.append(session_id)
+            return None
+
+        monkeypatch.setattr(capacity, "read_load", reading)
+        monkeypatch.setattr(sessions.db, "sessions_in_status", in_status)
+        monkeypatch.setattr(sessions.db, "next_queued_session", peek)
+        monkeypatch.setattr(sessions.db, "claim_session", claim_session)
+        monkeypatch.setattr(sessions.SessionManager, "_resume", no_resume)
+
+        await sessions.manager.scheduler_pass()
+
+        # Nothing was resumed, so the pass has not spent its turn: the work
+        # behind the stuck session gets its chance.
+        assert admitted == [37]

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -3929,7 +3929,7 @@ class TestAdmissionMeasuresTheRightLane:
         async def claim(_limit, *, include_triggered: bool = True):
             return []
 
-        async def claim_session(_session_id):
+        async def claim_session(_session_id, *, trigger_quota=None):
             return None
 
         async def none(_status):
@@ -4049,7 +4049,7 @@ def _claim_one(fake_claim):
     existing fakes honest without each of them growing a second one.
     """
 
-    async def claim_session(_session_id: int):
+    async def claim_session(_session_id: int, *, trigger_quota=None):
         taken = await fake_claim(1)
         return taken[0] if taken else None
 
@@ -4215,7 +4215,7 @@ class TestAPausedSessionThatCannotComeBack:
         async def peek(*, include_triggered: bool = True):
             return {"id": 37, "model": None, "workspace_id": 1}
 
-        async def claim_session(session_id):
+        async def claim_session(session_id, *, trigger_quota=None):
             admitted.append(session_id)
             return None
 

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -471,7 +471,7 @@ class TestPermissionsRevokedMidFlight:
         async def refresh():
             return revoked
 
-        async def read_load(timeout_s: float = 5.0, lane=None):
+        async def read_load(timeout_s: float = 5.0, lane=None, ours=None):
             # The lane an invalid policy hands over is empty, and an empty
             # lane is refused rather than measured.
             assert lane == frozenset()
@@ -855,11 +855,12 @@ class TestBackpressure:
 
 
 class TestAnAnswerThatWasNeverWritten:
-    """Somebody assigned something and is waiting to hear anything at all.
+    """A session that wrote nothing has nothing to say.
 
-    A session that finishes without writing a word is the one outcome that
-    must not be silent: it is the shape a silent failure takes, and from the
-    thread it is indistinguishable from being ignored.
+    Somebody is waiting to hear about their pull request, not about the
+    runner. So a session that finishes without a word is not announced —
+    the request is taken up again, and the thread hears from the attempt
+    that has something to report.
     """
 
     @staticmethod
@@ -880,73 +881,45 @@ class TestAnAnswerThatWasNeverWritten:
         async def record_reply_attempt(session_id, *, delivered):
             attempts.append((session_id, delivered))
 
+        async def abandon_reply(_session_id, *, attempts):
+            return None
+
         async def add_event(*_args, **_kwargs):
             return None
 
         monkeypatch.setattr(sessions.db, "get_session", get_session)
         monkeypatch.setattr(sessions.db, "record_reply_attempt", record_reply_attempt)
+        monkeypatch.setattr(sessions.db, "abandon_reply", abandon_reply)
         monkeypatch.setattr(sessions.db, "add_event", add_event)
         monkeypatch.setattr(sessions.github, "post_issue_comment", post_issue_comment)
         return posted, attempts
 
-    async def test_a_silent_success_still_says_something(self, monkeypatch, tmp_path):
-        from app import sessions
-
-        posted, attempts = self.install(
-            monkeypatch,
-            tmp_path,
-            {"id": 30, "status": "succeeded", "reply_target": "issue:886", "reply_posted_at": None, "pr_url": None},
-        )
-
-        await sessions.manager._post_reply(30)
-
-        assert attempts == [(30, True)]
-        number, body = posted[0]
-        assert number == 886
-        # It must not read as a verdict on the request.
-        assert "did not change anything" in body
-        assert "session 30" in body
-
-    async def test_a_session_that_opened_a_pull_request_says_where(self, monkeypatch, tmp_path):
+    async def test_a_silent_session_is_taken_up_again_rather_than_announced(self, monkeypatch, tmp_path):
         from app import sessions
 
         posted, _ = self.install(
             monkeypatch,
             tmp_path,
-            {
-                "id": 30,
-                "status": "succeeded",
-                "reply_target": "issue:886",
-                "reply_posted_at": None,
-                "pr_url": "https://github.com/x/y/pull/900",
-            },
+            {"id": 30, "status": "failed", "reply_target": "issue:886", "reply_posted_at": None, "pr_url": None},
         )
+        taken_up: list = []
+
+        async def take_up_again(_self, session, *, by="the runner"):
+            taken_up.append(session["id"])
+            return 99
+
+        monkeypatch.setattr(sessions.SessionManager, "take_up_again", take_up_again)
 
         await sessions.manager._post_reply(30)
 
-        assert "pull/900" in posted[0][1]
+        # "The session failed, run it again from the page" is the runner
+        # talking about itself in front of people who asked about their
+        # pull request. What it means is that the request was not dealt
+        # with — so it is dealt with again.
+        assert posted == []
+        assert taken_up == [30]
 
-    async def test_a_failure_says_what_went_wrong(self, monkeypatch, tmp_path):
-        from app import sessions
-
-        posted, _ = self.install(
-            monkeypatch,
-            tmp_path,
-            {
-                "id": 30,
-                "status": "failed",
-                "error": "agent exited with code 1",
-                "reply_target": "issue:886",
-                "reply_posted_at": None,
-                "pr_url": None,
-            },
-        )
-
-        await sessions.manager._post_reply(30)
-
-        assert "exited with code 1" in posted[0][1]
-
-    async def test_what_the_agent_wrote_wins(self, monkeypatch, tmp_path):
+    async def test_what_the_agent_wrote_is_posted(self, monkeypatch, tmp_path):
         from app import sessions
 
         posted, _ = self.install(
@@ -1394,7 +1367,7 @@ class TestAgentPhaseIsolation:
         paused: list = []
         events: list = []
 
-        async def fake_reading(_timeout_s=5.0, lane=None):
+        async def fake_reading(_timeout_s=5.0, lane=None, ours=None):
             return capacity.Reading(load=0.99, busy_slots=10, total_slots=10, queue_total=0, ok=True)
 
         async def fake_in_status(status):
@@ -2120,6 +2093,7 @@ class TestClaimToLaunchWindow:
         monkeypatch.setattr(sessions.capacity, "read_load", self._async_value(reading))
         monkeypatch.setattr(sessions.db, "sessions_in_status", self._async_value([]))
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.db, "add_event", slow_event)
         monkeypatch.setattr(sessions.db, "get_session", self._async_value({**session_row, "status": "starting"}))
@@ -2226,6 +2200,7 @@ class TestOverlappingAdmission:
         monkeypatch.setattr(sessions.capacity, "read_load", self._async_value(reading))
         monkeypatch.setattr(sessions.db, "sessions_in_status", fake_in_status)
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.db, "add_event", fake_event)
         monkeypatch.setattr(sessions.SessionManager, "_launch", fake_launch)
@@ -2279,6 +2254,7 @@ class TestOverlappingAdmission:
         monkeypatch.setattr(sessions.capacity, "read_load", self._async_value(reading))
         monkeypatch.setattr(sessions.db, "sessions_in_status", fake_in_status)
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.db, "add_event", fake_event)
         monkeypatch.setattr(sessions.SessionManager, "_launch", fake_launch)
@@ -2314,7 +2290,7 @@ class TestOverlappingAdmission:
         decided_loads: list = []
         real_start_decision = capacity.start_decision
 
-        async def fake_read_load(lane=None):
+        async def fake_read_load(lane=None, ours=None):
             return readings.pop(0) if len(readings) > 1 else readings[0]
 
         def spy_start_decision(reading, **kwargs):
@@ -2351,6 +2327,7 @@ class TestOverlappingAdmission:
         monkeypatch.setattr(sessions.capacity, "start_decision", spy_start_decision)
         monkeypatch.setattr(sessions.db, "sessions_in_status", fake_in_status)
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.db, "add_event", fake_event)
         monkeypatch.setattr(sessions.SessionManager, "_launch", fake_launch)
@@ -3663,6 +3640,7 @@ class TestOperatorControls:
         )
         monkeypatch.setattr(sessions.db, "sessions_in_status", self._async_value([{"id": 7, "container_id": "cid-7"}]))
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.db, "transition_session", self._async_value(True))
         monkeypatch.setattr(sessions.db, "add_event", self._async_value(None))
@@ -3704,6 +3682,7 @@ class TestOperatorControls:
 
         monkeypatch.setattr(sessions.db, "sessions_in_status", self._async_value([{"id": 7, "container_id": "cid-7"}]))
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", fake_claim)
+        monkeypatch.setattr(sessions.db, "claim_session", _claim_one(fake_claim))
         monkeypatch.setattr(sessions.db, "next_queued_session", _peek)
         monkeypatch.setattr(sessions.docker_engine, "pause_container", fake_pause)
         monkeypatch.setattr(sessions.docker_engine, "disconnect_network", self._async_value(True))
@@ -3940,7 +3919,7 @@ class TestAdmissionMeasuresTheRightLane:
         async def refresh():
             return policy
 
-        async def read_load(timeout_s: float = 5.0, lane=None):
+        async def read_load(timeout_s: float = 5.0, lane=None, ours=None):
             lanes.append(lane)
             return capacity.Reading(load=0.0, busy_slots=0, total_slots=20, queue_total=0, ok=True)
 
@@ -3950,6 +3929,9 @@ class TestAdmissionMeasuresTheRightLane:
         async def claim(_limit, *, include_triggered: bool = True):
             return []
 
+        async def claim_session(_session_id):
+            return None
+
         async def none(_status):
             return []
 
@@ -3958,6 +3940,7 @@ class TestAdmissionMeasuresTheRightLane:
         monkeypatch.setattr(capacity, "read_load", read_load)
         monkeypatch.setattr(sessions.db, "next_queued_session", peek)
         monkeypatch.setattr(sessions.db, "claim_queued_sessions", claim)
+        monkeypatch.setattr(sessions.db, "claim_session", claim_session)
         monkeypatch.setattr(sessions.db, "sessions_in_status", none)
 
         await sessions.manager.scheduler_pass()
@@ -3973,7 +3956,7 @@ class TestAdmissionMeasuresTheRightLane:
 
         readings: list = []
 
-        async def read_load(timeout_s: float = 5.0, lane=None):
+        async def read_load(timeout_s: float = 5.0, lane=None, ours=None):
             readings.append(lane)
             return capacity.Reading(load=0.0, busy_slots=0, total_slots=20, queue_total=0, ok=True)
 
@@ -4058,6 +4041,21 @@ class TestPicturesTravelWithTheRequest:
         assert await sessions.manager._collect_attachments(30, "![shot](https://example.com/a.png)") == []
 
 
+def _claim_one(fake_claim):
+    """The targeted claim, expressed through a test's own batch stub.
+
+    Admission takes the row it measured rather than "the next one"; these
+    tests care about *whether* something was claimed, so this keeps their
+    existing fakes honest without each of them growing a second one.
+    """
+
+    async def claim_session(_session_id: int):
+        taken = await fake_claim(1)
+        return taken[0] if taken else None
+
+    return claim_session
+
+
 async def _peek(*, include_triggered: bool = True):
     """What admission looks at before it measures: any queued session.
 
@@ -4066,3 +4064,66 @@ async def _peek(*, include_triggered: bool = True):
     model.
     """
     return {"id": 7, "model": None, "workspace_id": 1}
+
+
+class TestTakingWorkUpAgain:
+    """The same request, once more, without a person having to ask."""
+
+    ROW = {
+        "id": 30,
+        "workspace_id": 3,
+        "task": "answer the review on #858",
+        "trigger_kind": "review",
+        "trigger_ref": "pr-858-review-1",
+        "branch_name": "logos/issue-797",
+        "reply_target": "issue:858",
+        "reaction_target": "/repos/x/y/issues/858",
+        "priority": 80,
+        "open_pull_request": False,
+    }
+
+    @staticmethod
+    def install(monkeypatch, *, attempts: int):
+        from app import sessions
+
+        created: list = []
+
+        async def attempts_for_trigger(_ref):
+            return attempts
+
+        async def create_session(**kwargs):
+            created.append(kwargs)
+            return 99
+
+        async def add_event(*_args, **_kwargs):
+            return None
+
+        async def scheduler_pass(_self=None):
+            return None
+
+        monkeypatch.setattr(sessions.db, "attempts_for_trigger", attempts_for_trigger)
+        monkeypatch.setattr(sessions.db, "create_session", create_session)
+        monkeypatch.setattr(sessions.db, "add_event", add_event)
+        monkeypatch.setattr(sessions.SessionManager, "scheduler_pass", scheduler_pass)
+        return created
+
+    async def test_the_work_comes_back_where_it_came_from(self, monkeypatch):
+        from app import sessions
+
+        created = self.install(monkeypatch, attempts=1)
+
+        assert await sessions.manager.take_up_again(dict(self.ROW)) == 99
+        # The branch, the thread and the urgency belong to the request, not
+        # to the attempt that failed.
+        assert created[0]["branch"] == "logos/issue-797"
+        assert created[0]["reply_target"] == "issue:858"
+        assert created[0]["priority"] == 80
+        assert created[0]["deploy_to_dev"] is False
+
+    async def test_a_request_nothing_can_be_made_of_stops(self, monkeypatch):
+        from app import sessions
+
+        created = self.install(monkeypatch, attempts=sessions._MAX_ATTEMPTS_PER_REQUEST)
+
+        assert await sessions.manager.take_up_again(dict(self.ROW)) is None
+        assert created == []

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -4230,3 +4230,70 @@ class TestAPausedSessionThatCannotComeBack:
         # Nothing was resumed, so the pass has not spent its turn: the work
         # behind the stuck session gets its chance.
         assert admitted == [37]
+
+
+class TestWhoseContainerIsIt:
+    """Settlement may only clear up after a row that is finished.
+
+    Production: a settlement raced the pauser, found the row in 'paused',
+    declined to record anything — and removed the container anyway. The
+    session was then unresumable, held its workspace, and blocked the queue
+    behind it. Removing somebody else's container is the one thing a
+    settlement that has decided not to own the row must not do.
+    """
+
+    @staticmethod
+    def install(monkeypatch, tmp_path, status: str):
+        from app import sessions
+
+        monkeypatch.setattr(sessions, "settings", replace(sessions.settings, artifact_root=str(tmp_path)))
+        removed: list = []
+
+        async def get_session(_session_id):
+            return {"id": 34, "status": status, "container_id": "cid-34"}
+
+        async def cleanup(_self, session_id):
+            removed.append(session_id)
+
+        monkeypatch.setattr(sessions.db, "get_session", get_session)
+        monkeypatch.setattr(sessions.SessionManager, "_cleanup_container", cleanup)
+        return removed
+
+    async def test_a_paused_row_keeps_its_container(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        removed = self.install(monkeypatch, tmp_path, "paused")
+
+        await sessions.manager._settle(34, exit_code=0, error=None)
+
+        assert removed == []
+
+    async def test_a_cancelled_row_gives_its_container_back(self, monkeypatch, tmp_path):
+        from app import sessions
+
+        removed = self.install(monkeypatch, tmp_path, "cancelled")
+
+        await sessions.manager._settle(34, exit_code=0, error=None)
+
+        # Finished for good: the container is a leftover.
+        assert removed == [34]
+
+    async def test_a_resume_that_throws_does_not_take_the_pass_with_it(self, monkeypatch):
+        from app import sessions
+
+        async def exists(_container_id):
+            return "running", None
+
+        async def attach(_network, _container_id):
+            return True
+
+        async def explodes(_container_id):
+            raise sessions.docker_engine.DockerError(500, "something nobody expected")
+
+        monkeypatch.setattr(sessions.docker_engine, "container_state", exists)
+        monkeypatch.setattr(sessions.docker_engine, "connect_network", attach)
+        monkeypatch.setattr(sessions.docker_engine, "unpause_container", explodes)
+
+        # Everything behind this session — resuming the rest, admitting,
+        # sweeping — would otherwise stop with it.
+        assert await sessions.manager._resume({"id": 34, "container_id": "cid-34"}, "load 0%") is False

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -2095,7 +2095,7 @@ class TestClaimToLaunchWindow:
 
         reading = capacity.Reading(load=0.0, busy_slots=0, total_slots=4, queue_total=0, ok=True)
 
-        async def fake_claim(_limit):
+        async def fake_claim(_limit, *, include_triggered: bool = True):
             states[5] = "starting"
             return [session_row]
 
@@ -2204,7 +2204,7 @@ class TestOverlappingAdmission:
             # Always a fresh read, like the database: whatever is true now.
             return [{"id": sid, "workspace_id": sid} for sid, state in states.items() if state == status.value]
 
-        async def fake_claim(limit):
+        async def fake_claim(limit, *, include_triggered: bool = True):
             claimed = []
             while limit > 0 and queue:
                 session = queue.pop(0)
@@ -2257,7 +2257,7 @@ class TestOverlappingAdmission:
         async def fake_in_status(status):
             return [{"id": sid, "workspace_id": sid} for sid, state in states.items() if state == status.value]
 
-        async def fake_claim(limit):
+        async def fake_claim(limit, *, include_triggered: bool = True):
             claimed = []
             while limit > 0 and queue:
                 session = queue.pop(0)
@@ -2328,7 +2328,7 @@ class TestOverlappingAdmission:
         async def fake_in_status(status):
             return [{"id": sid, "workspace_id": sid} for sid, state in states.items() if state == status.value]
 
-        async def fake_claim(limit):
+        async def fake_claim(limit, *, include_triggered: bool = True):
             claimed = []
             while limit > 0 and queue:
                 session = queue.pop(0)
@@ -3650,7 +3650,7 @@ class TestOperatorControls:
             paused.append(cid)
             return True
 
-        async def fake_claim(_limit):
+        async def fake_claim(_limit, *, include_triggered: bool = True):
             claimed.append(1)
             return []
 
@@ -3685,7 +3685,7 @@ class TestOperatorControls:
         async def drained():
             return {"mode": "draining", "mode_reason": "before a deploy", "max_parallel": None, "updated_by": "t"}
 
-        async def fake_claim(_limit):
+        async def fake_claim(_limit, *, include_triggered: bool = True):
             claimed.append(1)
             return []
 
@@ -3944,10 +3944,10 @@ class TestAdmissionMeasuresTheRightLane:
             lanes.append(lane)
             return capacity.Reading(load=0.0, busy_slots=0, total_slots=20, queue_total=0, ok=True)
 
-        async def peek():
+        async def peek(*, include_triggered: bool = True):
             return {"id": 7, "model": "model-b", "workspace_id": 1}
 
-        async def claim(_limit):
+        async def claim(_limit, *, include_triggered: bool = True):
             return []
 
         async def none(_status):
@@ -3980,7 +3980,7 @@ class TestAdmissionMeasuresTheRightLane:
         async def none(_status):
             return []
 
-        async def refuse(_limit):
+        async def refuse(_limit, *, include_triggered: bool = True):
             raise AssertionError("nothing is queued; there is nothing to claim")
 
         monkeypatch.setattr(capacity, "read_load", read_load)
@@ -4058,7 +4058,7 @@ class TestPicturesTravelWithTheRequest:
         assert await sessions.manager._collect_attachments(30, "![shot](https://example.com/a.png)") == []
 
 
-async def _peek():
+async def _peek(*, include_triggered: bool = True):
     """What admission looks at before it measures: any queued session.
 
     The tests that stub the claim are about admission, not about which row

--- a/logos/logos-agent/tests/test_sessions.py
+++ b/logos/logos-agent/tests/test_sessions.py
@@ -2291,7 +2291,12 @@ class TestOverlappingAdmission:
         real_start_decision = capacity.start_decision
 
         async def fake_read_load(lane=None, ours=None):
-            return readings.pop(0) if len(readings) > 1 else readings[0]
+            # A pass takes two readings of one moment — the platform's, and
+            # the platform's minus this runner's share — so only the first
+            # of the pair advances the prepared sequence.
+            if ours is None and len(readings) > 1:
+                return readings.pop(0)
+            return readings[0]
 
         def spy_start_decision(reading, **kwargs):
             decided_loads.append(reading.load)
@@ -2344,10 +2349,7 @@ class TestOverlappingAdmission:
         assert launched == [1]
         assert [sid for sid, state in states.items() if state == "queued"] == [2, 3, 4]
         # And the second decision was made on a post-launch observation, not
-        # on the shared pre-launch one. The figure it decided on is that
-        # observation minus the runner's own session — the load the launch
-        # caused is this runner's, and reacting to it would be reacting to
-        # itself.
+        # on the shared pre-launch one.
         assert decided_loads[0] == 0.0
         assert decided_loads[1] > 0.0
 
@@ -3972,7 +3974,9 @@ class TestAdmissionMeasuresTheRightLane:
 
         await sessions.manager.scheduler_pass()
 
-        assert len(readings) == 1
+        # Two of the same moment — with and without this runner's share —
+        # and nothing queued, so admission takes none of its own.
+        assert len(readings) == 2
 
 
 class TestPicturesTravelWithTheRequest:

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -509,11 +509,11 @@ class TestBounds:
 
         queued = await triggers.TriggerPoller().poll_once()
 
-        # Half the ceiling *in force*, so an operator always has room — and
-        # it follows what they set at runtime, not what the environment
-        # configured.
-        assert triggers.max_active_sessions(4) == 2
-        assert len(queued) == 2
+        # The ceiling *in force*, less the places kept for people — and it
+        # follows what an operator set at runtime, not what the environment
+        # configured. With four, one stays free.
+        assert triggers.max_active_sessions(4) == 3
+        assert len(queued) == 3
 
     async def test_nothing_is_queued_while_the_ceiling_is_full(self, monkeypatch):
         FakeRepo(assigned_issues=[issue(1)]).install(monkeypatch)
@@ -535,10 +535,10 @@ class TestBounds:
     async def test_what_does_not_fit_now_is_found_again(self, monkeypatch):
         # Nothing is consumed by being seen: a pass reads the repository's
         # current state, so what it could not take on is still there.
-        repo = FakeRepo(assigned_issues=[issue(1), issue(2), issue(3)])
+        repo = FakeRepo(assigned_issues=[issue(number) for number in range(1, 6)])
         repo.install(monkeypatch)
         fake_db = FakeDb(
-            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)]
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 8)]
         )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
@@ -546,11 +546,13 @@ class TestBounds:
         poller = triggers.TriggerPoller()
 
         first = await poller.poll_once()
-        fake_db.active_triggers = 0  # the first two finished
+        fake_db.active_triggers = 0  # the first three finished
         second = await poller.poll_once()
 
-        assert len(first) == 2 and len(second) == 1
-        assert {c["trigger_ref"] for c in fake_db.created} == {"issue-1", "issue-2", "issue-3"}
+        # Three fit under the ceiling in force; the other two were left
+        # where they were and the next pass found them again.
+        assert len(first) == 3 and len(second) == 2
+        assert {c["trigger_ref"] for c in fake_db.created} == {f"issue-{n}" for n in range(1, 6)}
 
 
 class TestWorkspaceNaming:

--- a/logos/logos-agent/tests/test_triggers.py
+++ b/logos/logos-agent/tests/test_triggers.py
@@ -515,7 +515,9 @@ class TestBounds:
         assert triggers.max_active_sessions(4) == 3
         assert len(queued) == 3
 
-    async def test_nothing_is_queued_while_the_ceiling_is_full(self, monkeypatch):
+    async def test_nothing_is_queued_while_the_automation_is_full(self, monkeypatch):
+        # The quota counts what is *running*: with it used up, the pass adds
+        # nothing and the repository keeps the rest until a session ends.
         FakeRepo(assigned_issues=[issue(1)]).install(monkeypatch)
         fake_db = FakeDb(active_triggers=99)
         fake_db.install(monkeypatch)
@@ -535,24 +537,22 @@ class TestBounds:
     async def test_what_does_not_fit_now_is_found_again(self, monkeypatch):
         # Nothing is consumed by being seen: a pass reads the repository's
         # current state, so what it could not take on is still there.
-        repo = FakeRepo(assigned_issues=[issue(number) for number in range(1, 6)])
+        repo = FakeRepo(assigned_issues=[issue(1), issue(2), issue(3)])
         repo.install(monkeypatch)
         fake_db = FakeDb(
-            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 8)]
+            workspaces=[{"id": i, "name": f"w{i}", "active_sessions": 0, "base_branch": "main"} for i in range(1, 6)]
         )
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        ceiling(monkeypatch, 4)
+        ceiling(monkeypatch, 2)
         poller = triggers.TriggerPoller()
 
         first = await poller.poll_once()
-        fake_db.active_triggers = 0  # the first three finished
+        fake_db.active_triggers = 0  # the first one finished
         second = await poller.poll_once()
 
-        # Three fit under the ceiling in force; the other two were left
-        # where they were and the next pass found them again.
-        assert len(first) == 3 and len(second) == 2
-        assert {c["trigger_ref"] for c in fake_db.created} == {f"issue-{n}" for n in range(1, 6)}
+        assert len(first) == 1 and len(second) == 1
+        assert {c["trigger_ref"] for c in fake_db.created} == {"issue-1", "issue-2"}
 
 
 class TestWorkspaceNaming:
@@ -624,11 +624,13 @@ class TestTheCommentMark:
         assert fake_db.comment_mark is None
 
     async def test_work_left_for_the_next_pass_holds_the_mark(self, monkeypatch):
+        # One workspace, two pieces of work: the second is left where it
+        # was, so the mark must not move past the comments this pass saw.
         FakeRepo(assigned_issues=[issue(812), issue(813)]).install(monkeypatch)
         fake_db = FakeDb()
         fake_db.install(monkeypatch)
         allow_models(monkeypatch)
-        ceiling(monkeypatch, 1)
+        ceiling(monkeypatch, 2)
 
         queued = await triggers.TriggerPoller().poll_once()
 

--- a/logos/logos-agent/workspace/run_session.py
+++ b/logos/logos-agent/workspace/run_session.py
@@ -676,19 +676,18 @@ _spent = {"in": 0, "out": 0}
 def _report_usage(message: dict) -> None:
     """Print what has been spent so far, when it changes.
 
-    Both sides accumulate, because that is what the agent is charged for and
-    what the result file reports at the end: a turn's input is billed as
-    input even though most of it is the conversation being re-read. Taking
-    the largest turn instead would read lower here than in the final total,
-    and a number that jumps when the session ends is worse than no number.
+    Cache reads are deliberately not counted. Every turn re-reads the whole
+    conversation out of the cache, so summing that key means counting the
+    same tokens once per turn: a session reported seventeen million input
+    tokens against no output at all, which is a true sum of a meaningless
+    quantity. What is counted is what the model had to take in anew —
+    fresh input and cache writes — and what it wrote.
     """
     usage = message.get("usage")
     if not isinstance(usage, dict):
         return
     read = sum(
-        value
-        for key in ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens")
-        if isinstance(value := usage.get(key), int)
+        value for key in ("input_tokens", "cache_creation_input_tokens") if isinstance(value := usage.get(key), int)
     )
     written = usage.get("output_tokens")
     before = dict(_spent)
@@ -802,7 +801,11 @@ def usage_totals(usage: dict[str, object]) -> tuple[int, int, float]:
                 return value
         return 0
 
-    tokens_in = as_int("input_tokens") + as_int("cache_creation_input_tokens") + as_int("cache_read_input_tokens")
+    # Same definition as the running figures the session reports on its
+    # transcript, so the number does not change meaning when the session
+    # ends: fresh input and cache writes, not the conversation re-read out
+    # of the cache on every turn.
+    tokens_in = as_int("input_tokens") + as_int("cache_creation_input_tokens")
     tokens_out = as_int("output_tokens")
     # The CLI reports USD; Logos accounts in EUR. Without a live rate the
     # honest thing is to carry the number through unconverted and let the

--- a/logos/logos-ui/src/app/core/services/agent.service.ts
+++ b/logos/logos-ui/src/app/core/services/agent.service.ts
@@ -59,6 +59,13 @@ export class AgentService {
     );
   }
 
+  /** Move a queued session up, down, or to the front of the queue. */
+  moveInQueue(id: number, move: 'up' | 'down' | 'first'): Promise<AgentSession> {
+    return firstValueFrom(
+      this.http.post<AgentSession>(`${AgentService.BASE}/sessions/${id}/queue`, { move }),
+    );
+  }
+
   /** Queue the same work again — same task, workspace, branch and thread. */
   retrySession(id: number): Promise<AgentSession> {
     return firstValueFrom(

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -305,6 +305,18 @@
     <p class="empty">No sessions yet. Start one to put idle capacity to work.</p>
   }
 
+  @if (queuedSessions().length > 0) {
+    <!-- Its own group, in the order the scheduler will work through it:
+         shown among the running ones it would read newest-first, which is
+         not the order the arrows move things in. -->
+    <h2 class="section-title">Queue</h2>
+    <ul class="session-list">
+      @for (session of queuedSessions(); track session.id) {
+        <ng-container *ngTemplateOutlet="sessionRow; context: { $implicit: session }" />
+      }
+    </ul>
+  }
+
   @if (activeSessions().length > 0) {
     <h2 class="section-title">Active</h2>
     <ul class="session-list">

--- a/logos/logos-ui/src/app/features/agents/agents.html
+++ b/logos/logos-ui/src/app/features/agents/agents.html
@@ -155,8 +155,8 @@
           }
         </div>
         <span class="field__hint">
-          Takes effect on the next scheduler pass. Zero drains without pausing:
-          nothing new starts, what runs finishes.
+          Takes effect on the next scheduler pass. Zero drains without pausing: nothing new starts,
+          what runs finishes.
         </span>
       </div>
     </section>
@@ -340,6 +340,44 @@
           <span class="session__duration">{{ duration(session) }}</span>
         </span>
       </button>
+
+      @if (session.status === 'queued' && queuedSessions().length > 1) {
+        <!-- The order is what the runner works through while the platform
+             is busy. Priority is derived from what a request is, which is
+             right most of the time; the rest is what the person watching
+             knows and the rules do not. -->
+        <div class="session__queue" role="group" aria-label="Position in the queue">
+          <button
+            class="btn btn--ghost btn--icon"
+            (click)="move(session, 'first')"
+            [disabled]="moving() !== null || queuedSessions()[0].id === session.id"
+            title="Work on this one next"
+            aria-label="Move to the front of the queue"
+          >
+            <i class="pi pi-angle-double-up" aria-hidden="true"></i>
+          </button>
+          <button
+            class="btn btn--ghost btn--icon"
+            (click)="move(session, 'up')"
+            [disabled]="moving() !== null || queuedSessions()[0].id === session.id"
+            title="Move up one place"
+            aria-label="Move up in the queue"
+          >
+            <i class="pi pi-angle-up" aria-hidden="true"></i>
+          </button>
+          <button
+            class="btn btn--ghost btn--icon"
+            (click)="move(session, 'down')"
+            [disabled]="
+              moving() !== null || queuedSessions()[queuedSessions().length - 1].id === session.id
+            "
+            title="Move down one place"
+            aria-label="Move down in the queue"
+          >
+            <i class="pi pi-angle-down" aria-hidden="true"></i>
+          </button>
+        </div>
+      }
 
       @if (selectedId() === session.id) {
         <div class="session__detail">

--- a/logos/logos-ui/src/app/features/agents/agents.scss
+++ b/logos/logos-ui/src/app/features/agents/agents.scss
@@ -479,6 +479,17 @@
   }
 }
 
+.session__queue {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0 0.75rem 0.5rem;
+}
+
+.btn--icon {
+  padding: 0.2rem 0.45rem;
+  line-height: 1;
+}
+
 .field__value {
   margin-left: 0.4rem;
   font-size: var(--font-size-sm);

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -137,7 +137,10 @@ export class Agents implements OnInit {
   );
 
   // ── grouped view ─────────────────────────────────────────────────────────
-  activeSessions = computed(() => this.sessions().filter((s) => isActive(s.status)));
+  /** What is under way: everything active that is not still waiting. */
+  activeSessions = computed(() =>
+    this.sessions().filter((s) => isActive(s.status) && s.status !== 'queued'),
+  );
   finishedSessions = computed(() => this.sessions().filter((s) => !isActive(s.status)));
 
   loadPercent = computed(() => Math.round((this.capacity()?.load ?? 0) * 100));

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -373,6 +373,31 @@ export class Agents implements OnInit {
 
   private stream: AbortController | null = null;
   retrying = signal<number | null>(null);
+  moving = signal<number | null>(null);
+
+  /** The queue, in the order the runner will work through it. */
+  readonly queuedSessions = computed(() => this.sessions().filter((s) => s.status === 'queued'));
+
+  /**
+   * Move a queued session in the queue.
+   *
+   * Priority is derived from what a request is, which is right most of the
+   * time. The rest — which review is holding up a release, which issue can
+   * wait until tomorrow — is something the person watching knows and the
+   * rules do not.
+   */
+  async move(session: AgentSession, where: 'up' | 'down' | 'first'): Promise<void> {
+    if (this.moving() !== null) return;
+    this.moving.set(session.id);
+    try {
+      await this.agentService.moveInQueue(session.id, where);
+      await this.refresh({ quiet: true });
+    } catch (err: unknown) {
+      this.error.set(this.messageOf(err, 'Could not move that session in the queue.'));
+    } finally {
+      this.moving.set(null);
+    }
+  }
 
   /**
    * Queue a finished session's work again.

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -178,7 +178,12 @@ export class Agents implements OnInit {
   private async tick(): Promise<void> {
     // Only poll while something can change; a page left open on a finished
     // session should not keep the runner busy answering.
-    if (this.activeSessions().length === 0 && this.selectedId() === null) {
+    // Everything that has not finished, queued rows included: they are not
+    // rendered with the active ones any more, and gating the poll on that
+    // list would leave a page showing only a queue frozen — no start, no
+    // cancellation and no reordering would ever reach it.
+    const live = this.sessions().filter((s) => isActive(s.status)).length;
+    if (live === 0 && this.selectedId() === null) {
       await this.loadCapacity();
       return;
     }

--- a/logos/logos-ui/src/app/features/agents/agents.ts
+++ b/logos/logos-ui/src/app/features/agents/agents.ts
@@ -375,8 +375,21 @@ export class Agents implements OnInit {
   retrying = signal<number | null>(null);
   moving = signal<number | null>(null);
 
-  /** The queue, in the order the runner will work through it. */
-  readonly queuedSessions = computed(() => this.sessions().filter((s) => s.status === 'queued'));
+  /**
+   * The queue, in the order the runner will work through it.
+   *
+   * Not the order the list arrives in: sessions come newest-first, and the
+   * scheduler takes the most urgent, oldest among equals. Showing one and
+   * moving by the other would grey out the arrows on the wrong rows.
+   */
+  readonly queuedSessions = computed(() =>
+    this.sessions()
+      .filter((s) => s.status === 'queued')
+      .sort(
+        (a, b) =>
+          b.priority - a.priority || a.created_at.localeCompare(b.created_at) || a.id - b.id,
+      ),
+  );
 
   /**
    * Move a queued session in the queue.


### PR DESCRIPTION
Two things production showed within a minute of each other, both visible in the runner's own log.

## It paused itself for its own load

```
paused session 31: users are queueing (4 waiting)
paused session 32: users are queueing (4 waiting)
paused session 33: users are queueing (4 waiting)
```

Those four waiting were its own sessions. The orchestrator reports how busy a model is and never who is keeping it busy — I checked the payload: `active`, `queue_depth`, `scheduler_signals`, and nothing that attributes any of it to a caller. So a runner with four sessions in flight reads four users, pauses everything, watches the queue empty along with its own requests, resumes, and does it again.

It subtracts itself now. A running session has at most one request outstanding — being served, or waiting for a slot — so that many come off the figures before any decision is made, taken from the queue first because a request that is waiting is not being served. A real user waiting still shows and still stops the runner, which is the property that mattered.

## It kept half the fleet idle for nobody

The trigger quota was half the parallel ceiling. Ten pieces of re-triggered work today produced four running sessions and an empty queue: the other six were simply left in the repository, correctly but pointlessly, while five slots sat reserved for an operator who might turn up.

The reservation is a couple of places now — a fifth of the ceiling, at least one. Enough that a session queued by hand always finds room next to the automation, without holding half a platform idle whose whole point is spending capacity that would otherwise go to waste.

---

420 tests green, pre-commit clean. `TestNotReactingToItself` covers the discount from both sides: our own queueing is not a user waiting, and a user waiting behind us still is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Operators can reorder queued sessions, including moving them up, down, or to the front.
  - Pull request tasks now include review and discussion context, with supported image attachments.
  - Scheduling accounts for deployment-specific capacity, queue activity, and cache pressure.
  - Model aliases are recognized consistently across deployments.

- **Bug Fixes**
  - Failed session replies retry safely with bounded attempts.
  - Resuming already-running or exited containers no longer blocks scheduling.
  - Deployment image tags are validated before use.
  - Cache-read tokens are excluded from usage totals for more accurate reporting.

- **Documentation**
  - Updated capacity and queueing behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->