### PR TITLE
`Logos`: Fit the KPI card sparkline to its slot

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/components/sparkline/sparkline.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/sparkline/sparkline.scss
@@ -1,7 +1,22 @@
-.sparkline-svg {
-  display: inline-block;
+// The KPI card hands the sparkline whatever width is left after the value and
+// the gap — and in a card near its minimum that is less than the drawing's
+// natural 92px. The host therefore declares the natural width only as an
+// upper bound and may shrink, and the drawing fills the host it is given, so
+// a tight card scales the line down instead of letting it run into the card
+// border. The viewBox keeps the shape at any size.
+:host {
+  display: block;
   width: 92px;
-  height: 28px;
+  min-width: 0;
+}
+
+// The viewBox (0 0 92 28) carries the drawing's ratio, so a fluid width
+// keeps the shape at every size.
+.sparkline-svg {
+  display: block;
+  width: 100%;
+  max-width: 92px;
+  height: auto;
   overflow: visible;
 }
 

--- a/logos/logos-ui/src/app/features/statistics/components/sparkline/sparkline.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/sparkline/sparkline.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+import sparklineStyles from './sparkline.scss?raw';
+import { SparklineComponent } from './sparkline';
+
+/**
+ * The polyline the sparkline draws.
+ *
+ * The line always spans the full width of the drawing, and the largest value
+ * maps to the top edge, so a rising series reads as rising regardless of the
+ * magnitude of the values.
+ */
+describe('points', () => {
+  it('spans the full width and puts the maximum at the top', () => {
+    const c = new SparklineComponent();
+    c.data = [0, 1, 0];
+    expect(c.points).toBe('0.00,27.00 46.00,1.00 92.00,27.00');
+  });
+
+  it('keeps proportions for values below the maximum', () => {
+    const c = new SparklineComponent();
+    c.data = [2, 4];
+    expect(c.points).toBe('0.00,14.00 92.00,1.00');
+  });
+
+  it('centers a single point', () => {
+    const c = new SparklineComponent();
+    c.data = [5];
+    expect(c.points).toBe('46.00,1.00');
+  });
+
+  it('draws nothing without data or with a flat zero series', () => {
+    const c = new SparklineComponent();
+    c.data = [];
+    expect(c.points).toBe('');
+    c.data = [0, 0];
+    expect(c.points).toBe('');
+  });
+});
+
+describe('shouldRender', () => {
+  it('is true only for a series with at least one positive value', () => {
+    const c = new SparklineComponent();
+    c.data = [];
+    expect(c.shouldRender).toBe(false);
+    c.data = [0, 0];
+    expect(c.shouldRender).toBe(false);
+    c.data = [0, 3];
+    expect(c.shouldRender).toBe(true);
+  });
+});
+
+describe('rendered svg', () => {
+  it('draws into the viewBox and carries no fixed size attributes', async () => {
+    await TestBed.configureTestingModule({
+      imports: [SparklineComponent],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(SparklineComponent);
+    fixture.componentInstance.data = [0, 1, 0];
+    fixture.detectChanges();
+
+    const svg = fixture.nativeElement.querySelector('svg.sparkline-svg');
+    expect(svg).toBeInstanceOf(SVGElement);
+    // The size comes from the stylesheet (which scales the line to the KPI
+    // card slot), never from fixed attributes on the element — a fixed
+    // 92x28 box is what used to push the line into the card border.
+    expect(svg?.getAttribute('width')).toBeNull();
+    expect(svg?.getAttribute('height')).toBeNull();
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 92 28');
+  });
+
+  it('renders nothing while there is no series to draw', async () => {
+    await TestBed.configureTestingModule({
+      imports: [SparklineComponent],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(SparklineComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('svg.sparkline-svg')).toBeNull();
+  });
+});
+
+/**
+ * The sizing contract of the stylesheet.
+ *
+ * The unit-test environment applies no layout, so the declarations that keep
+ * the line inside the KPI card are pinned here as text: the host may shrink
+ * below its natural width, and the drawing fills the host it is given
+ * instead of keeping a fixed 92x28 box.
+ */
+describe('sparkline stylesheet', () => {
+  it('lets the host shrink below its natural width', () => {
+    expect(ruleBody(sparklineStyles, ':host')).toMatch(/min-width:\s*0/);
+  });
+
+  it('scales the drawing to the host instead of keeping a fixed box', () => {
+    const body = ruleBody(sparklineStyles, '.sparkline-svg');
+    expect(body).toMatch(/width:\s*100%/);
+    expect(body).toMatch(/max-width:\s*92px/);
+    // The lookbehind keeps this from matching the max-width cap.
+    expect(body).not.toMatch(/(?<!-)width:\s*92px/);
+    expect(body).not.toMatch(/height:\s*28px/);
+  });
+});
+
+/**
+ * The declaration block of a top-level rule, so the assertions above read
+ * against the stylesheet the same way a browser would apply it.
+ */
+function ruleBody(source: string, selector: string): string {
+  const start = source.indexOf(selector);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const open = source.indexOf('{', start);
+  expect(open).toBeGreaterThan(start);
+  const close = source.indexOf('}', open);
+  expect(close).toBeGreaterThan(open);
+  return source.slice(open + 1, close);
+}

--- a/logos/logos-ui/src/app/features/statistics/components/stat-kpi-card/stat-kpi-card.scss
+++ b/logos/logos-ui/src/app/features/statistics/components/stat-kpi-card/stat-kpi-card.scss
@@ -55,6 +55,16 @@
   line-height: var(--line-height-tight);
 }
 
+// The right slot is projected content, a flex item of this row. Its floor
+// must be zero: a card narrower than value + gap + slot would otherwise let
+// the slot keep the width of whatever it draws (a 92px sparkline, a run of
+// lane bars) and the drawing runs into the card border. With the floor at
+// zero the slot yields its width to the value, and the drawing inside scales
+// (sparkline) or clips (lane bars) to the space it is given.
+.kpi-row-2 ::ng-deep [kpiRight] {
+  min-width: 0;
+}
+
 // Row 3: hint slot
 .kpi-row-3 {
   // Uses .kpi-sub styling via projection

--- a/logos/logos-ui/src/app/features/statistics/components/stat-kpi-card/stat-kpi-card.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/stat-kpi-card/stat-kpi-card.spec.ts
@@ -1,0 +1,76 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import kpiCardStyles from './stat-kpi-card.scss?raw';
+import statisticsStyles from '../../statistics.scss?raw';
+import { StatKpiCardComponent } from './stat-kpi-card';
+import { SparklineComponent } from '../sparkline/sparkline';
+
+/**
+ * The card as the statistics page uses it: a value, the projected right
+ * slot, and the projected hint.
+ */
+@Component({
+  standalone: true,
+  imports: [StatKpiCardComponent, SparklineComponent],
+  template: `
+    <app-stats-kpi-card label="Requests" accent="#7C3AED" value="222,987">
+      <app-stats-sparkline kpiRight [data]="spark" [color]="'#7C3AED'" />
+      <span kpiHint>avg run 61.10s · queue 0.85s</span>
+    </app-stats-kpi-card>
+  `,
+})
+class KpiCardHost {
+  spark = [0, 1, 0];
+}
+
+describe('slot placement', () => {
+  it('keeps the right slot in the value row and the hint in its own', async () => {
+    await TestBed.configureTestingModule({
+      imports: [KpiCardHost],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(KpiCardHost);
+    fixture.detectChanges();
+
+    // The slot rule below targets [kpiRight] inside .kpi-row-2 — the pin is
+    // only meaningful while the projection really lands there.
+    const row2 = fixture.nativeElement.querySelector('.kpi-row-2');
+    expect(row2?.querySelector('[kpiRight] svg.sparkline-svg')).not.toBeNull();
+    expect(row2?.querySelector('.kpi-value')).not.toBeNull();
+    const row3 = fixture.nativeElement.querySelector('.kpi-row-3');
+    expect(row3?.querySelector('[kpiHint]')).not.toBeNull();
+  });
+});
+
+/**
+ * The sizing contract of the stylesheets.
+ *
+ * The unit-test environment applies no layout, so the declarations that keep
+ * a card's right slot inside the card's padding are pinned here as text: the
+ * slot may shrink below whatever it draws, and the lane bars — the one slot
+ * that cannot scale — clip at the padding instead of reaching the border.
+ */
+describe('right-slot sizing contract', () => {
+  it('lets the projected right slot shrink to the space the card offers', () => {
+    expect(ruleBody(kpiCardStyles, '.kpi-row-2 ::ng-deep [kpiRight]')).toMatch(
+      /min-width:\s*0/,
+    );
+  });
+
+  it('clips the lane micro-bars at the card padding', () => {
+    expect(ruleBody(statisticsStyles, '.stats-lane-bars')).toMatch(/overflow:\s*hidden/);
+  });
+});
+
+/**
+ * The declaration block of a top-level rule, so the assertions above read
+ * against the stylesheet the same way a browser would apply it.
+ */
+function ruleBody(source: string, selector: string): string {
+  const start = source.indexOf(selector);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const open = source.indexOf('{', start);
+  expect(open).toBeGreaterThan(start);
+  const close = source.indexOf('}', open);
+  expect(close).toBeGreaterThan(open);
+  return source.slice(open + 1, close);
+}

--- a/logos/logos-ui/src/app/features/statistics/raw-assets.d.ts
+++ b/logos/logos-ui/src/app/features/statistics/raw-assets.d.ts
@@ -1,0 +1,8 @@
+// Vite loads `?raw` imports as plain strings. The specs that pin a
+// stylesheet contract read the .scss source this way, because the unit-test
+// environment applies no layout and the declarations themselves are the
+// change under test.
+declare module '*.scss?raw' {
+  const content: string;
+  export default content;
+}

--- a/logos/logos-ui/src/app/features/statistics/statistics.scss
+++ b/logos/logos-ui/src/app/features/statistics/statistics.scss
@@ -149,6 +149,10 @@
   align-items: flex-end;
   height: 28px;
   gap: 2px;
+  // The bars are fixed-width and cannot compress, so in a card too narrow
+  // for a full run the last bars clip at the card's padding instead of
+  // running into the border.
+  overflow: hidden;
 }
 
 .stats-lane-bar {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrow KPI card layouts so sparklines and projected values shrink without overflowing.
  * Prevented lane micro-bars from extending beyond card padding or borders.
  * Preserved sparkline proportions across different available widths.

* **Tests**
  * Added coverage for sparkline rendering, sizing, scaling, and edge cases.
  * Added tests for KPI card content placement and responsive sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->