### PR TITLE
`Development`: Keep pull request workflow read-only for docs builds

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,6 +11,8 @@ concurrency:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   docs:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,10 +11,20 @@ concurrency:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
-  docs:
-    uses: ./.github/workflows/docs.yml
+  # Call the build workflows directly instead of docs.yml: the locally
+  # called reusable workflow is PR-controlled code, so this workflow must
+  # stay read-only and must not carry pages/id-token permissions. Pages
+  # deployment stays on the push-main.yml path.
+  build-athena:
+    uses: ./.github/workflows/athena_docs-build.yml
+    secrets: inherit
+
+  build-atlas:
+    uses: ./.github/workflows/atlas_docs-build.yml
+    secrets: inherit
+
+  build-iris:
+    uses: ./.github/workflows/iris_docs-build.yml
     secrets: inherit


### PR DESCRIPTION
## What

Fixes the invalid workflow reported in #480:

> .github/workflows/pullrequest.yml (Line: 16): Error calling workflow '.../docs.yml@...'. The workflow is requesting 'pages: write, id-token: write', but is only allowed 'pages: none, id-token: none'.

## Why

`pullrequest.yml` called `docs.yml` via `workflow_call`. GitHub statically validates the called workflow's top-level `permissions` against the caller's — `docs.yml` declares `pages: write` + `id-token: write` (needed by its `deploy` job on `main`), while the PR workflow only granted `contents: read`, so validation failed.

## Change

Keep the PR workflow **read-only** (`contents: read`) and call the three read-only `*_docs-build.yml` workflows directly, instead of granting Pages/OIDC permissions to the caller:

- The locally called reusable workflow is PR-controlled code, so a PR could modify `docs.yml` and execute a job with Pages deployment or OIDC capabilities — the `if: github.ref == 'refs/heads/main'` condition is not a security boundary.
- Pages deployment stays exclusively on the `push-main.yml` path, which already carries `pages: write` + `id-token: write`.

Closes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Documentation checks now build separately for Athena, Atlas, and Iris during pull requests.
  - Pull-request documentation workflows remain read-only, while documentation deployment continues through the main-branch release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->