### PR TITLE
`Logos`: Stop offering Claude Code a window it cannot start in

### DIFF
--- a/logos/docs/context-windows.md
+++ b/logos/docs/context-windows.md
@@ -189,6 +189,54 @@ carries on. If a single turn grows past `window − reserve − 3000` it refuses
 send and asks for a `/compact` instead. Neither is an error the user has to
 recover from — the failure mode this replaces was a 400 from vLLM mid-turn.
 
+#### The floor: 37,024 tokens
+
+The deductions above are fixed, so there is a window below which Claude Code
+cannot run **at all** — and it is much higher than it looks. Its own opening
+prompt (system prompt plus the schemas of every tool it carries) is around
+13,000 tokens before the user has typed anything, and none of it is compactable:
+
+```text
+floor       = 13000 opening prompt + 20000 reservation + 3000 hard stop + 1024 headroom  = 37024
+comfortable = 13000 opening prompt + 20000 reservation + 13000 auto-compact + 1024        = 47024
+```
+
+A 32,768-token lane leaves `32768 − 20000 = 12768` tokens of input — one token
+short of the opening prompt. The session's **first** message comes back as
+
+```text
+This model's maximum context length is 32768 tokens. However, you requested
+20000 output tokens and your prompt contains at least 12769 input tokens
+```
+
+and there is nothing to compact, so it never recovers. Between the floor and
+47,024 the session runs but auto-compaction fires from the first message on.
+
+Two places enforce this, because a model can be chosen in either:
+
+- **The AI Tools page** disables such a model for Claude Code (`claudeCodeFitFor`
+  in `ai-tools.ts`), names the window in the option label and blocks the wizard
+  on the model step with the arithmetic spelled out. OpenCode is unaffected — it
+  is told what to reserve (`min(8192, context/2)`), so a narrow window costs it
+  reply length, not the session. The figure judged is
+  `max_model_len_current_min` — the one a request meets whichever deployment
+  answers — falling through to the wider figures only when it is absent, and a
+  model no lane serves is never judged.
+- **The wrapper** refuses to start and prints what is left, what it costs and
+  the `LOGOS_MAX_OUTPUT_TOKENS` value that would fit — measured against the
+  auto-compact point rather than the hard stop, since a reservation that only
+  clears the hard stop leaves a session compacting on every turn. `--check`
+  prints all of it without refusing anything, which is what makes it the thing
+  to run when a session will not start.
+
+Lowering the reservation is the only lever on the client side: at 32,768 tokens
+`LOGOS_MAX_OUTPUT_TOKENS=5744` makes the model usable with shorter replies. The
+better lever is the window — §2 and §3.
+
+The check the wrapper used to have (`headroom + reservation >= window`) only
+caught the arithmetic going negative, which a 32,768-token window passes
+comfortably while being unusable.
+
 The "auto-compact fires at ~60%" effect that started this work is these two
 fixed deductions — 33,000 tokens in total — as a share of a window that was
 already too small. It is not a percentage, and there is no knob to raise it:
@@ -246,6 +294,8 @@ capacity is tight; the routing in §3 gives them the best available shot.
 | Symptom | Cause |
 | --- | --- |
 | Claude Code compacts far earlier than the window suggests | The output reservation is being subtracted twice, or the session is running on `guaranteed` while `available` is much larger. Check `claude-logos --check`. |
+| `claude-logos` refuses to start with `BLOCKED` | The window is below the 37,024-token floor, so the session's first request would be rejected. Pick a wider model, or take the `LOGOS_MAX_OUTPUT_TOKENS` value the message names. |
+| The very first message of a session 400s with `you requested 20000 output tokens` | The lane came up narrower than the window the session was sized from — the cold-start case: with no lane up, only `max_model_len_overall` is known, and that is the widest window the model has *ever* been calibrated for, not what the planner will give a new lane from the capacity free right now. The next start sizes itself against the lane that is now up. |
 | `maximum context length is N tokens` 400s | The request landed on a deployment narrower than the estimate expected — most likely one that reports no window. Switch that wrapper to `LOGOS_CONTEXT_SOURCE=guaranteed`. |
 | A model is never placed on a node | The placement floor cannot be met there. Look for the "no calibrated KV point serves the required minimum" line and lower `min_context_fraction` for that model in the worker's config.yml. |
 | `max_model_len` absent from `/v1/models` | Nothing reports a window that always holds: a cloud model, a vLLM lane running at the model's native maximum (which the worker does not report), or every workernode offline. In the last case `max_model_len_overall` still carries the model's historic maximum, and the claude-logos wrapper sizes the session from it (startup line says "no lane is up yet"). |

--- a/logos/logos-ui/public/claude-logos.ps1
+++ b/logos/logos-ui/public/claude-logos.ps1
@@ -51,7 +51,7 @@ $ErrorActionPreference = 'Stop'
 # Bump on every change installed copies should pick up. Keep in step with the same
 # constant in claude-logos.sh — the two wrappers are one tool with two front ends.
 # A monotonic integer, not a version string: the comparison cannot misread anything.
-$ClaudeLogosVersion = 1          # 2026-08-25
+$ClaudeLogosVersion = 2          # 2026-09-04
 
 $ConfigDir = if ($env:LOGOS_CONFIG_DIR) { $env:LOGOS_CONFIG_DIR }
              else { Join-Path $env:USERPROFILE '.config\claude-logos' }
@@ -100,7 +100,10 @@ $ContextFallback = [int](Get-Setting 'LOGOS_CONTEXT_FALLBACK' 111200)
 
 # Claude Code caps what it reserves for output at 20000 tokens no matter how large a
 # CLAUDE_CODE_MAX_OUTPUT_TOKENS it is given, and subtracts that reservation from the
-# window itself. Asking for more buys nothing and costs context.
+# window itself. Asking for more buys nothing and costs context. Lowering it is the
+# one knob that makes a narrow window usable: under ~37000 tokens the default leaves
+# less input room than Claude Code's own opening prompt and the session is refused
+# before it starts (see the floor check below, which prints the value that fits).
 $MaxOutputTokens = [int](Get-Setting 'LOGOS_MAX_OUTPUT_TOKENS' 20000)
 
 # Logos rejects reasoning effort "high" with HTTP 500 before the model sees anything,
@@ -437,10 +440,6 @@ if ($Headroom -le 0) {
     # small window alive.
     $Headroom = [Math]::Min(8192, [Math]::Max(1024, [int]($ContextTokens / 50)))
 }
-if ($Headroom + $MaxOutputTokens -ge $ContextTokens) {
-    Stop-WithError "context window $ContextTokens is too small for the $MaxOutputTokens-token output reservation plus $Headroom headroom"
-}
-
 # The number handed to Claude Code is the window MINUS the headroom and nothing else.
 # Claude Code subtracts its own output reservation — min(CLAUDE_CODE_MAX_OUTPUT_TOKENS,
 # 20000) — from whatever it is told, and then compacts 13000 tokens below that.
@@ -449,6 +448,27 @@ if ($Headroom + $MaxOutputTokens -ge $ContextTokens) {
 $ContextForCli = $ContextTokens - $Headroom
 $CompactAt = $ContextForCli - $MaxOutputTokens - 13000
 $HardStopAt = $ContextForCli - $MaxOutputTokens - 3000
+
+# ── Is there room for a session at all? ─────────────────────────────────────────
+# Claude Code's opening prompt — its system prompt plus the schemas of every tool
+# it carries — is around 13000 tokens before the user has typed anything, and none
+# of it is compactable. Since the output reservation is charged against the same
+# window, a narrow window can leave less input room than that, and then the FIRST
+# request of the session comes back as "maximum context length is 32768 tokens.
+# However, you requested 20000 output tokens and your prompt contains at least
+# 12769 input tokens" — with nothing to compact yet, and so no way back. The check
+# that used to sit here only caught the arithmetic going negative, which a
+# 32768-token window passes comfortably while being unusable.
+#
+# Recorded rather than acted on immediately: -Check exists to diagnose exactly
+# this, so it prints the arithmetic and only a real start refuses to run.
+$ClaudeCodeBasePromptTokens = 13000
+$ContextTooSmall = $HardStopAt -lt $ClaudeCodeBasePromptTokens
+# What the reservation would have to be for the opening prompt to fit — measured
+# against the auto-compact point (13000) rather than the hard stop (3000), because
+# a value that only clears the hard stop leaves auto-compaction firing on every
+# turn. Offered only when what is left is still a usable reply length.
+$AffordableOutputTokens = $ContextTokens - $Headroom - 13000 - $ClaudeCodeBasePromptTokens
 
 # ── New models since the last run ───────────────────────────────────────────────
 # Models get added to a team without anyone telling the people on it, and the
@@ -492,8 +512,10 @@ function Write-ContextReport {
         Write-Host ("context  : {0:N0} tokens (an estimate — Logos reports no size for this model)" -f $ContextTokens)
     } elseif ($ContextOrigin -eq 'cold') {
         Write-Host ("context  : {0:N0} tokens, the maximum this model is served with" -f $ContextTokens)
-        Write-Host '           (no lane is up yet, so Logos reports no current size — the first'
-        Write-Host '            request brings one up and it is sized against this number)'
+        Write-Host '           (no lane is up yet, so Logos reports no current size. The first request'
+        Write-Host '            brings one up, and how wide it comes up is decided then from whatever'
+        Write-Host '            capacity is free — it can land well below this number, in which case'
+        Write-Host '            that request is turned down and the next start sizes itself correctly)'
     } else {
         Write-Host ("context  : {0:N0} tokens, using ""{1}"" of what Logos offers" -f $ContextTokens, $ContextOrigin)
         Write-Host ("           (guaranteed {0:N0} / available now {1:N0} / model max {2:N0})" -f `
@@ -504,6 +526,25 @@ function Write-ContextReport {
         $ContextForCli, $Headroom, $MaxOutputTokens)
     if ($KnownModelIds.Count -gt 0) {
         Write-Host ("warning  : {0} is not served here. Known models: {1}" -f $LogosModel, ($KnownModelIds -join ' '))
+    }
+    if ($ContextTooSmall) {
+        Write-Host 'BLOCKED  : this window cannot host a Claude Code session.'
+        Write-Host ("           {0:N0} tokens of input are left after the {1:N0} reserved for replies and" -f `
+            $HardStopAt, $MaxOutputTokens)
+        Write-Host ("           the {0:N0} of headroom, and Claude Code needs about {1:N0} of that for its own" -f `
+            $Headroom, $ClaudeCodeBasePromptTokens)
+        Write-Host '           system prompt and tool definitions — so the first request is rejected.'
+        if ($AffordableOutputTokens -ge 4096) {
+            Write-Host '           Reserving less fits, at the cost of reply length:'
+            Write-Host ("             `$env:LOGOS_MAX_OUTPUT_TOKENS={0}; claude-logos" -f $AffordableOutputTokens)
+        }
+        Write-Host ("           Otherwise pick a model Logos serves with a wider window (at least {0:N0});" -f `
+            ($ClaudeCodeBasePromptTokens + 20000 + 3000 + 1024))
+        Write-Host '           the AI Tools page shows what each one gets.'
+    } elseif ($CompactAt -lt $ClaudeCodeBasePromptTokens) {
+        Write-Host 'warning  : this window is workable but tight — auto-compaction starts almost'
+        Write-Host ("           immediately, because {0:N0} tokens are left before it fires and the system" -f $CompactAt)
+        Write-Host ("           prompt and tools already take about {0:N0}." -f $ClaudeCodeBasePromptTokens)
     }
     if ($LogosModel -like 'claude-*' -or $LogosModel -like '*[[]1m[]]*') {
         Write-Host 'warning  : Claude Code resolves this id to one of its own models and ignores'
@@ -549,6 +590,15 @@ if ($Check) {
 }
 
 # ── Launch ──────────────────────────────────────────────────────────────────────
+# A window too narrow for the opening prompt is refused here rather than handed to
+# Claude Code, whose first request would come back as a 400 from the worker that
+# reads like a bug in Logos. The report says what is left and how to get around
+# it, and -Check above still prints all of it without refusing anything.
+if ($ContextTooSmall) {
+    Write-ContextReport
+    Stop-WithError 'refusing to start: see BLOCKED above'
+}
+
 if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
     Stop-WithError 'claude is not on your PATH — install Claude Code first'
 }

--- a/logos/logos-ui/public/claude-logos.sh
+++ b/logos/logos-ui/public/claude-logos.sh
@@ -34,7 +34,7 @@ set -euo pipefail
 # version string: the comparison is a single `-gt` that cannot misread anything,
 # where sorting "1.10" against "1.9" needs care to get right. The date is here for
 # people; only the number is compared.
-CLAUDE_LOGOS_VERSION=1          # 2026-08-25
+CLAUDE_LOGOS_VERSION=2          # 2026-09-04
 
 CONFIG_DIR="${LOGOS_CONFIG_DIR:-$HOME/.config/claude-logos}"
 CONFIG_FILE="$CONFIG_DIR/config"
@@ -92,6 +92,11 @@ LOGOS_CONTEXT_FALLBACK="${LOGOS_CONTEXT_FALLBACK:-111200}"
 # window itself (vLLM charges input and output against one budget, so that is correct).
 # Asking for more than the cap therefore buys nothing and costs context — see the
 # arithmetic printed by --check.
+#
+# Lowering it is the one knob that makes a narrow window usable: on a window under
+# ~37000 tokens the default leaves less input room than Claude Code's own opening
+# prompt, and the session is refused before it starts (see the floor check below,
+# which prints the value that would fit).
 LOGOS_MAX_OUTPUT_TOKENS="${LOGOS_MAX_OUTPUT_TOKENS:-20000}"
 
 # Safety margin taken off the window before Claude Code is told about it. Claude Code
@@ -592,11 +597,6 @@ if [[ -z "$LOGOS_CONTEXT_HEADROOM" ]]; then
   (( LOGOS_CONTEXT_HEADROOM > 8192 )) && LOGOS_CONTEXT_HEADROOM=8192
 fi
 
-if (( LOGOS_CONTEXT_HEADROOM + LOGOS_MAX_OUTPUT_TOKENS >= LOGOS_CONTEXT_TOKENS )); then
-  die "context window $LOGOS_CONTEXT_TOKENS is too small for the \
-$LOGOS_MAX_OUTPUT_TOKENS-token output reservation plus $LOGOS_CONTEXT_HEADROOM headroom"
-fi
-
 # The number handed to Claude Code is the window MINUS the headroom and nothing else.
 # Claude Code subtracts its own output reservation — min(CLAUDE_CODE_MAX_OUTPUT_TOKENS,
 # 20000) — from whatever it is told, and then compacts 13000 tokens below that. So the
@@ -609,6 +609,38 @@ fi
 CONTEXT_FOR_CLI=$(( LOGOS_CONTEXT_TOKENS - LOGOS_CONTEXT_HEADROOM ))
 COMPACT_AT=$(( CONTEXT_FOR_CLI - LOGOS_MAX_OUTPUT_TOKENS - 13000 ))
 HARD_STOP_AT=$(( CONTEXT_FOR_CLI - LOGOS_MAX_OUTPUT_TOKENS - 3000 ))
+
+# ── Is there room for a session at all? ─────────────────────────────────────────
+# Claude Code's opening prompt — its system prompt plus the schemas of every tool
+# it carries — is around 13000 tokens before the user has typed anything, and none
+# of it is compactable: it is what makes the agent an agent. Since the output
+# reservation is charged against the same window, a narrow window can leave less
+# input room than that, and then the FIRST request of the session comes back as
+#
+#   This model's maximum context length is 32768 tokens. However, you requested
+#   20000 output tokens and your prompt contains at least 12769 input tokens
+#
+# with no way for the session to recover: there is nothing to compact yet. The
+# check that used to sit here only caught the arithmetic going negative
+# (headroom + reservation >= window), which a 32768-token window passes
+# comfortably while being unusable — 32768 - 20000 = 12768 tokens of input, one
+# token short of the opening prompt. So the floor is that prompt.
+#
+# It is recorded rather than acted on immediately, because --check exists to
+# diagnose exactly this: it prints the arithmetic and the way out, and only a real
+# start refuses to run.
+CLAUDE_CODE_BASE_PROMPT_TOKENS=13000
+CONTEXT_TOO_SMALL=0
+# What the reservation would have to be for the opening prompt to fit — measured
+# against the auto-compact point (13000) rather than the hard stop (3000), because
+# a value that only clears the hard stop leaves auto-compaction firing on every
+# turn, which is a working session in name only. Offered only when what is left is
+# still a usable reply length; below that the window itself is the problem and
+# pointing at the knob would be a dead end.
+AFFORDABLE_OUTPUT_TOKENS=$(( LOGOS_CONTEXT_TOKENS - LOGOS_CONTEXT_HEADROOM - 13000 - CLAUDE_CODE_BASE_PROMPT_TOKENS ))
+if (( HARD_STOP_AT < CLAUDE_CODE_BASE_PROMPT_TOKENS )); then
+  CONTEXT_TOO_SMALL=1
+fi
 
 # Group digits in threes. printf "%'d" would do this, but only under a locale
 # that defines a thousands separator — under LANG=C, which is what a login shell
@@ -634,8 +666,10 @@ context_report() {
   elif [[ "$CONTEXT_ORIGIN" == "cold" ]]; then
     printf 'context  : %s tokens, the maximum this model is served with\n' \
       "$(thousands "$LOGOS_CONTEXT_TOKENS")"
-    printf '           (no lane is up yet, so Logos reports no current size — the first\n'
-    printf '            request brings one up and it is sized against this number)\n'
+    printf '           (no lane is up yet, so Logos reports no current size. The first request\n'
+    printf '            brings one up, and how wide it comes up is decided then from whatever\n'
+    printf '            capacity is free — it can land well below this number, in which case\n'
+    printf '            that request is turned down and the next start sizes itself correctly)\n'
   else
     printf 'context  : %s tokens, using "%s" of what Logos offers\n' \
       "$(thousands "$LOGOS_CONTEXT_TOKENS")" "$CONTEXT_ORIGIN"
@@ -655,6 +689,27 @@ context_warnings() {
   if [[ -n "$KNOWN_MODEL_IDS" ]]; then
     printf 'warning  : %s is not served here. Known models: %s\n' \
       "$LOGOS_MODEL" "$KNOWN_MODEL_IDS"
+  fi
+  if (( CONTEXT_TOO_SMALL )); then
+    printf 'BLOCKED  : this window cannot host a Claude Code session.\n'
+    printf '           %s tokens of input are left after the %s reserved for replies and\n' \
+      "$(thousands "$HARD_STOP_AT")" "$(thousands "$LOGOS_MAX_OUTPUT_TOKENS")"
+    printf '           the %s of headroom, and Claude Code needs about %s of that for its own\n' \
+      "$(thousands "$LOGOS_CONTEXT_HEADROOM")" "$(thousands "$CLAUDE_CODE_BASE_PROMPT_TOKENS")"
+    printf '           system prompt and tool definitions — so the first request is rejected.\n'
+    if (( AFFORDABLE_OUTPUT_TOKENS >= 4096 )); then
+      printf '           Reserving less fits, at the cost of reply length:\n'
+      printf '             LOGOS_MAX_OUTPUT_TOKENS=%s claude-logos\n' "$AFFORDABLE_OUTPUT_TOKENS"
+    fi
+    printf '           Otherwise pick a model Logos serves with a wider window (at least %s);\n' \
+      "$(thousands "$(( CLAUDE_CODE_BASE_PROMPT_TOKENS + 20000 + 3000 + 1024 ))")"
+    printf '           the AI Tools page shows what each one gets.\n'
+  elif (( COMPACT_AT < CLAUDE_CODE_BASE_PROMPT_TOKENS )); then
+    printf 'warning  : this window is workable but tight — auto-compaction starts almost\n'
+    printf '           immediately, because %s tokens are left before it fires and the system\n' \
+      "$(thousands "$COMPACT_AT")"
+    printf '           prompt and tools already take about %s.\n' \
+      "$(thousands "$CLAUDE_CODE_BASE_PROMPT_TOKENS")"
   fi
   case "$LOGOS_MODEL" in
     claude-*|*"[1m]"*)
@@ -709,6 +764,16 @@ if [[ "${1:-}" == "--check" ]]; then
 fi
 
 # ── Launch ──────────────────────────────────────────────────────────────────────
+# A window too narrow for the opening prompt is refused here rather than handed to
+# Claude Code, whose first request would come back as a 400 from the worker that
+# reads like a bug in Logos. The report says what is left, what it costs and how
+# to get around it, so this is not a dead end — and --check above still prints all
+# of it without refusing anything.
+if (( CONTEXT_TOO_SMALL )); then
+  context_report >&2
+  die "refusing to start: see BLOCKED above"
+fi
+
 command -v claude >/dev/null 2>&1 || die "claude is not on your PATH — install Claude Code first"
 
 # Ask Logos to get the model ready before handing over. Backgrounded and

--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.html
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.html
@@ -245,7 +245,7 @@
 
       <div class="step-nav">
         <button type="button" class="btn-secondary" (click)="back()">Back</button>
-        <button type="button" class="btn-primary" [disabled]="!modelChosen()" (click)="next()">
+        <button type="button" class="btn-primary" [disabled]="!modelUsable()" (click)="next()">
           Continue <i class="pi pi-arrow-right" aria-hidden="true"></i>
         </button>
       </div>
@@ -697,13 +697,50 @@
           @if (!hasCurrentWindow() && hasOverallWindow()) {
             <strong>No worker is serving this model at the moment</strong>, which is why the
             first two figures have no value yet — they only exist while a lane is up. Starting
-            a session tells Logos to bring one up, and it is sized against the maximum on the
+            a session tells Logos to bring one up; how wide it comes up is decided then, from
+            the capacity that happens to be free, so it can land well below the maximum on the
             right.
           } @else if (!hasOverallWindow()) {
             Logos reports no size for this model at all, so the figure above is a
             conservative estimate.
           }
         </p>
+
+        <!-- The window against Claude Code's own fixed deductions. Below the
+             floor the session's first request is a 400, so the model is out of
+             reach rather than merely warned about; just above it, it runs but
+             compacts from the first message on. -->
+        @if (activeTool() === 'claudecode' && claudeCodeFit() === 'unusable') {
+          <div class="privacy-callout" role="note">
+            <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
+            <p>
+              <strong>This window is too small for Claude Code, so it cannot be picked.</strong>
+              Logos serves this model at {{ selectedContextFloor() | number }} tokens and Claude
+              Code needs at least {{ claudeCodeContextFloor | number }}: it reserves
+              {{ claudeCodeOutputReserve | number }} tokens for a reply on every request
+              whatever it is told, and its own system prompt and tool definitions take about
+              {{ claudeCodeBasePrompt | number }} more before you have typed anything. Both are
+              charged against the one window, so the session's very first message would come
+              back as <code class="inline-code">maximum context length is
+              {{ selectedContextFloor() | number }} tokens</code> — and no amount of
+              compacting gets under that. Pick a model with a wider window, or use OpenCode,
+              which is told what to reserve and only loses reply length here.
+            </p>
+          </div>
+        } @else if (activeTool() === 'claudecode' && claudeCodeFit() === 'tight') {
+          <div class="privacy-callout" role="note">
+            <i class="pi pi-exclamation-triangle" aria-hidden="true"></i>
+            <p>
+              <strong>This window is workable but tight for Claude Code.</strong>
+              After the {{ claudeCodeOutputReserve | number }} tokens it reserves for a reply
+              and the ~{{ claudeCodeBasePrompt | number }} its own system prompt and tools
+              take, a {{ selectedContextFloor() | number }}-token window leaves little room
+              before auto-compaction starts, so long tasks will be summarised repeatedly. From
+              {{ claudeCodeContextComfortable | number }} tokens up that stops being the normal
+              case.
+            </p>
+          </div>
+        }
 
         @if (activeTool() === 'claudecode' && windowUnenforced()) {
           <div class="privacy-callout" role="note">

--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.spec.ts
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.spec.ts
@@ -1,0 +1,211 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MyKeysService } from '../../core/services/my-keys.service';
+import { MyKey, ModelAccess } from '../../shared/models/my-key.model';
+import {
+  AiTools,
+  CLAUDE_CODE_CONTEXT_COMFORTABLE,
+  CLAUDE_CODE_CONTEXT_FLOOR,
+  claudeCodeFitFor,
+  servedContextFloorFor,
+} from './ai-tools';
+
+/**
+ * Claude Code cannot run in an arbitrarily small context window, and the size
+ * it needs is arithmetic rather than taste: it reserves 20,000 tokens for a
+ * reply on every request whatever it is told, vLLM charges input and output
+ * against the same window, and its own system prompt plus tool definitions is
+ * ~13,000 tokens before the user has typed anything.
+ *
+ * A 32,768-token model therefore leaves 12,768 tokens of input — one token
+ * short of that opening prompt — and a freshly installed wrapper answered its
+ * first message with "maximum context length is 32768 tokens ... you requested
+ * 20000 output tokens and your prompt contains at least 12769 input tokens".
+ * Nothing in the session recovers from that, so the page must not hand out an
+ * install command for such a model in the first place.
+ */
+
+const model = (overrides: Partial<ModelAccess> = {}): ModelAccess => ({
+  model_name: 'a-model',
+  provider_type: 'logosnode',
+  context_window_current_min: 262144,
+  context_window_current_max: 262144,
+  context_window_overall: 262144,
+  ...overrides,
+});
+
+const KEY: MyKey = {
+  id: 1,
+  name: 'a key',
+  key_value: 'logos-key',
+  key_type: 'user',
+  environment: 'production',
+  log: 'BILLING',
+  use_custom_permissions: false,
+  used_micro_cents: 0,
+  settings: null,
+  last_used_at: null,
+  team: {
+    id: 1,
+    name: 'a team',
+    team_monthly_budget_micro_cents: null,
+    budget_used_micro_cents: 0,
+  },
+};
+
+class FakeMyKeysService {
+  models: ModelAccess[] = [];
+
+  async getMyKeys(): Promise<MyKey[]> {
+    return [KEY];
+  }
+
+  async getKeyModels(): Promise<ModelAccess[]> {
+    return this.models;
+  }
+}
+
+describe('the window Claude Code needs', () => {
+  it('puts the floor above the reply reservation plus the opening prompt', () => {
+    // 13000 opening prompt + 20000 reservation + 3000 hard stop + 1024 headroom.
+    expect(CLAUDE_CODE_CONTEXT_FLOOR).toBe(37024);
+    // The same, with the 13000-token auto-compact distance instead of the
+    // 3000-token hard stop.
+    expect(CLAUDE_CODE_CONTEXT_COMFORTABLE).toBe(47024);
+  });
+
+  it('rejects the window that produced the report', () => {
+    expect(claudeCodeFitFor(model({ context_window_current_min: 32768 }))).toBe('unusable');
+  });
+
+  it('accepts a window with room to work', () => {
+    // 61440: hard stop at 37212 against a real input cap of 41440, and 27212
+    // tokens before auto-compaction — the first window above both thresholds
+    // that a worker actually serves.
+    expect(claudeCodeFitFor(model({ context_window_current_min: 61440 }))).toBe('ok');
+  });
+
+  it('calls a window that starts but compacts at once tight rather than unusable', () => {
+    expect(claudeCodeFitFor(model({ context_window_current_min: 40000 }))).toBe('tight');
+  });
+
+  it('judges the narrowest reported window, not the widest', () => {
+    // The wrapper defaults to "available", but a request may land on any
+    // deployment, so the floor is what has to fit.
+    const narrowLaneWideModel = model({
+      context_window_current_min: 32768,
+      context_window_current_max: 32768,
+      context_window_overall: 262144,
+    });
+    expect(servedContextFloorFor(narrowLaneWideModel)).toBe(32768);
+    expect(claudeCodeFitFor(narrowLaneWideModel)).toBe('unusable');
+  });
+
+  it('never judges a model no lane is serving', () => {
+    // Only the profile maximum is known. That is missing information about the
+    // window a lane would come up with, not evidence of a narrow one.
+    const cold = model({
+      context_window_current_min: null,
+      context_window_current_max: null,
+      context_window_overall: 262144,
+    });
+    expect(claudeCodeFitFor(cold)).toBe('ok');
+
+    const unknown = model({
+      context_window_current_min: null,
+      context_window_current_max: null,
+      context_window_overall: null,
+    });
+    expect(claudeCodeFitFor(unknown)).toBe('unknown');
+  });
+});
+
+describe('AiTools model gating', () => {
+  let service: FakeMyKeysService;
+  let component: AiTools;
+
+  const build = async (models: ModelAccess[]): Promise<void> => {
+    service = new FakeMyKeysService();
+    service.models = models;
+    await TestBed.configureTestingModule({
+      imports: [AiTools],
+      providers: [{ provide: MyKeysService, useValue: service }],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(AiTools);
+    component = fixture.componentInstance;
+    // ngOnInit pre-selects the key and loads its models; every test starts from
+    // the state that leaves behind.
+    await component.ngOnInit();
+  };
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('disables a too-narrow model for Claude Code and says why in the label', async () => {
+    await build([model({ model_name: 'narrow', context_window_current_min: 32768 })]);
+    component.chooseTool('claudecode');
+
+    const option = component.modelOptions()[0];
+    expect(option.disabled).toBe(true);
+    expect(option.label).toContain('32,768');
+    expect(option.label).toContain('too small for Claude Code');
+  });
+
+  it('leaves the same model selectable for OpenCode', async () => {
+    // OpenCode is told what to reserve, so a narrow window costs it reply
+    // length rather than the whole session.
+    await build([model({ model_name: 'narrow', context_window_current_min: 32768 })]);
+    component.chooseTool('opencode');
+
+    expect(component.modelOptions()[0].disabled).toBe(false);
+    expect(component.modelUsable()).toBe(true);
+  });
+
+  it('stops the wizard on the model step rather than generating a doomed install', async () => {
+    await build([model({ model_name: 'narrow', context_window_current_min: 32768 })]);
+    component.chooseTool('claudecode');
+
+    expect(component.modelChosen()).toBe(true);
+    expect(component.modelUsable()).toBe(false);
+    expect(component.claudeCodeFit()).toBe('unusable');
+    expect(component.canOpen(4)).toBe(false);
+    expect(component.ready()).toBe(false);
+    // With one model, step 3 is normally skipped as holding no decision — but
+    // it is where the explanation lives, so it must stay on screen.
+    expect(component.isSkipped(3)).toBe(false);
+  });
+
+  it('pre-selects a model Claude Code can use instead of the first one', async () => {
+    await build([
+      model({ model_name: 'narrow', context_window_current_min: 32768 }),
+      model({ model_name: 'wide', context_window_current_min: 131072 }),
+    ]);
+    component.chooseTool('claudecode');
+
+    expect(component.selected()?.model_name).toBe('wide');
+    expect(component.modelUsable()).toBe(true);
+    expect(component.canOpen(4)).toBe(true);
+  });
+
+  it('moves off a blocked model when the tool is switched to Claude Code', async () => {
+    await build([
+      model({ model_name: 'narrow', context_window_current_min: 32768 }),
+      model({ model_name: 'wide', context_window_current_min: 131072 }),
+    ]);
+    component.chooseTool('opencode');
+    component.selectModel('narrow');
+    expect(component.modelUsable()).toBe(true);
+
+    component.chooseTool('claudecode');
+    expect(component.selected()?.model_name).toBe('wide');
+  });
+
+  it('keeps a wide model untouched by any of this', async () => {
+    await build([model({ model_name: 'wide', context_window_current_min: 131072 })]);
+    component.chooseTool('claudecode');
+
+    expect(component.modelOptions()[0].disabled).toBe(false);
+    expect(component.modelOptions()[0].label).toBe('wide');
+    expect(component.claudeCodeFit()).toBe('ok');
+    expect(component.isSkipped(3)).toBe(true);
+  });
+});

--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.ts
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.ts
@@ -15,6 +15,17 @@ import { SelectComponent, AppSelectOption } from '../../shared/components/select
 export type AiTool = 'claudecode' | 'opencode';
 export type OsTab = 'mac' | 'linux' | 'windows';
 
+/**
+ * Whether a model's context window can carry a Claude Code session.
+ *
+ * `unusable`  the first request of the session comes back as a 400.
+ * `tight`     it runs, but auto-compaction fires from the first message on.
+ * `ok`        room to work before anything is compacted.
+ * `unknown`   Logos reports no window being served, so there is nothing to
+ *             judge — never a reason to block.
+ */
+export type ClaudeCodeFit = 'ok' | 'tight' | 'unusable' | 'unknown';
+
 /** One piece of the finishing confetti. Values are randomised per piece. */
 interface ConfettiPiece {
   id: number;
@@ -96,7 +107,7 @@ export class AiTools implements OnInit, OnDestroy {
   readonly toolChosen = computed(() => this.activeTool() !== null);
   readonly teamChosen = computed(() => this.selectedKey() !== null);
   readonly modelChosen = computed(() => this.selected() !== null);
-  readonly ready = computed(() => this.teamChosen() && this.modelChosen());
+  readonly ready = computed(() => this.teamChosen() && this.modelUsable());
 
   /**
    * A step that holds no decision is not a step. With one team there is nothing
@@ -106,11 +117,13 @@ export class AiTools implements OnInit, OnDestroy {
    * Only while the list is loaded and holds exactly one entry. An empty list is
    * *not* skipped — that step is where "no keys for your account" is said, and
    * silently jumping over it would leave the user in a later step wondering why
-   * nothing is generated.
+   * nothing is generated. Neither is a single model the chosen tool cannot use:
+   * step 3 is where that is explained, and skipping it would drop the user into
+   * the install step with no idea why nothing continues.
    */
   isSkipped(step: number): boolean {
     if (step === 2) return !this.keysLoading() && this.keys().length === 1;
-    if (step === 3) return !this.modelsLoading() && this.models().length === 1;
+    if (step === 3) return !this.modelsLoading() && this.models().length === 1 && this.modelUsable();
     return false;
   }
 
@@ -133,7 +146,7 @@ export class AiTools implements OnInit, OnDestroy {
     if (step === 2) return true;
     if (!this.teamChosen()) return false;
     if (step === 3) return true;
-    return this.modelChosen();
+    return this.modelUsable();
   }
 
   stepState(step: number): 'done' | 'current' | 'locked' | 'upcoming' {
@@ -243,8 +256,14 @@ export class AiTools implements OnInit, OnDestroy {
   chooseTool(tool: AiTool): void {
     this.activeTool.set(tool);
     // A tool switch changes what the later steps say but nothing about the team
-    // or the model, so those choices are kept. Land on the next step that
-    // actually asks something — with one team and one model that is the install.
+    // or the model, so those choices are kept — with one exception: a model the
+    // newly chosen tool cannot host is not a choice worth keeping, and moving
+    // off it is what lets the wizard continue. It stays put when nothing fits,
+    // so step 3 can say why.
+    const models = this.models();
+    if (models.length > 0 && !this.modelUsable()) this.selected.set(this.preferredModel(models));
+    // Land on the next step that actually asks something — with one team and
+    // one model that is the install.
     const target = this.firstOpenFrom(2);
     if (target !== null) this.setStep(target);
   }
@@ -265,9 +284,29 @@ export class AiTools implements OnInit, OnDestroy {
     this.keys().map((k) => ({ value: String(k.id), label: k.team.name })),
   );
 
-  readonly modelOptions = computed<AppSelectOption[]>(() =>
-    this.models().map((m) => ({ value: m.model_name, label: m.model_name })),
-  );
+  /**
+   * The models, with the ones Claude Code cannot host taken out of reach.
+   *
+   * A disabled option rather than a hidden one: the model *is* accessible to
+   * this key, it just cannot carry a Claude Code session, and a list that
+   * silently omits it reads as a permission problem. The window is named in
+   * the label because a greyed-out row with no reason reads as a bug in the
+   * page. OpenCode is left alone — it is told what to reserve, so a narrow
+   * window costs it reply length, not the whole session.
+   */
+  readonly modelOptions = computed<AppSelectOption[]>(() => {
+    const forClaudeCode = this.activeTool() === 'claudecode';
+    return this.models().map((m) => {
+      const blocked = forClaudeCode && claudeCodeFitFor(m) === 'unusable';
+      return {
+        value: m.model_name,
+        label: blocked
+          ? `${m.model_name} — ${servedContextFloorFor(m).toLocaleString('en-US')} tokens, too small for Claude Code`
+          : m.model_name,
+        disabled: blocked,
+      };
+    });
+  });
 
   // ── Context windows ───────────────────────────────────────────────────────
   // Three numbers per model, and which one to use depends on who is asking.
@@ -321,6 +360,39 @@ export class AiTools implements OnInit, OnDestroy {
   windowUnenforced = computed(() => {
     const name = (this.selected()?.model_name ?? '').toLowerCase();
     return name.startsWith('claude-') || name.includes('[1m]');
+  });
+
+  // ── Does Claude Code fit in there at all? ─────────────────────────────────
+  // The numbers below are read by the template, which cannot see module
+  // constants.
+  readonly claudeCodeBasePrompt = CC_BASE_PROMPT_TOKENS;
+  readonly claudeCodeOutputReserve = CC_OUTPUT_RESERVE_TOKENS;
+  readonly claudeCodeContextFloor = CLAUDE_CODE_CONTEXT_FLOOR;
+  readonly claudeCodeContextComfortable = CLAUDE_CODE_CONTEXT_COMFORTABLE;
+
+  /** The window the selected model is actually served with, 0 when unknown. */
+  readonly selectedContextFloor = computed(() => {
+    const model = this.selected();
+    return model ? servedContextFloorFor(model) : 0;
+  });
+
+  /** How the selected model's window measures up to what Claude Code needs. */
+  readonly claudeCodeFit = computed<ClaudeCodeFit>(() => {
+    const model = this.selected();
+    return model ? claudeCodeFitFor(model) : 'unknown';
+  });
+
+  /**
+   * Whether the setup may proceed past the model.
+   *
+   * A model chosen is not the same as a model that works: a window below
+   * `CLAUDE_CODE_CONTEXT_FLOOR` fails on the session's first request, so the
+   * wizard stops here and says why instead of generating an install command
+   * whose first use is an error.
+   */
+  readonly modelUsable = computed(() => {
+    if (!this.modelChosen()) return false;
+    return !(this.activeTool() === 'claudecode' && this.claudeCodeFit() === 'unusable');
   });
 
   // ── OpenCode ──────────────────────────────────────────────────────────────
@@ -617,7 +689,7 @@ export class AiTools implements OnInit, OnDestroy {
       }
       const unique = [...byName.values()];
       this.models.set(unique);
-      if (unique.length > 0) this.selected.set(unique[0]);
+      if (unique.length > 0) this.selected.set(this.preferredModel(unique));
     } catch {
       if (requestId === this.modelsRequestId) this.modelsError.set(true);
     } finally {
@@ -627,6 +699,18 @@ export class AiTools implements OnInit, OnDestroy {
 
   selectModel(name: string) {
     this.selected.set(this.models().find((m) => m.model_name === name) ?? null);
+  }
+
+  /**
+   * Which model to start on. The first one, unless the chosen tool cannot host
+   * it: pre-selecting a model that blocks the next step makes the page look
+   * broken for a team whose first model happens to be a narrow one. Falls back
+   * to the first model when none fits, because the explanation in step 3 needs
+   * a selection to be about.
+   */
+  private preferredModel(models: ModelAccess[]): ModelAccess {
+    if (this.activeTool() !== 'claudecode') return models[0];
+    return models.find((m) => claudeCodeFitFor(m) !== 'unusable') ?? models[0];
   }
 
   copyCmd(text: string) {
@@ -639,6 +723,87 @@ export class AiTools implements OnInit, OnDestroy {
 
 function positive(value: number | null | undefined): number {
   return typeof value === 'number' && value > 0 ? value : 0;
+}
+
+// ── The window Claude Code needs ────────────────────────────────────────────
+// Claude Code's session arithmetic is fixed, so the smallest window that can
+// host it is arithmetic too, not taste. Four deductions, none of them optional:
+//
+//   * it puts min(CLAUDE_CODE_MAX_OUTPUT_TOKENS, 20000) in `max_tokens` on
+//     every request, and vLLM charges input and output against one budget, so
+//     that reservation comes off the window whether or not the reply uses it;
+//   * its own system prompt and tool definitions are ~13000 tokens before the
+//     user has typed anything, and there is nothing to compact away about them;
+//   * it refuses to send 3000 tokens short of the limit it was told, and
+//     compacts by itself 13000 tokens short of it;
+//   * the claude-logos wrapper takes tokenizer-drift headroom off the top
+//     (2% of the window, floored at 1024).
+//
+// A 32768-token window therefore leaves 12768 tokens for input — one token
+// less than Claude Code's own opening prompt, which is how a fresh install
+// answered its very first message with
+//
+//   "This model's maximum context length is 32768 tokens. However, you
+//    requested 20000 output tokens and your prompt contains at least 12769
+//    input tokens"
+//
+// Nothing inside the session recovers that, so a window below the floor is not
+// offered for Claude Code at all.
+
+/** Claude Code's own prompt before the first user message: system + tool schemas. */
+const CC_BASE_PROMPT_TOKENS = 13_000;
+
+/** What it reserves for a reply, capped there regardless of what it is told. */
+const CC_OUTPUT_RESERVE_TOKENS = 20_000;
+
+/** How far short of the limit it refuses to send and asks for a /compact. */
+const CC_HARD_STOP_TOKENS = 3_000;
+
+/** How far short of the limit it compacts the conversation by itself. */
+const CC_AUTOCOMPACT_TOKENS = 13_000;
+
+/** The wrapper's tokenizer-drift headroom at its floor (claude-logos.sh). */
+const WRAPPER_HEADROOM_FLOOR_TOKENS = 1_024;
+
+/** Below this a session cannot send its first message at all: 37,024 tokens. */
+export const CLAUDE_CODE_CONTEXT_FLOOR =
+  CC_BASE_PROMPT_TOKENS +
+  CC_OUTPUT_RESERVE_TOKENS +
+  CC_HARD_STOP_TOKENS +
+  WRAPPER_HEADROOM_FLOOR_TOKENS;
+
+/** Below this it starts, but compacts from the first message on: 47,024 tokens. */
+export const CLAUDE_CODE_CONTEXT_COMFORTABLE =
+  CC_BASE_PROMPT_TOKENS +
+  CC_OUTPUT_RESERVE_TOKENS +
+  CC_AUTOCOMPACT_TOKENS +
+  WRAPPER_HEADROOM_FLOOR_TOKENS;
+
+/**
+ * The window a model is actually being served with, 0 when none is known.
+ *
+ * The narrowest of the reported figures, because that is the one a request
+ * meets: `current_min` holds whichever deployment answers. It falls through to
+ * the wider figures only when the narrower one is absent, and to 0 when Logos
+ * reports nothing at all — which is missing information, not a narrow window,
+ * and must not be judged as one. Deliberately *not* `configuredContextFor`,
+ * whose job is the opposite: the widest number to write into a config file.
+ */
+export function servedContextFloorFor(model: ModelAccess): number {
+  return (
+    positive(model.context_window_current_min) ||
+    positive(model.context_window_current_max) ||
+    positive(model.context_window_overall)
+  );
+}
+
+/** Whether a model's served window can carry a Claude Code session. */
+export function claudeCodeFitFor(model: ModelAccess): ClaudeCodeFit {
+  const served = servedContextFloorFor(model);
+  if (served <= 0) return 'unknown';
+  if (served < CLAUDE_CODE_CONTEXT_FLOOR) return 'unusable';
+  if (served < CLAUDE_CODE_CONTEXT_COMFORTABLE) return 'tight';
+  return 'ok';
 }
 
 /** Best guess at the visitor's OS, so the install tab starts on the right one. */


### PR DESCRIPTION
## What was wrong

A freshly installed `claude-logos` on `logos-test` answered its **very first message** with a 400 from the worker:

```
This model's maximum context length is 32768 tokens. However, you requested 20000
output tokens and your prompt contains at least 12769 input tokens, for a total of
at least 32769 tokens.
```

That is not a coincidence of one long prompt — it is arithmetic, and it makes a 32,768-token lane unusable for Claude Code no matter what:

| | |
|---|---|
| window | 32,768 |
| headroom (`claude-logos.sh`, 2% floored at 1024) | 1,024 |
| `CLAUDE_CODE_MAX_CONTEXT_TOKENS` handed over | 31,744 |
| `COMPACT_AT` | **−1,256** |
| `HARD_STOP_AT` | 8,744 |
| real vLLM input cap (`window − max_tokens`) | **12,768** |

Claude Code reserves 20,000 tokens for a reply on every request whatever it is told, vLLM charges input and output against the same window, and Claude Code's own system prompt plus tool schemas is ~13,000 tokens before the user has typed anything — the 12,769 in the error message. One token short, with nothing to compact yet, so the session never recovers.

The wrapper's guard could not catch it: it only tested `headroom + reservation >= window`, which is `21024 >= 32768` — passed comfortably while being unusable.

## What this changes

The floor is Claude Code's own opening prompt, and it is enforced where the model gets chosen:

```
floor       = 13000 opening prompt + 20000 reservation + 3000 hard stop     + 1024 headroom = 37024
comfortable = 13000 opening prompt + 20000 reservation + 13000 auto-compact + 1024 headroom = 47024
```

**AI Tools page** (`ai-tools.ts` / `.html`) — per @tobiaswasner's suggestion, the model simply cannot be picked for Claude Code:

- the option is disabled and its label says why (`… — 32,768 tokens, too small for Claude Code`);
- the wizard stops on the model step with the arithmetic spelled out, rather than generating an install command whose first use is an error;
- step 3 is no longer skipped when the single available model is a blocked one — that step is where the explanation lives;
- the pre-selection and a tool switch land on a model Claude Code can use, when there is one;
- between 37,024 and 47,024 the model stays selectable with a "workable but tight" note;
- **OpenCode is untouched.** It is told what to reserve (`min(8192, context/2)`), so a narrow window costs it reply length, not the session.

The figure judged is `max_model_len_current_min` — the one a request meets whichever deployment answers — falling through to the wider figures only when absent. A model no lane is serving is never judged.

**The wrapper** (`.sh` + `.ps1`, revision 1 → 2) — because the page is not the only way in (an existing install, `LOGOS_MODEL=…` per invocation), it refuses to start rather than handing Claude Code a session that 400s:

```
BLOCKED  : this window cannot host a Claude Code session.
           8,744 tokens of input are left after the 20,000 reserved for replies and
           the 1,024 of headroom, and Claude Code needs about 13,000 of that for its own
           system prompt and tool definitions — so the first request is rejected.
           Reserving less fits, at the cost of reply length:
             LOGOS_MAX_OUTPUT_TOKENS=5744 claude-logos
           Otherwise pick a model Logos serves with a wider window (at least 37,024);
           the AI Tools page shows what each one gets.
```

The value it names is measured against the auto-compact point rather than the hard stop — a reservation that only clears the hard stop leaves a session compacting on every turn, which is a working session in name only. `--check` prints all of it and refuses nothing, which is what makes it the thing to run when a session will not start.

**One correction on the side:** the cold-start line claimed the first request brings a lane up "sized against this number". It is not — with no lane up only `max_model_len_overall` is known, which is the widest window the model has *ever* been calibrated for, while the planner sizes the new lane from whatever capacity is free at that moment. That is the second route to the same 400, and it is now stated honestly in the wrapper, on the page and in the troubleshooting table instead of promised.

## Verified

- `ai-tools.spec.ts`, 13 new cases: the thresholds, the reported window that produced the report, the narrow-lane/wide-model case, cold and unknown models, and every gating consequence. `ng test`: **121 passed**. `ng build`: clean.
- The wrapper run end-to-end against a stand-in `/v1/models`:
  - **32,768** → `BLOCKED`, real start exits 1, `LOGOS_MAX_OUTPUT_TOKENS=5744` then gives compact at 13,000 / hard stop at 23,000;
  - **40,000** → runs, "workable but tight";
  - **61,440** → clean, no warning (hard stop 37,212 against a 41,440 cap);
  - **cold** → still sizes from the maximum, now saying what that does and does not promise.
- `bash -n` on the shell wrapper. The PowerShell copy mirrors it line for line; no `pwsh` on this machine to execute it.

## Not in scope

Two things I deliberately left out, both worth their own decision:

1. **Clamping `max_tokens` server-side** to the window of the lane a request is routed to. It would make *any* client's window overestimate a shorter reply instead of a 400 — including the cold-start case above, and OpenCode. It also cuts against the "answer an honest 400" line from #810, so it should be a deliberate call, not a side effect of this fix.
2. **`ng test` does not run in CI** — `logos_test.yml` only builds the UI, so the 121 specs (8 files before this one) are local-only. Adding the step is a one-liner but changes what can go red on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLzCdi7A3JoWJW4qXmnaQD