### PR TITLE
`Logos`: Re-anchor the stats page range on a calendar rollover

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
@@ -212,4 +212,51 @@ describe('Statistics scope options', () => {
     expect(page.component.filterUserId()).toBe(7);
     expect(page.ws.setScope.mock.calls.length).toBe(scopesBefore);
   });
+
+  it('discards a stale response when the operator zooms into a custom range', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+
+    // Same shape as the preset-pick race, one different move: the range
+    // changes by zooming, and the in-flight request for the range the
+    // operator zoomed away from must be superseded by it.
+    let releaseStale: (value: { teams: FeedFilterOption[]; requesters: FeedFilterOption[] }) => void =
+      () => {};
+    const stale = new Promise<{ teams: FeedFilterOption[]; requesters: FeedFilterOption[] }>(
+      (resolve) => {
+        releaseStale = resolve;
+      },
+    );
+    const fresh: { teams: FeedFilterOption[]; requesters: FeedFilterOption[] } = {
+      teams: [{ id: 1, label: 'Team One', requestCount: 3 }],
+      requesters: [{ id: 7, label: 'User Seven', requestCount: 5 }],
+    };
+    let first = true;
+    const getScopeOptions = vi.fn(() => (first ? (first = false, stale) : Promise.resolve(fresh)));
+    const page = await pageAt(getScopeOptions);
+    fixture = page.fx;
+
+    page.component.setCustomRange({
+      start: new Date(2026, 8, 6, 12, 0),
+      end: new Date(2026, 8, 6, 13, 0),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(page.component.feedUsers()).toEqual(fresh.requesters);
+    expect(page.component.feedTeams()).toEqual(fresh.teams);
+
+    page.component.setUserFilter('7');
+    await Promise.resolve();
+    await Promise.resolve();
+    const scopesBefore = page.ws.setScope.mock.calls.length;
+
+    releaseStale({ teams: [], requesters: [] });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(page.component.feedUsers()).toEqual(fresh.requesters);
+    expect(page.component.feedTeams()).toEqual(fresh.teams);
+    expect(page.component.filterUserId()).toBe(7);
+    expect(page.ws.setScope.mock.calls.length).toBe(scopesBefore);
+  });
 });

--- a/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
@@ -5,7 +5,7 @@ import { Statistics } from './statistics';
 import { StatsWebsocketService } from './services/stats-websocket.service';
 import { StatisticsService } from './services/statistics.service';
 
-import type { TimelineRequestConfig } from './statistics.models';
+import type { FeedFilterOption, TimelineRequestConfig } from './statistics.models';
 
 // The range the page shows is resolved from the calendar when it is picked,
 // and then it sits: the server deliberately keeps the start where the preset
@@ -17,34 +17,38 @@ import type { TimelineRequestConfig } from './statistics.models';
 // apply the moved range exactly like a picked one. These tests run the ticker
 // against a frozen clock and step it across a midnight the only way time can
 // step it.
+const wsSpy = () => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  reconnect: vi.fn(),
+  setTimelineRange: vi.fn(),
+  setScope: vi.fn(),
+  setFeedStatus: vi.fn(),
+});
+
+/** Boot the page at the frozen clock and wire in the service spies. */
+async function pageAt(
+  getScopeOptions: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue({
+    teams: [],
+    requesters: [],
+  }),
+) {
+  const ws = wsSpy();
+  await TestBed.configureTestingModule({
+    imports: [Statistics],
+    providers: [
+      { provide: StatsWebsocketService, useValue: ws },
+      { provide: StatisticsService, useValue: { getScopeOptions } },
+    ],
+  }).compileComponents();
+  const fx = TestBed.createComponent(Statistics);
+  const component = fx.componentInstance;
+  component.ngOnInit();
+  return { fx, component, ws, getScopeOptions };
+}
+
 describe('Statistics calendar rollover', () => {
   let fixture: ComponentFixture<Statistics> | undefined;
-
-  const wsSpy = () => ({
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    reconnect: vi.fn(),
-    setTimelineRange: vi.fn(),
-    setScope: vi.fn(),
-    setFeedStatus: vi.fn(),
-  });
-
-  /** Boot the page at the frozen clock and wire in the service spies. */
-  async function pageAt() {
-    const ws = wsSpy();
-    const getScopeOptions = vi.fn().mockResolvedValue({ teams: [], requesters: [] });
-    await TestBed.configureTestingModule({
-      imports: [Statistics],
-      providers: [
-        { provide: StatsWebsocketService, useValue: ws },
-        { provide: StatisticsService, useValue: { getScopeOptions } },
-      ],
-    }).compileComponents();
-    const fx = TestBed.createComponent(Statistics);
-    const component = fx.componentInstance;
-    component.ngOnInit();
-    return { fx, component, ws, getScopeOptions };
-  }
 
   afterEach(() => {
     fixture?.destroy();
@@ -143,5 +147,69 @@ describe('Statistics calendar rollover', () => {
     // A window the operator zoomed into is pinned where they put it; the
     // calendar moving underneath it is no reason to drag them out of it.
     expect(page.ws.setTimelineRange.mock.calls.length).toBe(rangesBefore);
+  });
+});
+
+describe('Statistics scope options', () => {
+  let fixture: ComponentFixture<Statistics> | undefined;
+
+  afterEach(() => {
+    fixture?.destroy();
+    fixture = undefined;
+    vi.useRealTimers();
+  });
+
+  it('discards a scope-options response a newer range and selection already superseded', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+
+    // The init request is the one the operator outlives: it resolves only
+    // after a range pick and a requester selection it does not know about.
+    let releaseStale: (value: { teams: FeedFilterOption[]; requesters: FeedFilterOption[] }) => void =
+      () => {};
+    const stale = new Promise<{ teams: FeedFilterOption[]; requesters: FeedFilterOption[] }>(
+      (resolve) => {
+        releaseStale = resolve;
+      },
+    );
+    const fresh: { teams: FeedFilterOption[]; requesters: FeedFilterOption[] } = {
+      teams: [{ id: 1, label: 'Team One', requestCount: 3 }],
+      requesters: [{ id: 7, label: 'User Seven', requestCount: 5 }],
+    };
+    // First request (the init one) is the one that outlives the operator;
+    // everything after it serves the fresh range. State-based rather than
+    // call-queued, so the test holds no matter how many init requests the
+    // test harness fires.
+    let first = true;
+    const getScopeOptions = vi.fn(() => (first ? (first = false, stale) : Promise.resolve(fresh)));
+    const page = await pageAt(getScopeOptions);
+    fixture = page.fx;
+
+    // The operator picks a range; the fresh response lands and the dropdowns
+    // list it.
+    page.component.setPreset('day');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(page.component.feedUsers()).toEqual(fresh.requesters);
+    expect(page.component.feedTeams()).toEqual(fresh.teams);
+
+    // ...and narrows to a requester the stale response would not recognise.
+    page.component.setUserFilter('7');
+    await Promise.resolve();
+    await Promise.resolve();
+    const scopesBefore = page.ws.setScope.mock.calls.length;
+
+    // The stale response lands last: empty lists, no user 7.
+    releaseStale({ teams: [], requesters: [] });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // None of it may reach the page: the options of the current selection
+    // stand, the chosen requester stays chosen, and no scope is re-sent for
+    // lists that describe the previous range.
+    expect(page.component.feedUsers()).toEqual(fresh.requesters);
+    expect(page.component.feedTeams()).toEqual(fresh.teams);
+    expect(page.component.filterUserId()).toBe(7);
+    expect(page.ws.setScope.mock.calls.length).toBe(scopesBefore);
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.spec.ts
@@ -1,0 +1,147 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
+
+import { Statistics } from './statistics';
+import { StatsWebsocketService } from './services/stats-websocket.service';
+import { StatisticsService } from './services/statistics.service';
+
+import type { TimelineRequestConfig } from './statistics.models';
+
+// The range the page shows is resolved from the calendar when it is picked,
+// and then it sits: the server deliberately keeps the start where the preset
+// put it and only slides the end to now. A page that stays open across
+// midnight would otherwise keep counting the previous day's requests under a
+// header that still says "Today" — the new day never starts at zero.
+//
+// The page's own ticker is what has to notice the period moved, and it has to
+// apply the moved range exactly like a picked one. These tests run the ticker
+// against a frozen clock and step it across a midnight the only way time can
+// step it.
+describe('Statistics calendar rollover', () => {
+  let fixture: ComponentFixture<Statistics> | undefined;
+
+  const wsSpy = () => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reconnect: vi.fn(),
+    setTimelineRange: vi.fn(),
+    setScope: vi.fn(),
+    setFeedStatus: vi.fn(),
+  });
+
+  /** Boot the page at the frozen clock and wire in the service spies. */
+  async function pageAt() {
+    const ws = wsSpy();
+    const getScopeOptions = vi.fn().mockResolvedValue({ teams: [], requesters: [] });
+    await TestBed.configureTestingModule({
+      imports: [Statistics],
+      providers: [
+        { provide: StatsWebsocketService, useValue: ws },
+        { provide: StatisticsService, useValue: { getScopeOptions } },
+      ],
+    }).compileComponents();
+    const fx = TestBed.createComponent(Statistics);
+    const component = fx.componentInstance;
+    component.ngOnInit();
+    return { fx, component, ws, getScopeOptions };
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+    fixture = undefined;
+    vi.useRealTimers();
+  });
+
+  it('leaves the picked day alone while the calendar day holds', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+    const page = await pageAt();
+    fixture = page.fx;
+
+    page.component.setPreset('day');
+    const rangesBefore = page.ws.setTimelineRange.mock.calls.length;
+
+    // 23:50 to 23:59, still the same day: every tick is a no-op.
+    vi.advanceTimersByTime(9 * 60_000);
+
+    expect(page.ws.setTimelineRange.mock.calls.length).toBe(rangesBefore);
+    // The page is up and connected, so the silence is a decision, not an absence.
+    expect(page.ws.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-anchors the range at each midnight while the page stays open', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+    const page = await pageAt();
+    fixture = page.fx;
+
+    page.component.setPreset('day');
+    const rangesBefore = page.ws.setTimelineRange.mock.calls.length;
+    const scopesBefore = page.getScopeOptions.mock.calls.length;
+
+    // 23:50 to 00:10, with the midnight tick in between.
+    vi.advanceTimersByTime(20 * 60_000);
+
+    // The midnight tick — and only it: the following ticks compare against
+    // the new period and stay quiet.
+    expect(page.ws.setTimelineRange).toHaveBeenCalledTimes(rangesBefore + 1);
+
+    // The resends name the new day, not a range that still reaches into the old one.
+    const sent = page.ws.setTimelineRange.mock.calls[rangesBefore][0] as TimelineRequestConfig;
+    const newMidnight = new Date(2026, 8, 7, 0, 0, 0, 0).toISOString();
+    expect(sent.start).toBe(newMidnight);
+    expect(sent.end).toBe(newMidnight);
+
+    // The old numbers are marked stale until the server answers, so they are
+    // never read as the new day's.
+    expect(page.component.statsPending()).toBe(true);
+
+    // The scope dropdowns are refilled for the range actually on screen.
+    expect(page.getScopeOptions).toHaveBeenCalledTimes(scopesBefore + 1);
+    expect(page.getScopeOptions.mock.calls.at(-1)?.[0]).toBe(newMidnight);
+
+    // Left open a second night, the page re-anchors again rather than
+    // accumulating three days under one heading.
+    vi.advanceTimersByTime(23 * 3600_000 + 50 * 60_000);
+    expect(page.ws.setTimelineRange).toHaveBeenCalledTimes(rangesBefore + 2);
+    const second = page.ws.setTimelineRange.mock.calls[rangesBefore + 1][0] as
+      TimelineRequestConfig;
+    expect(second.start).toBe(new Date(2026, 8, 8, 0, 0, 0, 0).toISOString());
+  });
+
+  it('keeps the rolling 30-day window pinned across midnight', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+    const page = await pageAt();
+    fixture = page.fx;
+
+    // The default preset: nothing to pick, just a clock to run.
+    expect(page.component.preset()).toBe('30d');
+
+    // 23:50 to 00:20 — the window's meaning ("last 30 days") never rolls, so
+    // its start stays where the selection put it and nothing is re-sent.
+    vi.advanceTimersByTime(30 * 60_000);
+
+    expect(page.ws.setTimelineRange).not.toHaveBeenCalled();
+  });
+
+  it('leaves a user-picked custom range alone across midnight', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 6, 23, 50, 0, 0));
+    const page = await pageAt();
+    fixture = page.fx;
+
+    page.component.setPreset('day');
+    page.component.setCustomRange({
+      start: new Date(2026, 8, 6, 12, 0),
+      end: new Date(2026, 8, 6, 13, 0),
+    });
+    const rangesBefore = page.ws.setTimelineRange.mock.calls.length;
+
+    vi.advanceTimersByTime(20 * 60_000);
+
+    // A window the operator zoomed into is pinned where they put it; the
+    // calendar moving underneath it is no reason to drag them out of it.
+    expect(page.ws.setTimelineRange.mock.calls.length).toBe(rangesBefore);
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -1099,17 +1099,29 @@ export class Statistics implements OnInit, OnDestroy {
     this.customRange.set(range);
     this.markRangeChanged();
     this.statsWs.setTimelineRange(this.wsTimelineConfig());
+    // The zoomed window holds a different set of requesters and teams than
+    // the range it replaces — and the call supersedes whatever request is
+    // still in flight for the range the operator zoomed away from, so that
+    // stale response can no longer replace the new list or clear a requester
+    // it does not contain.
+    void this.loadScopeOptions();
   }
 
   clearCustomRange(): void {
     // Back on a preset, the period is resolved from the calendar again —
     // from *now*, so the anchor that marks the period on screen moves with
-    // it. (Every preset and offset change funnels through here.)
+    // it. (Every preset and offset change funnels through here — and the
+    // "back to a preset" button calls this directly, so the dropdown reload
+    // has to live here, not in the callers.)
     this.rangeAnchorMs.set(Date.now());
     this.customRange.set(null);
     this.resetZoomCounter.update((c) => c + 1);
     this.markRangeChanged();
     this.statsWs.setTimelineRange(this.wsTimelineConfig());
+    // Same reason as in setCustomRange: the preset range is a different list
+    // than the custom window it replaces, and the in-flight request for that
+    // window must be superseded.
+    void this.loadScopeOptions();
   }
 
   setPreset(p: TimePreset): void {
@@ -1117,16 +1129,12 @@ export class Statistics implements OnInit, OnDestroy {
     this.offset.set(0);
     this.clearCustomRange();
     this.statsWs.setTimelineRange(this.wsTimelineConfig());
-    // The dropdowns list what the range holds, so a different range is a
-    // different list — and possibly one the current selection is not in.
-    void this.loadScopeOptions();
   }
 
   setOffset(o: number): void {
     this.offset.set(o);
     this.clearCustomRange();
     this.statsWs.setTimelineRange(this.wsTimelineConfig());
-    void this.loadScopeOptions();
   }
 
   /**

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -35,7 +35,7 @@ import {
 } from './statistics.utils';
 
 import {
-  TimePreset, calendarRange, periodLabel as periodLabelFn,
+  TimePreset, calendarRange, periodLabel as periodLabelFn, periodRolloverDue,
 } from '../../shared/utils/time-range';
 import { formatUsd } from '../../shared/utils/currency';
 import { TimeRangeBarComponent } from '../../shared/components/time-range-bar/time-range-bar';
@@ -248,7 +248,16 @@ export class Statistics implements OnInit, OnDestroy {
   // ── Preset / time-range-bar state ─────────────────────────────────────────────
   readonly preset = signal<TimePreset>('30d');
   readonly offset = signal(0);
-  readonly presetRange = computed(() => calendarRange(this.preset(), this.offset()));
+  /**
+   * The instant the calendar range on screen was resolved. `presetRange`
+   * resolves from this instead of from "now at first read", so the page
+   * remembers which period it is showing and can notice when the period
+   * moves out from under it — see `handleCalendarRollover`.
+   */
+  private readonly rangeAnchorMs = signal(Date.now());
+  readonly presetRange = computed(() =>
+    calendarRange(this.preset(), this.offset(), new Date(this.rangeAnchorMs())),
+  );
   readonly periodLabel = computed(() =>
     periodLabelFn(this.preset(), this.offset(), this.presetRange()),
   );
@@ -891,7 +900,11 @@ export class Statistics implements OnInit, OnDestroy {
       },
     });
 
-    this.nowInterval = setInterval(() => this.nowMs.set(Date.now()), 30_000);
+    this.nowInterval = setInterval(() => {
+      const now = Date.now();
+      this.nowMs.set(now);
+      this.handleCalendarRollover(now);
+    }, 30_000);
     void this.loadScopeOptions();
   }
 
@@ -1073,6 +1086,10 @@ export class Statistics implements OnInit, OnDestroy {
   }
 
   clearCustomRange(): void {
+    // Back on a preset, the period is resolved from the calendar again —
+    // from *now*, so the anchor that marks the period on screen moves with
+    // it. (Every preset and offset change funnels through here.)
+    this.rangeAnchorMs.set(Date.now());
     this.customRange.set(null);
     this.resetZoomCounter.update((c) => c + 1);
     this.markRangeChanged();
@@ -1092,6 +1109,40 @@ export class Statistics implements OnInit, OnDestroy {
   setOffset(o: number): void {
     this.offset.set(o);
     this.clearCustomRange();
+    this.statsWs.setTimelineRange(this.wsTimelineConfig());
+    void this.loadScopeOptions();
+  }
+
+  /**
+   * Re-anchor the range once the period it names has moved on.
+   *
+   * The range is resolved from the calendar when it is picked and then it
+   * sits: the server deliberately keeps the start where the preset put it and
+   * only slides the end to now, so a page that stays open across midnight
+   * keeps counting the previous day's requests under a header that still
+   * says "Today" — the counters never start the new day at zero.
+   *
+   * The page's ticker is its only clock, so it doubles as the rollover
+   * detector: when the period the preset names at the new instant is not the
+   * one the range was resolved from, the moved range is applied exactly as a
+   * picked one — pending flags up, new range to the server, scope dropdowns
+   * reloaded — and the anchor follows it so the next tick compares against
+   * the new period.
+   */
+  private handleCalendarRollover(nowMs: number): void {
+    if (
+      !periodRolloverDue(
+        this.preset(),
+        this.offset(),
+        this.rangeAnchorMs(),
+        nowMs,
+        this.customRange() !== null,
+      )
+    ) {
+      return;
+    }
+    this.rangeAnchorMs.set(nowMs);
+    this.markRangeChanged();
     this.statsWs.setTimelineRange(this.wsTimelineConfig());
     void this.loadScopeOptions();
   }

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -126,6 +126,12 @@ export class Statistics implements OnInit, OnDestroy {
   readonly filterUserId = signal<number | null>(null);
   readonly filterTeamId = signal<number | null>(null);
 
+  // Every loadScopeOptions bumps this; a response that resolves for an older
+  // value is stale — its range or team moved on while the request was in
+  // flight, and applying it would replace the options of the current
+  // selection and could clear a requester the fresh list does contain.
+  private scopeOptionsGeneration = 0;
+
   readonly filterActive = computed(
     () => this.filterUserId() !== null || this.filterTeamId() !== null,
   );
@@ -969,8 +975,18 @@ export class Statistics implements OnInit, OnDestroy {
   private async loadScopeOptions(): Promise<void> {
     const cfg = this.wsTimelineConfig();
     const teamId = this.filterTeamId();
+    // Claim this request before the await: any later range or team change
+    // bumps the counter and supersedes whatever this response still carries.
+    const generation = ++this.scopeOptionsGeneration;
     try {
       const options = await this.statisticsService.getScopeOptions(cfg.start, cfg.end, teamId);
+      if (generation !== this.scopeOptionsGeneration) {
+        // A newer request is in flight or already applied — its lists
+        // describe the selection on screen. This one describes the one
+        // before it, and neither its options nor its "the selected requester
+        // is gone" check may touch the current state.
+        return;
+      }
       this.feedTeams.set(options.teams ?? []);
       this.feedUsers.set(options.requesters ?? []);
 

--- a/logos/logos-ui/src/app/shared/utils/time-range.spec.ts
+++ b/logos/logos-ui/src/app/shared/utils/time-range.spec.ts
@@ -1,0 +1,156 @@
+import { calendarRange, periodRolloverDue, periodStartMs } from './time-range';
+
+// All instants are built from local time components, so the expectations hold
+// in any timezone: the ranges under test are local-calendar ranges, and the
+// comparisons below never span a named instant.
+
+const eveningOf = (year: number, month: number, day: number) =>
+  new Date(year, month, day, 23, 50).getTime();
+const afterMidnightOf = (year: number, month: number, day: number) =>
+  new Date(year, month, day, 0, 10).getTime();
+
+describe('periodStartMs', () => {
+  it('pins a day to its local midnight', () => {
+    expect(periodStartMs('day', 0, eveningOf(2026, 8, 6))).toBe(
+      new Date(2026, 8, 6, 0, 0, 0, 0).getTime(),
+    );
+    // The same midnight at any hour of the day, the anchor does not crawl
+    // forward with the clock.
+    expect(periodStartMs('day', 0, new Date(2026, 8, 6, 0, 30).getTime())).toBe(
+      new Date(2026, 8, 6, 0, 0, 0, 0).getTime(),
+    );
+  });
+
+  it('pins a week to its Monday', () => {
+    const wednesday = new Date(2026, 5, 10, 12);
+    const dow = wednesday.getDay() || 7;
+    const monday = new Date(2026, 5, 10 - dow + 1, 0, 0, 0, 0);
+    expect(periodStartMs('week', 0, wednesday.getTime())).toBe(monday.getTime());
+  });
+
+  it('pins a month to the first', () => {
+    expect(periodStartMs('month', 0, new Date(2026, 8, 15, 10).getTime())).toBe(
+      new Date(2026, 8, 1, 0, 0, 0, 0).getTime(),
+    );
+  });
+
+  it('pins a year to January 1st', () => {
+    expect(periodStartMs('year', 0, new Date(2026, 11, 31, 23, 0).getTime())).toBe(
+      new Date(2026, 0, 1, 0, 0, 0, 0).getTime(),
+    );
+  });
+
+  it('moves with the clock for the rolling 30-day window', () => {
+    // The 30-day preset is anchored to the instant it was picked, so its start
+    // is not a calendar boundary at all. That is exactly why the rollover
+    // test below excludes it.
+    const earlier = periodStartMs('30d', 0, eveningOf(2026, 8, 6));
+    const later = periodStartMs('30d', 0, afterMidnightOf(2026, 8, 7));
+    expect(later).not.toBe(earlier);
+    // The start crawled exactly as far as the clock did: 23:50 to 00:10 is
+    // twenty minutes, and the window follows.
+    expect(later - earlier).toBe(20 * 60_000);
+  });
+});
+
+describe('periodRolloverDue', () => {
+  it('fires for a day once the midnight has passed', () => {
+    const anchor = eveningOf(2026, 8, 6);
+    expect(periodRolloverDue('day', 0, anchor, afterMidnightOf(2026, 8, 7), false)).toBe(true);
+  });
+
+  it('does not fire inside the same day', () => {
+    const anchor = eveningOf(2026, 8, 6);
+    expect(periodRolloverDue('day', 0, anchor, anchor + 30_000, false)).toBe(false);
+    const earlyMorning = new Date(2026, 8, 6, 0, 5).getTime();
+    const lateEvening = new Date(2026, 8, 6, 23, 59).getTime();
+    expect(periodRolloverDue('day', 0, earlyMorning, lateEvening, false)).toBe(false);
+  });
+
+  it('fires for a picked past day when it stops being the day it was named after', () => {
+    // "Yesterday" at 23:50 is a different day than "yesterday" at 00:10: the
+    // name kept its meaning only by moving. The page has to notice, because
+    // the range on screen still covers the old one.
+    const anchor = eveningOf(2026, 8, 6);
+    const afterMidnight = afterMidnightOf(2026, 8, 7);
+    expect(periodRolloverDue('day', 1, anchor, afterMidnight, false)).toBe(true);
+    // Within the same night the named day does not move yet.
+    expect(periodRolloverDue('day', 1, anchor, anchor + 30_000, false)).toBe(false);
+  });
+
+  it('fires for a week only when the Monday rolls in', () => {
+    const wednesday = new Date(2026, 5, 10, 12);
+    const dow = wednesday.getDay() || 7;
+    const monday = new Date(2026, 5, 10 - dow + 1, 0, 0, 0, 0);
+    const nextMonday = new Date(
+      monday.getFullYear(),
+      monday.getMonth(),
+      monday.getDate() + 7,
+      0,
+      30,
+    );
+    const anHourLater = wednesday.getTime() + 3600_000;
+    expect(periodRolloverDue('week', 0, wednesday.getTime(), anHourLater, false)).toBe(false);
+    expect(periodRolloverDue('week', 0, wednesday.getTime(), nextMonday.getTime(), false)).toBe(true);
+  });
+
+  it('fires for a month only on the first', () => {
+    const midSeptember = new Date(2026, 8, 15, 10).getTime();
+    const sameMonthLater = new Date(2026, 8, 15, 23, 59).getTime();
+    const firstOfOctober = new Date(2026, 9, 1, 0, 5).getTime();
+    expect(periodRolloverDue('month', 0, midSeptember, sameMonthLater, false)).toBe(false);
+    expect(periodRolloverDue('month', 0, midSeptember, firstOfOctober, false)).toBe(true);
+  });
+
+  it('fires for the six-month window when its month boundary rolls', () => {
+    const endOfSeptember = new Date(2026, 8, 30, 23, 50).getTime();
+    const fiveMinutesLater = new Date(2026, 8, 30, 23, 55).getTime();
+    const firstOfOctober = new Date(2026, 9, 1, 0, 5).getTime();
+    expect(periodRolloverDue('6m', 0, endOfSeptember, fiveMinutesLater, false)).toBe(false);
+    expect(periodRolloverDue('6m', 0, endOfSeptember, firstOfOctober, false)).toBe(true);
+  });
+
+  it('fires for a year only on January 1st', () => {
+    const newYearsEve = new Date(2026, 11, 31, 23, 50).getTime();
+    const fiveMinutesLater = new Date(2026, 11, 31, 23, 55).getTime();
+    const newYear = new Date(2027, 0, 1, 0, 10).getTime();
+    expect(periodRolloverDue('year', 0, newYearsEve, fiveMinutesLater, false)).toBe(false);
+    expect(periodRolloverDue('year', 0, newYearsEve, newYear, false)).toBe(true);
+  });
+
+  it('never fires for the rolling 30-day window', () => {
+    // Its start moves with every comparison, so it is excluded rather than
+    // compared: re-anchoring it on each tick would change what the selection
+    // means instead of noticing that the calendar moved.
+    const evening = eveningOf(2026, 8, 6);
+    const afterMidnight = afterMidnightOf(2026, 8, 7);
+    expect(periodRolloverDue('30d', 0, evening, afterMidnight, false)).toBe(false);
+    expect(periodRolloverDue('30d', 1, evening, afterMidnight, false)).toBe(false);
+  });
+
+  it('never fires while a custom range is on screen', () => {
+    // A range the user picked by hand is pinned where they put it; the
+    // calendar rolling under it is no reason to drag them out of it.
+    const evening = eveningOf(2026, 8, 6);
+    const afterMidnight = afterMidnightOf(2026, 8, 7);
+    expect(periodRolloverDue('day', 0, evening, afterMidnight, true)).toBe(false);
+    expect(periodRolloverDue('week', 0, evening, afterMidnight, true)).toBe(false);
+  });
+});
+
+describe('calendarRange with an explicit instant', () => {
+  it('resolves "today" from the given instant, not from the wall clock', () => {
+    const lateEvening = new Date(2026, 8, 6, 23, 50);
+    const range = calendarRange('day', 0, lateEvening);
+    expect(range.currStart).toEqual(new Date(2026, 8, 6, 0, 0, 0, 0));
+    expect(range.currEnd).toEqual(new Date(2026, 8, 7, 0, 0, 0, 0));
+  });
+
+  it('still defaults to the wall clock when no instant is given', () => {
+    const now = new Date();
+    const range = calendarRange('day', 0);
+    expect(range.currStart).toEqual(
+      new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0),
+    );
+  });
+});

--- a/logos/logos-ui/src/app/shared/utils/time-range.ts
+++ b/logos/logos-ui/src/app/shared/utils/time-range.ts
@@ -34,8 +34,11 @@ export const AVG_UNIT: Record<TimePreset, string> = {
   year: 'avg / month',
 };
 
-export function calendarRange(preset: TimePreset, offset: number): CalendarRange {
-  const now = new Date();
+export function calendarRange(
+  preset: TimePreset,
+  offset: number,
+  now: Date = new Date(),
+): CalendarRange {
   let currStart: Date, currEnd: Date, prevStart: Date, prevEnd: Date;
 
   switch (preset) {
@@ -90,6 +93,47 @@ export function calendarRange(preset: TimePreset, offset: number): CalendarRange
   }
 
   return { currStart: currStart!, currEnd: currEnd!, prevStart: prevStart!, prevEnd: prevEnd! };
+}
+
+/**
+ * The start of the period a preset+offset denotes at `nowMs` — the instant
+ * that pins the period (local midnight for a day, the Monday for a week, the
+ * first of the month for a month, January 1 for a year).
+ *
+ * Two instants denote the same period iff they agree here, so the start
+ * doubles as the period's identity. That is what makes the rollover test
+ * below a single comparison instead of a switch over the presets.
+ */
+export function periodStartMs(preset: TimePreset, offset: number, nowMs: number): number {
+  return calendarRange(preset, offset, new Date(nowMs)).currStart.getTime();
+}
+
+/**
+ * Whether the period a preset+offset denotes at `nowMs` is a different
+ * calendar unit than the one it denoted at `anchorMs` — that is, whether the
+ * calendar rolled over (midnight, a Monday, the first of a month, January 1)
+ * while a range resolved from `anchorMs` was still on screen.
+ *
+ * `customRangeActive` short-circuits to false: a range the user picked by
+ * hand is pinned exactly where they put it, and the calendar moving underneath
+ * it is no reason to drag them out of the window they chose.
+ *
+ * The rolling preset (`30d`) is deliberately excluded: its range is anchored
+ * to the instant it was picked, so `periodStartMs` moves with `nowMs` on
+ * every comparison and would report a rollover on every tick. "Last 30 days"
+ * names no calendar unit, so there is nothing for it to roll into — the
+ * window keeps the start it was picked with and only grows its end.
+ */
+export function periodRolloverDue(
+  preset: TimePreset,
+  offset: number,
+  anchorMs: number,
+  nowMs: number,
+  customRangeActive: boolean,
+): boolean {
+  if (customRangeActive) return false;
+  if (preset === '30d') return false;
+  return periodStartMs(preset, offset, anchorMs) !== periodStartMs(preset, offset, nowMs);
 }
 
 export function periodLabel(preset: TimePreset, offset: number, range: CalendarRange): string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Statistics views using calendar-based presets now automatically roll over at the correct day, week, month, or year boundary.
  - Timeline data and available scope options refresh when a calendar period changes.
  - Rolling 30-day views and user-selected custom ranges remain anchored and are not unexpectedly reset.
  - Outdated scope-option responses no longer overwrite newer selections.

- **Tests**
  - Added coverage for calendar range calculations and statistics behavior across period boundaries and refreshed scope selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->