### PR TITLE
`Iris`: Report a chat run's token usage to Artemis exactly once

### DIFF
--- a/iris/src/iris/pipeline/abstract_agent_pipeline.py
+++ b/iris/src/iris/pipeline/abstract_agent_pipeline.py
@@ -640,6 +640,12 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
 
         # 0. Initialize the execution state
         state = AgentPipelineExecutionState[DTO, VARIANT]()
+        # Bound before anything fallible runs: the run accumulates usage into the run-local state,
+        # while a subclass' outer error path lives outside this method and can only reach
+        # self.tokens. Both names point at the same list, so a run that dies mid-flight reports
+        # what it spent up to that point, and never the leftovers of the instance's previous run.
+        state.tokens = []
+        self.tokens = state.tokens
         state.dto = dto
         state.db = VectorDatabase()
         state.variant = variant
@@ -651,7 +657,6 @@ class AbstractAgentPipeline(ABC, Pipeline, Generic[DTO, VARIANT]):
         state.result = ""
         state.llm = None
         state.prompt = None
-        state.tokens = []
         state.local = local  # Store local flag in state
         state.query_text = ""
         state.lecture_content_storage = {}

--- a/iris/src/iris/pipeline/chat/chat_pipeline.py
+++ b/iris/src/iris/pipeline/chat/chat_pipeline.py
@@ -227,6 +227,9 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
             "exercise_chat_guide_prompt.j2"
         )
         self._guide_model_cache = {}
+        # Bound to the run's list by AbstractAgentPipeline.__call__; initialised here so the
+        # outer error path can report usage even for a run that died before that binding.
+        self.tokens = []
 
     def __repr__(self):
         return f"{self.__class__.__name__}(context={self.chat_mode.value})"
@@ -397,10 +400,14 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
         except Exception as e:
             logger.error("Error in post agent hook", exc_info=e)
             activities, activity_seq = _tool_activity_snapshot(state)
+            # fail() is terminal, so this is the last chance to report what the run spent.
+            # The callback drops whatever a previous send already delivered, so an answer
+            # that went out before the failure is not billed a second time.
             state.callback.fail(
                 "Error in processing response",
                 activities=activities,
                 activity_seq=activity_seq,
+                tokens=state.tokens,
                 exception=e,
             )
             return state.result
@@ -1028,5 +1035,6 @@ class ChatPipeline(AbstractAgentPipeline[ChatPipelineExecutionDTO, Variant]):
             )
             callback.fail(
                 "An error occurred while running the chat pipeline.",
+                tokens=self.tokens,
                 exception=e,
             )

--- a/iris/src/iris/web/status/status_update.py
+++ b/iris/src/iris/web/status/status_update.py
@@ -109,6 +109,29 @@ class StatusCallback:
                 capture_exception(e)
             return False
 
+    # Delay before each retry of a delivery-critical send. The nth entry sits between attempt n and
+    # n+1, so a three-attempt send waits 1s and then 2s. A send with more attempts than entries keeps
+    # repeating the last delay rather than growing one.
+    _RETRY_BACKOFF_S: tuple[int, ...] = (1, 2, 4)
+
+    def _send_payload_with_backoff(
+        self, payload: dict[str, Any], attempts: int
+    ) -> bool:
+        """Send a payload, retrying up to ``attempts`` times with backoff.
+
+        A frame Artemis must not lose (the chat answer, a terminal decision) is worth a second and a
+        third try; everything else is sent once, because a heartbeat that fails is superseded by the
+        next one anyway and retrying it only delays the pipeline.
+        """
+        for attempt in range(attempts):
+            if self._send_status_payload(payload):
+                return True
+            if attempt < attempts - 1:
+                time.sleep(
+                    self._RETRY_BACKOFF_S[min(attempt, len(self._RETRY_BACKOFF_S) - 1)]
+                )
+        return False
+
     def _get_running_update_executor(self) -> TracedThreadPoolExecutor:
         """Create the FIFO async sender lazily for running updates."""
         with self._running_update_lock:
@@ -282,6 +305,8 @@ class ChatRunCallback(StatusCallback):
             url, run_id, ChatStatusUpdateDTO(run_state=RunStateEnum.RUNNING)
         )
         self._undelivered_result_fields: Optional[dict[str, Any]] = None
+        # How many entries of the run's cumulative token list Artemis has received.
+        self._delivered_token_count = 0
 
     def activity_snapshot(self, activities: list[ActivityDTO], seq: int) -> None:
         payload = self._payload(
@@ -290,6 +315,20 @@ class ChatRunCallback(StatusCallback):
             activity_seq=seq,
         )
         self._enqueue_running_update(payload)
+
+    def update(self, **fields) -> bool:
+        """Post a RUNNING update. Usage must not travel this way.
+
+        ``update`` posts the reusable status DTO directly and would therefore bypass the
+        delta bookkeeping every other send goes through. Chat usage belongs on
+        ``send_result``, ``finish`` or ``fail``.
+        """
+        if "tokens" in fields:
+            raise ValueError(
+                "ChatRunCallback.update() must not carry tokens; "
+                "use send_result(), finish() or fail() so the usage is reported once."
+            )
+        return super().update(**fields)
 
     def send_result(
         self,
@@ -410,6 +449,13 @@ class ChatRunCallback(StatusCallback):
 
         fields, carried_result = self._merge_undelivered_result(fields)
 
+        pending_tokens: Optional[list[TokenUsageDTO]] = None
+        if "tokens" in fields:
+            pending_tokens = self._tokens_not_yet_delivered(fields["tokens"])
+            # A copy: the caller keeps the cumulative list it passed, which send_result
+            # stores as the undelivered payload and the next send slices again.
+            fields = {**fields, "tokens": pending_tokens}
+
         # A terminal send is the LAST chance to deliver an answer that a prior
         # send_result() failed to hand off. Give it the same retry/backoff so a
         # transient failure there does not drop the delivery-critical answer.
@@ -426,17 +472,40 @@ class ChatRunCallback(StatusCallback):
         self._drain_running_updates()
 
         try:
-            for attempt in range(attempts):
-                if self._send_status_payload(payload):
-                    if carried_result:
-                        self._undelivered_result_fields = None
-                    return True
-                if attempt < attempts - 1:
-                    time.sleep((1, 2, 4)[attempt])
+            if self._send_payload_with_backoff(payload, attempts):
+                if carried_result:
+                    self._undelivered_result_fields = None
+                if pending_tokens:
+                    self._delivered_token_count += len(pending_tokens)
+                return True
             return False
         finally:
             if terminal_send:
                 self._shutdown_running_update_executor()
+
+    def _tokens_not_yet_delivered(
+        self, tokens: list[TokenUsageDTO]
+    ) -> list[TokenUsageDTO]:
+        """Return the part of the run's usage Artemis has not been told about yet.
+
+        Every send hands over the run's cumulative token list, but Artemis appends what
+        arrives to the run's trace without deduplicating it, so an entry sent twice is
+        billed twice. The counter only advances after a delivered POST, which is what
+        carries the usage of a failed send forward to the next one.
+        """
+        if len(tokens) < self._delivered_token_count:
+            # Someone passed a partial list instead of the run's cumulative one. Sending it
+            # would re-report what Artemis already has, so report nothing and say so loudly.
+            message = (
+                f"Token list for run {self.run_id} shrank from "
+                f"{self._delivered_token_count} to {len(tokens)} entries; "
+                "expected the run's cumulative usage. Reporting nothing for this send."
+            )
+            logger.error(message)
+            capture_message(message)
+            return []
+        delivered = self._delivered_token_count
+        return tokens[delivered:]
 
     def _merge_undelivered_result(
         self, fields: dict[str, Any]

--- a/iris/tests/test_chat_latency_ordering.py
+++ b/iris/tests/test_chat_latency_ordering.py
@@ -335,3 +335,49 @@ def test_azure_chat_client_is_reused():
         api_version="2024-02-01",
     )
     assert model.get_client() is model.get_client()
+
+
+def _spent(name: str) -> TokenUsageDTO:
+    return TokenUsageDTO(model=name, numInputTokens=10, numOutputTokens=5)
+
+
+def test_a_failure_in_the_post_agent_hook_still_reports_the_runs_usage():
+    """
+    fail() is terminal, so nothing after it can report what the run spent. The pipeline hands
+    over its cumulative list; dropping what Artemis already received is the callback's job.
+    """
+    call_log: list[str] = []
+    pipeline = _make_pipeline(IrisChatMode.LECTURE, call_log)
+    callback = _RecordingCallback(call_log)
+    answer = _spent("answer")
+
+    def spend_then_break(state, _result):
+        state.tokens.append(answer)
+        raise RuntimeError("citations blew up")
+
+    # Through a mock rather than a bare function: assigning one makes pylint infer the method
+    # as returning nothing, and the production call site then trips assignment-from-no-return.
+    pipeline._add_citations = MagicMock(side_effect=spend_then_break)
+
+    _run_pipeline(pipeline, callback)
+
+    assert callback.calls_named("fail")[0][1]["tokens"] == [answer]
+
+
+def test_a_run_that_dies_before_the_hook_reports_its_usage_too():
+    """The outer handler runs outside the execution state and reaches the list via self.tokens."""
+    call_log: list[str] = []
+    pipeline = _make_pipeline(IrisChatMode.LECTURE, call_log)
+    callback = _RecordingCallback(call_log)
+    pipeline.tokens = []
+    answer = _spent("answer")
+
+    def spend_then_break(state):
+        state.tokens.append(answer)
+        raise RuntimeError("agent blew up")
+
+    pipeline.execute_agent = MagicMock(side_effect=spend_then_break)
+
+    _run_pipeline(pipeline, callback)
+
+    assert callback.calls_named("fail")[0][1]["tokens"] == [answer]

--- a/iris/tests/test_chat_run_callback.py
+++ b/iris/tests/test_chat_run_callback.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
+import pytest
 import requests
 
+from iris.common.token_usage_dto import TokenUsageDTO
 from iris.domain.status.activity_dto import ActivityDTO, ActivityKind, ActivityState
 from iris.web.status.status_update import ChatRunCallback
 
@@ -176,3 +178,187 @@ def test_send_result_carries_authoritative_activities():
     payload = post.call_args.kwargs["json"]
     assert payload["activities"][0]["state"] == "FINISHED"
     assert payload["activitySeq"] == 7
+
+
+def _token(name: str) -> TokenUsageDTO:
+    return TokenUsageDTO(model=name, numInputTokens=10, numOutputTokens=5)
+
+
+def _sent_tokens(post) -> list[list[str]]:
+    """The `model` of every token in every payload that was actually posted."""
+    return [
+        [token["model"] for token in call.kwargs["json"]["tokens"]]
+        for call in post.call_args_list
+    ]
+
+
+def test_usage_already_reported_is_not_sent_again():
+    """
+    Artemis appends the tokens of every callback to the run's trace without deduplicating
+    them, so re-sending the answer's usage on the trailing finish bills it twice. Each send
+    carries only what the previous ones did not deliver.
+    """
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        assert cb.send_result("answer", tokens=[answer]) is True
+        assert cb.finish(tokens=[answer, title]) is True
+
+    assert _sent_tokens(post) == [["answer"], ["title"]]
+
+
+def test_suggestions_between_result_and_finish_do_not_disturb_the_split():
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        cb.send_result("answer", tokens=[answer])
+        cb.send_suggestions(["s1"], session_title="t")
+        cb.finish(tokens=[answer, title])
+
+    assert _sent_tokens(post) == [["answer"], [], ["title"]]
+
+
+def test_usage_of_an_undelivered_result_rides_the_next_send():
+    """The counter advances on delivery, not on the attempt, so nothing is lost."""
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with (
+        patch("requests.post") as post,
+        patch("time.sleep"),
+    ):
+        post.side_effect = [
+            requests.RequestException(),
+            requests.RequestException(),
+            requests.RequestException(),
+            _ok(),
+        ]
+        assert cb.send_result("answer", tokens=[answer]) is False
+        assert cb.finish(tokens=[answer, title]) is True
+
+    assert _sent_tokens(post)[-1] == ["answer", "title"]
+
+
+def test_suggestions_that_carry_an_undelivered_answer_also_carry_its_usage():
+    """
+    A failed send_result rides along with the next send. That send delivers the answer, so
+    it owes the answer's usage too, and the finish behind it owes only what came later.
+    """
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with (
+        patch("requests.post") as post,
+        patch("time.sleep"),
+    ):
+        post.side_effect = [
+            requests.RequestException(),
+            requests.RequestException(),
+            requests.RequestException(),
+            _ok(),
+            _ok(),
+        ]
+        assert cb.send_result("answer", tokens=[answer]) is False
+        assert cb.send_suggestions(["s1"], session_title="t") is True
+        assert cb.finish(tokens=[answer, title]) is True
+
+    assert _sent_tokens(post)[-2:] == [["answer"], ["title"]]
+
+
+def test_a_failed_answer_followed_by_a_failing_run_reports_everything_once():
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with (
+        patch("requests.post") as post,
+        patch("time.sleep"),
+    ):
+        post.side_effect = [
+            requests.RequestException(),
+            requests.RequestException(),
+            requests.RequestException(),
+            _ok(),
+        ]
+        assert cb.send_result("answer", tokens=[answer]) is False
+        assert (
+            cb.fail(
+                "Generating interaction suggestions failed.", tokens=[answer, title]
+            )
+            is True
+        )
+
+    assert _sent_tokens(post)[-1] == ["answer", "title"]
+
+
+def test_a_failure_after_a_delivered_answer_reports_only_the_rest():
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        cb.send_result("answer", tokens=[answer])
+        cb.fail("Error in processing response", tokens=[answer, title])
+
+    assert _sent_tokens(post) == [["answer"], ["title"]]
+
+
+def test_a_failure_before_any_answer_reports_everything():
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        cb.fail(
+            "An error occurred while running the chat pipeline.", tokens=[answer, title]
+        )
+
+    assert _sent_tokens(post) == [["answer", "title"]]
+
+
+def test_activity_snapshots_do_not_move_the_token_cursor():
+    cb = _callback()
+    answer = _token("answer")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        cb.activity_snapshot([_activity()], 1)
+        cb.send_result("answer", tokens=[answer])
+
+    assert _sent_tokens(post)[-1] == ["answer"]
+
+
+def test_retried_attempts_of_one_send_count_as_one_delivery():
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with (
+        patch("requests.post") as post,
+        patch("time.sleep"),
+    ):
+        post.side_effect = [requests.RequestException(), _ok(), _ok()]
+        assert cb.send_result("answer", tokens=[answer]) is True
+        assert cb.finish(tokens=[answer, title]) is True
+
+    # Two attempts carried the answer, one delivered it; the finish still owes only the title.
+    assert _sent_tokens(post) == [["answer"], ["answer"], ["title"]]
+
+
+def test_a_partial_token_list_is_refused_rather_than_reported_twice():
+    """
+    Callers owe this callback the run's cumulative usage. A shorter list means someone
+    passed a slice, and sending it would re-report what Artemis already has.
+    """
+    cb = _callback()
+    answer, title = _token("answer"), _token("title")
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        with patch("iris.web.status.status_update.capture_message") as captured:
+            cb.send_result("answer", tokens=[answer, title])
+            cb.finish(tokens=[title])
+
+    assert _sent_tokens(post) == [["answer", "title"], []]
+    assert "shrank from 2 to 1" in captured.call_args.args[0]
+
+
+def test_update_refuses_to_carry_tokens():
+    cb = _callback()
+    with patch("requests.post") as post:
+        post.return_value = _ok()
+        with pytest.raises(ValueError, match="must not carry tokens"):
+            cb.update(tokens=[_token("answer")])
+    post.assert_not_called()


### PR DESCRIPTION
### Motivation

Split out of #756. These three fixes were found while wiring the struggle-intervention callback, but they belong to the chat pipeline and the shared agent base, not to that feature, so they should be reviewed by the people who own that code rather than be waved through inside a feature PR.

Three separate defects in how a run's token usage reaches Artemis:

1. **A run that dies reports nothing.** The agent accumulates usage into `state.tokens`, a local of `AbstractAgentPipeline.__call__`. A subclass' outer error path lives outside that method and only reaches `self.tokens`, which stays empty since `__init__`. This also hits `AutonomousTutorPipeline` and `TutorSuggestionPipeline`, which pass `self.tokens` on their success path and so far reported no usage at all.
2. **A successful chat run is billed twice.** Every callback hands over the cumulative list: `send_result` the answer's tokens, the closing `finish` the same ones again. Artemis appends on every callback without deduplicating, so the answer's tokens stood in the trace twice.
3. **A failed chat run reports nothing.** Both error paths of `ChatPipeline` called `fail()` without tokens, and `fail()` is terminal.

### Description

`state.tokens` and `self.tokens` now point at the same list, bound before anything fallible runs so a run that fails during setup cannot report the previous run's tokens.

`ChatRunCallback` keeps count of how many entries Artemis has already received and sends only the remainder. The counter advances only after a delivered POST, so a failed send carries its tokens to the next one. A list that shrank is logged loudly instead of being sent, and `update()` rejects tokens outright because it would bypass the count. Delivery stays at-least-once by design: the counter reflects what this client saw succeed.

Both chat error paths now pass the run's cumulative list; the callback subtracts what Artemis already has, so this costs no double booking.

The chat and struggle callbacks carried two retry loops with two delay tables for the same requirement, so both now go through one helper on the base callback: three attempts for a frame Artemis must not lose, one for everything else.

### Relationship to #756

#756 keeps the parts the struggle feature is actually built on: the `AbstractAgentPipeline` binding (its outer error path reads `self.tokens`) and `_send_payload_with_backoff` (`StruggleInterventionCallback` uses it). Those therefore appear in both branches and resolve on merge.

**Merge #756 first.** This branch should then be rebased onto `main`, which drops the overlap. Draft until that happens.

### Steps for testing

1. Start a chat run and let it finish normally, then check the run's token trace in Artemis: the answer's tokens appear once, not twice.
2. Force an exception in the chat pipeline and confirm the failed run is still billed for what it spent.
3. `pytest` in `iris/`.

### Review progress

- [ ] Code review
- [ ] Manual test

### Test coverage

`tests/test_chat_run_callback.py` and `tests/test_chat_latency_ordering.py` cover the dedup counter, the shrunk-list refusal, the token-carrying retry and the send ordering. Full suite: 425 passed. black, isort and flake8 clean; the two remaining pylint `no-member` hits in `abstract_agent_pipeline.py` are at lines 606/607 and predate this branch.