### PR TITLE
`Logos`: Fix add-provider dialog — hide cloud field for local nodes, auto-generate worker key

### DIFF
--- a/logos/logos-ui/src/app/features/providers/providers.html
+++ b/logos/logos-ui/src/app/features/providers/providers.html
@@ -276,23 +276,25 @@
         (valueChange)="onAddProviderTypeChange($any($event))"
       />
     </div>
+    @if (addProviderType() === 'cloud') {
     <div class="form-field">
       <label class="field-label" for="add-cloud-type">Cloud Provider</label>
       <app-select
         [id]="'add-cloud-type'"
         [options]="addCloudProviderTypeOptions()"
         [value]="addCloudProviderType()"
-        [disabled]="addLoading() || addProviderType() === 'logosnode'"
+        [disabled]="addLoading()"
         (valueChange)="addCloudProviderType.set($any($event))"
       />
     </div>
+    }
     <div class="form-field">
       <label class="field-label" for="add-privacy">Privacy Level</label>
       <app-select
         [id]="'add-privacy'"
         [options]="addPrivacyLevelOptions()"
         [value]="addPrivacyLevel()"
-        [disabled]="addLoading() || addProviderType() === 'logosnode'"
+        [disabled]="addLoading()"
         (valueChange)="addPrivacyLevel.set($any($event))"
       />
     </div>
@@ -319,6 +321,47 @@
         <i class="pi pi-spin pi-spinner" aria-hidden="true"></i>
       }
       Add Provider
+    </button>
+  </div>
+</app-modal-form>
+
+<!-- ── Created Provider API Key Dialog ─────────────────────────────────────── -->
+<app-modal-form
+  [visible]="createdKeyOpen()"
+  (visibleChange)="$event || closeCreatedKeyDialog()"
+  title="Provider created"
+>
+  <div class="form-body">
+    <p class="created-key-intro">
+      <strong>{{ createdKeyName() }}</strong> is a Logos worker node. Authenticate it
+      with the shared key below — it is shown only now, so copy it to your worker
+      configuration.
+    </p>
+    <div class="form-field">
+      <label class="field-label" for="created-key">Shared API Key</label>
+      <div class="created-key-row">
+        <input
+          id="created-key"
+          class="field-input"
+          type="text"
+          readonly
+          [value]="createdKey()"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button class="btn-secondary" type="button" (click)="copyCreatedKey()">
+          @if (createdKeyCopied()) {
+            <i class="pi pi-check" aria-hidden="true"></i> Copied!
+          } @else {
+            <i class="pi pi-copy" aria-hidden="true"></i> Copy
+          }
+        </button>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer" modal-footer>
+    <button class="btn-primary" type="button" (click)="closeCreatedKeyDialog()">
+      Done
     </button>
   </div>
 </app-modal-form>
@@ -408,23 +451,25 @@
         (valueChange)="onEditProviderTypeChange($any($event))"
       />
     </div>
+    @if (editProviderType() === 'cloud') {
     <div class="form-field">
       <label class="field-label" for="edit-cloud-type">Cloud Provider</label>
       <app-select
         [id]="'edit-cloud-type'"
         [options]="editCloudProviderTypeOptions()"
         [value]="editCloudProviderType()"
-        [disabled]="editLoading() || editProviderType() === 'logosnode'"
+        [disabled]="editLoading()"
         (valueChange)="editCloudProviderType.set($any($event))"
       />
     </div>
+    }
     <div class="form-field">
       <label class="field-label" for="edit-privacy">Privacy Level</label>
       <app-select
         [id]="'edit-privacy'"
         [options]="editPrivacyLevelOptions()"
         [value]="editPrivacyLevel()"
-        [disabled]="editLoading() || editProviderType() === 'logosnode'"
+        [disabled]="editLoading()"
         (valueChange)="editPrivacyLevel.set($any($event))"
       />
     </div>

--- a/logos/logos-ui/src/app/features/providers/providers.scss
+++ b/logos/logos-ui/src/app/features/providers/providers.scss
@@ -200,6 +200,24 @@
   &:disabled { opacity: var(--opacity-disabled); cursor: not-allowed; }
 }
 
+.created-key-intro {
+  margin: 0 0 4px;
+  color: rgb(var(--color-typography-300));
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+
+  strong { color: rgb(var(--color-typography-0)); }
+}
+
+.created-key-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: stretch;
+
+  .field-input { font-family: var(--font-family-mono, monospace); font-size: var(--font-size-sm); }
+}
+
 @media (max-width: 768px) {
   .providers { padding: 24px 16px 32px; }
 

--- a/logos/logos-ui/src/app/features/providers/providers.ts
+++ b/logos/logos-ui/src/app/features/providers/providers.ts
@@ -372,7 +372,10 @@ export class Providers implements OnInit {
       await this.fetchProviders();
       this.addOpen.set(false);
       const generatedKey: string = (res && (res as { api_key?: string }).api_key) || '';
-      if (generatedKey) {
+      // Only surface the key when we actually generated one, i.e. the operator
+      // left the key field empty. An operator-supplied key is echoed back by the
+      // backend too, and there is nothing new to show for that case.
+      if (generatedKey && payload.api_key === undefined) {
         this.createdKeyName.set(payload.name);
         this.createdKey.set(generatedKey);
         this.createdKeyCopied.set(false);

--- a/logos/logos-ui/src/app/features/providers/providers.ts
+++ b/logos/logos-ui/src/app/features/providers/providers.ts
@@ -182,6 +182,15 @@ export class Providers implements OnInit {
   addLoading = signal(false);
   addError = signal('');
 
+  // ── Created-provider key modal ───────────────────────────────────────────
+  // Logosnode providers are given a generated shared key on creation; the
+  // operator must be able to copy it to configure the worker node, so we
+  // surface it in a follow-up modal once the add flow succeeds.
+  createdKeyOpen = signal(false);
+  createdKeyName = signal('');
+  createdKey = signal('');
+  createdKeyCopied = signal(false);
+
   // ── Edit modal ────────────────────────────────────────────────────────────
   editTarget = signal<Provider | null>(null);
   editName = signal('');
@@ -359,14 +368,38 @@ export class Providers implements OnInit {
       privacy_level: this.addPrivacyLevel(),
     };
     try {
-      await this.providerService.addProvider(payload);
+      const res = await this.providerService.addProvider(payload);
       await this.fetchProviders();
       this.addOpen.set(false);
+      const generatedKey: string = (res && (res as { api_key?: string }).api_key) || '';
+      if (generatedKey) {
+        this.createdKeyName.set(payload.name);
+        this.createdKey.set(generatedKey);
+        this.createdKeyCopied.set(false);
+        this.createdKeyOpen.set(true);
+      }
     } catch {
       this.addError.set('Failed to add provider, please try again.');
     } finally {
       this.addLoading.set(false);
     }
+  }
+
+  async copyCreatedKey(): Promise<void> {
+    const key = this.createdKey();
+    if (!key) return;
+    try {
+      await navigator.clipboard.writeText(key);
+      this.createdKeyCopied.set(true);
+      setTimeout(() => this.createdKeyCopied.set(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. non-secure context) — the key is still
+      // visible in the field above for manual copying.
+    }
+  }
+
+  closeCreatedKeyDialog(): void {
+    this.createdKeyOpen.set(false);
   }
 
   // ── Edit flow ─────────────────────────────────────────────────────────────

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration.service;
 
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,18 +63,38 @@ public class ProviderService {
         if (req.privacyLevel() == null || !VALID_PRIVACY_LEVELS.contains(req.privacyLevel())) {
             throw new IllegalArgumentException("privacy_level is required and must be one of " + VALID_PRIVACY_LEVELS);
         }
+        ProviderType providerType = parseProviderType(req.providerType());
+
         Provider p = new Provider();
         p.setName(req.providerName());
         p.setBaseUrl(normalizeBaseUrl(req.baseUrl()));
-        p.setApiKey(req.apiKey());
         p.setAuthName(req.authName() != null ? req.authName() : "");
         p.setAuthFormat(req.authFormat() != null ? req.authFormat() : "");
-        p.setProviderType(parseProviderType(req.providerType()));
+        p.setProviderType(providerType);
         p.setCloudProviderType(parseCloudProviderType(req.cloudProviderType()));
         p.setPrivacyLevel(ThresholdLevel.valueOf(req.privacyLevel()));
+
+        // Logosnode providers authenticate their worker node with a shared key.
+        // When the caller did not supply one, generate a random key (mirroring
+        // the orchestrator's logosnode_register bootstrap) and echo it back in
+        // the response so the operator can use it to configure the worker.
+        // Cloud providers keep whatever key was sent.
+        String apiKey = req.apiKey();
+        if (providerType == ProviderType.logosnode && (apiKey == null || apiKey.isBlank())) {
+            apiKey = generateApiKey();
+        }
+        p.setApiKey(apiKey);
+
         p = providerRepository.save(p);
         orchestratorNotificationService.notifyRefresh(false);
-        return Map.of("result", "Created Provider.", "provider-id", p.getId());
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("result", "Created Provider.");
+        response.put("provider-id", p.getId());
+        if (providerType == ProviderType.logosnode && apiKey != null) {
+            response.put("api_key", apiKey);
+        }
+        return response;
     }
 
     @Transactional
@@ -153,6 +175,18 @@ public class ProviderService {
 
     private static String normalizeBaseUrl(String raw) {
         return raw == null || raw.isBlank() ? null : raw;
+    }
+
+    /**
+     * Generate a URL-safe random API key. Matches the orchestrator's
+     * {@code secrets.token_urlsafe(48)} (48 random bytes, base64url, no
+     * padding) so a key minted here is interchangeable with one minted by the
+     * {@code logosnode_register} bootstrap endpoint.
+     */
+    private static String generateApiKey() {
+        byte[] bytes = new byte[48];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     private static ProviderType parseProviderType(String raw) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
@@ -177,6 +177,10 @@ public class ProviderService {
         return raw == null || raw.isBlank() ? null : raw;
     }
 
+    // Shared across calls — mirrors ApiKeyFactory's static SecureRandom.
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final Base64.Encoder API_KEY_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
     /**
      * Generate a URL-safe random API key. Matches the orchestrator's
      * {@code secrets.token_urlsafe(48)} (48 random bytes, base64url, no
@@ -185,8 +189,8 @@ public class ProviderService {
      */
     private static String generateApiKey() {
         byte[] bytes = new byte[48];
-        new SecureRandom().nextBytes(bytes);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
+        return API_KEY_ENCODER.encodeToString(bytes);
     }
 
     private static ProviderType parseProviderType(String raw) {

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
@@ -86,7 +86,8 @@ class ProviderControllerTest {
                     + "\"auth_name\":\"\",\"auth_format\":\"{}\"}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.result").value("Created Provider."))
-           .andExpect(jsonPath("$.api_key").isString());
+           .andExpect(jsonPath("$.api_key")
+               .value(org.hamcrest.Matchers.matchesPattern("[A-Za-z0-9_-]{64}")));
     }
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
@@ -77,6 +77,43 @@ class ProviderControllerTest {
     }
 
     @Test
+    void addProvider_logosnodeGeneratesApiKeyWhenAbsent() throws Exception {
+        mvc.perform(post("/logosdb/add_provider")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"provider_name\":\"local-node\",\"base_url\":\"http://example.com\","
+                    + "\"provider_type\":\"logosnode\",\"privacy_level\":\"LOCAL\","
+                    + "\"auth_name\":\"\",\"auth_format\":\"{}\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.result").value("Created Provider."))
+           .andExpect(jsonPath("$.api_key").isString());
+    }
+
+    @Test
+    void addProvider_logosnodeEchoesExplicitlyProvidedKey() throws Exception {
+        mvc.perform(post("/logosdb/add_provider")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"provider_name\":\"local-node-2\",\"base_url\":\"http://example.com\","
+                    + "\"provider_type\":\"logosnode\",\"privacy_level\":\"LOCAL\","
+                    + "\"auth_name\":\"\",\"auth_format\":\"{}\",\"api_key\":\"my-shared-key\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.api_key").value("my-shared-key"));
+    }
+
+    @Test
+    void addProvider_cloudDoesNotGenerateApiKey() throws Exception {
+        mvc.perform(post("/logosdb/add_provider")
+                .with(TestJwt.logosAdmin())
+                .contentType("application/json")
+                .content("{\"provider_name\":\"cloud-p\",\"base_url\":\"http://example.com\","
+                    + "\"provider_type\":\"cloud\",\"privacy_level\":\"CLOUD_IN_EU_BY_US_PROVIDER\","
+                    + "\"auth_name\":\"Authorization\",\"auth_format\":\"Bearer {}\"}"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.api_key").doesNotExist());
+    }
+
+    @Test
     void updateProvider_updatesName() throws Exception {
         mvc.perform(post("/logosdb/update_provider")
                 .with(TestJwt.logosAdmin())


### PR DESCRIPTION
## Summary

Fixes #902 — two bugs in the Add Provider dialog.

**1. Cloud Provider select shown for local nodes.**
For `logosnode` (local) providers the *Cloud Provider* select was still displayed, only disabled with `none` pre-filled. Cloud vendors don't apply to self-hosted nodes, so the field is now hidden entirely (`@if (addProviderType() === 'cloud')`). The *Privacy Level* select stays **enabled** for logosnode, so a node on hardware outside operator control (e.g. a personal Mac MLX worker) can be marked `THIRD_PARTY_HARDWARE` instead of `LOCAL` — the comment on the issue. Same change applied to the Edit dialog.

**2. No API key auto-generated for new providers.**
The webservice stored whatever key was submitted as-is (i.e. an empty string). For logosnode this is the key the worker node uses to authenticate, so it must not be left blank. `ProviderService.addProvider` now generates a random key when none is supplied for a `logosnode` provider — `SecureRandom` 48 bytes, base64url, no padding, i.e. equivalent to the orchestrator's `secrets.token_urlsafe(48)` used in `logosnode_register`. Cloud providers keep whatever key was sent, unchanged.

The generated key is echoed back in the `add_provider` response and shown to the operator in a copyable follow-up modal (it's only available at creation time, so the UI makes it easy to copy into the worker config).

## Changes

- `logos/logos-ui/src/app/features/providers/providers.html`
  - Add dialog: hide Cloud Provider select for logosnode; keep Privacy Level enabled for both types.
  - Edit dialog: same.
  - New "Provider created" modal displaying the generated shared key with a copy button.
- `logos/logos-ui/src/app/features/providers/providers.ts`
  - Signals + methods for the created-key modal (`createdKey*`, `copyCreatedKey`, `closeCreatedKeyDialog`).
  - `submitAdd` captures the `api_key` from the response and opens the modal when a key was generated.
- `logos/logos-ui/src/app/features/providers/providers.scss`
  - Styles for the created-key modal (`.created-key-intro`, `.created-key-row`).
- `logos/logos-webservice/.../configuration/service/ProviderService.java`
  - Auto-generate + echo API key for logosnode; `generateApiKey()` helper.
- `logos/logos-webservice/.../configuration/ProviderControllerTest.java`
  - 3 new tests: logosnode generates a key when absent, echoes an explicitly supplied key, cloud does not generate one.

## Verification

- `mvn test -Dtest=ProviderControllerTest` → 20 tests, 0 failures, 0 errors (full Liquibase schema incl. changeset 024 applied in Testcontainers Postgres 17).
- `ng build` → success (only pre-existing SCSS budget warnings for unrelated files).

## Out of scope

No new provider type, no `provider_type_enum` migration, no orchestrator changes. `THIRD_PARTY_HARDWARE` remains a **privacy level** (introduced on main in #801), selectable through the now-enabled Privacy Level field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic API key generation when creating Logos worker node providers without a supplied key.
  * Added a one-time dialog displaying the generated API key, with copy-to-clipboard support and confirmation feedback.
  * Cloud Provider selection now appears only for cloud provider types.
* **Bug Fixes**
  * Removed unnecessary disabling of Cloud Provider and Privacy Level fields for Logos worker node providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->