### PR TITLE
`Logos`: Show the exact cold-start percentage on the stats page

### DIFF
--- a/logos/logos-ui/src/app/features/statistics/statistics.html
+++ b/logos/logos-ui/src/app/features/statistics/statistics.html
@@ -113,7 +113,7 @@
         <app-stats-kpi-card
           label="Cold starts"
           [accent]="CHART_ROLE.local"
-          [value]="coldPct() + '%'"
+          [value]="formatColdPct()"
         >
           <app-stats-sparkline kpiRight [data]="sparkLocal()" [color]="CHART_ROLE.local" />
           <span kpiHint>

--- a/logos/logos-ui/src/app/features/statistics/statistics.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.ts
@@ -23,6 +23,7 @@ import {
   chooseDynamicBucketMs,
   chooseDynamicTargetBuckets,
   extractProviderVramMb,
+  formatPercent,
   formatRangeLabel,
   formatTokenCount as formatTokenCountValue,
   normalizeFeedStatus,
@@ -737,15 +738,15 @@ export class Statistics implements OnInit, OnDestroy {
 
   readonly coldStarts = computed(() => this.stats()?.totals.coldStarts ?? 0);
   readonly warmStarts = computed(() => this.stats()?.totals.warmStarts ?? 0);
-
-  readonly coldPct = computed(() => {
-    const cold = this.coldStarts();
-    const warm = this.warmStarts();
-    const denom = cold + warm;
-    return denom > 0 ? Math.round((cold / denom) * 100) : 0;
-  });
-
   readonly coldDenominator = computed(() => this.coldStarts() + this.warmStarts());
+
+  /**
+   * The cold-start share as the KPI card shows it: the exact percentage, so a
+   * rare share (694 of 317.265) reads 0.22% instead of a rounded "0%".
+   */
+  formatColdPct(): string {
+    return formatPercent(this.coldStarts(), this.coldDenominator());
+  }
 
   readonly sparkTotal = computed(() =>
     (this.stats()?.timeSeries ?? []).slice(-30).map((p) => p.total || 0),

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -169,4 +169,14 @@ describe('formatPercent', () => {
     expect(formatPercent(1, 300_000)).toBe('0.0003%');
     expect(formatPercent(1, 10_000_000)).toBe('0.00001%');
   });
+
+  it('bounds a share too small for six decimals instead of reading "0%"', () => {
+    // Past the widening loop's cap toFixed(6) still rounds to zero. A single
+    // cold start among billions of starts is vanishingly rare, not absent —
+    // reporting it as "0%" would contradict the point of the helper.
+    expect(formatPercent(1, 10_000_000_000)).toBe('<0.000001%');
+    expect(formatPercent(1, 1_000_000_000)).toBe('<0.000001%');
+    // The last share that still fits six decimals keeps its exact reading.
+    expect(formatPercent(1, 100_000_000)).toBe('0.000001%');
+  });
 });

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  formatPercent,
   formatTokenCount,
   normalizeFeedStatus,
   resolveFeedTotal,
@@ -118,5 +119,54 @@ describe('formatTokenCount', () => {
   it('stays on T once the scale is exhausted', () => {
     expect(formatTokenCount(2_000_000_000_000)).toBe('2 T');
     expect(formatTokenCount(15_000_000_000_000)).toBe('15 T');
+  });
+});
+
+/**
+ * The share of a part in a total, as the cold-start KPI card shows it.
+ *
+ * The point is the small end: a share that integer rounding collapses to
+ * "0%" — 694 of 317.265 local starts — must read as the percentage it is,
+ * while an everyday share like 34% stays plain and a genuinely zero share
+ * still reads "0%".
+ */
+describe('formatPercent', () => {
+  it('reads "0%" when the total is not a positive finite number', () => {
+    expect(formatPercent(5, 0)).toBe('0%');
+    expect(formatPercent(5, -100)).toBe('0%');
+    expect(formatPercent(5, Number.NaN)).toBe('0%');
+    expect(formatPercent(5, Number.POSITIVE_INFINITY)).toBe('0%');
+    expect(formatPercent(5, null)).toBe('0%');
+    expect(formatPercent(5, undefined)).toBe('0%');
+  });
+
+  it('reads "0%" when the share is zero or the part is not a number', () => {
+    expect(formatPercent(0, 317_265)).toBe('0%');
+    expect(formatPercent(null, 100)).toBe('0%');
+    expect(formatPercent(undefined, 100)).toBe('0%');
+    expect(formatPercent(Number.NaN, 100)).toBe('0%');
+  });
+
+  it('keeps everyday shares of 10% and up plain', () => {
+    expect(formatPercent(34, 100)).toBe('34%');
+    expect(formatPercent(1, 2)).toBe('50%');
+    expect(formatPercent(10, 10)).toBe('100%');
+  });
+
+  it('keeps one decimal for single-digit shares, dropped when it is zero', () => {
+    expect(formatPercent(35, 1000)).toBe('3.5%');
+    expect(formatPercent(1, 32)).toBe('3.1%'); // 3.125 keeps its first decimal
+    expect(formatPercent(3, 100)).toBe('3%');
+  });
+
+  it('shows two decimals below one percent', () => {
+    // The case the helper exists for: 694 of 317.265 is 0.22%, not "0%".
+    expect(formatPercent(694, 317_265)).toBe('0.22%');
+    expect(formatPercent(1, 10_000)).toBe('0.01%');
+  });
+
+  it('widens the decimals until the share reads non-zero', () => {
+    expect(formatPercent(1, 300_000)).toBe('0.0003%');
+    expect(formatPercent(1, 10_000_000)).toBe('0.00001%');
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -146,6 +146,36 @@ export function formatTokenCount(count: number | null | undefined): string {
   return `${(tenths / 10).toFixed(1).replace(/\.0$/, '')} ${unit.label}`;
 }
 
+// ── Percentage scale ──────────────────────────────────────────────────────────
+
+/**
+ * The share of `part` in `total` as a percentage that never collapses a
+ * non-zero share to "0%": 694 of 317.265 local starts is 0.22%, not the "0%"
+ * an integer rounding shows. Shares of 10% and up stay plain, single-digit
+ * shares keep one decimal, and below 1% the decimals widen (two by default,
+ * up to six) until the value reads non-zero. A zero share — or an input that
+ * is not a positive finite total — reads "0%".
+ */
+export function formatPercent(
+  part: number | null | undefined,
+  total: number | null | undefined,
+): string {
+  if (
+    typeof part !== 'number' ||
+    typeof total !== 'number' ||
+    !Number.isFinite(part) ||
+    !Number.isFinite(total) ||
+    total <= 0
+  ) {
+    return '0%';
+  }
+  const pct = (part / total) * 100;
+  if (pct >= 10) return `${Math.round(pct)}%`;
+  let decimals = pct >= 1 ? 1 : 2;
+  while (pct > 0 && decimals < 6 && Number(pct.toFixed(decimals)) === 0) decimals += 1;
+  return `${pct.toFixed(decimals).replace(/\.0+$/, '')}%`;
+}
+
 // ── X-axis labels (shared by request-volume and VRAM charts) ─────────────────
 
 export interface TimeAxisLabel {

--- a/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
+++ b/logos/logos-ui/src/app/features/statistics/statistics.utils.ts
@@ -153,8 +153,10 @@ export function formatTokenCount(count: number | null | undefined): string {
  * non-zero share to "0%": 694 of 317.265 local starts is 0.22%, not the "0%"
  * an integer rounding shows. Shares of 10% and up stay plain, single-digit
  * shares keep one decimal, and below 1% the decimals widen (two by default,
- * up to six) until the value reads non-zero. A zero share — or an input that
- * is not a positive finite total — reads "0%".
+ * up to six) until the value reads non-zero. A share too small even for six
+ * decimals reads "<0.000001%" rather than "0%" — the card must not report a
+ * cold start that happened as none at all. A zero share — or an input that is
+ * not a positive finite total — reads "0%".
  */
 export function formatPercent(
   part: number | null | undefined,
@@ -173,6 +175,9 @@ export function formatPercent(
   if (pct >= 10) return `${Math.round(pct)}%`;
   let decimals = pct >= 1 ? 1 : 2;
   while (pct > 0 && decimals < 6 && Number(pct.toFixed(decimals)) === 0) decimals += 1;
+  // Below the six-decimal cap the widening loop runs out and toFixed still
+  // rounds to zero. Bound it instead of printing "0%" for a share that is not.
+  if (pct > 0 && Number(pct.toFixed(decimals)) === 0) return '<0.000001%';
   return `${pct.toFixed(decimals).replace(/\.0+$/, '')}%`;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved percentage formatting on the Statistics page.
  * Cold-start rates now show precise values, including small percentages, instead of rounding them to whole numbers.
  * Invalid or unavailable percentage values display as `0%`.

* **Tests**
  * Added coverage for standard, fractional, very small, and invalid percentage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->