### PR TITLE
`Logos`: Adjust Capacity Planner to only load calibrated models on non-metal nodes

### DIFF
--- a/logos/docs/context-windows.md
+++ b/logos/docs/context-windows.md
@@ -83,9 +83,12 @@ The first is temporary — it clears when VRAM frees up. The second will not: no
 calibrated point on that node reaches the floor at any KV size, so either lower
 `min_context_fraction` for that model or re-calibrate it.
 
-A model whose context length is unknown is never blocked by the floor. It exists
-to stop the planner *choosing* a narrow window, not to keep uncalibrated models
-off the cluster.
+A model whose context length is unknown is never blocked by the floor itself —
+it exists to stop the planner *choosing* a narrow window, not to gate on
+calibration. That gate is separate: `_passes_minimum_load_feasibility` refuses
+to load any model that has never been calibrated on that node, unless the
+provider is Metal/MLX (which runs on operator-provided override profiles
+instead — calibration is impossible there by design).
 
 ## 3. Context-aware routing — send long requests where they fit
 

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -3781,6 +3781,17 @@ class CapacityPlanner:
             # load that needs eviction, deadlocking the planner cycle).
             has_queued = self._get_queue_depth_for_model(provider_id, model_name, lanes) > 0
 
+            # The contention branch below skips _passes_minimum_load_
+            # feasibility entirely (see its own comment), so gate
+            # calibration here instead, before the if/else split.
+            if self._load_requires_calibration(profile, provider_id):
+                logger.info(
+                    "Skipping load of %s on worker=%s: never calibrated here " "and not a Metal/MLX provider",
+                    model_name,
+                    self._facade.get_provider_name(provider_id) or provider_id,
+                )
+                continue
+
             if not eviction_set:
                 # Resources freely available — act on floor score. An announced
                 # upcoming use counts alongside a queued request: nothing has to
@@ -4300,6 +4311,14 @@ class CapacityPlanner:
             capacity = await self._wait_for_provider(provider_id, deadline)
             if capacity is None:
                 return False
+
+        if self._load_requires_calibration(profile, provider_id):
+            logger.info(
+                "ensure_capacity worker=%s model=%s: refusing — never calibrated " "on this (non-Metal) provider",
+                self._facade.get_provider_name(provider_id) or provider_id,
+                target.model_name,
+            )
+            return False
 
         target_action = CapacityPlanAction(
             action="wake" if target.runtime_state == "sleeping" else "load",
@@ -5446,6 +5465,36 @@ class CapacityPlanner:
     # VRAM budget validation
     # ------------------------------------------------------------------
 
+    def _provider_is_metal(self, provider_id: Optional[int]) -> bool:
+        """True when this provider's devices report the Metal backend.
+
+        Metal/MLX workers can't be calibrated (no nvidia-smi/proc-meminfo),
+        so they run on operator-provided overrides instead.
+        """
+        if provider_id is None or self._registry is None:
+            return False
+        snap = self._registry.peek_runtime_snapshot(provider_id)
+        if not snap:
+            return False
+        runtime = snap.get("runtime")
+        devices = runtime.get("devices") if isinstance(runtime, dict) else None
+        return isinstance(devices, dict) and devices.get("mode") == "metal"
+
+    def _load_requires_calibration(
+        self,
+        profile: Optional[ModelProfile],
+        provider_id: Optional[int],
+    ) -> bool:
+        """True when this profile must not be used to load a lane.
+
+        Calibrated/measured profiles always pass; everything else needs
+        a Metal/MLX provider (see _provider_is_metal).
+        """
+        is_calibrated = profile is not None and profile.residency_source in ("calibrated", "measured")
+        if is_calibrated:
+            return False
+        return not self._provider_is_metal(provider_id)
+
     def _passes_minimum_load_feasibility(
         self,
         model_name: str,
@@ -5456,14 +5505,18 @@ class CapacityPlanner:
     ) -> bool:
         """Quick gate before emitting a planner-initiated load action.
 
-        Checks base_residency + KV cache ≤ available_vram (with safety margin).
-        Uses the profile's HF-derived data when available, falls back to a name
-        heuristic.  Returns True (allow) when no estimate is possible — unknown
-        models should not be silently blocked.
+        Refuses outright when the model has never been calibrated on this
+        node and the provider is not Metal/MLX — see
+        _load_requires_calibration. Past that gate, base_residency only
+        ever comes from a calibrated profile or a Metal override; a
+        Metal provider with no profile at all (a misconfigured override)
+        is refused too rather than guessed at from the model's name.
 
-        For TP > 1 models, also checks per-GPU feasibility from runtime snapshot
-        device info, since total free VRAM can be misleading on heterogeneous or
-        unevenly loaded multi-GPU nodes (e.g. 20 GB total free but split 18+2).
+        Checks base_residency + KV cache ≤ available_vram (with safety
+        margin). For TP > 1 models, also checks per-GPU feasibility from
+        runtime snapshot device info, since total free VRAM can be
+        misleading on heterogeneous or unevenly loaded multi-GPU nodes
+        (e.g. 20 GB total free but split 18+2).
         """
         if capacity is None:
             return False
@@ -5474,16 +5527,28 @@ class CapacityPlanner:
         if available_mb <= 0:
             return False
 
+        if self._load_requires_calibration(profile, provider_id):
+            logger.info(
+                "Feasibility FAILED for %s: never calibrated on worker=%s and "
+                "not a Metal/MLX provider — calibrate it before loading",
+                model_name,
+                provider_id,
+            )
+            return False
+
         base_mb: Optional[float] = None
         if profile is not None:
             base_mb = profile.estimate_base_residency_mb()
         if base_mb is None:
-            from logos.sdi.models import _base_residency_from_bytes, _estimated_disk_size_bytes_from_model_name
-
-            disk = _estimated_disk_size_bytes_from_model_name(model_name)
-            base_mb = _base_residency_from_bytes(disk)
-        if base_mb is None:
-            return True  # can't estimate, allow
+            # Only reachable on a Metal provider with no profile at all
+            # (see _load_requires_calibration) — a misconfigured override,
+            # not a case to guess a size for from the model's name.
+            logger.info(
+                "Feasibility FAILED for %s: no profile/override data on " "worker=%s to estimate a size from",
+                model_name,
+                provider_id,
+            )
+            return False
 
         is_calibrated = profile is not None and profile.residency_source in (
             "calibrated",
@@ -5816,13 +5881,20 @@ class CapacityPlanner:
         sanitized = model_name.replace("/", "_").replace(":", "_").replace(" ", "_")
         return f"planner-{sanitized}"
 
-    def manual_load_rejection_reason(self, provider_id: int) -> Optional[str]:
+    def manual_load_rejection_reason(
+        self,
+        provider_id: int,
+        model_name: Optional[str] = None,
+    ) -> Optional[str]:
         """Why a manual load must not be attempted now, or None if it may run.
 
         The message is meant for the operator who clicked "Load lane", so the
         API layer calls this before it accepts the request: the load itself runs
         as a background task, and a refusal raised in there has nobody left to
         report to.
+
+        Passing ``model_name`` also rejects a model never calibrated here
+        (see _load_requires_calibration); omit it to skip that check.
         """
         if not self._is_plannable(provider_id):
             if self._registry is not None and self._registry.is_calibrating(provider_id):
@@ -5833,6 +5905,12 @@ class CapacityPlanner:
             # reservation, i.e. it would place the lane without checking whether
             # it fits. Request-time cold loads bail out here for the same reason.
             return "No capacity information for this provider yet; its free VRAM is unknown."
+        if model_name is not None:
+            profile = self._safe_get_profiles(provider_id).get(model_name)
+            if self._load_requires_calibration(profile, provider_id):
+                return (
+                    f"Model {model_name!r} has never been calibrated on this " "provider; calibrate it before loading."
+                )
         return None
 
     async def load_lane_manually(self, provider_id: int, model_name: str) -> bool:
@@ -5869,7 +5947,7 @@ class CapacityPlanner:
         ``add_lane`` for it, and the check inside the lock is what turns the
         second into a no-op instead of a duplicate.
         """
-        rejection = self.manual_load_rejection_reason(provider_id)
+        rejection = self.manual_load_rejection_reason(provider_id, model_name)
         if rejection is not None:
             logger.warning("Refusing manual load of %s on worker=%s: %s", model_name, provider_id, rejection)
             return False
@@ -5888,7 +5966,7 @@ class CapacityPlanner:
                 )
                 return False
 
-            rejection = self.manual_load_rejection_reason(provider_id)
+            rejection = self.manual_load_rejection_reason(provider_id, model_name)
             if rejection is not None:
                 logger.warning(
                     "Refusing manual load of %s on worker=%s after waiting for the lane lock: %s",

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5500,7 +5500,7 @@ class CapacityPlanner:
             return True
         if profile.residency_source in ("calibrated", "measured"):
             return False
-        return not self._provider_is_metal(provider_id)
+        return not (profile.residency_source == "override" and self._provider_is_metal(provider_id))
 
     def _passes_minimum_load_feasibility(
         self,

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -3022,6 +3022,12 @@ class CapacityPlanner:
             else:
                 needed_mb = 0.0
         else:
+            # Never-calibrated on a non-Metal provider can't actually load
+            # here (see _load_requires_calibration) — mark infeasible before
+            # it wins the ranking on a falsely cheap 4096 MB guess, leaving
+            # every provider that could serve it deferring to a dead end.
+            if self._load_requires_calibration(profile, provider_id):
+                return None
             target_cost = self.TARGET_ACTION_COST_S["load"]
             # Cold-load VRAM need = full base_residency (with KV+TP if profile knows).
             if profile is not None:

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -5493,11 +5493,12 @@ class CapacityPlanner:
     ) -> bool:
         """True when this profile must not be used to load a lane.
 
-        Calibrated/measured profiles always pass; everything else needs
-        a Metal/MLX provider (see _provider_is_metal).
+        No profile at all always fails, even on Metal — only an override
+        profile is exempt there, not having nothing (see load_lane_manually).
         """
-        is_calibrated = profile is not None and profile.residency_source in ("calibrated", "measured")
-        if is_calibrated:
+        if profile is None:
+            return True
+        if profile.residency_source in ("calibrated", "measured"):
             return False
         return not self._provider_is_metal(provider_id)
 
@@ -5512,11 +5513,10 @@ class CapacityPlanner:
         """Quick gate before emitting a planner-initiated load action.
 
         Refuses outright when the model has never been calibrated on this
-        node and the provider is not Metal/MLX — see
-        _load_requires_calibration. Past that gate, base_residency only
-        ever comes from a calibrated profile or a Metal override; a
-        Metal provider with no profile at all (a misconfigured override)
-        is refused too rather than guessed at from the model's name.
+        node and the provider is not Metal/MLX, and refuses a missing
+        profile outright too, even on Metal — see
+        _load_requires_calibration. Past that gate, base_residency comes
+        from the profile itself, never guessed at from the model's name.
 
         Checks base_residency + KV cache ≤ available_vram (with safety
         margin). For TP > 1 models, also checks per-GPU feasibility from
@@ -5542,15 +5542,15 @@ class CapacityPlanner:
             )
             return False
 
-        base_mb: Optional[float] = None
-        if profile is not None:
-            base_mb = profile.estimate_base_residency_mb()
+        # profile is guaranteed non-None here: _load_requires_calibration
+        # above already rejects a missing profile on every provider.
+        base_mb = profile.estimate_base_residency_mb()
         if base_mb is None:
-            # Only reachable on a Metal provider with no profile at all
-            # (see _load_requires_calibration) — a misconfigured override,
-            # not a case to guess a size for from the model's name.
+            # Defensive: a profile can pass the gate above yet still have
+            # no usable size (base_residency_mb, disk_size_bytes and the
+            # name heuristic all unset) — not a case to guess from the name.
             logger.info(
-                "Feasibility FAILED for %s: no profile/override data on " "worker=%s to estimate a size from",
+                "Feasibility FAILED for %s: no usable size data on " "worker=%s to estimate from",
                 model_name,
                 provider_id,
             )

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2880,7 +2880,7 @@ async def internal_logosnode_add_lane(data: _InternalAddLaneRequest, request: Re
         raise HTTPException(status_code=503, detail="Capacity planner not ready")
 
     # Answer a refusal synchronously — a background task has nobody to report to.
-    rejection = _capacity_planner.manual_load_rejection_reason(data.provider_id)
+    rejection = _capacity_planner.manual_load_rejection_reason(data.provider_id, model)
     if rejection is not None:
         raise HTTPException(status_code=409, detail=rejection)
 

--- a/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_best_first_scenarios.py
@@ -410,6 +410,28 @@ class TestEstimateDemandActionCost:
             CapacityPlanner.TARGET_ACTION_COST_S["load"] + CapacityPlanner.VICTIM_ACTION_COST_S["stop"]
         )
 
+    def test_cold_load_never_calibrated_on_non_metal_returns_none(self):
+        """A model with no profile on a non-Metal worker can't actually
+        cold-load there (see _load_requires_calibration), no matter how
+        much free VRAM the cheap 4096 MB guess would otherwise fit into.
+        """
+        provider = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            profiles={},  # no profile for "X" at all
+            available_vram_mb=80_000.0,
+        )
+        planner = _planner([provider])
+        result = planner._estimate_demand_action_cost(
+            1,
+            "X",
+            provider.lanes,
+            provider.profiles,
+            planner._facade.get_capacity_info(1),
+        )
+        assert result is None
+
     def test_no_lane_no_evict_target_returns_none(self):
         """Pathological: needs eviction but no displaceable lanes → None (infeasible)."""
         provider = _MockProvider(
@@ -556,6 +578,37 @@ class TestRankProvidersForDemandedModels:
         )
         planner = _planner([a, b])
         planner._lane_load_failure_until[(a.provider_id, planner._planner_lane_id("X"))] = time.time() + 120.0
+
+        winners = planner._rank_providers_for_demanded_models(
+            [a.provider_id, b.provider_id],
+            [("X", 1.5)],
+        )
+        assert winners == {"X": b.provider_id}
+
+    def test_a_never_calibrated_worker_does_not_win_over_a_feasible_one(self):
+        """A has no profile for X at all and would win on free-VRAM alone —
+        the cheap 4096 MB guess for an unknown model fits easily and no
+        eviction is needed. But A is not Metal, so it could never actually
+        load X (see _load_requires_calibration): the calibrated B, with less
+        free VRAM, must win instead of both providers deferring to a dead end.
+        """
+        a = _MockProvider(
+            provider_id=1,
+            name="A",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=90_000,  # would otherwise win the free-VRAM tiebreak
+            profiles={},
+        )
+        b = _MockProvider(
+            provider_id=2,
+            name="B",
+            lanes=[],
+            capabilities=["X"],
+            available_vram_mb=80_000,
+            profiles={"X": _profile(loaded_vram_mb=20_000)},
+        )
+        planner = _planner([a, b])
 
         winners = planner._rank_providers_for_demanded_models(
             [a.provider_id, b.provider_id],

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
@@ -1,0 +1,111 @@
+"""No model may be loaded before it has been calibrated here.
+
+Except on Metal/MLX providers, where calibration is impossible by
+design — they run on operator-provided override profiles instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from logos.capacity.capacity_planner import CapacityPlanner
+from logos.sdi.models import ModelProfile
+
+
+def _planner(*, metal: bool = False) -> CapacityPlanner:
+    planner = CapacityPlanner.__new__(CapacityPlanner)
+    snapshot = {"runtime": {"devices": {"mode": "metal"}}} if metal else None
+    planner._registry = SimpleNamespace(peek_runtime_snapshot=lambda provider_id: snapshot)
+    return planner
+
+
+def _profile(residency_source: str, base_residency_mb: float = 4000.0) -> ModelProfile:
+    return ModelProfile(
+        model_name="org/model-a",
+        engine="vllm",
+        residency_source=residency_source,
+        base_residency_mb=base_residency_mb,
+    )
+
+
+class TestProviderIsMetal:
+    def test_no_registry_means_not_metal(self):
+        planner = CapacityPlanner.__new__(CapacityPlanner)
+        planner._registry = None
+        assert planner._provider_is_metal(1) is False
+
+    def test_no_snapshot_means_not_metal(self):
+        assert _planner(metal=False)._provider_is_metal(1) is False
+
+    def test_metal_device_mode_is_detected(self):
+        assert _planner(metal=True)._provider_is_metal(1) is True
+
+    def test_none_provider_id_is_not_metal(self):
+        assert _planner(metal=True)._provider_is_metal(None) is False
+
+
+class TestLoadRequiresCalibration:
+    def test_calibrated_never_requires_it(self):
+        assert _planner()._load_requires_calibration(_profile("calibrated"), 1) is False
+
+    def test_measured_never_requires_it(self):
+        assert _planner()._load_requires_calibration(_profile("measured"), 1) is False
+
+    def test_override_requires_it_on_cuda(self):
+        assert _planner()._load_requires_calibration(_profile("override"), 1) is True
+
+    def test_override_is_exempt_on_metal(self):
+        planner = _planner(metal=True)
+        assert planner._load_requires_calibration(_profile("override"), 1) is False
+
+    def test_hf_precheck_requires_it_on_cuda(self):
+        """A compatibility-precheck estimate is not a calibration run."""
+        assert _planner()._load_requires_calibration(_profile("hf"), 1) is True
+
+    def test_cached_requires_it_on_cuda(self):
+        """A profile reloaded from disk with no recorded source is unproven."""
+        assert _planner()._load_requires_calibration(_profile("cached"), 1) is True
+
+    def test_no_profile_requires_it_on_cuda(self):
+        assert _planner()._load_requires_calibration(None, 1) is True
+
+    def test_no_profile_is_exempt_on_metal(self):
+        planner = _planner(metal=True)
+        assert planner._load_requires_calibration(None, 1) is False
+
+
+class TestFeasibilityGateRequiresCalibration:
+    """``_passes_minimum_load_feasibility`` refuses a never-calibrated load."""
+
+    def _capacity(self):
+        return SimpleNamespace(available_vram_mb=80_000.0)
+
+    def test_rejects_hf_precheck_profile_on_cuda(self):
+        planner = _planner(metal=False)
+        planner.get_pending_vram_mb = lambda pid: 0.0
+        ok = planner._passes_minimum_load_feasibility("org/model-a", _profile("hf"), self._capacity(), provider_id=1)
+        assert ok is False
+
+    def test_rejects_model_with_no_profile_on_cuda(self):
+        planner = _planner(metal=False)
+        planner.get_pending_vram_mb = lambda pid: 0.0
+        ok = planner._passes_minimum_load_feasibility("org/model-a", None, self._capacity(), provider_id=1)
+        assert ok is False
+
+    def test_accepts_override_profile_on_metal(self):
+        planner = _planner(metal=True)
+        planner.get_pending_vram_mb = lambda pid: 0.0
+        ok = planner._passes_minimum_load_feasibility(
+            "org/model-a", _profile("override", base_residency_mb=2000.0), self._capacity(), provider_id=1
+        )
+        assert ok is True
+
+    def test_rejects_model_with_no_profile_even_on_metal(self):
+        """Metal is exempt from calibration, not from having a profile at
+        all — a missing override is refused, not guessed from the name."""
+        planner = _planner(metal=True)
+        planner.get_pending_vram_mb = lambda pid: 0.0
+        # "70B" would match the disk-size-from-name heuristic if it were
+        # still consulted here — it must not be.
+        ok = planner._passes_minimum_load_feasibility("org/model-70B", None, self._capacity(), provider_id=1)
+        assert ok is False

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
@@ -58,6 +58,16 @@ class TestLoadRequiresCalibration:
         planner = _planner(metal=True)
         assert planner._load_requires_calibration(_profile("override"), 1) is False
 
+    def test_only_override_is_exempt_on_metal(self):
+        """The Metal exemption is for an operator override specifically —
+        not a seeded stub (residency_source=None), an HF-precheck estimate,
+        or a cached/unproven source; those must still be refused.
+        """
+        planner = _planner(metal=True)
+        for residency_source in (None, "hf", "cached"):
+            assert planner._load_requires_calibration(_profile(residency_source), 1) is True
+        assert planner._load_requires_calibration(_profile("override"), 1) is False
+
     def test_hf_precheck_requires_it_on_cuda(self):
         """A compatibility-precheck estimate is not a calibration run."""
         assert _planner()._load_requires_calibration(_profile("hf"), 1) is True

--- a/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_calibration_required_to_load.py
@@ -69,9 +69,12 @@ class TestLoadRequiresCalibration:
     def test_no_profile_requires_it_on_cuda(self):
         assert _planner()._load_requires_calibration(None, 1) is True
 
-    def test_no_profile_is_exempt_on_metal(self):
+    def test_no_profile_requires_it_even_on_metal(self):
+        """The Metal exemption is for an override profile, not for having
+        nothing — a missing profile would build a load with no backend
+        config (see load_lane_manually's docstring)."""
         planner = _planner(metal=True)
-        assert planner._load_requires_calibration(None, 1) is False
+        assert planner._load_requires_calibration(None, 1) is True
 
 
 class TestFeasibilityGateRequiresCalibration:

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_guard.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_guard.py
@@ -93,6 +93,15 @@ def test_override_profile_is_refused_on_cuda():
     assert "never been calibrated" in reason
 
 
+def test_missing_profile_is_refused_even_on_metal():
+    """A missing profile is not the same as an override — building a load
+    with profile=None starts a lane with the wrong backend config (see
+    load_lane_manually's docstring), so Metal must not wave this through."""
+    reason = _planner(profiles={}, metal=True).manual_load_rejection_reason(1, "org/does-not-exist")
+    assert reason is not None
+    assert "never been calibrated" in reason
+
+
 def test_model_name_omitted_skips_the_calibration_check():
     """Provider-level readiness checks (no model chosen yet) are unaffected."""
     profiles = {"org/model-a": SimpleNamespace(residency_source=None)}

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_guard.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_guard.py
@@ -16,20 +16,29 @@ reasons:
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from logos.capacity.capacity_planner import CapacityPlanner
 
+# Stands in for a real calibrated ModelProfile — load_lane_manually's own
+# calibration gate only ever reads .residency_source.
+_CALIBRATED_PROFILE = SimpleNamespace(residency_source="calibrated")
 
-def _planner(*, calibrating=False, has_status=True, capacity=object()) -> CapacityPlanner:
+
+def _planner(*, calibrating=False, has_status=True, capacity=object(), profiles=None, metal=False) -> CapacityPlanner:
     planner = CapacityPlanner.__new__(CapacityPlanner)
     registry = MagicMock()
     registry.is_calibrating.return_value = calibrating
     registry.has_received_first_status.return_value = has_status
+    registry.peek_runtime_snapshot.return_value = {"runtime": {"devices": {"mode": "metal"}}} if metal else None
     planner._registry = registry
     facade = MagicMock()
     facade.get_capacity_info.return_value = capacity
     facade.get_provider_name.return_value = "worker-a"
+    # load_lane_manually tests below target "org/model-a"; default it to a
+    # calibrated profile so the new calibration gate stays out of their way.
+    facade.get_model_profiles.return_value = profiles if profiles is not None else {"org/model-a": _CALIBRATED_PROFILE}
     planner._facade = facade
     planner._lane_action_locks = {}
     return planner
@@ -55,6 +64,48 @@ def test_provider_without_capacity_snapshot_is_refused():
     reason = _planner(capacity=None).manual_load_rejection_reason(1)
     assert reason is not None
     assert "capacity information" in reason
+
+
+def test_never_calibrated_model_is_refused_on_cuda():
+    profiles = {"org/model-a": SimpleNamespace(residency_source=None)}
+    reason = _planner(profiles=profiles).manual_load_rejection_reason(1, "org/model-a")
+    assert reason is not None
+    assert "never been calibrated" in reason
+
+
+def test_hf_precheck_profile_is_refused_on_cuda():
+    profiles = {"org/model-a": SimpleNamespace(residency_source="hf")}
+    reason = _planner(profiles=profiles).manual_load_rejection_reason(1, "org/model-a")
+    assert reason is not None
+    assert "never been calibrated" in reason
+
+
+def test_override_profile_is_accepted_on_metal():
+    profiles = {"org/model-a": SimpleNamespace(residency_source="override")}
+    reason = _planner(profiles=profiles, metal=True).manual_load_rejection_reason(1, "org/model-a")
+    assert reason is None
+
+
+def test_override_profile_is_refused_on_cuda():
+    profiles = {"org/model-a": SimpleNamespace(residency_source="override")}
+    reason = _planner(profiles=profiles).manual_load_rejection_reason(1, "org/model-a")
+    assert reason is not None
+    assert "never been calibrated" in reason
+
+
+def test_model_name_omitted_skips_the_calibration_check():
+    """Provider-level readiness checks (no model chosen yet) are unaffected."""
+    profiles = {"org/model-a": SimpleNamespace(residency_source=None)}
+    assert _planner(profiles=profiles).manual_load_rejection_reason(1) is None
+
+
+def test_load_lane_manually_rejects_a_never_calibrated_model_on_cuda():
+    profiles = {"org/model-a": SimpleNamespace(residency_source=None)}
+    planner = _planner(profiles=profiles)
+    planner._execute_action_with_confirmation = MagicMock()
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+    planner._execute_action_with_confirmation.assert_not_called()
 
 
 def test_calibrating_wins_over_missing_capacity():
@@ -108,7 +159,6 @@ def test_concurrent_manual_loads_dispatch_once():
         return True
 
     planner._execute_action_with_confirmation = execute
-    planner._safe_get_profiles = MagicMock(return_value={})
     planner._build_load_params = MagicMock(return_value={})
     # Stands in for the registry snapshot: the runtime knows the lane from the
     # moment the command goes out, which is what the second attempt must see.

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_add_lane_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_add_lane_endpoint.py
@@ -111,6 +111,9 @@ async def test_accepts_and_loads_through_the_planner(monkeypatch):
     assert response.status_code == 202
     assert json.loads(response.body) == {"status": "accepted", "model": "org/model-a", "provider_id": 7}
     planner.load_lane_manually.assert_called_once_with(7, "org/model-a")
+    # The model must reach the sync gate too, or an uncalibrated model would
+    # only be caught inside the background task, with nobody left to tell.
+    planner.manual_load_rejection_reason.assert_called_once_with(7, "org/model-a")
     # Let the scheduled task run so it does not outlive the test.
     await asyncio.sleep(0)
 

--- a/logos/logos-workernode/MACOS.md
+++ b/logos/logos-workernode/MACOS.md
@@ -168,6 +168,10 @@ dot and `Excluding 1 uncalibrated model(s) from capabilities` instead means
 the model is advertised to no one — the profile is missing or has no
 `base_residency_mb` (*Troubleshooting*).
 
+The orchestrator otherwise refuses to load a model that has never been
+calibrated on the node it would run on — Metal/MLX providers are the one
+exception, so an `override` profile here keeps working exactly as before.
+
 On the orchestrator, add this Mac as a provider with the privacy level
 **`THIRD_PARTY_HARDWARE`** (*Privacy* below). When a request routed there
 arrives, the worker spawns the lane — a native

--- a/logos/logos-workernode/logos_worker_node/logos_bridge.py
+++ b/logos/logos-workernode/logos_worker_node/logos_bridge.py
@@ -893,6 +893,25 @@ class LogosBridgeClient:
 
         ``persist=False`` skips the model_profiles write. Never raises.
         """
+        if is_metal_backend():
+            # No nvidia-smi here, so the VRAM-fit half could never run
+            # anyway — skip up front rather than fall through that
+            # exception. Metal profiles come from model_profile_overrides,
+            # not this precheck.
+            return {
+                "model": model_name,
+                "hf_source": "skipped:metal-backend",
+                "weight_bytes": None,
+                "kv_per_token_bytes": None,
+                "max_context_length": None,
+                "quantization_method": None,
+                "per_gpu_total_mb": None,
+                "per_gpu_free_mb": None,
+                "hardware_max_tp": None,
+                "fit_tp_idle": None,
+                "fit_tp_current": None,
+                "unsupported_reason": None,
+            }
         from logos_worker_node.calibration import (  # noqa: PLC0415
             _max_tp_for_plan,
             calibration_gpu_slice,

--- a/logos/logos-workernode/tests/test_logos_bridge.py
+++ b/logos/logos-workernode/tests/test_logos_bridge.py
@@ -1362,6 +1362,31 @@ async def test_run_compatibility_precheck_rpc_requires_model_param(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_run_compatibility_precheck_skips_on_metal_backend(tmp_path, monkeypatch):
+    """No nvidia-smi on Metal, so the VRAM-fit half could never run — skip
+    the whole precheck up front instead of fetching HF metadata for
+    nothing. Metal profiles come from model_profile_overrides, not this."""
+    from logos_worker_node import config as _wcfg
+
+    monkeypatch.setenv("LOGOS_WORKER_BACKEND", "metal")
+    monkeypatch.setattr(_wcfg, "STATE_DIR", tmp_path)
+    app = _make_app_for_calibration(tmp_path)
+    cfg = LogosConfig(enabled=True, logos_url="https://logos.example", shared_key="secret", configured_models=[])
+    client = LogosBridgeClient(app, cfg)
+
+    fetch_spy = MagicMock(side_effect=AssertionError("should not fetch HF metadata on Metal"))
+    monkeypatch.setattr("logos_worker_node.hf_model_info.fetch_hf_model_metadata", fetch_spy)
+
+    response = await client._execute_command("run_compatibility_precheck", {"model": "org/model"})  # noqa: SLF001
+
+    assert response["ok"] is True
+    assert response["hf_source"] == "skipped:metal-backend"
+    assert response["fit_tp_idle"] is None
+    assert response["unsupported_reason"] is None
+    fetch_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_run_compatibility_precheck_rpc_returns_fit_result(tmp_path, monkeypatch):
     """The standalone RPC is callable outside any calibration session — no
     session needs to be started, no lanes are touched."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for uncapped speculative replicas across lanes and providers, while preventing duplicate or conflicting loads.
  - Manual model loading now validates model-specific calibration and capacity before scheduling.
  - Failed or stuck lanes remain blocked from repeated cold loads until they recover or disappear.

- **Bug Fixes**
  - Provider selection now favors calibrated, feasible workers.
  - Metal/MLX loading accepts only explicit override profiles and skips unsupported macOS VRAM checks.

- **Documentation**
  - Added guidance on calibration requirements and Metal/MLX exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->