### PR TITLE
`Logos`: Serve the OpenAI Batch API, on the provider or in Logos

### DIFF
--- a/logos/README.md
+++ b/logos/README.md
@@ -364,6 +364,44 @@ When the provider reports duration-based usage, Logos stores millisecond
 precision and applies the provider's per-second catalogue price. This avoids
 discarding fractional audio duration while retaining the integer usage schema.
 
+### Batch processing
+
+Logos serves the OpenAI Batch API (`/v1/files` for the input and result files,
+`/v1/batches` for the job lifecycle) for workloads with many requests and
+nobody waiting.
+
+A batch runs in one of two places, decided when its input file is uploaded:
+
+- **At the provider**, when one the key may use has a Batch API that serves
+  every model the file names. That is where the provider's batch rate applies
+  (about half the standard price), so it is preferred.
+- **In Logos**, otherwise — a model served by a worker node has no upstream
+  Batch API, and a cloud model can be missing from its provider's batch
+  offering. Logos then schedules the file's requests itself at the lowest queue
+  priority: they fill whatever capacity interactive traffic leaves and finish as
+  fast as that allows. No discount (the requests are ordinary requests), but the
+  same API.
+
+Both paths answer the same routes, so a script can upload, poll every few
+minutes, and chain the next batch onto the last without knowing which one it
+got; `logos_execution` on the batch object says which it was. Send
+`X-Logos-Batch-Execution: logos` or `provider` to force one.
+
+Whatever a batch names in its request lines is checked against the key's model
+permissions line by line, the ids it hands back are owned by the key's team (a
+lifecycle call for another team's id is a 404), and its usage is booked into the
+same budget and statistics as everything else — at the provider's batch rate
+where one is configured. See
+[docs/batch-processing.md](docs/batch-processing.md) for the full route list,
+Azure's batch availability, and the limits.
+
+The **Batches** page in the UI does the same thing without a script: upload a
+`.jsonl`, watch the progress, download the results.
+
+For a single latency-tolerant request the async job API remains simpler:
+`POST /jobs/v1/chat/completions` returns `202` with a `Location` header, and
+`GET /jobs/{job_id}` polls for the result.
+
 ## Accessing the Database
 
 The PostgreSQL database is not directly reachable from outside the server. You need to tunnel through SSH, which most database clients (e.g. DBeaver) support natively.

--- a/logos/docs/batch-processing.md
+++ b/logos/docs/batch-processing.md
@@ -78,6 +78,8 @@ A request line looks like this:
 A polling script is the normal client:
 
 ```python
+import time
+
 while batch.status not in ("completed", "failed", "expired", "cancelled"):
     time.sleep(120)
     batch = client.batches.retrieve(batch.id)
@@ -103,6 +105,18 @@ Whether a provider serves a Batch API is probed rather than configured — a
 self-hosted OpenAI-shaped inference endpoint answers `/chat/completions` and
 nothing else, and a hand-set flag would go stale. The result is cached for
 `LOGOS_BATCH_CAPABILITY_TTL_HOURS` (default 24).
+
+Serving a Batch API and batching a *given model* are two different things:
+on Azure each model needs its own Global-Batch deployment, and a model that
+only exists as a Standard deployment cannot be batched there even though the
+resource serves the Batch API. The provider does not publish its batch model
+list, so Logos learns this from its own refusals: when it refuses a batch
+creation (or a batch finishes failed) with a model-availability error, the
+models of that input file are recorded as not batch-eligible on that provider
+and route to Logos execution from the next file on. The record expires after
+`LOGOS_BATCH_MODEL_ELIGIBILITY_TTL_DAYS` (default 90), so a model the provider
+adds to Batch later is picked up automatically; the cost of a stale record is
+one more refused batch.
 
 `X-Logos-Batch-Execution` overrides the choice:
 
@@ -141,8 +155,9 @@ do, so the passthrough is not blind:
   addressed.
 - **Ownership.** File and batch ids are used for hours after the call that
   minted them, with a provider credential shared by every key allowed to use
-  that provider. Logos records each id with its owning team; a lifecycle call
-  for an id another team owns is answered `404`, exactly like an id that never
+  that provider. Logos records each id with its owner — the creating team, or
+  the creating user and key for a team-less personal key; a lifecycle call for
+  an id someone else owns is answered `404`, exactly like an id that never
   existed. `GET /v1/batches` and `GET /v1/files` are answered from Logos' own
   record rather than forwarded, so they show the caller team's objects and
   nobody else's — and cover the batches Logos ran itself, which no provider

--- a/logos/docs/batch-processing.md
+++ b/logos/docs/batch-processing.md
@@ -124,7 +124,9 @@ are held by Logos (in the database, so the UI can serve them and a redeploy
 does not lose them). Progress is published as it goes, so
 `request_counts.completed` moves while the batch runs; cancelling stops it
 before the next line rather than killing the one in flight. A batch left
-running by a restart is picked up again.
+running by a restart is picked up again on the next pass of the runner
+(`LOGOS_BATCH_LOCAL_POLL_INTERVAL_S`, default 15 s), which is also what starts
+one submitted while the process was down.
 
 ## What Logos enforces
 
@@ -141,7 +143,12 @@ do, so the passthrough is not blind:
   minted them, with a provider credential shared by every key allowed to use
   that provider. Logos records each id with its owning team; a lifecycle call
   for an id another team owns is answered `404`, exactly like an id that never
-  existed, and listings show only the caller team's objects.
+  existed. `GET /v1/batches` and `GET /v1/files` are answered from Logos' own
+  record rather than forwarded, so they show the caller team's objects and
+  nobody else's — and cover the batches Logos ran itself, which no provider
+  knows about. They return one page (`has_more` is always `false`); the
+  provider's paging cursors describe its own unfiltered list and would mislead
+  a client walking ours.
 - **Budget.** Creating a batch is refused with `402` when the key or its team is
   already over its monthly budget. The batch's own cost is settled when it
   finishes (see below), so it is not known up front.

--- a/logos/docs/batch-processing.md
+++ b/logos/docs/batch-processing.md
@@ -1,0 +1,260 @@
+# Batch processing
+
+Many requests, nobody waiting. Logos serves the OpenAI Batch API for that, and
+runs it in one of two places:
+
+- **At the provider**, when a provider the key may use offers a Batch API that
+  serves every model the file names. That is where the provider's batch rate
+  applies (roughly half the standard price), so it is always preferred.
+- **In Logos**, otherwise. A model served by a worker node has no upstream Batch
+  API at all, and a cloud model can be missing from its provider's batch
+  offering — Azure adds models to Batch long after Standard, so the newest ones
+  cannot be batched there for months. Logos then schedules the file's requests
+  itself at the **lowest queue priority**: they fill whatever capacity
+  interactive traffic is not using and finish as fast as that capacity allows.
+
+Both paths speak the same API, so a script uploads, polls, and chains the next
+batch onto the last without knowing or caring which one it got.
+
+- [What Logos serves](#what-logos-serves)
+- [Using it](#using-it)
+- [Where a batch runs](#where-a-batch-runs)
+- [What Logos enforces](#what-logos-enforces)
+- [Billing](#billing)
+- [Azure specifics](#azure-specifics)
+- [The batch page in the UI](#the-batch-page-in-the-ui)
+- [Limits and what is deliberately not supported](#limits-and-what-is-deliberately-not-supported)
+- [Alternative: the async job API](#alternative-the-async-job-api)
+
+## What Logos serves
+
+| Operation | Route |
+| --- | --- |
+| Upload a batch input file | `POST /v1/files` (`purpose=batch`) |
+| List your files | `GET /v1/files` |
+| Retrieve a file object | `GET /v1/files/{file_id}` |
+| Download file content | `GET /v1/files/{file_id}/content` |
+| Delete a file | `DELETE /v1/files/{file_id}` |
+| Create a batch | `POST /v1/batches` |
+| List your batches | `GET /v1/batches` |
+| Retrieve a batch | `GET /v1/batches/{batch_id}` |
+| Cancel a batch | `POST /v1/batches/{batch_id}/cancel` |
+
+Every route is also served under the `/openai/`, `/jobs/v1/` and
+`/jobs/openai/` mirrors. The `/v2/` (Cohere) surface has no batch routes.
+
+Responses are the provider's own objects and errors, unchanged, so the OpenAI
+SDKs work against Logos without modification.
+
+## Using it
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://logos.ase.cit.tum.de/v1", api_key=LOGOS_KEY)
+
+# One JSON object per line. `model` is the Logos model name, exactly as in a
+# normal request — Logos translates it to whatever the provider calls it.
+batch_input = client.files.create(file=open("requests.jsonl", "rb"), purpose="batch")
+
+batch = client.batches.create(
+    input_file_id=batch_input.id,
+    endpoint="/v1/chat/completions",
+    completion_window="24h",
+)
+
+# Poll until terminal, then read the results.
+batch = client.batches.retrieve(batch.id)
+results = client.files.content(batch.output_file_id)
+```
+
+A request line looks like this:
+
+```json
+{"custom_id": "q-1", "method": "POST", "url": "/v1/chat/completions",
+ "body": {"model": "gpt-4.1", "messages": [{"role": "user", "content": "…"}]}}
+```
+
+A polling script is the normal client:
+
+```python
+while batch.status not in ("completed", "failed", "expired", "cancelled"):
+    time.sleep(120)
+    batch = client.batches.retrieve(batch.id)
+```
+
+## Where a batch runs
+
+The decision is made when the **input file** is uploaded, because what the file
+asks for is what decides where it can go. The batch inherits it.
+
+1. A batch body carries no `model`, so the provider cannot be routed to the way
+   an inference request is. Logos takes the key's provider permissions instead:
+   if exactly one provider the key may use serves a Batch API, that is the
+   candidate. With several, name one in the `X-Logos-Provider` header (name or
+   id); without it the request is refused with `multiple_batch_providers` rather
+   than guessed.
+2. The candidate is used only if it serves **every** model the file names — a
+   provider cannot run a request for a model it does not host, and a batch is
+   one job at one place.
+3. Otherwise Logos runs the batch itself.
+
+Whether a provider serves a Batch API is probed rather than configured — a
+self-hosted OpenAI-shaped inference endpoint answers `/chat/completions` and
+nothing else, and a hand-set flag would go stale. The result is cached for
+`LOGOS_BATCH_CAPABILITY_TTL_HOURS` (default 24).
+
+`X-Logos-Batch-Execution` overrides the choice:
+
+| Value | Effect |
+| --- | --- |
+| `auto` (default) | Forward when possible, run here otherwise. |
+| `logos` | Run here even when a provider could have taken it. |
+| `provider` | Fail with `501`/`model_not_available_for_batch` rather than run here. |
+
+The batch object carries `logos_execution` (`"provider"` or `"logos"`) so a
+client that cares whether it got the discounted rate can tell.
+
+**What a Logos-run batch does.** Each request line is scheduled through the
+ordinary pipeline at queue priority `LOW`, `LOGOS_BATCH_LOCAL_CONCURRENCY`
+(default 8) at a time. Every line is an ordinary request — authorised, routed,
+logged and metered exactly like one a client sent — so the batch shows up in
+statistics and budgets request by request as it runs. Input and result files
+are held by Logos (in the database, so the UI can serve them and a redeploy
+does not lose them). Progress is published as it goes, so
+`request_counts.completed` moves while the batch runs; cancelling stops it
+before the next line rather than killing the one in flight. A batch left
+running by a restart is picked up again.
+
+## What Logos enforces
+
+Being allowed to use a provider does not authorise everything that provider can
+do, so the passthrough is not blind:
+
+- **Model permissions per request line.** Each line of the input file names its
+  own model. Every line is checked against the key's model permissions on the
+  target provider before the file is accepted; a line naming a model the key may
+  not use fails the upload with `403 model_not_permitted` and the line number.
+  Only `/v1/chat/completions`, `/v1/responses` and `/v1/embeddings` may be
+  addressed.
+- **Ownership.** File and batch ids are used for hours after the call that
+  minted them, with a provider credential shared by every key allowed to use
+  that provider. Logos records each id with its owning team; a lifecycle call
+  for an id another team owns is answered `404`, exactly like an id that never
+  existed, and listings show only the caller team's objects.
+- **Budget.** Creating a batch is refused with `402` when the key or its team is
+  already over its monthly budget. The batch's own cost is settled when it
+  finishes (see below), so it is not known up front.
+
+Uploads are capped at `LOGOS_MAX_BATCH_FILE_BYTES` (default 50 MiB) and
+`LOGOS_MAX_BATCH_REQUESTS` lines (default 50 000, the provider's own ceiling).
+Only `purpose="batch"` is accepted: Logos serves the Files API as the Batch
+API's transport, not as a general-purpose object store.
+
+## Billing
+
+A **Logos-run** batch needs no special handling: its lines are ordinary
+requests, so they are metered as they run, at the ordinary rate (the provider
+never saw a batch, so there is no batch rate to apply — and for a worker-node
+model there is nothing to pay in the first place).
+
+A **forwarded** batch is metered when it finishes. When it reaches a terminal
+state — either because the client polled it or because the background
+reconciler found it (`LOGOS_BATCH_RECONCILE_INTERVAL_S`, default 300 s) — Logos
+reads its output file once and books **one usage row per result line**, with
+the owning key, team, model and provider. Batch spend therefore appears in the
+same budget, statistics and export surfaces as everything else.
+
+Those rows carry `service_tier = 'batch'`, which makes the price lookup use the
+provider's batch rate (imported from the model catalogue's `*_batches` prices).
+A model with no published batch rate falls back to its standard rate, so an
+unpriced batch is over- rather than under-charged.
+
+Settlement is latched in the database, so a batch is metered exactly once even
+when the client's poll and the reconciler reach it simultaneously; a settlement
+that fails (an unreadable output file, say) releases the latch and is retried.
+
+Note that Logos books what the *result rows* report. The provider is the source
+of truth for the invoice; these rows are Logos' attribution of it.
+
+## Azure specifics
+
+Azure serves Batch at the resource level (`{resource}/openai/v1/batches`), not
+under a deployment, so Logos addresses it there rather than through the
+deployment URLs it uses for inference. The dated data-plane spelling
+(`{resource}/openai/batches?api-version=…`) is reachable by setting
+`LOGOS_AZURE_BATCH_API_VERSION`; note that `2024-02-01`, the version some docs
+still name, does **not** serve these routes.
+
+Azure identifies models by *deployment*, so the `model` field of every request
+line is rewritten from the Logos model name to the deployment id on upload, and
+mapped back when the results are metered. Clients keep using Logos model names.
+
+**Two operational prerequisites, both outside Logos:**
+
+1. **A Global-Batch (or Data Zone Batch) deployment must exist** on the Azure
+   resource for each model you want to batch. Batch is a separate deployment
+   type with its own quota; a Standard deployment of the same model cannot run
+   batch jobs.
+2. **The model must be offered for batch at all.** Azure adds models to Batch
+   later than to Standard, with no published parity timeline. As of
+   September 2026 the Global Batch and Data Zone Batch availability tables list
+   `gpt-4.1` (and mini/nano), `gpt-4o` (and mini), `gpt-5`, `gpt-5.1`, `gpt-5.4`,
+   `gpt-5.4-mini`, `o3`, `o3-mini` and `o4-mini` — the GPT-5.5 and GPT-5.6
+   families (`gpt-5.6-luna`, `-terra`, `-sol`) are **not** available for batch,
+   so there is no batch discount for them on Azure today. They do have one on
+   OpenAI direct.
+
+   A batch naming one of those models is not refused: Logos runs it here
+   instead, at the standard rate but with the same API. The day Azure adds the
+   model to Batch, the same file starts taking the discounted path with no
+   change on the client side.
+
+Run-time: `completion_window` must be `"24h"`, and that is a **service goal,
+not a deadline**. Azure aims to finish within 24 hours but does not expire jobs
+that take longer — they keep running until they complete or you cancel them,
+and cancelling bills the work already done. A job the service could not finish
+inside the window is reported as `expired`.
+
+Sources: [Azure OpenAI global batch](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/batch),
+[model region availability](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure-region-availability),
+[pricing](https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/).
+
+## The batch page in the UI
+
+**Batches** under *Personal* does the same three things without a script: pick
+one of your API keys, upload a `.jsonl`, and watch the list. A running batch
+shows its progress, a finished one offers its results as a download, and an
+unfinished one can be cancelled. The page refreshes itself every 30 seconds
+while something is still moving.
+
+It is a forward to the same API: the webservice calls the orchestrator's Batch
+API as the key you selected, so the per-line permission check, the ownership
+rule and the budget guard are exactly the ones a script gets. The browser never
+sees the key value — it names a key by id, and the webservice refuses one that
+is not yours.
+
+## Limits and what is deliberately not supported
+
+- **No cross-provider batches.** One batch runs in one place. A file whose
+  models are not all on one Batch-capable provider runs in Logos rather than
+  being split.
+- **A Logos-run batch gets no discount.** There is none to get: the requests are
+  ordinary requests. It buys the API and the low-priority scheduling, not a
+  lower rate.
+- **No rate-limit accounting.** A batch consumes the provider's separate
+  enqueued-token quota, which Logos does not model. An oversized batch is
+  refused by the provider, and that error is passed through.
+- **Derived billable quantities** (image counts, search queries) are not
+  reconstructed from batch results; token usage is taken from the result rows.
+- **`purpose` values other than `batch`** are refused, so the Files API cannot
+  be used as general storage through Logos.
+
+## Alternative: the async job API
+
+For work that is merely latency-tolerant rather than large, the async job API
+decouples the client from the wait without the Batch API's machinery:
+`POST /jobs/v1/chat/completions` returns `202` with a `Location` header and
+`GET /jobs/{job_id}` polls for the result. Those jobs run the ordinary
+pipeline and are billed at the **standard** per-token rate — the batch discount
+comes from the provider's batch endpoint, which only the routes above use.

--- a/logos/logos-orchestrator/src/logos/__init__.py
+++ b/logos/logos-orchestrator/src/logos/__init__.py
@@ -100,6 +100,7 @@ _m._render_lane_summary = _render_lane_summary
 # These sub-packages are already in sys.modules (imported above via logos.main),
 # but logos.main itself has no attribute for them — add them explicitly.
 
+import logos.batch_api as _batch_api_mod  # noqa: E402
 import logos.pipeline as _pipeline_pkg  # noqa: E402
 import logos.responses as _responses_mod  # noqa: E402
 import logos.sdi as _sdi_pkg  # noqa: E402
@@ -107,6 +108,9 @@ import logos.sdi as _sdi_pkg  # noqa: E402
 _m.sdi = _sdi_pkg
 _m.pipeline = _pipeline_pkg
 _m.responses = _responses_mod
+# Without this, `from logos import batch_api` re-imports the file under a
+# second name and patches applied to it are invisible to the running code.
+_m.batch_api = _batch_api_mod
 
 # ── Replace logos package with logos.main ────────────────────────────────────
 # Preserve __path__ so `from logos.X import Y` submodule imports still work.

--- a/logos/logos-orchestrator/src/logos/auth.py
+++ b/logos/logos-orchestrator/src/logos/auth.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from fastapi import HTTPException
 
+from logos import batch_credential
 from logos.dbutils.dbmanager import DBManager
 
 
@@ -64,11 +65,33 @@ class AuthContext:
     local_rl: Optional[dict] = None
 
 
+def _resolve_batch_credential(credential: str) -> Optional[Dict[str, Any]]:
+    """The key row a scoped batch credential names, or None.
+
+    The webservice's batch proxy authenticates with a short-lived credential
+    instead of the user's raw key value (see batch_credential): this turns it
+    back into the key's own row. The row lookup is what keeps it honest — a
+    key revoked after the credential was handed out stops working the moment
+    it is presented again.
+    """
+    if not isinstance(credential, str) or not credential.startswith(batch_credential.BATCH_CREDENTIAL_PREFIX):
+        return None
+    api_key_id = batch_credential.resolve_batch_credential(credential)
+    if api_key_id is None:
+        return None
+    with DBManager() as db:
+        return db.get_api_key_by_id(api_key_id)
+
+
 def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
     logos_key = _resolve_logos_key(headers)
     with DBManager() as db:
         row = db.get_api_key_by_value(logos_key)
-
+    if row is None:
+        # A key value that is not a key value: try the scoped credential the
+        # batch proxy exchanges for the key (the raw value never reaches the
+        # Batch API over the internal hop).
+        row = _resolve_batch_credential(logos_key)
     if row is None:
         raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
 
@@ -77,7 +100,10 @@ def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
         k_type = k_type.value
 
     return AuthContext(
-        key_value=logos_key,
+        # The key's own value, not what the header carried: for a scoped
+        # credential the header holds the credential, and the downstream
+        # (batch lines re-enter the pipeline as the key) needs the value.
+        key_value=row["key_value"],
         api_key_id=row["id"],
         api_key_name=row["name"],
         key_type=str(k_type),

--- a/logos/logos-orchestrator/src/logos/auth.py
+++ b/logos/logos-orchestrator/src/logos/auth.py
@@ -83,18 +83,7 @@ def _resolve_batch_credential(credential: str) -> Optional[Dict[str, Any]]:
         return db.get_api_key_by_id(api_key_id)
 
 
-def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
-    logos_key = _resolve_logos_key(headers)
-    with DBManager() as db:
-        row = db.get_api_key_by_value(logos_key)
-    if row is None:
-        # A key value that is not a key value: try the scoped credential the
-        # batch proxy exchanges for the key (the raw value never reaches the
-        # Batch API over the internal hop).
-        row = _resolve_batch_credential(logos_key)
-    if row is None:
-        raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
-
+def _auth_context_from_key_row(row: Dict[str, Any]) -> AuthContext:
     k_type = row["key_type"]
     if hasattr(k_type, "value"):
         k_type = k_type.value
@@ -116,3 +105,33 @@ def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
         # can fall back to the policy-level priority.
         default_priority=row.get("default_priority") or 0,
     )
+
+
+def authenticate_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
+    logos_key = _resolve_logos_key(headers)
+    with DBManager() as db:
+        row = db.get_api_key_by_value(logos_key)
+    if row is None:
+        raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
+    return _auth_context_from_key_row(row)
+
+
+def authenticate_batch_api_key(headers: Optional[Dict[str, str]]) -> AuthContext:
+    """Auth for the Batch API, which also takes the scoped credential.
+
+    The credential resolves to the key's own row here and nowhere else: it is
+    a batch-only bearer (the webservice exchanges it for the key instead of
+    sending the raw value over the internal hop), and the global key auth
+    must keep refusing it, or it would open ordinary inference — and, for an
+    admin-owned key, the role-gated routes — for its whole TTL.
+    """
+    logos_key = _resolve_logos_key(headers)
+    with DBManager() as db:
+        row = db.get_api_key_by_value(logos_key)
+    if row is None:
+        # A key value that is not a key value: try the scoped credential the
+        # batch proxy exchanged for the key.
+        row = _resolve_batch_credential(logos_key)
+    if row is None:
+        raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
+    return _auth_context_from_key_row(row)

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -44,7 +44,7 @@ import httpx
 from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
-from logos.auth import AuthContext, authenticate_api_key
+from logos.auth import AuthContext, authenticate_batch_api_key
 from logos.batch_local import local_batch_object, local_file_object, new_object_id, parse_request_lines, run_local_batch
 from logos.benchmarks.guidellm_runner import credential_transport_is_secure
 from logos.billing.budget import check_monthly_budget
@@ -1445,7 +1445,9 @@ async def handle_batch_api_request(request: Request) -> Response:
         raise_openai_error(404, f"No Batch API route at {request.url.path!r}", code="unknown_batch_route")
 
     headers = dict(request.headers)
-    auth = authenticate_api_key(headers)
+    # The Batch API — and only it — resolves the scoped credential; every
+    # other route authenticates with key values alone.
+    auth = authenticate_batch_api_key(headers)
 
     request_id = secrets.token_urlsafe(16)
     log_id: Optional[int] = None

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1333,6 +1333,77 @@ async def _handle_file_upload(request: Request, auth: AuthContext, headers: Dict
     return JSONResponse(content=local_file_object(stored)), None, log_payload
 
 
+def _assert_still_permitted(
+    db: DBManager, auth: AuthContext, provider: Dict[str, Any], input_file: Dict[str, Any]
+) -> None:
+    """The key that creates the batch may still use what the file lives on.
+
+    Ownership says who may order the job — the team. It does not say what the
+    creating key may still run: permissions can be key-specific, and they can
+    move after the upload. Without this re-check a narrower team key — or the
+    uploading key after its links were revoked — would run the file's
+    previously authorised models through the shared provider credential. Both
+    halves are therefore asked again at creation: the provider the file lives
+    on, and every model the file row recorded.
+    """
+    candidates = db.get_batch_provider_candidates(auth.api_key_id)
+    if not any(int(row["id"]) == int(provider["id"]) for row in candidates):
+        raise_openai_error(
+            403,
+            f"This key may no longer use provider {provider.get('name')!r}, which holds this file.",
+            code="batch_provider_not_authorized",
+        )
+    permitted = {str(row["model_name"]).lower() for row in db.get_batch_model_deployments(auth.api_key_id)}
+    missing = sorted(str(name) for name in (input_file.get("models") or []) if str(name).lower() not in permitted)
+    if missing:
+        raise_openai_error(
+            403,
+            f"This key may not use {', '.join(repr(name) for name in missing)}: the file asks for "
+            "models the key no longer may run.",
+            code="model_not_permitted",
+        )
+
+
+def _local_batch_contract(content: bytes, json_body: Dict[str, Any]) -> str:
+    """The contract a locally-run batch keeps with its stored lines, or a 400.
+
+    The provider enforces this contract for the batches it runs and refuses
+    the rest, so a batch Logos runs itself is held to the same one before it
+    exists: one supported endpoint, the one completion window, and every
+    stored line a POST to exactly that endpoint — because the runner executes
+    the lines' own urls while the batch object advertises the endpoint it was
+    created with. Returns the endpoint to store on the batch.
+    """
+    endpoint = str(json_body.get("endpoint") or "/v1/chat/completions")
+    wanted = _request_endpoint(endpoint)
+    if wanted not in _BATCH_REQUEST_ENDPOINTS:
+        raise_openai_error(
+            400,
+            f"Batch endpoint {endpoint!r} is not supported. Batches through Logos may call "
+            f"{', '.join('/v1/' + name for name in sorted(_BATCH_REQUEST_ENDPOINTS))}.",
+            code="unsupported_batch_endpoint",
+        )
+    if json_body.get("completion_window") != "24h":
+        raise_openai_error(400, "completion_window must be '24h'.", code="invalid_request_error")
+
+    for number, line in enumerate(parse_request_lines(content), start=1):
+        method = line.get("method")
+        if method is not None and str(method).upper() != "POST":
+            raise_openai_error(
+                400,
+                f"Line {number} uses method {method!r}; batch lines are POST requests.",
+                code="invalid_batch_line",
+            )
+        if _request_endpoint(line.get("url")) != wanted:
+            raise_openai_error(
+                400,
+                f"Line {number} addresses {line.get('url')!r}, but the batch is {endpoint!r}: every "
+                "line of a batch must call the endpoint the batch was created with.",
+                code="invalid_batch_line",
+            )
+    return f"/v1/{wanted}"
+
+
 async def _handle_batch_creation(json_body: Dict[str, Any], auth: AuthContext, db: DBManager):
     """Authorise a batch and either create it here or hand it to the provider."""
     input_file_id = json_body.get("input_file_id")
@@ -1348,15 +1419,17 @@ async def _handle_batch_creation(json_body: Dict[str, Any], auth: AuthContext, d
         provider = db.get_batch_provider(int(input_file["provider_id"]))
         if provider is None:
             raise_openai_error(502, "The provider holding this file is gone.", code="batch_upstream_unreachable")
+        _assert_still_permitted(db, auth, provider, input_file)
         return None, provider
 
     content = db.get_local_batch_file_content(int(input_file["id"])) or b""
+    endpoint = _local_batch_contract(content, json_body)
     batch_id = new_object_id("batch")
     db.create_local_batch(
         upstream_id=batch_id,
         input_file_id=input_file_id,
-        endpoint=str(json_body.get("endpoint") or "/v1/chat/completions"),
-        completion_window=json_body.get("completion_window"),
+        endpoint=endpoint,
+        completion_window="24h",
         metadata=json_body.get("metadata") if isinstance(json_body.get("metadata"), dict) else None,
         total_requests=len(parse_request_lines(content)),
         api_key_id=auth.api_key_id,
@@ -1406,6 +1479,14 @@ async def _rerun_refused_creation_locally(
     if not lines:
         return None
     stored = b"\n".join(lines) + b"\n"
+    try:
+        endpoint = _local_batch_contract(stored, json_body)
+    except HTTPException:
+        # The rerun is the alternative to the provider's refusal, not a
+        # rewrite of it: an input that no longer keeps the batch contract
+        # leaves the refusal standing. Checked before anything is stored, so
+        # a refusal here orphans no file.
+        return None
     file_id = new_object_id("file")
     batch_id = new_object_id("batch")
     with DBManager() as db:
@@ -1420,8 +1501,8 @@ async def _rerun_refused_creation_locally(
         db.create_local_batch(
             upstream_id=batch_id,
             input_file_id=file_id,
-            endpoint=str(json_body.get("endpoint") or "/v1/chat/completions"),
-            completion_window=json_body.get("completion_window"),
+            endpoint=endpoint,
+            completion_window="24h",
             metadata=json_body.get("metadata") if isinstance(json_body.get("metadata"), dict) else None,
             total_requests=len(parse_request_lines(stored)),
             api_key_id=auth.api_key_id,

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1,0 +1,1298 @@
+"""OpenAI Batch API support.
+
+Logos serves the Batch API surface — ``/v1/files`` for the input/output files
+and ``/v1/batches`` for the job lifecycle, plus the ``openai/`` and ``jobs/``
+mirrors — by forwarding each operation to the Batch API of a cloud provider the
+calling key may use. The job itself runs at the provider, on its batch
+endpoint, which is the whole point: that is where the provider's batch rate
+applies, and a fan-out Logos ran itself would pay the standard rate.
+
+What Logos keeps is everything a proxy exists for:
+
+* **Authorisation.** A batch body carries no ``model``, so the provider is
+  resolved from the key's provider permissions. That alone would say nothing
+  about *what* the batch runs, so every request line of the input file is
+  checked against the key's model permissions before the file is accepted.
+* **Ownership.** File and batch ids live at the provider and are used for hours
+  after the call that minted them, with a credential shared by every key that
+  may use the provider. Each id is therefore recorded with its owning team
+  (``batch_objects``), and a lifecycle call for an id another team owns is
+  answered exactly like one that never existed.
+* **Billing.** When a batch reaches a terminal state its output file is read
+  once and each result row is booked as an ordinary usage row with
+  ``service_tier='batch'``, so batch spend lands in the same budget,
+  statistics and export surfaces as everything else — priced at the provider's
+  batch rate where one is configured.
+
+Addressing differs per upstream: Azure serves Batch at the resource level
+(``{host}/openai/v1/batches``, no deployment segment) while an OpenAI-shaped
+provider is addressed under its own ``base_url``. Azure also names models by
+*deployment*, so the input file's model names are translated on the way in and
+back on the way out.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+from fastapi import HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+
+from logos.auth import AuthContext, authenticate_api_key
+from logos.batch_local import local_batch_object, local_file_object, new_object_id, parse_request_lines, run_local_batch
+from logos.benchmarks.guidellm_runner import credential_transport_is_secure
+from logos.billing.budget import check_monthly_budget
+from logos.billing.finalize import finalize_billing_inputs
+from logos.dbutils.dbmanager import DBManager
+from logos.dbutils.types import cloud_auth_header
+from logos.errors import openai_error_response, raise_openai_error
+from logos.request_content import parse_batch_file_upload, sanitized_headers_for_persistence, strip_proxy_prefixes
+from logos.responses import get_client_ip
+from logos.sdi.azure_deployment_sync import azure_host_from_base_url
+from logos.sdi.providers.azure_provider import extract_azure_deployment_name
+
+logger = logging.getLogger(__name__)
+
+# Header a client with more than one Batch-capable provider uses to name the
+# one it wants. Compared case-insensitively: Starlette lowercases header names.
+BATCH_PROVIDER_HEADER = "X-Logos-Provider"
+
+# Forces where a batch runs: 'provider' (fail if no provider Batch API applies),
+# 'logos' (run it here even when a provider could), or 'auto' (the default —
+# forward when possible, because that is where the batch rate is).
+BATCH_EXECUTION_HEADER = "X-Logos-Batch-Execution"
+
+# Azure serves Batch at the resource level. The ``/openai/v1`` surface is the
+# addressing that carries newer models and needs no api-version; the dated
+# data-plane route stays reachable through the env override for a resource that
+# only serves that one. (Verified against the production resource: the batch
+# routes answer under /openai/v1 and under 2024-10-21 or later, while the
+# 2024-02-01 data-plane version 404s.)
+AZURE_BATCH_API_VERSION = os.getenv("LOGOS_AZURE_BATCH_API_VERSION", "").strip()
+
+# Batch operations are control-plane calls plus the file transfer around them,
+# not inference, so a real timeout applies here.
+_BATCH_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=300.0, pool=10.0)
+
+# A batch result file is read in one go; give it room but keep it bounded.
+_SETTLE_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=10.0)
+
+# How long a provider's probed Batch API capability is trusted before it is
+# re-probed. A provider gains or loses the surface rarely, so this is generous.
+CAPABILITY_TTL = timedelta(hours=int(os.getenv("LOGOS_BATCH_CAPABILITY_TTL_HOURS", "24")))
+
+# Request lines per batch input file. OpenAI and Azure both cap a batch at
+# 50 000 requests; rejecting here names the file rather than the upstream.
+MAX_BATCH_REQUESTS = int(os.getenv("LOGOS_MAX_BATCH_REQUESTS", "50000"))
+
+# How often the reconciler looks for batches that finished while nobody polled.
+RECONCILE_INTERVAL_S = int(os.getenv("LOGOS_BATCH_RECONCILE_INTERVAL_S", "300"))
+
+# The operations a batch request line may address. A batch is an inference
+# channel; the Files API is its transport, not a general object store.
+_BATCH_REQUEST_ENDPOINTS = {
+    "chat/completions",
+    "responses",
+    "embeddings",
+}
+
+# Batch states the provider will not move away from on its own.
+TERMINAL_BATCH_STATES = {"completed", "failed", "expired", "cancelled"}
+
+_MIRROR_PREFIXES = ("jobs/", "openai/")
+
+
+def _http_client() -> httpx.AsyncClient:
+    """Outbound client factory — a seam tests replace with a MockTransport."""
+    return httpx.AsyncClient(follow_redirects=False)
+
+
+@dataclass(frozen=True)
+class BatchOperation:
+    """One inbound Batch API call, normalised across the proxy prefixes.
+
+    ``path`` is the canonical ``v1/...`` form: the ``jobs/`` and ``openai/``
+    mirrors are peeled and the version segment restored, because a generic
+    provider is addressed like-for-like on that path and its ``base_url`` may
+    not carry the version itself.
+    """
+
+    resource: str  # "files" | "batches"
+    method: str
+    path: str  # e.g. "v1/files/file-123"
+    query: str = ""
+    resource_id: Optional[str] = None
+    suboperation: Optional[str] = None  # "content" (files) | "cancel" (batches)
+
+    @property
+    def is_file_upload(self) -> bool:
+        return self.resource == "files" and self.method == "POST" and self.resource_id is None
+
+    @property
+    def is_batch_creation(self) -> bool:
+        return self.resource == "batches" and self.method == "POST" and self.resource_id is None
+
+    @property
+    def is_listing(self) -> bool:
+        return self.method == "GET" and self.resource_id is None
+
+
+def _canonical_path(path: str, resource: str, resource_id: Optional[str], suboperation: Optional[str]) -> str:
+    """The ``v1/...`` spelling of an operation, whichever mirror it arrived on."""
+    tail = resource
+    if resource_id:
+        tail = f"{tail}/{resource_id}"
+    if suboperation:
+        tail = f"{tail}/{suboperation}"
+    return f"v1/{tail}"
+
+
+def parse_batch_api_path(path: str, method: str = "POST", query: str = "") -> Optional[BatchOperation]:
+    """Parse an inbound Batch API path into its operation.
+
+    ``is_batch_api_path`` (request_content) is the cheap membership test; this
+    recovers the resource id and suboperation the forwarder needs and returns
+    ``None`` for shapes that are not one of the Batch API routes (e.g.
+    ``batches/<id>/unknown``) so the caller can 404 them cleanly.
+    """
+    normalized = strip_proxy_prefixes(path)
+    segments = [segment for segment in normalized.split("/") if segment]
+    if not segments or segments[0] not in {"batches", "files"}:
+        return None
+    resource = segments[0]
+    if len(segments) == 1:
+        return BatchOperation(
+            resource=resource, method=method, path=_canonical_path(path, resource, None, None), query=query
+        )
+    if len(segments) == 2:
+        return BatchOperation(
+            resource=resource,
+            method=method,
+            path=_canonical_path(path, resource, segments[1], None),
+            query=query,
+            resource_id=segments[1],
+        )
+    if len(segments) == 3:
+        suboperation = {"files": "content", "batches": "cancel"}.get(resource)
+        if segments[2] == suboperation:
+            return BatchOperation(
+                resource=resource,
+                method=method,
+                path=_canonical_path(path, resource, segments[1], segments[2]),
+                query=query,
+                resource_id=segments[1],
+                suboperation=segments[2],
+            )
+    return None
+
+
+def _generic_tail(base_url: str, path: str) -> str:
+    """The operation path a generic cloud provider is addressed under.
+
+    Mirrors ``ContextResolver._cloud_forward_url``: the canonical path, with the
+    version prefix deduplicated when the provider's base_url already ends in it
+    (``.../v1`` + ``v1/batches`` → ``.../v1/batches``).
+    """
+    base = base_url.rstrip("/")
+    tail = path.lstrip("/")
+    for prefix in ("v1/", "v2/"):
+        if base.endswith("/" + prefix.rstrip("/")) and tail.startswith(prefix):
+            tail = tail[len(prefix) :]
+            break
+    return tail
+
+
+def _batch_tail(operation: BatchOperation) -> str:
+    tail = operation.resource
+    if operation.resource_id:
+        tail = f"{tail}/{operation.resource_id}"
+    if operation.suboperation:
+        tail = f"{tail}/{operation.suboperation}"
+    return tail
+
+
+def is_azure_provider(provider: Dict[str, Any]) -> bool:
+    return str(provider.get("cloud_provider_type") or "").lower() == "azure"
+
+
+def batch_base_url(provider: Dict[str, Any]) -> str:
+    """Where this provider's Batch API root lives, without the operation."""
+    base_url = (provider.get("base_url") or "").strip()
+    if not base_url:
+        raise_openai_error(
+            502,
+            f"Provider {provider.get('name')} has no base_url configured and cannot serve the Batch API",
+            code="batch_upstream_unreachable",
+        )
+    if not is_azure_provider(provider):
+        return base_url.rstrip("/")
+    host = azure_host_from_base_url(base_url).rstrip("/")
+    return f"{host}/openai" if AZURE_BATCH_API_VERSION else f"{host}/openai/v1"
+
+
+def batch_operation_url(provider: Dict[str, Any], operation: BatchOperation) -> str:
+    """Build the upstream URL for one Batch API operation.
+
+    Azure's Batch API lives at the resource level (no deployment segment), so it
+    is addressed on the resource host derived from the provider base_url. Every
+    other OpenAI-shaped provider is addressed by appending the canonical
+    operation path to its base_url, exactly like the inference forward.
+    """
+    base = batch_base_url(provider)
+    if is_azure_provider(provider):
+        query = operation.query
+        if AZURE_BATCH_API_VERSION and "api-version=" not in query:
+            query = (
+                f"{query}&api-version={AZURE_BATCH_API_VERSION}" if query else f"api-version={AZURE_BATCH_API_VERSION}"
+            )
+        return f"{base}/{_batch_tail(operation)}" + (f"?{query}" if query else "")
+    return f"{base}/{_generic_tail(base, operation.path)}" + (f"?{operation.query}" if operation.query else "")
+
+
+def batch_provider_headers(provider: Dict[str, Any]) -> Dict[str, str]:
+    """The auth header the provider's stored credentials produce for batch calls.
+
+    Azure batch routes authenticate with the resource ``api-key`` header the
+    deployment sync already uses; everything else follows the provider's stored
+    ``auth_name`` / ``auth_format`` (empty is legitimate for an upstream that
+    serves unauthenticated).
+    """
+    api_key = provider.get("api_key")
+    if is_azure_provider(provider):
+        if not api_key:
+            raise_openai_error(
+                502,
+                f"Azure provider {provider.get('name')} has no API key configured for its Batch API",
+                code="batch_upstream_unreachable",
+            )
+        return {"api-key": api_key}
+    header = cloud_auth_header(
+        provider.get("auth_name"),
+        provider.get("auth_format"),
+        api_key,
+        str(provider.get("cloud_provider_type") or "") or None,
+    )
+    return {} if header is None else {header[0]: header[1]}
+
+
+def _assert_secure_transport(provider: Dict[str, Any], url: str, headers: Dict[str, str]) -> None:
+    if headers and not credential_transport_is_secure(url):
+        logger.error(
+            "Refusing to send the credentials of provider %s (%s) over an insecure transport (%s)",
+            provider.get("id"),
+            provider.get("name"),
+            url.split("?", 1)[0],
+        )
+        raise_openai_error(
+            502,
+            "The Batch API provider is configured over an insecure transport; Logos will not "
+            "send its credentials there.",
+            code="batch_upstream_unreachable",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Choosing where a batch runs
+# ---------------------------------------------------------------------------
+
+
+async def probe_batch_capability(provider: Dict[str, Any]) -> Tuple[bool, str]:
+    """Ask a provider whether it serves the Batch API at all.
+
+    Being a cloud provider says nothing about this: an OpenAI-shaped resource
+    can be a self-hosted inference endpoint that serves chat and nothing else.
+    A listing call is the cheapest question that distinguishes them, and its
+    answer is cached so this runs about once a day per provider.
+    """
+    listing = BatchOperation(resource="batches", method="GET", path="v1/batches", query="limit=1")
+    try:
+        url = batch_operation_url(provider, listing)
+        headers = batch_provider_headers(provider)
+        _assert_secure_transport(provider, url, headers)
+    except HTTPException as exc:
+        return False, f"not addressable: {exc.detail}"
+
+    try:
+        async with _http_client() as client:
+            response = await client.get(url, headers=headers, timeout=_BATCH_TIMEOUT)
+    except httpx.HTTPError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+    if response.status_code < 400:
+        return True, ""
+    return False, f"HTTP {response.status_code}"
+
+
+async def _batch_capable(provider: Dict[str, Any]) -> bool:
+    """Whether this provider serves Batch, probing when the cache is cold or stale."""
+    cached = provider.get("supports_batch")
+    checked_at = provider.get("capability_checked_at")
+    if cached is not None and isinstance(checked_at, datetime):
+        age = datetime.now(timezone.utc) - checked_at.astimezone(timezone.utc)
+        if age < CAPABILITY_TTL:
+            return bool(cached)
+
+    supports, detail = await probe_batch_capability(provider)
+    try:
+        with DBManager() as db:
+            db.record_provider_batch_capability(int(provider["id"]), supports, detail)
+    except Exception:  # noqa: BLE001 - a cache write must not fail the request
+        logger.exception("Could not cache the Batch API capability of provider %s", provider.get("id"))
+    if not supports:
+        logger.info("Provider %s does not serve the Batch API (%s)", provider.get("name"), detail)
+    return supports
+
+
+def _header(headers: Dict[str, str], name: str) -> str:
+    """A header value, read case-insensitively — Starlette lowercases names."""
+    wanted = name.lower()
+    for key, value in (headers or {}).items():
+        if str(key).lower() == wanted:
+            return (value or "").strip()
+    return ""
+
+
+async def resolve_batch_provider(
+    auth: AuthContext, headers: Dict[str, str], db: DBManager, required: bool = True
+) -> Optional[Dict[str, Any]]:
+    """Pick the provider a Batch API operation is forwarded to.
+
+    Candidates are the key's effective cloud providers that actually serve a
+    Batch API. Exactly one is selected implicitly; with several the
+    ``X-Logos-Provider`` header must name one. With none, ``required`` decides
+    between the historical 501 and letting the caller run the batch here.
+    """
+    candidates = []
+    for provider in db.get_batch_provider_candidates(auth.api_key_id):
+        if await _batch_capable(provider):
+            candidates.append(provider)
+
+    if not candidates:
+        if not required:
+            return None
+        raise_openai_error(
+            501,
+            "The OpenAI Batch API is not available for this key: none of the providers it may use " "serves one.",
+            code="batch_api_not_supported",
+        )
+
+    requested = _header(headers, BATCH_PROVIDER_HEADER)
+    if requested:
+        matches = [
+            provider
+            for provider in candidates
+            if str(provider["id"]) == requested or str(provider["name"]).lower() == requested.lower()
+        ]
+        if not matches:
+            raise_openai_error(
+                403,
+                f"Provider {requested!r} is not one of the Batch-capable providers this key may use "
+                f"({', '.join(sorted(str(p['name']) for p in candidates))}).",
+                code="batch_provider_not_authorized",
+            )
+        return matches[0]
+
+    if len(candidates) == 1:
+        return candidates[0]
+
+    names = ", ".join(sorted(f"{p['name']} (id {p['id']})" for p in candidates))
+    raise_openai_error(
+        400,
+        f"This key may use several Batch-capable providers ({names}). Name one in the "
+        f"{BATCH_PROVIDER_HEADER} header (provider name or id) so Logos knows where to forward.",
+        code="multiple_batch_providers",
+    )
+
+
+async def choose_execution_target(
+    auth: AuthContext,
+    headers: Dict[str, str],
+    db: DBManager,
+    model_names: set,
+) -> Tuple[Optional[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Decide whether a batch is forwarded to a provider or run by Logos.
+
+    Forwarding is preferred where it is possible, because that is the only way
+    to get the provider's batch rate. It is possible only when one Batch-capable
+    provider serves *every* model the file names — a provider cannot run a
+    request for a model it does not host, and a batch is one job at one place.
+
+    Everything else runs here: models served by worker nodes (which have no
+    Batch API at all) and cloud models their provider does not offer for batch
+    (Azure adds models to Batch long after Standard). ``X-Logos-Batch-Execution:
+    logos`` forces the local path even when forwarding would work.
+
+    Returns ``(provider or None, the key's deployments on it)``.
+    """
+    permitted = db.get_batch_model_deployments(auth.api_key_id)
+    permitted_names = {str(row["model_name"]).lower() for row in permitted}
+    unknown = sorted(name for name in model_names if name.lower() not in permitted_names)
+    if unknown:
+        raise_openai_error(
+            403,
+            f"This key may not use {', '.join(repr(name) for name in unknown)}. "
+            "A batch may only request models the key is permitted to run.",
+            code="model_not_permitted",
+        )
+
+    requested_execution = _header(headers, BATCH_EXECUTION_HEADER).lower()
+    if requested_execution and requested_execution not in {"logos", "provider", "auto"}:
+        raise_openai_error(
+            400,
+            f"{BATCH_EXECUTION_HEADER} must be 'auto', 'provider' or 'logos'.",
+            code="invalid_request_error",
+        )
+    if requested_execution == "logos":
+        return None, permitted
+
+    provider = await resolve_batch_provider(auth, headers, db, required=requested_execution == "provider")
+    if provider is None:
+        return None, permitted
+
+    # The provider only qualifies if it hosts every model the file names.
+    on_provider = [row for row in permitted if int(row["provider_id"]) == int(provider["id"])]
+    hosted = {str(row["model_name"]).lower() for row in on_provider}
+    missing = sorted(name for name in model_names if name.lower() not in hosted)
+    if missing:
+        if requested_execution == "provider" or _header(headers, BATCH_PROVIDER_HEADER):
+            raise_openai_error(
+                400,
+                f"Provider {provider['name']!r} does not serve {', '.join(repr(n) for n in missing)}, "
+                "so it cannot run this batch. Omit the provider header to have Logos run it instead.",
+                code="model_not_available_for_batch",
+            )
+        logger.info("Running batch locally: provider %s does not serve %s", provider.get("name"), ", ".join(missing))
+        return None, permitted
+    return provider, on_provider
+
+
+# ---------------------------------------------------------------------------
+# Input file validation
+# ---------------------------------------------------------------------------
+
+
+def _deployment_for(provider: Optional[Dict[str, Any]], deployment_row: Dict[str, Any]) -> str:
+    """What the execution target calls this model in a request body.
+
+    Azure addresses deployments, not models, so a line that says ``gpt-4.1``
+    has to leave as the deployment id the resource serves it under. A batch
+    Logos runs itself keeps the Logos model name: its lines go through the
+    ordinary pipeline, which does that translation per request.
+    """
+    if provider is None or not is_azure_provider(provider):
+        return str(deployment_row["model_name"])
+    return extract_azure_deployment_name(deployment_row.get("endpoint") or "") or str(deployment_row["model_name"])
+
+
+def _request_endpoint(url: str) -> str:
+    """The operation a request line addresses, without version or mirror prefix."""
+    return strip_proxy_prefixes(str(url or "")).strip("/")
+
+
+def batch_input_models(content: bytes) -> set:
+    """Every model name a batch input file asks for.
+
+    Read before the target is chosen: what the file wants decides where it can
+    run.
+    """
+    names = set()
+    for raw_line in (content or b"").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            line = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(line, dict) and isinstance(line.get("body"), dict):
+            model = line["body"].get("model")
+            if isinstance(model, str) and model:
+                names.add(model)
+    return names
+
+
+def validate_and_rewrite_batch_input(
+    content: bytes,
+    provider: Optional[Dict[str, Any]],
+    deployments: List[Dict[str, Any]],
+) -> Tuple[bytes, Dict[int, int]]:
+    """Check every request line of a batch input file and retarget its model.
+
+    Provider permission alone does not authorise what a batch runs: each line
+    picks its own model, and the upstream would happily run one this key may
+    not use and bill it to the shared credential. Every line is therefore
+    matched against the key's permitted models, and the model name rewritten to
+    what the execution target expects (an Azure deployment id when the batch is
+    forwarded there; the Logos name when Logos runs it).
+
+    Returns the rewritten file and the model-id histogram of its lines.
+    """
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for row in deployments:
+        by_name.setdefault(str(row["model_name"]).lower(), row)
+    rewritten_lines: List[bytes] = []
+    model_counts: Dict[int, int] = {}
+    seen_ids: set = set()
+
+    for number, raw_line in enumerate(content.splitlines(), start=1):
+        if not raw_line.strip():
+            continue
+        if len(rewritten_lines) >= MAX_BATCH_REQUESTS:
+            raise_openai_error(
+                400,
+                f"A batch input file may hold at most {MAX_BATCH_REQUESTS} request lines.",
+                code="batch_file_too_many_requests",
+            )
+        try:
+            line = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise_openai_error(
+                400, f"Line {number} of the batch file is not valid JSON: {exc}", code="invalid_batch_line"
+            )
+        if not isinstance(line, dict):
+            raise_openai_error(400, f"Line {number} of the batch file is not a JSON object.", code="invalid_batch_line")
+
+        custom_id = line.get("custom_id")
+        if not isinstance(custom_id, str) or not custom_id:
+            raise_openai_error(400, f"Line {number} of the batch file has no 'custom_id'.", code="invalid_batch_line")
+        if custom_id in seen_ids:
+            raise_openai_error(
+                400,
+                f"Line {number} repeats custom_id {custom_id!r}; each line needs its own.",
+                code="invalid_batch_line",
+            )
+        seen_ids.add(custom_id)
+
+        endpoint = _request_endpoint(line.get("url"))
+        if endpoint not in _BATCH_REQUEST_ENDPOINTS:
+            raise_openai_error(
+                400,
+                f"Line {number} addresses {line.get('url')!r}. Batch requests through Logos may call "
+                f"{', '.join('/v1/' + name for name in sorted(_BATCH_REQUEST_ENDPOINTS))}.",
+                code="unsupported_batch_endpoint",
+            )
+
+        body = line.get("body")
+        if not isinstance(body, dict):
+            raise_openai_error(
+                400, f"Line {number} of the batch file has no request 'body'.", code="invalid_batch_line"
+            )
+        model = body.get("model")
+        if not isinstance(model, str) or not model:
+            raise_openai_error(400, f"Line {number} of the batch file names no model.", code="invalid_batch_line")
+
+        deployment_row = by_name.get(model.lower())
+        if deployment_row is None:
+            raise_openai_error(
+                403,
+                f"Line {number} requests model {model!r}, which this key may not use"
+                + (f" on provider {provider.get('name')!r}." if provider else "."),
+                code="model_not_permitted",
+            )
+
+        model_id = int(deployment_row["model_id"])
+        model_counts[model_id] = model_counts.get(model_id, 0) + 1
+        rewritten = {**line, "body": {**body, "model": _deployment_for(provider, deployment_row)}}
+        # Azure names its batch operations without the version segment; OpenAI
+        # with it. Send each what it answers to, so one file works on both.
+        rewritten["url"] = f"/{endpoint}" if (provider and is_azure_provider(provider)) else f"/v1/{endpoint}"
+        rewritten_lines.append(json.dumps(rewritten, ensure_ascii=False).encode("utf-8"))
+
+    if not rewritten_lines:
+        raise_openai_error(400, "The batch input file holds no request lines.", code="empty_batch_file")
+
+    return b"\n".join(rewritten_lines) + b"\n", model_counts
+
+
+# ---------------------------------------------------------------------------
+# Forwarding
+# ---------------------------------------------------------------------------
+
+
+def _upstream_response(operation: BatchOperation, resp: httpx.Response) -> Response:
+    """Turn an upstream batch response into the client's response, as-is.
+
+    The provider speaks the Batch API; its objects and errors are returned
+    unmodified so OpenAI clients keep working. Only non-JSON bodies are wrapped
+    in the OpenAI error shape.
+    """
+    if operation.resource == "files" and operation.suboperation == "content":
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=resp.headers.get("content-type", "application/octet-stream"),
+        )
+    try:
+        body = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        body = None
+    if isinstance(body, (dict, list)):
+        return JSONResponse(content=body, status_code=resp.status_code)
+    if resp.status_code < 400:
+        raise_openai_error(502, "Batch API upstream returned a non-JSON response", code="batch_upstream_unreachable")
+    return openai_error_response(resp.status_code, (resp.text or "Upstream error")[:500], code="upstream_error")
+
+
+async def forward_batch_operation(
+    provider: Dict[str, Any],
+    operation: BatchOperation,
+    upload: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Dict[str, Any]] = None,
+) -> Response:
+    """Forward one Batch API operation to the provider and pass the answer back."""
+    url = batch_operation_url(provider, operation)
+    headers = batch_provider_headers(provider)
+    _assert_secure_transport(provider, url, headers)
+
+    try:
+        async with _http_client() as client:
+            if operation.is_file_upload:
+                file = upload["file"]
+                data = {"purpose": upload["purpose"]}
+                if upload.get("metadata"):
+                    data["metadata"] = upload["metadata"]
+                resp = await client.post(
+                    url,
+                    headers=headers,
+                    data=data,
+                    files=[("file", (file["filename"], file["bytes"], file["content_type"]))],
+                    timeout=_BATCH_TIMEOUT,
+                )
+            elif json_body is not None:
+                resp = await client.post(
+                    url,
+                    headers={**headers, "Content-Type": "application/json"},
+                    json=json_body,
+                    timeout=_BATCH_TIMEOUT,
+                )
+            else:
+                # GET/DELETE, and bodyless POSTs (batch cancel): no body sent.
+                resp = await client.request(operation.method, url, headers=headers, timeout=_BATCH_TIMEOUT)
+    except httpx.HTTPError as exc:
+        logger.error("Batch API forward to %s failed: %s: %s", url, type(exc).__name__, exc)
+        raise_openai_error(
+            502,
+            f"Batch API upstream unreachable: {type(exc).__name__}: {exc}",
+            code="batch_upstream_unreachable",
+        )
+
+    return _upstream_response(operation, resp)
+
+
+# ---------------------------------------------------------------------------
+# Settlement
+# ---------------------------------------------------------------------------
+
+
+async def _download_file(provider: Dict[str, Any], file_id: str) -> Optional[bytes]:
+    """Fetch one provider-side file's content, or None when it is gone."""
+    operation = BatchOperation(
+        resource="files", method="GET", path=f"v1/files/{file_id}/content", resource_id=file_id, suboperation="content"
+    )
+    url = batch_operation_url(provider, operation)
+    headers = batch_provider_headers(provider)
+    _assert_secure_transport(provider, url, headers)
+    try:
+        async with _http_client() as client:
+            resp = await client.get(url, headers=headers, timeout=_SETTLE_TIMEOUT)
+    except httpx.HTTPError as exc:
+        logger.warning("Could not read batch file %s: %s: %s", file_id, type(exc).__name__, exc)
+        return None
+    if resp.status_code >= 400:
+        logger.warning("Could not read batch file %s: HTTP %s", file_id, resp.status_code)
+        return None
+    return resp.content
+
+
+def _model_index(db: DBManager, provider: Dict[str, Any]) -> Dict[str, int]:
+    """Every spelling of a model on this provider, mapped to its model id.
+
+    The output rows name what the provider ran — an Azure deployment id, or the
+    model name elsewhere — and both have to land on the Logos model whose
+    prices apply.
+    """
+    index: Dict[str, int] = {}
+    for row in db.get_provider_model_deployments(int(provider["id"])):
+        model_id = int(row["model_id"])
+        index[str(row["model_name"]).lower()] = model_id
+        deployment = extract_azure_deployment_name(row.get("endpoint") or "")
+        if deployment:
+            index[deployment.lower()] = model_id
+    return index
+
+
+def _model_id_for(index: Dict[str, int], name: Any) -> Optional[int]:
+    """Resolve a model or deployment name from a result row to a Logos model id."""
+    if not isinstance(name, str) or not name:
+        return None
+    candidate = name.lower()
+    if candidate in index:
+        return index[candidate]
+    # Providers append a dated version to the model they actually ran
+    # (``gpt-4.1-2025-04-14``); fall back to the longest configured name that
+    # prefixes it.
+    matches = [key for key in index if candidate.startswith(key)]
+    return index[max(matches, key=len)] if matches else None
+
+
+def _usage_rows_from_output(
+    content: bytes,
+    owner: Dict[str, Any],
+    provider: Dict[str, Any],
+    model_index: Dict[str, int],
+    input_models: Dict[str, str],
+    logging_context: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Turn a batch output file into one usage row per finished request."""
+    rows: List[Dict[str, Any]] = []
+    now = datetime.now(timezone.utc)
+    for raw_line in content.splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            record = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+
+        response = record.get("response") if isinstance(record.get("response"), dict) else {}
+        body = response.get("body") if isinstance(response.get("body"), dict) else {}
+        status_code = response.get("status_code")
+        custom_id = record.get("custom_id")
+
+        usage, _ = finalize_billing_inputs({}, body, "v1/chat/completions")
+        model_id = _model_id_for(model_index, body.get("model"))
+        if model_id is None and isinstance(custom_id, str):
+            model_id = _model_id_for(model_index, input_models.get(custom_id))
+
+        failed = record.get("error") is not None or (isinstance(status_code, int) and status_code >= 400)
+        rows.append(
+            {
+                "timestamp": now,
+                "api_key_id": owner.get("api_key_id"),
+                "team_id": owner.get("team_id"),
+                "user_id": owner.get("user_id"),
+                "environment": logging_context.get("environment"),
+                "privacy_level": logging_context.get("log_level"),
+                "provider_id": int(provider["id"]),
+                "model_id": model_id,
+                "request_id": custom_id if isinstance(custom_id, str) else None,
+                "service_tier": "batch",
+                "result_status": "error" if failed else "success",
+                "error_message": json.dumps(record.get("error"))[:500] if record.get("error") else None,
+                "usage": usage,
+            }
+        )
+    return rows
+
+
+def _input_model_map(content: Optional[bytes]) -> Dict[str, str]:
+    """custom_id → the model name the request line asked for.
+
+    A result row names the model the provider ran, which is usually enough; the
+    input file is the exact answer for the rows where it is not (an error row
+    carries no response body at all).
+    """
+    mapping: Dict[str, str] = {}
+    if not content:
+        return mapping
+    for raw_line in content.splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            line = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(line, dict):
+            continue
+        custom_id = line.get("custom_id")
+        body = line.get("body")
+        if isinstance(custom_id, str) and isinstance(body, dict) and isinstance(body.get("model"), str):
+            mapping[custom_id] = body["model"]
+    return mapping
+
+
+async def settle_batch(provider: Dict[str, Any], owner: Dict[str, Any], batch_body: Dict[str, Any]) -> int:
+    """Book a finished batch's usage, exactly once.
+
+    The provider metered the job and charged its batch rate; this brings the
+    same numbers into Logos so the spend shows up under the team that ordered
+    it. The settlement latch is taken first, and released again if the output
+    file could not be read, so a transient failure is retried rather than
+    silently dropping a batch's cost.
+    """
+    output_file_id = batch_body.get("output_file_id") or batch_body.get("error_file_id")
+    with DBManager() as db:
+        if not db.claim_batch_for_settlement(int(owner["id"])):
+            return 0
+        logging_context = (
+            db.get_api_key_logging_context(int(owner["api_key_id"]))
+            if owner.get("api_key_id")
+            else {"log_level": "BILLING"}
+        )
+        model_index = _model_index(db, provider)
+
+    if not output_file_id:
+        # A batch that failed before producing any output still costs nothing;
+        # keep the latch so it is not polled forever.
+        logger.info("Batch %s finished without an output file; nothing to meter", owner.get("upstream_id"))
+        return 0
+
+    try:
+        output = await _download_file(provider, str(output_file_id))
+        if output is None:
+            raise RuntimeError("output file unreadable")
+        input_models = _input_model_map(
+            await _download_file(provider, str(batch_body.get("input_file_id") or owner.get("input_file_id") or ""))
+            if (batch_body.get("input_file_id") or owner.get("input_file_id"))
+            else None
+        )
+        rows = _usage_rows_from_output(output, owner, provider, model_index, input_models, logging_context)
+        with DBManager() as db:
+            written = db.record_batch_usage(rows)
+    except Exception:  # noqa: BLE001 - a failed settlement must stay retryable
+        logger.exception("Settlement of batch %s failed; it will be retried", owner.get("upstream_id"))
+        with DBManager() as db:
+            db.release_batch_settlement(int(owner["id"]))
+        return 0
+
+    logger.info("Metered %d rows of batch %s", written, owner.get("upstream_id"))
+    return written
+
+
+def _schedule_settlement(provider: Dict[str, Any], owner: Dict[str, Any], batch_body: Dict[str, Any]) -> None:
+    """Settle in the background so a client's poll is not held up by it."""
+    try:
+        asyncio.get_running_loop().create_task(settle_batch(provider, owner, batch_body))
+    except RuntimeError:  # pragma: no cover - no loop (sync test context)
+        logger.debug("No running loop for batch settlement of %s", owner.get("upstream_id"))
+
+
+async def reconcile_batches_once() -> int:
+    """Settle every finished batch nobody polled to completion.
+
+    A client is free to fire a batch and never come back; without this its cost
+    would never be booked.
+    """
+    settled = 0
+    with DBManager() as db:
+        pending = db.get_unsettled_batches()
+        providers = {
+            provider_id: db.get_batch_provider(provider_id) for provider_id in {row["provider_id"] for row in pending}
+        }
+
+    for owner in pending:
+        provider = providers.get(owner["provider_id"])
+        if not provider:
+            continue
+        operation = BatchOperation(
+            resource="batches",
+            method="GET",
+            path=f"v1/batches/{owner['upstream_id']}",
+            resource_id=str(owner["upstream_id"]),
+        )
+        try:
+            response = await forward_batch_operation(provider, operation)
+        except HTTPException:
+            continue
+        body = _response_json(response) or {}
+        status = body.get("status")
+        with DBManager() as db:
+            db.update_batch_object_status(str(owner["upstream_id"]), status)
+        if status in TERMINAL_BATCH_STATES:
+            settled += await settle_batch(provider, owner, body)
+    return settled
+
+
+async def batch_reconciler_loop() -> None:
+    """Periodically settle batches that finished while nobody was polling."""
+    while True:
+        try:
+            await asyncio.sleep(RECONCILE_INTERVAL_S)
+            await reconcile_batches_once()
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            raise
+        except Exception:  # noqa: BLE001 - the loop outlives its failures
+            logger.exception("Batch reconciliation pass failed")
+
+
+# ---------------------------------------------------------------------------
+# Ownership
+# ---------------------------------------------------------------------------
+
+
+def _owned_or_404(db: DBManager, auth: AuthContext, operation: BatchOperation) -> Dict[str, Any]:
+    """The ownership row for the addressed id, or a 404 if it isn't the caller's.
+
+    An id another team owns is answered exactly like one that never existed:
+    saying it exists would already leak that another team is running it.
+    """
+    kind = "file" if operation.resource == "files" else "batch"
+    owned = db.get_batch_object(kind, str(operation.resource_id))
+    if owned is None or owned.get("team_id") != auth.team_id:
+        raise_openai_error(404, f"No such {kind}: {operation.resource_id!r}.", code="not_found")
+    return owned
+
+
+def _response_json(response: Response) -> Optional[Dict[str, Any]]:
+    body = getattr(response, "body", None)
+    if not isinstance(body, (bytes, bytearray)):
+        return None
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _listing_response(db: DBManager, auth: AuthContext, operation: BatchOperation) -> Response:
+    """List the caller team's own objects, from Logos' own record.
+
+    Not forwarded: the shared upstream credential sees every team's objects,
+    and Logos minted all of its own — so its record is both the safe answer and
+    the complete one, covering batches it ran itself that no provider knows.
+    """
+    kind = "file" if operation.resource == "files" else "batch"
+    rows = db.list_batch_objects_for_team(auth.team_id, kind)
+    data = [
+        (
+            (local_file_object(row) if kind == "file" else local_batch_object(row))
+            if row.get("execution") == "logos"
+            else _remote_object_summary(row, kind)
+        )
+        for row in rows
+    ]
+    return JSONResponse(
+        content={
+            "object": "list",
+            "data": data,
+            "has_more": False,
+            "first_id": data[0]["id"] if data else None,
+            "last_id": data[-1]["id"] if data else None,
+        }
+    )
+
+
+def _remote_object_summary(row: Dict[str, Any], kind: str) -> Dict[str, Any]:
+    """What Logos knows about an object the provider holds.
+
+    A listing reports the status of the last poll; retrieving the object
+    individually asks the provider and is authoritative.
+    """
+    created_at = row.get("created_at")
+    summary = {
+        "id": row.get("upstream_id"),
+        "object": kind,
+        "created_at": int(created_at.timestamp()) if isinstance(created_at, datetime) else None,
+        "logos_execution": "provider",
+        "logos_provider_id": row.get("provider_id"),
+    }
+    if kind == "batch":
+        summary["status"] = row.get("status")
+        summary["input_file_id"] = row.get("input_file_id")
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Serving a batch Logos runs itself
+# ---------------------------------------------------------------------------
+
+
+def _serve_local_operation(db: DBManager, operation: BatchOperation, owner: Dict[str, Any]) -> Response:
+    """Answer a lifecycle call for an object Logos holds."""
+    if operation.resource == "batches":
+        if operation.suboperation == "cancel":
+            db.request_local_batch_cancel(int(owner["id"]))
+            refreshed = db.get_local_batch(str(owner["upstream_id"])) or owner
+            return JSONResponse(content=local_batch_object(refreshed))
+        return JSONResponse(content=local_batch_object(owner))
+
+    if operation.suboperation == "content":
+        content = db.get_local_batch_file_content(int(owner["id"]))
+        if content is None:
+            raise_openai_error(404, f"No content for file {owner['upstream_id']!r}.", code="not_found")
+        return Response(content=content, media_type="application/jsonl")
+
+    if operation.method == "DELETE":
+        db.delete_batch_object(int(owner["id"]))
+        return JSONResponse(content={"id": owner["upstream_id"], "object": "file", "deleted": True})
+
+    return JSONResponse(content=local_file_object(owner))
+
+
+def _start_local_batch(batch_row: Dict[str, Any]) -> None:
+    """Kick a freshly created batch off now instead of waiting for the poller."""
+    try:
+        asyncio.get_running_loop().create_task(run_local_batch(batch_row))
+    except RuntimeError:  # pragma: no cover - no loop (sync test context)
+        logger.debug("No running loop to start batch %s", batch_row.get("upstream_id"))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _finalize_batch_log(
+    log_id: Optional[int],
+    *,
+    provider_id: Optional[int],
+    result_status: str,
+    error_message: Optional[str] = None,
+) -> None:
+    """Close out the usage-log row a batch *operation* opened.
+
+    This row records the control-plane call (upload, create, poll), not the
+    work: a forwarded batch's tokens are booked when its result file is read,
+    and a Logos-run batch's are booked request by request as it runs.
+    """
+    if not log_id:
+        return
+    now = datetime.now(timezone.utc)
+    try:
+        with DBManager() as db:
+            db.update_log_entry_metrics(
+                log_id=log_id,
+                provider_id=provider_id,
+                result_status=result_status,
+                error_message=error_message,
+                scheduled_ts=now,
+                request_complete_ts=now,
+            )
+    except Exception:  # noqa: BLE001 - logging must never break the forward
+        logger.exception("Failed to finalise Batch API log entry %s", log_id)
+
+
+async def _read_json_body(request: Request) -> Dict[str, Any]:
+    try:
+        json_body = await request.json()
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+    if json_body is None:
+        return {}
+    if not isinstance(json_body, dict):
+        raise HTTPException(status_code=400, detail="JSON payload must be an object")
+    return json_body
+
+
+def _check_batch_budget(db: DBManager, auth: AuthContext) -> None:
+    """A key already over its monthly budget does not get to start more work.
+
+    The batch's own cost lands when it finishes, so this is the same guard the
+    request pipeline applies, not a forecast.
+    """
+    check_monthly_budget(db, auth, True, datetime.now(timezone.utc).date().replace(day=1).isoformat())
+
+
+async def _handle_file_upload(request: Request, auth: AuthContext, headers: Dict[str, str], db: DBManager):
+    """Validate an input file, choose where it will run, and put it there.
+
+    Returns ``(response_or_None, forward_args, log_payload)``: a response when
+    Logos stored the file itself, otherwise what the forward needs.
+    """
+    upload = await parse_batch_file_upload(request)
+    raw = upload["file"]["bytes"]
+    provider, deployments = await choose_execution_target(auth, headers, db, batch_input_models(raw))
+    rewritten, model_counts = validate_and_rewrite_batch_input(raw, provider, deployments)
+    log_payload = {
+        "purpose": upload["purpose"],
+        "filename": upload["file"]["filename"],
+        "size": len(rewritten),
+        "requests": sum(model_counts.values()),
+        "model_ids": sorted(model_counts),
+        "execution": "provider" if provider else "logos",
+    }
+
+    if provider is not None:
+        upload = {**upload, "file": {**upload["file"], "bytes": rewritten}}
+        return None, (provider, upload), log_payload
+
+    file_id = new_object_id("file")
+    db.store_local_batch_file(
+        upstream_id=file_id,
+        content=rewritten,
+        filename=upload["file"]["filename"],
+        api_key_id=auth.api_key_id,
+        team_id=auth.team_id,
+        user_id=auth.user_id,
+    )
+    stored = db.get_local_object_by_upstream_id("file", file_id)
+    return JSONResponse(content=local_file_object(stored)), None, log_payload
+
+
+async def _handle_batch_creation(json_body: Dict[str, Any], auth: AuthContext, db: DBManager):
+    """Authorise a batch and either create it here or hand it to the provider."""
+    input_file_id = json_body.get("input_file_id")
+    if not isinstance(input_file_id, str) or not input_file_id:
+        raise_openai_error(400, "A batch needs an 'input_file_id'.", code="invalid_request_error")
+    input_file = db.get_batch_object("file", input_file_id)
+    if input_file is None or input_file.get("team_id") != auth.team_id:
+        raise_openai_error(404, f"No such file: {input_file_id!r}.", code="not_found")
+
+    _check_batch_budget(db, auth)
+
+    if input_file.get("execution") != "logos":
+        provider = db.get_batch_provider(int(input_file["provider_id"]))
+        if provider is None:
+            raise_openai_error(502, "The provider holding this file is gone.", code="batch_upstream_unreachable")
+        return None, provider
+
+    content = db.get_local_batch_file_content(int(input_file["id"])) or b""
+    batch_id = new_object_id("batch")
+    db.create_local_batch(
+        upstream_id=batch_id,
+        input_file_id=input_file_id,
+        endpoint=str(json_body.get("endpoint") or "/v1/chat/completions"),
+        completion_window=json_body.get("completion_window"),
+        metadata=json_body.get("metadata") if isinstance(json_body.get("metadata"), dict) else None,
+        total_requests=len(parse_request_lines(content)),
+        api_key_id=auth.api_key_id,
+        team_id=auth.team_id,
+        user_id=auth.user_id,
+    )
+    created = db.get_local_batch(batch_id)
+    _start_local_batch(created)
+    return JSONResponse(content=local_batch_object(created)), None
+
+
+async def handle_batch_api_request(request: Request) -> Response:
+    """Authenticate, authorise, run or forward, and account for one operation.
+
+    Entry point for every files/batches route and its mirrors.
+    """
+    operation = parse_batch_api_path(request.url.path, method=request.method, query=request.url.query)
+    if operation is None:
+        raise_openai_error(404, f"No Batch API route at {request.url.path!r}", code="unknown_batch_route")
+
+    headers = dict(request.headers)
+    auth = authenticate_api_key(headers)
+
+    request_id = secrets.token_urlsafe(16)
+    log_id: Optional[int] = None
+    provider: Optional[Dict[str, Any]] = None
+    owner: Optional[Dict[str, Any]] = None
+    upload: Optional[Dict[str, Any]] = None
+    json_body: Optional[Dict[str, Any]] = None
+    log_payload: Dict[str, Any] = {}
+    response: Optional[Response] = None
+
+    try:
+        with DBManager() as db:
+            if operation.resource_id:
+                owner = _owned_or_404(db, auth, operation)
+
+            # Bodies are read after the caller is known to be entitled to the
+            # operation, so an unauthorised request cannot spend the upload
+            # budget.
+            if operation.is_file_upload:
+                response, forward_args, log_payload = await _handle_file_upload(request, auth, headers, db)
+                if forward_args:
+                    provider, upload = forward_args
+            elif operation.is_batch_creation:
+                json_body = await _read_json_body(request)
+                log_payload = dict(json_body)
+                response, provider = await _handle_batch_creation(json_body, auth, db)
+            elif operation.is_listing:
+                response = _listing_response(db, auth, operation)
+            elif owner is not None and owner.get("execution") == "logos":
+                response = _serve_local_operation(db, operation, owner)
+            elif owner is not None:
+                provider = db.get_batch_provider(int(owner["provider_id"]))
+                if provider is None:
+                    raise_openai_error(
+                        502, "The provider holding this object is gone.", code="batch_upstream_unreachable"
+                    )
+
+            r_log, c_log = db.log_usage(
+                api_key_id=auth.api_key_id,
+                team_id=auth.team_id,
+                user_id=auth.user_id,
+                environment=auth.environment,
+                log_level=auth.log_level,
+                client_ip=get_client_ip(request),
+                input_payload=log_payload,
+                headers=sanitized_headers_for_persistence(headers),
+                request_id=request_id,
+            )
+            log_id = int(r_log["log-id"]) if c_log == 200 else None
+
+        if response is None:
+            response = await forward_batch_operation(provider, operation, upload, json_body)
+            response = _register_upstream_object(response, operation, provider, auth, owner)
+    except HTTPException as exc:
+        _finalize_batch_log(
+            log_id,
+            provider_id=provider.get("id") if provider else None,
+            result_status="error",
+            error_message=str(exc.detail),
+        )
+        raise
+
+    provider_id = provider.get("id") if provider else None
+    if response.status_code < 400:
+        _finalize_batch_log(log_id, provider_id=provider_id, result_status="success")
+    else:
+        payload = _response_json(response) or {}
+        error_text = ""
+        if isinstance(payload.get("error"), dict):
+            error_text = str(payload["error"].get("message") or "")
+        _finalize_batch_log(
+            log_id,
+            provider_id=provider_id,
+            result_status="error",
+            error_message=error_text or f"Batch API upstream returned {response.status_code}",
+        )
+    return response
+
+
+def _register_upstream_object(
+    response: Response,
+    operation: BatchOperation,
+    provider: Dict[str, Any],
+    auth: AuthContext,
+    owner: Optional[Dict[str, Any]],
+) -> Response:
+    """Record what the provider just minted, and settle a batch that finished."""
+    if response.status_code >= 400:
+        return response
+    payload = _response_json(response)
+    if payload is None:
+        return response
+
+    upstream_id = payload.get("id")
+    if operation.is_file_upload and isinstance(upstream_id, str):
+        with DBManager() as db:
+            db.register_batch_object(
+                kind="file",
+                upstream_id=upstream_id,
+                provider_id=int(provider["id"]),
+                api_key_id=auth.api_key_id,
+                team_id=auth.team_id,
+                user_id=auth.user_id,
+            )
+    elif operation.is_batch_creation and isinstance(upstream_id, str):
+        with DBManager() as db:
+            db.register_batch_object(
+                kind="batch",
+                upstream_id=upstream_id,
+                provider_id=int(provider["id"]),
+                api_key_id=auth.api_key_id,
+                team_id=auth.team_id,
+                user_id=auth.user_id,
+                input_file_id=payload.get("input_file_id"),
+                status=payload.get("status"),
+            )
+    elif operation.resource == "batches" and operation.resource_id and owner is not None:
+        status = payload.get("status")
+        with DBManager() as db:
+            db.update_batch_object_status(str(operation.resource_id), status)
+        if status in TERMINAL_BATCH_STATES and owner.get("settled_at") is None:
+            _schedule_settlement(provider, owner, payload)
+
+    return response

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -32,11 +32,12 @@ back on the way out.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import secrets
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -1048,7 +1049,11 @@ async def reconcile_batches_once() -> int:
         body = _response_json(response) or {}
         status = body.get("status")
         with DBManager() as db:
-            db.record_batch_provider_state(str(owner["upstream_id"]), body)
+            # The same naming the client poll does: the stored state carries
+            # Logos ids, while the settlement below downloads from the
+            # provider by its own.
+            stored = _register_result_files(db, provider, owner, body)
+            db.record_batch_provider_state(str(owner["upstream_id"]), stored)
         if status in TERMINAL_BATCH_STATES:
             if status == "failed":
                 # The unsettled-batches query does not carry the input file id,
@@ -1578,6 +1583,20 @@ async def handle_batch_api_request(request: Request) -> Response:
                     raise_openai_error(
                         502, "The provider holding this object is gone.", code="batch_upstream_unreachable"
                     )
+                # A result file is exposed under Logos's own id; the forward
+                # must address the provider's, which the mapping row keeps.
+                # The path was parsed with the id the client supplied, so it
+                # is rebuilt for the forward, not just the resource id
+                # swapped — the non-Azure url is built from the path.
+                if owner.get("provider_object_id"):
+                    provider_object_id = str(owner["provider_object_id"])
+                    operation = replace(
+                        operation,
+                        resource_id=provider_object_id,
+                        path=_canonical_path(
+                            operation.path, operation.resource, provider_object_id, operation.suboperation
+                        ),
+                    )
 
             r_log, c_log = db.log_usage(
                 api_key_id=auth.api_key_id,
@@ -1660,6 +1679,51 @@ async def handle_batch_api_request(request: Request) -> Response:
                 if rerun is not None:
                     return rerun
     return response
+
+
+def _logos_result_file_id(provider: Dict[str, Any], provider_file_id: str) -> str:
+    """The id Logos exposes for a result file the provider minted.
+
+    A result file's provider id is only unique at that provider, and the
+    client downloads it by the id it was handed, without naming a provider —
+    so the provider id is not exposed verbatim. The exposed id is derived
+    from the provider that minted the file and the id that provider chose:
+    the same pair always yields the same id, so the repeated polls of a
+    finished batch upsert the one mapping row instead of minting duplicates,
+    and two providers minting the same file id expose two different ones.
+    """
+    digest = hashlib.sha256(f"{int(provider['id'])}:{provider_file_id}".encode("utf-8")).hexdigest()
+    return f"file-lg-{digest[:24]}"
+
+
+def _register_result_files(
+    db: DBManager, provider: Dict[str, Any], owner: Dict[str, Any], body: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Name a terminal answer's result files with ids of Logos's own.
+
+    The answer names them by the provider's file ids; they are registered
+    for the batch's owner — like the batch, they appear in the provider's
+    list for every key that may use the provider — and rewritten to Logos's
+    ids before the answer is stored or returned, so the batch row, the
+    answer, and the download route all carry the same id. The mapping row
+    keeps the provider's id, which the download forward uses.
+    """
+    rewritten = dict(body)
+    for field in ("output_file_id", "error_file_id"):
+        provider_file_id = rewritten.get(field)
+        if isinstance(provider_file_id, str) and provider_file_id:
+            logos_id = _logos_result_file_id(provider, provider_file_id)
+            db.register_batch_object(
+                kind="file",
+                upstream_id=logos_id,
+                provider_id=int(provider["id"]),
+                api_key_id=owner.get("api_key_id"),
+                team_id=owner.get("team_id"),
+                user_id=owner.get("user_id"),
+                provider_object_id=provider_file_id,
+            )
+            rewritten[field] = logos_id
+    return rewritten
 
 
 async def _record_upstream_object(db: DBManager, register_kwargs: Dict[str, Any]) -> None:
@@ -1798,30 +1862,29 @@ async def _register_upstream_object(
         # next poll and by the reconciler, so it must not turn a successful
         # upstream poll into a 500.
         status = payload.get("status")
+        stored = payload
         try:
             with DBManager() as db:
-                db.record_batch_provider_state(str(operation.resource_id), payload)
                 # A terminal response is what names the result file (and the
-                # error file). Register both for the batch's owner now: they
-                # appear in the provider's list for every key that may use the
-                # provider, and without a row of their own the owner's result
-                # download would be a 404 while a stranger's would work.
-                for file_field in ("output_file_id", "error_file_id"):
-                    file_id = payload.get(file_field)
-                    if isinstance(file_id, str) and file_id:
-                        db.register_batch_object(
-                            kind="file",
-                            upstream_id=file_id,
-                            provider_id=int(provider["id"]),
-                            api_key_id=owner.get("api_key_id"),
-                            team_id=owner.get("team_id"),
-                            user_id=owner.get("user_id"),
-                        )
+                # error file). They are registered for the batch's owner —
+                # without a row of their own the owner's result download
+                # would be a 404 while a stranger's would work — and
+                # rewritten to Logos's ids before the state stores them, so
+                # the stored state, the answer below, and the download route
+                # all carry the same id.
+                stored = _register_result_files(db, provider, owner, payload)
+                db.record_batch_provider_state(str(operation.resource_id), stored)
             if status == "failed":
                 _learn_batch_ineligibility(provider, owner.get("input_file_id"), _provider_error_text(payload))
         except Exception:  # noqa: BLE001 - the next poll (and the reconciler) retries this
             logger.exception("Could not update the state of batch %s", operation.resource_id)
+        if stored != payload:
+            # The client downloads the result by the id Logos resolves, so
+            # the answer carries the rewritten ids, not the provider's.
+            response = JSONResponse(content=stored, status_code=response.status_code, media_type="application/json")
         if status in TERMINAL_BATCH_STATES and owner.get("settled_at") is None:
+            # Settlement downloads from the provider, so it keeps the answer
+            # with the provider's own file ids.
             _schedule_settlement(provider, owner, payload)
 
     return response

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -455,19 +455,32 @@ async def choose_execution_target(
     if provider is None:
         return None, permitted
 
-    # The provider only qualifies if it hosts every model the file names.
+    # The provider only qualifies if it hosts every model the file names — and
+    # actually batches every one of them. Hosting is the weaker half: a model
+    # can be linked on the provider through a Standard deployment while the
+    # provider's Batch API refuses it (Azure adds models to Batch long after
+    # Standard). What the provider has refused before is tracked per model,
+    # and those models count as not hosted for the choice made here.
     on_provider = [row for row in permitted if int(row["provider_id"]) == int(provider["id"])]
     hosted = {str(row["model_name"]).lower() for row in on_provider}
-    missing = sorted(name for name in model_names if name.lower() not in hosted)
+    model_id_by_name = {str(row["model_name"]).lower(): int(row["model_id"]) for row in on_provider}
+    ineligible = db.get_batch_model_ineligibility(int(provider["id"]))
+    missing = sorted(
+        name for name in model_names if name.lower() not in hosted or model_id_by_name.get(name.lower()) in ineligible
+    )
     if missing:
         if requested_execution == "provider" or _header(headers, BATCH_PROVIDER_HEADER):
             raise_openai_error(
                 400,
-                f"Provider {provider['name']!r} does not serve {', '.join(repr(n) for n in missing)}, "
+                f"Provider {provider['name']!r} cannot batch {', '.join(repr(n) for n in missing)}, "
                 "so it cannot run this batch. Omit the provider header to have Logos run it instead.",
                 code="model_not_available_for_batch",
             )
-        logger.info("Running batch locally: provider %s does not serve %s", provider.get("name"), ", ".join(missing))
+        logger.info(
+            "Running batch locally: provider %s cannot batch %s",
+            provider.get("name"),
+            ", ".join(missing),
+        )
         return None, permitted
     return provider, on_provider
 
@@ -866,12 +879,108 @@ async def settle_batch(provider: Dict[str, Any], owner: Dict[str, Any], batch_bo
     return written
 
 
+# Background work this module starts. The event loop keeps only weak
+# references to tasks, so a fire-and-forget task with no other reference can
+# be garbage collected while it is still running — which would abandon a
+# batch's settlement mid-download. Holding each task here until it finishes is
+# the remedy the asyncio documentation recommends.
+_background_tasks: set = set()
+
+
+def _spawn_background(coro, what: str) -> Optional[asyncio.Task]:
+    """Run a coroutine in the background, holding the task until it finishes."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # no loop (sync test context): nothing can run
+        coro.close()
+        logger.debug("No running loop for %s", what)
+        return None
+    task = loop.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
 def _schedule_settlement(provider: Dict[str, Any], owner: Dict[str, Any], batch_body: Dict[str, Any]) -> None:
     """Settle in the background so a client's poll is not held up by it."""
+    _spawn_background(settle_batch(provider, owner, batch_body), f"batch settlement of {owner.get('upstream_id')}")
+
+
+# ---------------------------------------------------------------------------
+# Per-model Batch eligibility, learned from the provider
+# ---------------------------------------------------------------------------
+
+
+def _provider_error_text(body: Dict[str, Any]) -> str:
+    """The error messages a provider object or response carries, flattened."""
+    error = body.get("error")
+    if isinstance(error, dict) and error.get("message"):
+        return str(error["message"])
+    errors = body.get("errors")
+    if isinstance(errors, list):
+        parts = []
+        for item in errors:
+            if isinstance(item, dict) and item.get("message"):
+                parts.append(str(item["message"]))
+            elif isinstance(item, str):
+                parts.append(item)
+        if parts:
+            return " ".join(parts)
+    return ""
+
+
+def _looks_like_batch_model_error(text: str) -> bool:
+    """Whether a provider error says a model cannot be batched there.
+
+    Deliberately narrow: this text becomes a routing decision (the model's
+    batches move to Logos), and an unrelated failure — a quota error, a bad
+    deployment name — must not be read as "this model is not for batch".
+    """
+    lowered = (text or "").lower()
+    return "batch" in lowered and any(marker in lowered for marker in ("not supported", "sku", "globalbatch"))
+
+
+def _learn_batch_ineligibility(provider: Dict[str, Any], input_file_id: Any, error_text: str) -> None:
+    """Remember, per model, that this provider refused to batch it.
+
+    The provider does not publish which of its models it offers for batch, so
+    its refusal is the only reliable source. The input file's model list (kept
+    at upload) is what says which models the refused batch named: an error
+    that names one of them marks just that model, and a refusal that does not
+    name any marks all of them — a batch file is one job at one place, so if
+    the provider could not batch the file it could not batch its models.
+    """
+    if not error_text or not _looks_like_batch_model_error(error_text) or not input_file_id:
+        return
     try:
-        asyncio.get_running_loop().create_task(settle_batch(provider, owner, batch_body))
-    except RuntimeError:  # pragma: no cover - no loop (sync test context)
-        logger.debug("No running loop for batch settlement of %s", owner.get("upstream_id"))
+        with DBManager() as db:
+            input_file = db.get_batch_object("file", str(input_file_id))
+        if not input_file:
+            return
+        models = input_file.get("models")
+        if not isinstance(models, list):
+            return
+        model_names = [name for name in models if isinstance(name, str)]
+        if not model_names:
+            return
+        lowered = error_text.lower()
+        targets = [name for name in model_names if name.lower() in lowered] or model_names
+        with DBManager() as db:
+            index = {
+                str(row["model_name"]).lower(): int(row["model_id"])
+                for row in db.get_provider_model_deployments(int(provider["id"]))
+            }
+            for name in targets:
+                model_id = index.get(name.lower())
+                if model_id is not None:
+                    db.record_model_batch_ineligibility(int(provider["id"]), model_id, error_text[:400])
+        logger.info(
+            "Provider %s refused to batch %s; that model's batches will run in Logos",
+            provider.get("name"),
+            ", ".join(targets),
+        )
+    except Exception:  # noqa: BLE001 - learning must never break the request path
+        logger.exception("Could not record Batch ineligibility on provider %s", provider.get("id"))
 
 
 async def reconcile_batches_once() -> int:
@@ -906,6 +1015,8 @@ async def reconcile_batches_once() -> int:
         with DBManager() as db:
             db.update_batch_object_status(str(owner["upstream_id"]), status)
         if status in TERMINAL_BATCH_STATES:
+            if status == "failed":
+                _learn_batch_ineligibility(provider, owner.get("input_file_id"), _provider_error_text(body))
             settled += await settle_batch(provider, owner, body)
     return settled
 
@@ -927,15 +1038,35 @@ async def batch_reconciler_loop() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _owns_object(auth: AuthContext, owned: Dict[str, Any]) -> bool:
+    """Whether this caller's principal owns the object's row.
+
+    A team's objects belong to the team; an object a team-less key created
+    belongs to that user alone, and to the key itself when even the user is
+    absent. Comparing team ids alone is not a scope: personal keys carry
+    ``team_id = NULL``, and ``NULL == NULL`` would make every unteamed key on
+    the instance the owner of every other one's batches and their output
+    files.
+    """
+    if auth.team_id is not None:
+        return owned.get("team_id") == auth.team_id
+    if owned.get("team_id") is not None:
+        return False
+    if auth.user_id is not None:
+        return owned.get("user_id") == auth.user_id
+    return owned.get("api_key_id") == auth.api_key_id
+
+
 def _owned_or_404(db: DBManager, auth: AuthContext, operation: BatchOperation) -> Dict[str, Any]:
     """The ownership row for the addressed id, or a 404 if it isn't the caller's.
 
-    An id another team owns is answered exactly like one that never existed:
-    saying it exists would already leak that another team is running it.
+    An id another principal owns is answered exactly like one that never
+    existed: saying it exists would already leak that someone else is running
+    it.
     """
     kind = "file" if operation.resource == "files" else "batch"
     owned = db.get_batch_object(kind, str(operation.resource_id))
-    if owned is None or owned.get("team_id") != auth.team_id:
+    if owned is None or not _owns_object(auth, owned):
         raise_openai_error(404, f"No such {kind}: {operation.resource_id!r}.", code="not_found")
     return owned
 
@@ -952,14 +1083,14 @@ def _response_json(response: Response) -> Optional[Dict[str, Any]]:
 
 
 def _listing_response(db: DBManager, auth: AuthContext, operation: BatchOperation) -> Response:
-    """List the caller team's own objects, from Logos' own record.
+    """List the caller's own objects (team, else user, else key), from Logos' record.
 
     Not forwarded: the shared upstream credential sees every team's objects,
     and Logos minted all of its own — so its record is both the safe answer and
     the complete one, covering batches it ran itself that no provider knows.
     """
     kind = "file" if operation.resource == "files" else "batch"
-    rows = db.list_batch_objects_for_team(auth.team_id, kind)
+    rows = db.list_batch_objects_for_principal(kind, auth.team_id, auth.user_id, auth.api_key_id)
     data = [
         (
             (local_file_object(row) if kind == "file" else local_batch_object(row))
@@ -1028,10 +1159,7 @@ def _serve_local_operation(db: DBManager, operation: BatchOperation, owner: Dict
 
 def _start_local_batch(batch_row: Dict[str, Any]) -> None:
     """Kick a freshly created batch off now instead of waiting for the poller."""
-    try:
-        asyncio.get_running_loop().create_task(run_local_batch(batch_row))
-    except RuntimeError:  # pragma: no cover - no loop (sync test context)
-        logger.debug("No running loop to start batch %s", batch_row.get("upstream_id"))
+    _spawn_background(run_local_batch(batch_row), f"local batch {batch_row.get('upstream_id')}")
 
 
 # ---------------------------------------------------------------------------
@@ -1106,6 +1234,7 @@ async def _handle_file_upload(request: Request, auth: AuthContext, headers: Dict
         "size": len(rewritten),
         "requests": sum(model_counts.values()),
         "model_ids": sorted(model_counts),
+        "models": sorted(str(row["model_name"]) for row in deployments if int(row["model_id"]) in model_counts),
         "execution": "provider" if provider else "logos",
     }
 
@@ -1132,7 +1261,7 @@ async def _handle_batch_creation(json_body: Dict[str, Any], auth: AuthContext, d
     if not isinstance(input_file_id, str) or not input_file_id:
         raise_openai_error(400, "A batch needs an 'input_file_id'.", code="invalid_request_error")
     input_file = db.get_batch_object("file", input_file_id)
-    if input_file is None or input_file.get("team_id") != auth.team_id:
+    if input_file is None or not _owns_object(auth, input_file):
         raise_openai_error(404, f"No such file: {input_file_id!r}.", code="not_found")
 
     _check_batch_budget(db, auth)
@@ -1224,7 +1353,9 @@ async def handle_batch_api_request(request: Request) -> Response:
 
         if response is None:
             response = await forward_batch_operation(provider, operation, upload, json_body)
-            response = _register_upstream_object(response, operation, provider, auth, owner)
+            response = await _register_upstream_object(
+                response, operation, provider, auth, owner, file_models=log_payload.get("models")
+            )
     except HTTPException as exc:
         _finalize_batch_log(
             log_id,
@@ -1248,17 +1379,76 @@ async def handle_batch_api_request(request: Request) -> Response:
             result_status="error",
             error_message=error_text or f"Batch API upstream returned {response.status_code}",
         )
+        # A creation refused because one of the file's models is not batchable
+        # is the one refusal that teaches Logos to route that model locally
+        # from now on, instead of failing the same way on the next file.
+        if (
+            operation.is_batch_creation
+            and provider is not None
+            and isinstance(json_body, dict)
+            and json_body.get("input_file_id")
+        ):
+            _learn_batch_ineligibility(provider, json_body.get("input_file_id"), error_text)
     return response
 
 
-def _register_upstream_object(
+async def _record_upstream_object(db: DBManager, register_kwargs: Dict[str, Any]) -> None:
+    """Commit one ownership row, retrying the write.
+
+    The provider has already created the object when this runs, so a
+    transient database failure must not turn into "the object exists upstream
+    but nobody at Logos knows who owns it" — that orphan is both unreachable
+    for its owner and invisible to the settlement path. A few short retries
+    ride out the transient case; what survives them is handled by the caller,
+    which removes the provider object again.
+    """
+    last: Optional[Exception] = None
+    for attempt in range(3):
+        try:
+            db.register_batch_object(**register_kwargs)
+            return
+        except Exception as exc:  # noqa: BLE001 - the retries are the handling
+            last = exc
+            await asyncio.sleep(0.2 * (attempt + 1))
+    assert last is not None
+    raise last
+
+
+async def _remove_upstream_object(provider: Dict[str, Any], operation: BatchOperation, upstream_id: str) -> None:
+    """Best effort: delete what the provider just minted, so an unowned object does not linger there."""
+    resource = "files" if operation.resource == "files" else "batches"
+    delete = BatchOperation(
+        resource=resource,
+        method="DELETE",
+        path=f"v1/{resource}/{upstream_id}",
+        resource_id=upstream_id,
+    )
+    try:
+        await forward_batch_operation(provider, delete)
+        logger.warning("Removed upstream %s %s whose ownership could not be recorded", resource, upstream_id)
+    except Exception:  # noqa: BLE001 - the error below already says what happened
+        logger.exception("Could not remove upstream %s %s", resource, upstream_id)
+
+
+async def _register_upstream_object(
     response: Response,
     operation: BatchOperation,
     provider: Dict[str, Any],
     auth: AuthContext,
     owner: Optional[Dict[str, Any]],
+    file_models: Optional[List[str]] = None,
 ) -> Response:
-    """Record what the provider just minted, and settle a batch that finished."""
+    """Record what the provider just minted, and settle a batch that finished.
+
+    For the operations that mint something new (a file upload, a batch
+    creation) the response is not returned before the ownership row is
+    durable: with the provider credential shared by every key allowed to use
+    the provider, an object without an owner is an object anyone could later
+    fail to reach or — worse, if the row were simply skipped — an object any
+    key could use. When the row cannot be committed the provider object is
+    removed again and the caller gets an error, so the provider never holds
+    what Logos cannot account for.
+    """
     if response.status_code >= 400:
         return response
     payload = _response_json(response)
@@ -1267,31 +1457,78 @@ def _register_upstream_object(
 
     upstream_id = payload.get("id")
     if operation.is_file_upload and isinstance(upstream_id, str):
-        with DBManager() as db:
-            db.register_batch_object(
-                kind="file",
-                upstream_id=upstream_id,
-                provider_id=int(provider["id"]),
-                api_key_id=auth.api_key_id,
-                team_id=auth.team_id,
-                user_id=auth.user_id,
+        register_kwargs = dict(
+            kind="file",
+            upstream_id=upstream_id,
+            provider_id=int(provider["id"]),
+            api_key_id=auth.api_key_id,
+            team_id=auth.team_id,
+            user_id=auth.user_id,
+            models=file_models,
+        )
+        try:
+            with DBManager() as db:
+                await _record_upstream_object(db, register_kwargs)
+        except Exception:  # noqa: BLE001 - see the error below for the outcome
+            logger.exception("Could not record ownership of upstream file %s", upstream_id)
+            await _remove_upstream_object(provider, operation, upstream_id)
+            raise_openai_error(
+                502,
+                "The provider created the file, but Logos could not record who owns it and "
+                "removed it again. Try the upload once more.",
+                code="batch_ownership_unrecorded",
             )
     elif operation.is_batch_creation and isinstance(upstream_id, str):
-        with DBManager() as db:
-            db.register_batch_object(
-                kind="batch",
-                upstream_id=upstream_id,
-                provider_id=int(provider["id"]),
-                api_key_id=auth.api_key_id,
-                team_id=auth.team_id,
-                user_id=auth.user_id,
-                input_file_id=payload.get("input_file_id"),
-                status=payload.get("status"),
+        register_kwargs = dict(
+            kind="batch",
+            upstream_id=upstream_id,
+            provider_id=int(provider["id"]),
+            api_key_id=auth.api_key_id,
+            team_id=auth.team_id,
+            user_id=auth.user_id,
+            input_file_id=payload.get("input_file_id"),
+            status=payload.get("status"),
+        )
+        try:
+            with DBManager() as db:
+                await _record_upstream_object(db, register_kwargs)
+        except Exception:  # noqa: BLE001 - see the error below for the outcome
+            logger.exception("Could not record ownership of upstream batch %s", upstream_id)
+            await _remove_upstream_object(provider, operation, upstream_id)
+            raise_openai_error(
+                502,
+                "The provider created the batch, but Logos could not record who owns it and "
+                "removed it again. Try the creation once more.",
+                code="batch_ownership_unrecorded",
             )
     elif operation.resource == "batches" and operation.resource_id and owner is not None:
+        # Polling: nothing new to own, and a failure here is retried by the
+        # next poll and by the reconciler, so it must not turn a successful
+        # upstream poll into a 500.
         status = payload.get("status")
-        with DBManager() as db:
-            db.update_batch_object_status(str(operation.resource_id), status)
+        try:
+            with DBManager() as db:
+                db.update_batch_object_status(str(operation.resource_id), status)
+                # A terminal response is what names the result file (and the
+                # error file). Register both for the batch's owner now: they
+                # appear in the provider's list for every key that may use the
+                # provider, and without a row of their own the owner's result
+                # download would be a 404 while a stranger's would work.
+                for file_field in ("output_file_id", "error_file_id"):
+                    file_id = payload.get(file_field)
+                    if isinstance(file_id, str) and file_id:
+                        db.register_batch_object(
+                            kind="file",
+                            upstream_id=file_id,
+                            provider_id=int(provider["id"]),
+                            api_key_id=owner.get("api_key_id"),
+                            team_id=owner.get("team_id"),
+                            user_id=owner.get("user_id"),
+                        )
+            if status == "failed":
+                _learn_batch_ineligibility(provider, owner.get("input_file_id"), _provider_error_text(payload))
+        except Exception:  # noqa: BLE001 - the next poll (and the reconciler) retries this
+            logger.exception("Could not update the state of batch %s", operation.resource_id)
         if status in TERMINAL_BATCH_STATES and owner.get("settled_at") is None:
             _schedule_settlement(provider, owner, payload)
 

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1016,7 +1016,11 @@ async def reconcile_batches_once() -> int:
             db.update_batch_object_status(str(owner["upstream_id"]), status)
         if status in TERMINAL_BATCH_STATES:
             if status == "failed":
-                _learn_batch_ineligibility(provider, owner.get("input_file_id"), _provider_error_text(body))
+                # The unsettled-batches query does not carry the input file id,
+                # so take it from the provider's answer, as settlement does —
+                # otherwise a failure nobody polled could never teach.
+                input_file_id = body.get("input_file_id") or owner.get("input_file_id")
+                _learn_batch_ineligibility(provider, input_file_id, _provider_error_text(body))
             settled += await settle_batch(provider, owner, body)
     return settled
 

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -94,6 +94,12 @@ MAX_BATCH_REQUESTS = int(os.getenv("LOGOS_MAX_BATCH_REQUESTS", "50000"))
 # How often the reconciler looks for batches that finished while nobody polled.
 RECONCILE_INTERVAL_S = int(os.getenv("LOGOS_BATCH_RECONCILE_INTERVAL_S", "300"))
 
+# How long a settlement's exclusive claim on a batch lasts. Settlement is a
+# download plus a ledger write, so this is generous; it only matters in the
+# failure case, where a shorter lease means the retried settlement can start
+# sooner after the first one died.
+SETTLEMENT_LEASE_TTL_S = int(os.getenv("LOGOS_BATCH_SETTLEMENT_LEASE_TTL_S", "1800"))
+
 # The operations a batch request line may address. A batch is an inference
 # channel; the Files API is its transport, not a general object store.
 _BATCH_REQUEST_ENDPOINTS = {
@@ -761,12 +767,23 @@ def _usage_rows_from_output(
     input_models: Dict[str, str],
     logging_context: Dict[str, Any],
 ) -> List[Dict[str, Any]]:
-    """Turn a batch output file into one usage row per finished request."""
+    """Turn a batch output file into one usage row per finished request.
+
+    Each row's ``request_id`` is scoped to this batch (the batch object's id,
+    not the provider's id: it is the same for a settlement retry and unique
+    across batches no matter what two clients call their lines). The id is
+    what makes the ledger write idempotent — a settlement that is retried after
+    a partial commit skips its already-booked rows on it, and two batches that
+    reuse the same custom_id can no longer collide in the ledger at all.
+    """
     rows: List[Dict[str, Any]] = []
     now = datetime.now(timezone.utc)
+    batch_scope = f"batch-{owner.get('id')}-"
+    line_number = 0
     for raw_line in content.splitlines():
         if not raw_line.strip():
             continue
+        line_number += 1
         try:
             record = json.loads(raw_line)
         except (json.JSONDecodeError, UnicodeDecodeError):
@@ -778,6 +795,9 @@ def _usage_rows_from_output(
         body = response.get("body") if isinstance(response.get("body"), dict) else {}
         status_code = response.get("status_code")
         custom_id = record.get("custom_id")
+        # A line without a custom_id still gets a stable identity: its position
+        # in the result file, which the provider does not change.
+        request_id = f"{batch_scope}{custom_id}" if isinstance(custom_id, str) else f"{batch_scope}line-{line_number}"
 
         usage, _ = finalize_billing_inputs({}, body, "v1/chat/completions")
         model_id = _model_id_for(model_index, body.get("model"))
@@ -795,7 +815,7 @@ def _usage_rows_from_output(
                 "privacy_level": logging_context.get("log_level"),
                 "provider_id": int(provider["id"]),
                 "model_id": model_id,
-                "request_id": custom_id if isinstance(custom_id, str) else None,
+                "request_id": request_id,
                 "service_tier": "batch",
                 "result_status": "error" if failed else "success",
                 "error_message": json.dumps(record.get("error"))[:500] if record.get("error") else None,
@@ -836,13 +856,20 @@ async def settle_batch(provider: Dict[str, Any], owner: Dict[str, Any], batch_bo
 
     The provider metered the job and charged its batch rate; this brings the
     same numbers into Logos so the spend shows up under the team that ordered
-    it. The settlement latch is taken first, and released again if the output
-    file could not be read, so a transient failure is retried rather than
-    silently dropping a batch's cost.
+    it.
+
+    The order is what makes this safe to retry: the settlement *lease* is
+    taken first (what keeps the poll path and the reconciler exclusive of each
+    other), and ``settled_at`` is stamped only after the usage rows are
+    durably written. A settlement that dies in between — the process exits,
+    the task is cancelled — leaves the batch unsettled: the lease lapses and
+    the reconciler picks the batch up again, and the idempotent ledger write
+    skips whatever the first attempt already booked. Stamping first would have
+    put the batch out of the reconciler's reach forever and its cost with it.
     """
     output_file_id = batch_body.get("output_file_id") or batch_body.get("error_file_id")
     with DBManager() as db:
-        if not db.claim_batch_for_settlement(int(owner["id"])):
+        if not db.claim_batch_for_settlement(int(owner["id"]), SETTLEMENT_LEASE_TTL_S):
             return 0
         logging_context = (
             db.get_api_key_logging_context(int(owner["api_key_id"]))
@@ -853,8 +880,10 @@ async def settle_batch(provider: Dict[str, Any], owner: Dict[str, Any], batch_bo
 
     if not output_file_id:
         # A batch that failed before producing any output still costs nothing;
-        # keep the latch so it is not polled forever.
+        # close it out so it is not re-checked forever.
         logger.info("Batch %s finished without an output file; nothing to meter", owner.get("upstream_id"))
+        with DBManager() as db:
+            db.mark_batch_settled(int(owner["id"]))
         return 0
 
     try:
@@ -869,6 +898,10 @@ async def settle_batch(provider: Dict[str, Any], owner: Dict[str, Any], batch_bo
         rows = _usage_rows_from_output(output, owner, provider, model_index, input_models, logging_context)
         with DBManager() as db:
             written = db.record_batch_usage(rows)
+            # Only now is the batch settled: the rows above are durably in the
+            # ledger (or were already there from an earlier attempt of this
+            # same settlement, which the write skips by request_id).
+            db.mark_batch_settled(int(owner["id"]))
     except Exception:  # noqa: BLE001 - a failed settlement must stay retryable
         logger.exception("Settlement of batch %s failed; it will be retried", owner.get("upstream_id"))
         with DBManager() as db:
@@ -1155,6 +1188,18 @@ def _serve_local_operation(db: DBManager, operation: BatchOperation, owner: Dict
         return Response(content=content, media_type="application/jsonl")
 
     if operation.method == "DELETE":
+        # The runner reads the input's bytes when it starts the batch, not
+        # when the batch is created. Deleting a file a not-yet-finished batch
+        # still references would strand that batch: it would find no content
+        # and fail one it was accepted to run, so the delete is refused until
+        # every referencing batch is terminal.
+        if db.count_nonterminal_batches_for_input_file(str(owner["upstream_id"])) > 0:
+            raise_openai_error(
+                409,
+                f"File {owner['upstream_id']!r} is still the input of a batch that has not finished; "
+                "it can be deleted once that batch is done.",
+                code="batch_input_file_in_use",
+            )
         db.delete_batch_object(int(owner["id"]))
         return JSONResponse(content={"id": owner["upstream_id"], "object": "file", "deleted": True})
 
@@ -1294,6 +1339,73 @@ async def _handle_batch_creation(json_body: Dict[str, Any], auth: AuthContext, d
     return JSONResponse(content=local_batch_object(created)), None
 
 
+async def _rerun_refused_creation_locally(
+    provider: Dict[str, Any], json_body: Dict[str, Any], auth: AuthContext
+) -> Optional[JSONResponse]:
+    """Run a refused batch creation here, from the file the provider holds.
+
+    Auto mode means "forward when that can work". A creation the provider
+    refused with a model-availability error has just said it cannot, so the
+    batch is created locally from the same input instead of the refusal being
+    the answer: the first request still ends in a batch, and the ineligibility
+    recorded alongside this rerun routes the next upload of the file locally
+    on its own.
+    """
+    input_file_id = json_body.get("input_file_id")
+    content = await _download_file(provider, str(input_file_id))
+    if content is None:
+        return None
+    # The provider holds the file as Logos uploaded it, i.e. with the model
+    # spellings the provider's deployments use. The local pipeline wants Logos
+    # model names, so those spellings are translated back on the way in.
+    with DBManager() as db:
+        deployments = db.get_provider_model_deployments(int(provider["id"]))
+    name_by_deployment = {str(_deployment_for(provider, row)).lower(): str(row["model_name"]) for row in deployments}
+    lines: List[bytes] = []
+    for raw_line in content.splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            line = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(line, dict) and isinstance(line.get("body"), dict):
+            model = line["body"].get("model")
+            if isinstance(model, str) and model.lower() in name_by_deployment:
+                line["body"]["model"] = name_by_deployment[model.lower()]
+        lines.append(json.dumps(line, ensure_ascii=False).encode("utf-8"))
+    if not lines:
+        return None
+    stored = b"\n".join(lines) + b"\n"
+    file_id = new_object_id("file")
+    batch_id = new_object_id("batch")
+    with DBManager() as db:
+        db.store_local_batch_file(
+            upstream_id=file_id,
+            content=stored,
+            filename=f"{input_file_id}_rerun.jsonl",
+            api_key_id=auth.api_key_id,
+            team_id=auth.team_id,
+            user_id=auth.user_id,
+        )
+        db.create_local_batch(
+            upstream_id=batch_id,
+            input_file_id=file_id,
+            endpoint=str(json_body.get("endpoint") or "/v1/chat/completions"),
+            completion_window=json_body.get("completion_window"),
+            metadata=json_body.get("metadata") if isinstance(json_body.get("metadata"), dict) else None,
+            total_requests=len(parse_request_lines(stored)),
+            api_key_id=auth.api_key_id,
+            team_id=auth.team_id,
+            user_id=auth.user_id,
+        )
+        created = db.get_local_batch(batch_id)
+    if created is None:
+        return None
+    _start_local_batch(created)
+    return JSONResponse(content=local_batch_object(created))
+
+
 async def handle_batch_api_request(request: Request) -> Response:
     """Authenticate, authorise, run or forward, and account for one operation.
 
@@ -1360,6 +1472,18 @@ async def handle_batch_api_request(request: Request) -> Response:
             response = await _register_upstream_object(
                 response, operation, provider, auth, owner, file_models=log_payload.get("models")
             )
+            # A file the provider actually deleted is gone from Logos's books
+            # as well: the ownership row would keep the dead id in the listing,
+            # and a later creation naming it would pass the local ownership
+            # check and only fail upstream.
+            if (
+                operation.method == "DELETE"
+                and owner is not None
+                and owner.get("execution") == "provider"
+                and response.status_code < 400
+            ):
+                with DBManager() as db:
+                    db.delete_batch_object(int(owner["id"]))
     except HTTPException as exc:
         _finalize_batch_log(
             log_id,
@@ -1393,6 +1517,16 @@ async def handle_batch_api_request(request: Request) -> Response:
             and json_body.get("input_file_id")
         ):
             _learn_batch_ineligibility(provider, json_body.get("input_file_id"), error_text)
+            # In auto mode the refusal is not the answer: the provider just
+            # said it cannot batch this file's models, so the same file is run
+            # here instead, and the first request still ends in a batch. A
+            # provider that was named or forced keeps the refusal — that is
+            # what it asked for.
+            execution = _header(headers, BATCH_EXECUTION_HEADER).lower()
+            if execution not in {"provider", "logos"} and not _header(headers, BATCH_PROVIDER_HEADER):
+                rerun = await _rerun_refused_creation_locally(provider, json_body, auth)
+                if rerun is not None:
+                    return rerun
     return response
 
 
@@ -1413,25 +1547,47 @@ async def _record_upstream_object(db: DBManager, register_kwargs: Dict[str, Any]
             return
         except Exception as exc:  # noqa: BLE001 - the retries are the handling
             last = exc
+            # A failed write leaves the shared session in an aborted
+            # transaction; without a rollback the next attempt would raise
+            # PendingRollbackError instead of retrying the write.
+            try:
+                db.session.rollback()
+            except Exception:  # noqa: BLE001 - the retry (or the raise) reports the state
+                pass
             await asyncio.sleep(0.2 * (attempt + 1))
     assert last is not None
     raise last
 
 
 async def _remove_upstream_object(provider: Dict[str, Any], operation: BatchOperation, upstream_id: str) -> None:
-    """Best effort: delete what the provider just minted, so an unowned object does not linger there."""
-    resource = "files" if operation.resource == "files" else "batches"
-    delete = BatchOperation(
-        resource=resource,
-        method="DELETE",
-        path=f"v1/{resource}/{upstream_id}",
-        resource_id=upstream_id,
-    )
+    """Best effort: undo what the provider just minted, so an unowned object does not linger there.
+
+    Files are deleted; a batch job is *cancelled*. The OpenAI Batch API has no
+    delete operation — the only way to stop a job is ``POST /v1/batches/{id}/cancel`` —
+    and a DELETE there comes back 405, which would leave the job running (and
+    billing under the shared credential) with nobody at Logos to account for it.
+    """
+    if operation.resource == "batches":
+        cleanup = BatchOperation(
+            resource="batches",
+            method="POST",
+            path=f"v1/batches/{upstream_id}/cancel",
+            resource_id=upstream_id,
+            suboperation="cancel",
+        )
+    else:
+        cleanup = BatchOperation(
+            resource="files",
+            method="DELETE",
+            path=f"v1/files/{upstream_id}",
+            resource_id=upstream_id,
+        )
     try:
-        await forward_batch_operation(provider, delete)
-        logger.warning("Removed upstream %s %s whose ownership could not be recorded", resource, upstream_id)
+        await forward_batch_operation(provider, cleanup)
+        verb = "cancelled" if operation.resource == "batches" else "removed"
+        logger.warning("%s upstream %s %s whose ownership could not be recorded", verb, operation.resource, upstream_id)
     except Exception:  # noqa: BLE001 - the error below already says what happened
-        logger.exception("Could not remove upstream %s %s", resource, upstream_id)
+        logger.exception("Could not remove upstream %s %s", operation.resource, upstream_id)
 
 
 async def _register_upstream_object(

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1616,6 +1616,16 @@ async def handle_batch_api_request(request: Request) -> Response:
             response = await _register_upstream_object(
                 response, operation, provider, auth, owner, file_models=log_payload.get("models")
             )
+            # A mapped result file was addressed upstream by the provider's
+            # id; the object answer comes back named by it, so it is
+            # re-exposed under the id the client holds before it is returned.
+            if (
+                owner is not None
+                and owner.get("provider_object_id")
+                and operation.resource == "files"
+                and operation.suboperation != "content"
+            ):
+                response = _restore_exposed_file_id(response, owner)
             # A file the provider actually deleted is gone from Logos's books
             # as well: the ownership row would keep the dead id in the listing,
             # and a later creation naming it would pass the local ownership
@@ -1724,6 +1734,28 @@ def _register_result_files(
             )
             rewritten[field] = logos_id
     return rewritten
+
+
+def _restore_exposed_file_id(response: Response, owner: Dict[str, Any]) -> Response:
+    """Re-expose a mapped result file's answer under the id Logos gave out.
+
+    The file is addressed upstream by the provider's id, so the provider
+    names its object answer by it — but the client only holds Logos's id:
+    reusing the returned id for the download or the deletion would 404,
+    because ownership is keyed by Logos's id. The content suboperation is
+    the one answer that must not be touched: those bytes are the file
+    itself, not an object representation.
+    """
+    if response.status_code >= 400:
+        return response
+    payload = _response_json(response)
+    if not isinstance(payload, dict) or not isinstance(payload.get("id"), str):
+        return response
+    return JSONResponse(
+        content={**payload, "id": str(owner["upstream_id"])},
+        status_code=response.status_code,
+        media_type="application/json",
+    )
 
 
 async def _record_upstream_object(db: DBManager, register_kwargs: Dict[str, Any]) -> None:

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1344,7 +1344,9 @@ def _assert_still_permitted(
     uploading key after its links were revoked — would run the file's
     previously authorised models through the shared provider credential. Both
     halves are therefore asked again at creation: the provider the file lives
-    on, and every model the file row recorded.
+    on, and every model the file row recorded *on that provider* — a model the
+    key may still run through a different permitted provider does not authorise
+    spending this one's credential on a link the stored provider no longer has.
     """
     candidates = db.get_batch_provider_candidates(auth.api_key_id)
     if not any(int(row["id"]) == int(provider["id"]) for row in candidates):
@@ -1353,7 +1355,10 @@ def _assert_still_permitted(
             f"This key may no longer use provider {provider.get('name')!r}, which holds this file.",
             code="batch_provider_not_authorized",
         )
-    permitted = {str(row["model_name"]).lower() for row in db.get_batch_model_deployments(auth.api_key_id)}
+    permitted = {
+        str(row["model_name"]).lower()
+        for row in db.get_batch_model_deployments(auth.api_key_id, provider_id=int(provider["id"]))
+    }
     missing = sorted(str(name) for name in (input_file.get("models") or []) if str(name).lower() not in permitted)
     if missing:
         raise_openai_error(
@@ -1374,7 +1379,9 @@ def _local_batch_contract(content: bytes, json_body: Dict[str, Any]) -> str:
     the lines' own urls while the batch object advertises the endpoint it was
     created with. Returns the endpoint to store on the batch.
     """
-    endpoint = str(json_body.get("endpoint") or "/v1/chat/completions")
+    endpoint = json_body.get("endpoint")
+    if not isinstance(endpoint, str) or not endpoint:
+        raise_openai_error(400, "A batch needs an 'endpoint'.", code="invalid_request_error")
     wanted = _request_endpoint(endpoint)
     if wanted not in _BATCH_REQUEST_ENDPOINTS:
         raise_openai_error(
@@ -1388,7 +1395,13 @@ def _local_batch_contract(content: bytes, json_body: Dict[str, Any]) -> str:
 
     for number, line in enumerate(parse_request_lines(content), start=1):
         method = line.get("method")
-        if method is not None and str(method).upper() != "POST":
+        if method is None:
+            raise_openai_error(
+                400,
+                f"Line {number} has no 'method'; batch lines are POST requests.",
+                code="invalid_batch_line",
+            )
+        if str(method).upper() != "POST":
             raise_openai_error(
                 400,
                 f"Line {number} uses method {method!r}; batch lines are POST requests.",

--- a/logos/logos-orchestrator/src/logos/batch_api.py
+++ b/logos/logos-orchestrator/src/logos/batch_api.py
@@ -1032,6 +1032,7 @@ async def reconcile_batches_once() -> int:
     for owner in pending:
         provider = providers.get(owner["provider_id"])
         if not provider:
+            _rotate_unsettled_batch_out_of_the_window(owner)
             continue
         operation = BatchOperation(
             resource="batches",
@@ -1042,11 +1043,12 @@ async def reconcile_batches_once() -> int:
         try:
             response = await forward_batch_operation(provider, operation)
         except HTTPException:
+            _rotate_unsettled_batch_out_of_the_window(owner)
             continue
         body = _response_json(response) or {}
         status = body.get("status")
         with DBManager() as db:
-            db.update_batch_object_status(str(owner["upstream_id"]), status)
+            db.record_batch_provider_state(str(owner["upstream_id"]), body)
         if status in TERMINAL_BATCH_STATES:
             if status == "failed":
                 # The unsettled-batches query does not carry the input file id,
@@ -1056,6 +1058,21 @@ async def reconcile_batches_once() -> int:
                 _learn_batch_ineligibility(provider, input_file_id, _provider_error_text(body))
             settled += await settle_batch(provider, owner, body)
     return settled
+
+
+def _rotate_unsettled_batch_out_of_the_window(owner: Dict[str, Any]) -> None:
+    """Mark an uncheckable batch as seen, so the window can move on.
+
+    The unsettled-batches window leads with the least recently checked. A
+    batch whose check could not run — its provider row is gone, or the
+    upstream refused the call — must not keep its place in it, or every
+    batch behind it waits on every pass.
+    """
+    try:
+        with DBManager() as db:
+            db.update_batch_object_status(str(owner["upstream_id"]), None)
+    except Exception:  # noqa: BLE001 - the next pass simply takes the same window
+        logger.debug("Could not rotate unsettled batch %s out of the window", owner.get("upstream_id"))
 
 
 async def batch_reconciler_loop() -> None:
@@ -1150,8 +1167,10 @@ def _listing_response(db: DBManager, auth: AuthContext, operation: BatchOperatio
 def _remote_object_summary(row: Dict[str, Any], kind: str) -> Dict[str, Any]:
     """What Logos knows about an object the provider holds.
 
-    A listing reports the status of the last poll; retrieving the object
-    individually asks the provider and is authoritative.
+    A listing reports the last poll's view — status, and for a batch its
+    result file and running counts, stored with the status when the provider
+    last answered for it; retrieving the object individually asks the
+    provider and is authoritative.
     """
     created_at = row.get("created_at")
     summary = {
@@ -1164,6 +1183,16 @@ def _remote_object_summary(row: Dict[str, Any], kind: str) -> Dict[str, Any]:
     if kind == "batch":
         summary["status"] = row.get("status")
         summary["input_file_id"] = row.get("input_file_id")
+        # Without these a finished provider batch would never show its result
+        # download and a running one its progress: the listing does not ask
+        # the provider for each row, it renders what the last poll stored.
+        summary["output_file_id"] = row.get("output_file_id")
+        summary["error_file_id"] = row.get("error_file_id")
+        summary["request_counts"] = {
+            "total": int(row.get("total_requests") or 0),
+            "completed": int(row.get("completed_requests") or 0),
+            "failed": int(row.get("failed_requests") or 0),
+        }
     return summary
 
 
@@ -1517,13 +1546,20 @@ async def handle_batch_api_request(request: Request) -> Response:
             and json_body.get("input_file_id")
         ):
             _learn_batch_ineligibility(provider, json_body.get("input_file_id"), error_text)
-            # In auto mode the refusal is not the answer: the provider just
-            # said it cannot batch this file's models, so the same file is run
-            # here instead, and the first request still ends in a batch. A
-            # provider that was named or forced keeps the refusal — that is
-            # what it asked for.
+            # In auto mode only the model-availability refusal is not the
+            # answer: the provider just said it cannot batch this file's
+            # models, so the same file is run here instead, and the first
+            # request still ends in a batch. Every other refusal — a quota,
+            # a window, an upstream of its own — is the provider's answer,
+            # not a reason to re-run the job locally, so the same gate that
+            # limits the learning limits the rerun. A provider that was
+            # named or forced keeps the refusal — that is what it asked for.
             execution = _header(headers, BATCH_EXECUTION_HEADER).lower()
-            if execution not in {"provider", "logos"} and not _header(headers, BATCH_PROVIDER_HEADER):
+            if (
+                _looks_like_batch_model_error(error_text)
+                and execution not in {"provider", "logos"}
+                and not _header(headers, BATCH_PROVIDER_HEADER)
+            ):
                 rerun = await _rerun_refused_creation_locally(provider, json_body, auth)
                 if rerun is not None:
                     return rerun
@@ -1668,7 +1704,7 @@ async def _register_upstream_object(
         status = payload.get("status")
         try:
             with DBManager() as db:
-                db.update_batch_object_status(str(operation.resource_id), status)
+                db.record_batch_provider_state(str(operation.resource_id), payload)
                 # A terminal response is what names the result file (and the
                 # error file). Register both for the batch's owner now: they
                 # appear in the provider's list for every key that may use the

--- a/logos/logos-orchestrator/src/logos/batch_credential.py
+++ b/logos/logos-orchestrator/src/logos/batch_credential.py
@@ -1,0 +1,100 @@
+"""Scoped, short-lived credentials for the batch proxy.
+
+The Spring webservice sits on the internal network next to the orchestrator
+and proxies the UI's batch pages to the Batch API as the caller's own key.
+That key is a long-lived secret: the shipped Compose setup reaches the
+orchestrator over plain HTTP, so sending the key value on that hop would put
+the user's own credential on a cleartext wire.
+
+So the webservice never sends the key itself. It names the key by id to the
+secret-gated internal endpoint (its ownership check has already run), and the
+orchestrator answers with a scoped credential: bound to that one key, valid
+for a few minutes, and verifiable without a round trip. The Batch API accepts
+the credential where it accepts a key value, and resolves it through the
+key's own row — which is also what re-checks, at presentation time, that the
+key is still active.
+"""
+
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# How long a handed-out credential stays good. Long enough for the upload and
+# the batch creation it serves; short enough that a credential read off the
+# internal network stops working quickly.
+BATCH_CREDENTIAL_TTL_S = int(os.getenv("LOGOS_BATCH_CREDENTIAL_TTL_S", "300"))
+
+# What marks a value as a scoped credential rather than a key value: the key
+# lookup tries the plain interpretation first, and only falls back to this.
+BATCH_CREDENTIAL_PREFIX = "bc1."
+
+
+def _signing_secret() -> str:
+    # The same shared secret that gates /internal/*: it is already the trust
+    # root between the webservice and the orchestrator, so the credential
+    # rides on it instead of a second secret to configure. Read per call so a
+    # test (or a restart with a changed secret) is picked up without a reload.
+    return os.getenv("LOGOS_INTERNAL_SECRET", "")
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+
+def issue_batch_credential(api_key_id: int, now: Optional[datetime.datetime] = None) -> Tuple[str, int]:
+    """A scoped credential for one key: ``(credential, ttl_seconds)``.
+
+    Raises RuntimeError when no internal secret is configured: without it the
+    credential would be verifiable by nobody, and issuing one would only make
+    the failure look like it is in the key.
+    """
+    secret = _signing_secret()
+    if not secret:
+        raise RuntimeError("No internal secret configured; no batch credential can be issued.")
+    issued = now or datetime.datetime.now(datetime.timezone.utc)
+    expires_at = int(issued.timestamp()) + BATCH_CREDENTIAL_TTL_S
+    payload = _b64encode(
+        json.dumps({"kid": int(api_key_id), "exp": expires_at, "nonce": secrets.token_hex(8)}, sort_keys=True).encode()
+    )
+    signature = _b64encode(hmac.new(secret.encode("utf-8"), payload.encode("ascii"), hashlib.sha256).digest())
+    return f"{BATCH_CREDENTIAL_PREFIX}{payload}.{signature}", BATCH_CREDENTIAL_TTL_S
+
+
+def resolve_batch_credential(credential: str) -> Optional[int]:
+    """The api_key_id a credential names, or None when it is not one of ours.
+
+    None covers every way a value can fail to be a live credential — wrong
+    shape, signature that does not match, expiry passed, no secret
+    configured — and the caller treats it exactly like an unknown key.
+    """
+    if not isinstance(credential, str) or not credential.startswith(BATCH_CREDENTIAL_PREFIX):
+        return None
+    secret = _signing_secret()
+    if not secret:
+        return None
+    body = credential[len(BATCH_CREDENTIAL_PREFIX) :]
+    try:
+        payload, signature = body.rsplit(".", 1)
+        expected = _b64encode(hmac.new(secret.encode("utf-8"), payload.encode("ascii"), hashlib.sha256).digest())
+        if not hmac.compare_digest(signature, expected):
+            return None
+        record = json.loads(_b64decode(payload))
+        api_key_id = int(record["kid"])
+        expires_at = int(record["exp"])
+    except (ValueError, KeyError, TypeError):
+        return None
+    if expires_at < datetime.datetime.now(datetime.timezone.utc).timestamp():
+        return None
+    return api_key_id

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -31,6 +31,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from logos.auth import AuthContext
 from logos.dbutils.dbmanager import DBManager
+from logos.request_content import sanitized_payload_for_logging
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,32 @@ def _result_row(line: Dict[str, Any], result: Dict[str, Any]) -> Tuple[Dict[str,
     return row, failed
 
 
+def _open_line_log(auth: AuthContext, body: Dict[str, Any]) -> Optional[int]:
+    """Open the usage-log row this request line will be metered into.
+
+    The pipeline writes a response's usage onto an existing ``log_entry``; the
+    sync and job paths create it before they call in, and a batch line is no
+    different. Without it the request would run and cost money without ever
+    reaching the ledger.
+    """
+    try:
+        with DBManager() as db:
+            row, code = db.log_usage(
+                api_key_id=auth.api_key_id,
+                team_id=auth.team_id,
+                user_id=auth.user_id,
+                environment=auth.environment,
+                log_level=auth.log_level,
+                client_ip=None,
+                input_payload=sanitized_payload_for_logging(body),
+                headers=None,
+            )
+        return int(row["log-id"]) if code == 200 else None
+    except Exception:  # noqa: BLE001 - a logging failure must not drop the line
+        logger.exception("Could not open a log entry for a batch line")
+        return None
+
+
 async def _run_line(
     line: Dict[str, Any],
     auth: AuthContext,
@@ -141,8 +168,9 @@ async def _run_line(
     body = line.get("body") if isinstance(line.get("body"), dict) else {}
 
     async with semaphore:
+        log_id = _open_line_log(auth, body)
         try:
-            result = await execute_proxy_job(endpoint, dict(headers), dict(body), None, auth, None)
+            result = await execute_proxy_job(endpoint, dict(headers), dict(body), None, auth, log_id)
         except Exception as exc:  # noqa: BLE001 - one bad line must not stop the batch
             logger.exception("Batch line %s failed", line.get("custom_id"))
             result = {"status_code": 500, "data": {"error": {"message": f"{type(exc).__name__}: {exc}"}}}

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -1,0 +1,333 @@
+"""Batches Logos runs itself.
+
+Not every model can be batched at a provider. A model served by a worker node
+has no upstream Batch API at all, and a cloud model can be missing from its
+provider's batch offering (Azure adds models to Batch long after Standard, so
+the newest ones cannot be batched there for months). Those workloads are the
+same workload — many requests, nobody waiting — and researchers should not have
+to write a different client for them.
+
+So Logos runs them itself: the input file is stored here, and each request line
+is scheduled through the ordinary pipeline at the **lowest queue priority**, so
+it fills whatever capacity interactive traffic is not using and finishes as
+soon as that capacity exists. Every line is an ordinary request — authorised,
+routed, logged and metered exactly like one a client sent — which is why a
+Logos-run batch needs no settlement pass afterwards.
+
+The surface is the OpenAI Batch API, unchanged: a script uploads a file, polls
+``GET /v1/batches/{id}`` every few minutes, and downloads
+``output_file_id`` when the status turns terminal — the same code it would run
+against a provider-executed batch, so chaining one batch onto the result of the
+last works either way.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from logos.auth import AuthContext
+from logos.dbutils.dbmanager import DBManager
+
+logger = logging.getLogger(__name__)
+
+# How many of a batch's request lines are in flight at once. They queue at the
+# lowest priority, so this is about not flooding the queue with one batch's
+# worth of entries rather than about capacity — the scheduler decides that.
+LOCAL_BATCH_CONCURRENCY = int(os.getenv("LOGOS_BATCH_LOCAL_CONCURRENCY", "8"))
+
+# How often the runner looks for batches waiting to be executed.
+LOCAL_BATCH_POLL_INTERVAL_S = int(os.getenv("LOGOS_BATCH_LOCAL_POLL_INTERVAL_S", "15"))
+
+# Queue priority a batch line runs at. 1 is LOW on the 1/5/10 scale the
+# scheduler uses: batch work yields to everything interactive.
+LOCAL_BATCH_PRIORITY = 1
+
+_TERMINAL_LOCAL_STATES = {"completed", "failed", "cancelled", "expired"}
+
+# Batches currently being run by this process, so a second pass does not start
+# one twice within the same orchestrator.
+_running: set[int] = set()
+
+
+def new_object_id(prefix: str) -> str:
+    """An id in the provider-ish shape clients expect (``file-…``/``batch_…``)."""
+    separator = "-" if prefix == "file" else "_"
+    return f"{prefix}{separator}{secrets.token_hex(12)}"
+
+
+def auth_context_for_key(api_key_id: int) -> Optional[AuthContext]:
+    """Rebuild the submitting key's auth context, at batch priority.
+
+    The runner acts for the key that submitted the batch, long after its
+    request is gone. ``default_priority`` is forced to LOW rather than taken
+    from the key: a batch is background work even when its owner's interactive
+    traffic is not.
+    """
+    with DBManager() as db:
+        row = db.get_api_key_by_id(api_key_id)
+    if row is None:
+        return None
+    key_type = row["key_type"]
+    if hasattr(key_type, "value"):
+        key_type = key_type.value
+    return AuthContext(
+        key_value=row["key_value"],
+        api_key_id=row["id"],
+        api_key_name=row["name"],
+        key_type=str(key_type),
+        team_id=row["team_id"],
+        user_id=row["user_id"],
+        environment=row["environment"],
+        log_level=row.get("log") or "BILLING",
+        settings=row.get("settings") if row.get("settings") is not None else {},
+        default_priority=LOCAL_BATCH_PRIORITY,
+    )
+
+
+def parse_request_lines(content: bytes) -> List[Dict[str, Any]]:
+    """The request lines of a validated input file, in order."""
+    lines: List[Dict[str, Any]] = []
+    for raw_line in (content or b"").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            line = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(line, dict):
+            lines.append(line)
+    return lines
+
+
+def _result_row(line: Dict[str, Any], result: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    """One output-file row in the shape the Batch API defines."""
+    status_code = int(result.get("status_code") or 500)
+    body = result.get("data")
+    failed = status_code >= 400
+    row: Dict[str, Any] = {
+        "id": new_object_id("resp"),
+        "custom_id": line.get("custom_id"),
+        "response": {"status_code": status_code, "request_id": None, "body": body},
+        "error": None,
+    }
+    if failed:
+        # The Batch API reports a failed line in `error`, with the upstream
+        # body kept in `response` so the caller can still see what happened.
+        message = ""
+        if isinstance(body, dict) and isinstance(body.get("error"), dict):
+            message = str(body["error"].get("message") or "")
+        row["error"] = {"code": str(status_code), "message": message or f"request failed with {status_code}"}
+    return row, failed
+
+
+async def _run_line(
+    line: Dict[str, Any],
+    auth: AuthContext,
+    headers: Dict[str, str],
+    semaphore: asyncio.Semaphore,
+) -> Tuple[Dict[str, Any], bool]:
+    """Run one request line through the ordinary pipeline."""
+    # Imported here rather than at module scope: main imports the batch modules,
+    # so the reverse edge can only be taken once the app is up.
+    from logos.main import execute_proxy_job
+
+    endpoint = str(line.get("url") or "").strip("/")
+    if not endpoint.startswith("v1/"):
+        endpoint = f"v1/{endpoint}"
+    body = line.get("body") if isinstance(line.get("body"), dict) else {}
+
+    async with semaphore:
+        try:
+            result = await execute_proxy_job(endpoint, dict(headers), dict(body), None, auth, None)
+        except Exception as exc:  # noqa: BLE001 - one bad line must not stop the batch
+            logger.exception("Batch line %s failed", line.get("custom_id"))
+            result = {"status_code": 500, "data": {"error": {"message": f"{type(exc).__name__}: {exc}"}}}
+    return _result_row(line, result if isinstance(result, dict) else {})
+
+
+async def run_local_batch(batch: Dict[str, Any]) -> Optional[str]:
+    """Execute one Logos-run batch and store its result file.
+
+    Returns the output file id, or None when the batch could not be started.
+    """
+    batch_object_id = int(batch["id"])
+    if batch_object_id in _running:
+        return None
+    with DBManager() as db:
+        # in_progress rows are re-offered after a restart, so a batch this
+        # process already owns must not be started twice; the conditional
+        # claim only lets the first attempt through.
+        if batch.get("status") == "validating" and not db.claim_local_batch(batch_object_id):
+            return None
+        input_object = db.get_local_object_by_upstream_id("file", str(batch["input_file_id"]))
+        content = db.get_local_batch_file_content(int(input_object["id"])) if input_object else None
+
+    if content is None:
+        logger.error("Batch %s has no readable input file", batch.get("upstream_id"))
+        with DBManager() as db:
+            db.finish_local_batch(batch_object_id, status="failed")
+        return None
+
+    auth = auth_context_for_key(int(batch["api_key_id"])) if batch.get("api_key_id") else None
+    if auth is None:
+        logger.error("Batch %s was submitted by a key that no longer exists", batch.get("upstream_id"))
+        with DBManager() as db:
+            db.finish_local_batch(batch_object_id, status="failed")
+        return None
+
+    _running.add(batch_object_id)
+    try:
+        return await _execute_lines(batch_object_id, batch, parse_request_lines(content), auth)
+    finally:
+        _running.discard(batch_object_id)
+
+
+async def _execute_lines(
+    batch_object_id: int,
+    batch: Dict[str, Any],
+    lines: List[Dict[str, Any]],
+    auth: AuthContext,
+) -> Optional[str]:
+    """Run every line, publishing progress, and write the result file."""
+    headers = {"logos_key": auth.key_value}
+    semaphore = asyncio.Semaphore(max(1, LOCAL_BATCH_CONCURRENCY))
+    rows: List[Dict[str, Any]] = []
+    completed = 0
+    failed = 0
+    cancelled = False
+
+    # Chunked rather than one gather over the whole file: progress becomes
+    # visible while the batch runs, which is what a polling script watches, and
+    # a cancel takes effect within a chunk instead of at the end.
+    chunk_size = max(1, LOCAL_BATCH_CONCURRENCY)
+    for start in range(0, len(lines), chunk_size):
+        with DBManager() as db:
+            if db.update_local_batch_progress(batch_object_id, completed, failed):
+                cancelled = True
+                break
+        chunk = lines[start : start + chunk_size]
+        results = await asyncio.gather(
+            *(_run_line(line, auth, headers, semaphore) for line in chunk), return_exceptions=True
+        )
+        for line, outcome in zip(chunk, results):
+            if isinstance(outcome, BaseException):
+                logger.exception("Batch line %s raised", line.get("custom_id"), exc_info=outcome)
+                row, line_failed = _result_row(line, {"status_code": 500, "data": {"error": {"message": "failed"}}})
+            else:
+                row, line_failed = outcome
+            rows.append(row)
+            if line_failed:
+                failed += 1
+            else:
+                completed += 1
+
+    output_file_id = new_object_id("file")
+    content = ("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n").encode() if rows else b""
+    with DBManager() as db:
+        db.store_local_batch_file(
+            upstream_id=output_file_id,
+            content=content,
+            filename=f"{batch.get('upstream_id')}_output.jsonl",
+            api_key_id=batch.get("api_key_id"),
+            team_id=batch.get("team_id"),
+            user_id=batch.get("user_id"),
+            purpose="batch_output",
+        )
+        db.finish_local_batch(
+            batch_object_id,
+            status="cancelled" if cancelled else "completed",
+            output_file_id=output_file_id,
+            completed=completed,
+            failed=failed,
+        )
+    logger.info(
+        "Local batch %s finished: %d ok, %d failed%s",
+        batch.get("upstream_id"),
+        completed,
+        failed,
+        " (cancelled)" if cancelled else "",
+    )
+    return output_file_id
+
+
+def local_batch_object(batch: Dict[str, Any]) -> Dict[str, Any]:
+    """Render a Logos-run batch as the OpenAI batch object clients expect.
+
+    A polling script must not be able to tell the difference between this and a
+    provider's own object, or the two execution paths would need two clients.
+    """
+
+    def _epoch(value: Any) -> Optional[int]:
+        return int(value.timestamp()) if isinstance(value, datetime) else None
+
+    status = batch.get("status") or "validating"
+    created = _epoch(batch.get("created_at"))
+    finished = _epoch(batch.get("finished_at"))
+    return {
+        "id": batch.get("upstream_id"),
+        "object": "batch",
+        "endpoint": batch.get("endpoint"),
+        "errors": None,
+        "input_file_id": batch.get("input_file_id"),
+        "completion_window": batch.get("completion_window") or "24h",
+        "status": status,
+        "output_file_id": batch.get("output_file_id"),
+        "error_file_id": batch.get("error_file_id"),
+        "created_at": created,
+        "in_progress_at": _epoch(batch.get("started_at")),
+        "expires_at": None,
+        "finalizing_at": finished if status == "completed" else None,
+        "completed_at": finished if status == "completed" else None,
+        "failed_at": finished if status == "failed" else None,
+        "expired_at": finished if status == "expired" else None,
+        "cancelling_at": None,
+        "cancelled_at": finished if status == "cancelled" else None,
+        "request_counts": {
+            "total": int(batch.get("total_requests") or 0),
+            "completed": int(batch.get("completed_requests") or 0),
+            "failed": int(batch.get("failed_requests") or 0),
+        },
+        "metadata": batch.get("request_metadata"),
+        # Not part of the OpenAI object: which side ran the job. A client that
+        # cares whether it got the provider's batch rate can read it; one that
+        # does not can ignore it.
+        "logos_execution": "logos",
+    }
+
+
+def local_file_object(file_row: Dict[str, Any]) -> Dict[str, Any]:
+    """Render a Logos-held file as the OpenAI file object."""
+    created_at = file_row.get("created_at")
+    return {
+        "id": file_row.get("upstream_id"),
+        "object": "file",
+        "bytes": int(file_row.get("size_bytes") or 0),
+        "created_at": int(created_at.timestamp()) if isinstance(created_at, datetime) else None,
+        "filename": file_row.get("filename"),
+        "purpose": file_row.get("status") or "batch",
+        "logos_execution": "logos",
+    }
+
+
+async def local_batch_runner_loop() -> None:
+    """Start every queued Logos-run batch, forever.
+
+    Also picks up batches left ``in_progress`` by a process that died mid-file:
+    their remaining lines are re-run rather than the batch hanging.
+    """
+    while True:
+        try:
+            await asyncio.sleep(LOCAL_BATCH_POLL_INTERVAL_S)
+            with DBManager() as db:
+                pending = db.get_runnable_local_batches()
+            for batch in pending:
+                if int(batch["id"]) not in _running:
+                    asyncio.create_task(run_local_batch(batch))
+        except asyncio.CancelledError:  # pragma: no cover - shutdown path
+            raise
+        except Exception:  # noqa: BLE001 - the loop outlives its failures
+            logger.exception("Local batch runner pass failed")

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -47,11 +47,41 @@ LOCAL_BATCH_POLL_INTERVAL_S = int(os.getenv("LOGOS_BATCH_LOCAL_POLL_INTERVAL_S",
 # scheduler uses: batch work yields to everything interactive.
 LOCAL_BATCH_PRIORITY = 1
 
+# How long the runner's right to a batch lasts before another process may take
+# it over. Refreshed with every chunk of progress, so a live runner holds its
+# batch and a dead one's lease runs out; the trade-off is that a batch whose
+# runner just died stays paused for up to this long before it is resumed.
+LOCAL_BATCH_LEASE_TTL_S = int(os.getenv("LOGOS_BATCH_LEASE_TTL_S", "600"))
+
 _TERMINAL_LOCAL_STATES = {"completed", "failed", "cancelled", "expired"}
+
+# This process, as named in the batch_objects lease. One id per process, so
+# the lease tells the database which runner holds a batch.
+RUNNER_ID = secrets.token_hex(8)
 
 # Batches currently being run by this process, so a second pass does not start
 # one twice within the same orchestrator.
 _running: set[int] = set()
+
+# The background tasks this module starts, held for their whole lifetime.
+# The event loop keeps only weak references to tasks, so an unheld task can be
+# garbage collected while it is still running — which would drop a batch's
+# execution mid-file.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def spawn_background(coro, what: str) -> Optional[asyncio.Task]:
+    """Run a coroutine in the background, holding the task until it finishes."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # no loop (sync test context): nothing can run
+        coro.close()
+        logger.debug("No running loop for %s", what)
+        return None
+    task = loop.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
 
 
 def new_object_id(prefix: str) -> str:
@@ -169,11 +199,22 @@ async def _run_line(
 
     async with semaphore:
         log_id = _open_line_log(auth, body)
+        if log_id is None:
+            # Fail closed: without the log row the pipeline would run the
+            # request and bill nothing, so the line is refused instead of run
+            # unbilled. The batch reports it as a failed line like any other.
+            logger.error("No usage log for batch line %s; refusing to run it unbilled", line.get("custom_id"))
+            return _result_row(
+                line, {"status_code": 500, "data": {"error": {"message": "the request could not be started"}}}
+            )
         try:
             result = await execute_proxy_job(endpoint, dict(headers), dict(body), None, auth, log_id)
-        except Exception as exc:  # noqa: BLE001 - one bad line must not stop the batch
+        except Exception:  # noqa: BLE001 - one bad line must not stop the batch
+            # The exception itself stays in the server log; the result file is
+            # downloadable by the caller, so it carries a generic message
+            # rather than internal details.
             logger.exception("Batch line %s failed", line.get("custom_id"))
-            result = {"status_code": 500, "data": {"error": {"message": f"{type(exc).__name__}: {exc}"}}}
+            result = {"status_code": 500, "data": {"error": {"message": "the request failed"}}}
     return _result_row(line, result if isinstance(result, dict) else {})
 
 
@@ -198,10 +239,12 @@ async def run_local_batch(batch: Dict[str, Any]) -> Optional[str]:
 async def _start(batch: Dict[str, Any], batch_object_id: int) -> Optional[str]:
     """Load a batch's input and hand it to the runner."""
     with DBManager() as db:
-        # in_progress rows are re-offered after a restart, so a batch this
-        # process already owns must not be started twice; the conditional
-        # claim only lets the first attempt through.
-        if batch.get("status") == "validating" and not db.claim_local_batch(batch_object_id):
+        # Every state the runner can take over — queued, or left in_progress
+        # by a process that died — goes through the lease claim. It is what
+        # keeps two processes from running the same batch: a live lease keeps
+        # everyone else out, and an expired one is exactly what makes a dead
+        # runner's batch recoverable.
+        if not db.claim_local_batch(batch_object_id, RUNNER_ID, LOCAL_BATCH_LEASE_TTL_S):
             return None
         input_object = db.get_local_object_by_upstream_id("file", str(batch["input_file_id"]))
         content = db.get_local_batch_file_content(int(input_object["id"])) if input_object else None
@@ -228,39 +271,65 @@ async def _execute_lines(
     lines: List[Dict[str, Any]],
     auth: AuthContext,
 ) -> Optional[str]:
-    """Run every line, publishing progress, and write the result file."""
+    """Run every unfinished line, publishing progress, and write the result file.
+
+    A batch that is resumed after its runner died does not start over: each
+    finished line was checkpointed as it completed, and those lines already
+    went through the pipeline and were billed, so only the lines without a
+    checkpoint are run.
+    """
     headers = {"logos_key": auth.key_value}
     semaphore = asyncio.Semaphore(max(1, LOCAL_BATCH_CONCURRENCY))
-    rows: List[Dict[str, Any]] = []
-    completed = 0
-    failed = 0
+
+    with DBManager() as db:
+        finished = db.get_local_batch_lines(batch_object_id)
+    completed = sum(1 for row in finished.values() if not row.get("error"))
+    failed = len(finished) - completed
+    pending = [line for line in lines if line.get("custom_id") not in finished]
     cancelled = False
 
     # Chunked rather than one gather over the whole file: progress becomes
     # visible while the batch runs, which is what a polling script watches, and
     # a cancel takes effect within a chunk instead of at the end.
     chunk_size = max(1, LOCAL_BATCH_CONCURRENCY)
-    for start in range(0, len(lines), chunk_size):
+    for start in range(0, len(pending), chunk_size):
+        # The progress write is also the lease heartbeat. None means the lease
+        # was lost — another runner took the batch over after it lapsed — and
+        # this one must stop touching it. Its finished lines are checkpointed,
+        # so the new holder resumes from where this one got to.
         with DBManager() as db:
-            if db.update_local_batch_progress(batch_object_id, completed, failed):
-                cancelled = True
-                break
-        chunk = lines[start : start + chunk_size]
+            still_running = db.update_local_batch_progress(
+                batch_object_id, RUNNER_ID, completed, failed, LOCAL_BATCH_LEASE_TTL_S
+            )
+        if still_running is None:
+            logger.warning("Lost the lease on batch %s; another runner takes over", batch.get("upstream_id"))
+            return None
+        if still_running:
+            cancelled = True
+            break
+        chunk = pending[start : start + chunk_size]
         results = await asyncio.gather(
             *(_run_line(line, auth, headers, semaphore) for line in chunk), return_exceptions=True
         )
+        checkpoint: List[Dict[str, Any]] = []
         for line, outcome in zip(chunk, results):
             if isinstance(outcome, BaseException):
                 logger.exception("Batch line %s raised", line.get("custom_id"), exc_info=outcome)
                 row, line_failed = _result_row(line, {"status_code": 500, "data": {"error": {"message": "failed"}}})
             else:
                 row, line_failed = outcome
-            rows.append(row)
+            finished[line.get("custom_id")] = row
             if line_failed:
                 failed += 1
             else:
                 completed += 1
+            checkpoint.append({"custom_id": line.get("custom_id"), "row": row})
+        # Durable per chunk: that is what makes the resume below skip exactly
+        # these lines, no matter when the process dies.
+        with DBManager() as db:
+            db.save_local_batch_lines(batch_object_id, checkpoint)
 
+    rows = [finished[line.get("custom_id")] for line in lines if line.get("custom_id") in finished]
     output_file_id = new_object_id("file")
     content = ("\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n").encode() if rows else b""
     with DBManager() as db:
@@ -352,8 +421,9 @@ def local_file_object(file_row: Dict[str, Any]) -> Dict[str, Any]:
 async def local_batch_runner_loop() -> None:
     """Start every queued Logos-run batch, forever.
 
-    Also picks up batches left ``in_progress`` by a process that died mid-file:
-    their remaining lines are re-run rather than the batch hanging.
+    Also offers batches left ``in_progress`` by a process that died mid-file:
+    the lease claim lets exactly one runner take each of them over, and it
+    resumes from the checkpointed lines rather than re-running the file.
     """
     while True:
         try:
@@ -362,7 +432,9 @@ async def local_batch_runner_loop() -> None:
                 pending = db.get_runnable_local_batches()
             for batch in pending:
                 if int(batch["id"]) not in _running:
-                    asyncio.create_task(run_local_batch(batch))
+                    # The claim each run makes decides across processes; this
+                    # pass simply offers the batch.
+                    spawn_background(run_local_batch(batch), f"local batch {batch.get('upstream_id')}")
         except asyncio.CancelledError:  # pragma: no cover - shutdown path
             raise
         except Exception:  # noqa: BLE001 - the loop outlives its failures

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -185,6 +185,18 @@ async def run_local_batch(batch: Dict[str, Any]) -> Optional[str]:
     batch_object_id = int(batch["id"])
     if batch_object_id in _running:
         return None
+    # Claimed before the first await, so two passes of the runner loop in this
+    # process cannot both take the same batch. The database claim below is the
+    # equivalent guard across processes.
+    _running.add(batch_object_id)
+    try:
+        return await _start(batch, batch_object_id)
+    finally:
+        _running.discard(batch_object_id)
+
+
+async def _start(batch: Dict[str, Any], batch_object_id: int) -> Optional[str]:
+    """Load a batch's input and hand it to the runner."""
     with DBManager() as db:
         # in_progress rows are re-offered after a restart, so a batch this
         # process already owns must not be started twice; the conditional
@@ -207,11 +219,7 @@ async def run_local_batch(batch: Dict[str, Any]) -> Optional[str]:
             db.finish_local_batch(batch_object_id, status="failed")
         return None
 
-    _running.add(batch_object_id)
-    try:
-        return await _execute_lines(batch_object_id, batch, parse_request_lines(content), auth)
-    finally:
-        _running.discard(batch_object_id)
+    return await _execute_lines(batch_object_id, batch, parse_request_lines(content), auth)
 
 
 async def _execute_lines(

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -252,14 +252,14 @@ async def _start(batch: Dict[str, Any], batch_object_id: int) -> Optional[str]:
     if content is None:
         logger.error("Batch %s has no readable input file", batch.get("upstream_id"))
         with DBManager() as db:
-            db.finish_local_batch(batch_object_id, status="failed")
+            db.finish_local_batch(batch_object_id, RUNNER_ID, status="failed")
         return None
 
     auth = auth_context_for_key(int(batch["api_key_id"])) if batch.get("api_key_id") else None
     if auth is None:
         logger.error("Batch %s was submitted by a key that no longer exists", batch.get("upstream_id"))
         with DBManager() as db:
-            db.finish_local_batch(batch_object_id, status="failed")
+            db.finish_local_batch(batch_object_id, RUNNER_ID, status="failed")
         return None
 
     return await _execute_lines(batch_object_id, batch, parse_request_lines(content), auth)
@@ -292,6 +292,10 @@ async def _execute_lines(
     # visible while the batch runs, which is what a polling script watches, and
     # a cancel takes effect within a chunk instead of at the end.
     chunk_size = max(1, LOCAL_BATCH_CONCURRENCY)
+    # The in-chunk heartbeat interval: a single line can legitimately run
+    # longer than the whole lease, and the write before the chunk alone would
+    # let the lease lapse while the lines are in flight.
+    heartbeat_interval = max(0.2, LOCAL_BATCH_LEASE_TTL_S / 3)
     for start in range(0, len(pending), chunk_size):
         # The progress write is also the lease heartbeat. None means the lease
         # was lost — another runner took the batch over after it lapsed — and
@@ -308,9 +312,41 @@ async def _execute_lines(
             cancelled = True
             break
         chunk = pending[start : start + chunk_size]
-        results = await asyncio.gather(
-            *(_run_line(line, auth, headers, semaphore) for line in chunk), return_exceptions=True
+        lost = asyncio.Event()
+        chunk_task = asyncio.ensure_future(
+            asyncio.gather(*(_run_line(line, auth, headers, semaphore) for line in chunk), return_exceptions=True)
         )
+
+        async def _heartbeat(chunk_task=chunk_task):
+            # Refresh the lease while the lines run. A None answer is the
+            # lease being gone: stop this runner before it checkpoints or
+            # finalizes, and cancel the in-flight lines so the new holder's
+            # run of them is not billed twice.
+            while not lost.is_set():
+                await asyncio.sleep(heartbeat_interval)
+                with DBManager() as db:
+                    still = db.update_local_batch_progress(
+                        batch_object_id, RUNNER_ID, completed, failed, LOCAL_BATCH_LEASE_TTL_S
+                    )
+                if still is None:
+                    lost.set()
+                    chunk_task.cancel()
+                    return
+
+        heartbeat_task = asyncio.ensure_future(_heartbeat())
+        try:
+            results = await chunk_task
+        except asyncio.CancelledError:
+            if lost.is_set():
+                logger.warning(
+                    "Lost the lease on batch %s mid-chunk; another runner takes over", batch.get("upstream_id")
+                )
+                return None
+            raise
+        finally:
+            lost.set()
+            if not heartbeat_task.done():
+                heartbeat_task.cancel()
         checkpoint: List[Dict[str, Any]] = []
         for line, outcome in zip(chunk, results):
             if isinstance(outcome, BaseException):
@@ -325,9 +361,11 @@ async def _execute_lines(
                 completed += 1
             checkpoint.append({"custom_id": line.get("custom_id"), "row": row})
         # Durable per chunk: that is what makes the resume below skip exactly
-        # these lines, no matter when the process dies.
+        # these lines, no matter when the process dies. The write is
+        # conditional on the lease — a runner that was deposed mid-batch must
+        # not overwrite the rows the new holder wrote.
         with DBManager() as db:
-            db.save_local_batch_lines(batch_object_id, checkpoint)
+            db.save_local_batch_lines(batch_object_id, RUNNER_ID, checkpoint)
 
     rows = [finished[line.get("custom_id")] for line in lines if line.get("custom_id") in finished]
     output_file_id = new_object_id("file")
@@ -342,13 +380,22 @@ async def _execute_lines(
             user_id=batch.get("user_id"),
             purpose="batch_output",
         )
-        db.finish_local_batch(
+        finished = db.finish_local_batch(
             batch_object_id,
+            RUNNER_ID,
             status="cancelled" if cancelled else "completed",
             output_file_id=output_file_id,
             completed=completed,
             failed=failed,
         )
+    if not finished:
+        # The lease lapsed before the close-out; the new holder resumes from
+        # the checkpoint (every line is written by now) and finalizes the
+        # batch. This runner reports no result of its own.
+        logger.warning(
+            "Lost the lease on batch %s before finalizing; the new holder closes it out", batch.get("upstream_id")
+        )
+        return None
     logger.info(
         "Local batch %s finished: %d ok, %d failed%s",
         batch.get("upstream_id"),

--- a/logos/logos-orchestrator/src/logos/batch_local.py
+++ b/logos/logos-orchestrator/src/logos/batch_local.py
@@ -318,16 +318,22 @@ async def _execute_lines(
         )
 
         async def _heartbeat(chunk_task=chunk_task):
-            # Refresh the lease while the lines run. A None answer is the
+            # Refresh the lease while the lines run. A None answer — or a
+            # check that failed, which fails closed the same way, because a
+            # heartbeat that cannot confirm the lease cannot keep it — is the
             # lease being gone: stop this runner before it checkpoints or
             # finalizes, and cancel the in-flight lines so the new holder's
             # run of them is not billed twice.
             while not lost.is_set():
                 await asyncio.sleep(heartbeat_interval)
-                with DBManager() as db:
-                    still = db.update_local_batch_progress(
-                        batch_object_id, RUNNER_ID, completed, failed, LOCAL_BATCH_LEASE_TTL_S
-                    )
+                try:
+                    with DBManager() as db:
+                        still = db.update_local_batch_progress(
+                            batch_object_id, RUNNER_ID, completed, failed, LOCAL_BATCH_LEASE_TTL_S
+                        )
+                except Exception:  # noqa: BLE001 - the batch resumes from its checkpoint
+                    logger.exception("Lease heartbeat failed for batch %s", batch.get("upstream_id"))
+                    still = None
                 if still is None:
                     lost.set()
                     chunk_task.cancel()
@@ -347,6 +353,13 @@ async def _execute_lines(
             lost.set()
             if not heartbeat_task.done():
                 heartbeat_task.cancel()
+            # Await the cleanup so the heartbeat cannot outlive the chunk: an
+            # unawaited, uncancelled task would keep refreshing a lease this
+            # runner is done with.
+            try:
+                await heartbeat_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001 - its state is in `lost`
+                pass
         checkpoint: List[Dict[str, Any]] = []
         for line, outcome in zip(chunk, results):
             if isinstance(outcome, BaseException):

--- a/logos/logos-orchestrator/src/logos/billing/budget.py
+++ b/logos/logos-orchestrator/src/logos/billing/budget.py
@@ -1,0 +1,48 @@
+"""Monthly budget enforcement, shared by the request pipeline and the Batch API."""
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from logos.auth import AuthContext
+    from logos.dbutils.dbmanager import DBManager
+
+
+def check_monthly_budget(db: "DBManager", auth: "AuthContext", is_cloud: bool, month_start: str) -> None:
+    """
+    Raise HTTPException(402) if this key/team is over its monthly budget.
+
+    Only cloud usage is metered (logosnode/local providers have no configured
+    token pricing in token_prices, so they always cost $0), so this is a
+    no-op when the request that actually got scheduled isn't routing to a
+    cloud provider at all. Called post-scheduling (see _execute_resource_mode)
+    with the real resolved provider type, not a guess from the permission list --
+    that's what lets this be exact for mixed cloud+local keys instead of only
+    for pure-type ones.
+    """
+    if not is_cloud:
+        return
+
+    key_type = getattr(auth, "key_type", "user")
+
+    if key_type == "application":
+        app_budget_limit = db.get_api_key_budget_limit(auth.api_key_id)
+        if app_budget_limit is not None:
+            app_used = db.get_api_key_budget_usage(auth.api_key_id, month_start)
+            if app_used >= app_budget_limit:
+                raise HTTPException(status_code=402, detail="Application monthly budget exceeded.")
+    else:
+        if auth.team_id is not None:
+            team_info = db.get_team(auth.team_id)
+            if team_info and team_info.get("team_monthly_budget_micro_cents"):
+                team_limit = team_info["team_monthly_budget_micro_cents"]
+                team_used = db.get_team_budget_usage(auth.team_id, month_start)
+                if team_used >= team_limit:
+                    raise HTTPException(status_code=402, detail="Team monthly budget exceeded. Contact your admin.")
+
+        personal_limit = db.get_api_key_budget_limit(auth.api_key_id)
+        if personal_limit is not None:
+            personal_used = db.get_api_key_budget_usage(auth.api_key_id, month_start)
+            if personal_used >= personal_limit:
+                raise HTTPException(status_code=402, detail="Personal monthly budget exceeded.")

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -54,6 +54,13 @@ DEFAULT_LOCAL_TPM_LIMIT = 10000
 DEFAULT_MONTHLY_BUDGET_MICRO_CENTS = 100000000
 TEAM_MONTHLY_BUDGET_MICRO_CENTS = 500000000
 
+# How long a learned "this provider does not batch this model" fact is trusted
+# before the model is offered to the provider again. Generous, because the
+# change it guards against (the provider adding the model to Batch) is rare —
+# and the cost of a stale row is one more failed batch, from which the row is
+# re-learned only if the refusal repeats.
+BATCH_MODEL_ELIGIBILITY_TTL_DAYS = int(os.getenv("LOGOS_BATCH_MODEL_ELIGIBILITY_TTL_DAYS", "90"))
+
 # Derived from the ThresholdLevel declaration order (the single definition —
 # see that class for the trust ordering and the copies this mirrors): a new
 # level added to the enum is accepted by provider registration automatically.
@@ -2381,6 +2388,59 @@ class DBManager:
         )
         self.session.commit()
 
+    def get_batch_model_ineligibility(self, provider_id: int) -> set:
+        """The model ids this provider is known not to batch, right now.
+
+        Feeds the choice of where a batch runs: a model on this list counts as
+        not hosted for Batch, so a file naming it runs in Logos instead of
+        being forwarded to a provider that would refuse it. Rows expire after
+        the eligibility TTL — a model the provider adds to Batch later is
+        picked up automatically.
+        """
+        rows = self.session.execute(
+            text(
+                """
+                SELECT model_id FROM provider_model_batch_eligibility
+                WHERE provider_id = :pid AND eligible = false
+                  AND checked_at > :now - make_interval(days => :ttl)
+                """
+            ),
+            {
+                "pid": int(provider_id),
+                "now": datetime.datetime.now(datetime.timezone.utc),
+                "ttl": int(BATCH_MODEL_ELIGIBILITY_TTL_DAYS),
+            },
+        ).fetchall()
+        return {int(row[0]) for row in rows}
+
+    def record_model_batch_ineligibility(self, provider_id: int, model_id: int, detail: str = "") -> None:
+        """Remember that the provider refused to batch one of its models.
+
+        Learned from the provider's own refusal — a batch creation refused for
+        the model, or a batch that finished failed with its SKU error — rather
+        than configured, because which models a resource offers for batch is a
+        fact about the upstream that changes on the provider's schedule.
+        """
+        self.session.execute(
+            text(
+                """
+                INSERT INTO provider_model_batch_eligibility (provider_id, model_id, eligible, detail, checked_at)
+                VALUES (:pid, :mid, false, :detail, :now)
+                ON CONFLICT (provider_id, model_id)
+                DO UPDATE SET eligible = false,
+                              detail = EXCLUDED.detail,
+                              checked_at = EXCLUDED.checked_at
+                """
+            ),
+            {
+                "pid": int(provider_id),
+                "mid": int(model_id),
+                "detail": (detail or "")[:500],
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
     def get_batch_model_deployments(self, api_key_id: int, provider_id: Optional[int] = None) -> list[Dict[str, Any]]:
         """The models this key may run, with the provider that serves each.
 
@@ -2474,19 +2534,27 @@ class DBManager:
         user_id: Optional[int],
         input_file_id: Optional[str] = None,
         status: Optional[str] = None,
+        models: Optional[List[str]] = None,
     ) -> None:
-        """Record who owns an object the provider just minted."""
+        """Record who owns an object the provider just minted.
+
+        ``models`` is the input file's Logos model names, kept on file rows:
+        when the provider later shows it cannot batch one of them, the batch
+        that named them is the evidence, and this list is what still says which
+        models the file asked for.
+        """
         self.session.execute(
             text(
                 """
                 INSERT INTO batch_objects
                     (kind, upstream_id, provider_id, api_key_id, team_id, user_id,
-                     input_file_id, status, created_at, updated_at)
+                     input_file_id, status, models, created_at, updated_at)
                 VALUES (:kind, :upstream_id, :provider_id, :api_key_id, :team_id, :user_id,
-                        :input_file_id, :status, :now, :now)
+                        :input_file_id, :status, CAST(:models AS JSONB), :now, :now)
                 ON CONFLICT (provider_id, kind, upstream_id)
                 DO UPDATE SET status = COALESCE(EXCLUDED.status, batch_objects.status),
                               input_file_id = COALESCE(EXCLUDED.input_file_id, batch_objects.input_file_id),
+                              models = COALESCE(EXCLUDED.models, batch_objects.models),
                               updated_at = EXCLUDED.updated_at
                 """
             ),
@@ -2499,6 +2567,7 @@ class DBManager:
                 "user_id": user_id,
                 "input_file_id": input_file_id,
                 "status": status,
+                "models": _json_for_jsonb(models) if models else None,
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         )
@@ -2521,25 +2590,48 @@ class DBManager:
         )
         return dict(row) if row else None
 
-    def list_batch_objects_for_team(self, team_id: Optional[int], kind: str, limit: int = 100) -> list[Dict[str, Any]]:
-        """The team's own batch objects of one kind, newest first.
+    def list_batch_objects_for_principal(
+        self,
+        kind: str,
+        team_id: Optional[int],
+        user_id: Optional[int],
+        api_key_id: int,
+        limit: int = 100,
+    ) -> list[Dict[str, Any]]:
+        """The caller's own batch objects of one kind, newest first.
 
         Listings are answered from here rather than by forwarding to the
         provider: the shared upstream credential sees every team's objects, and
         Logos minted all of its own, so its own record is both the safe answer
         and the complete one — it covers batches it ran itself, which no
         provider knows about.
+
+        The scope is the same principal predicate a lifecycle check uses: a
+        team sees the team's objects, and a team-less key sees only what its
+        own user created (falling back to the key itself when even that is
+        absent). Scoping team-less keys by "team_id IS NULL" alone would let
+        every personal key on the instance list — and reach — every other
+        personal key's objects.
         """
+        if team_id is not None:
+            where = "kind = :kind AND team_id = :team_id"
+            params: Dict[str, Any] = {"kind": kind, "team_id": int(team_id), "limit": int(limit)}
+        elif user_id is not None:
+            where = "kind = :kind AND team_id IS NULL AND user_id = :user_id"
+            params = {"kind": kind, "user_id": int(user_id), "limit": int(limit)}
+        else:
+            where = "kind = :kind AND api_key_id = :api_key_id"
+            params = {"kind": kind, "api_key_id": int(api_key_id), "limit": int(limit)}
         row_set = self.session.execute(
             text(
-                """
+                f"""
                 SELECT * FROM batch_objects
-                WHERE kind = :kind AND team_id IS NOT DISTINCT FROM :team_id
+                WHERE {where}
                 ORDER BY created_at DESC
                 LIMIT :limit
                 """
             ),
-            {"kind": kind, "team_id": team_id, "limit": int(limit)},
+            params,
         ).mappings()
         return [dict(row) for row in row_set.all()]
 
@@ -2742,21 +2834,38 @@ class DBManager:
         )
         return dict(row) if row else None
 
-    def claim_local_batch(self, batch_object_id: int) -> bool:
-        """Move a queued batch to in_progress; False when another runner won it.
+    def claim_local_batch(self, batch_object_id: int, runner_id: str, lease_seconds: int) -> bool:
+        """Take the lease on a Logos-run batch; False when another runner holds it.
 
-        Conditional on the status, so two orchestrator processes cannot run the
-        same file twice.
+        Queued batches (``validating``) and batches left behind by a dead
+        runner (``in_progress`` with an expired lease) are claimed the same
+        way: the conditional update stamps ``runner_id`` and a lease deadline,
+        and only lets a caller through when no *live* lease exists. That is
+        what separates "the process is gone, recover the batch" from "another
+        replica is running it right now, stay out" — without the lease the
+        recovery path that re-offers in_progress rows would run an active
+        batch a second time.
         """
         result = self.session.execute(
             text(
                 """
                 UPDATE batch_objects
-                SET status = 'in_progress', started_at = COALESCE(started_at, :now), updated_at = :now
-                WHERE id = :id AND kind = 'batch' AND execution = 'logos' AND status = 'validating'
+                SET status = CASE WHEN status = 'validating' THEN 'in_progress' ELSE status END,
+                    started_at = COALESCE(started_at, :now),
+                    runner_id = :runner,
+                    lease_expires_at = :now + make_interval(secs => :lease),
+                    updated_at = :now
+                WHERE id = :id AND kind = 'batch' AND execution = 'logos'
+                  AND status IN ('validating', 'in_progress', 'cancelling')
+                  AND (runner_id IS NULL OR lease_expires_at IS NULL OR lease_expires_at <= :now)
                 """
             ),
-            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
+            {
+                "id": int(batch_object_id),
+                "runner": str(runner_id),
+                "lease": int(lease_seconds),
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
         )
         self.session.commit()
         return bool(result.rowcount)
@@ -2782,26 +2891,42 @@ class DBManager:
         ).mappings()
         return [dict(row) for row in rows.all()]
 
-    def update_local_batch_progress(self, batch_object_id: int, completed: int, failed: int) -> bool:
-        """Publish how far the runner has got, and report a pending cancel."""
+    def update_local_batch_progress(
+        self, batch_object_id: int, runner_id: str, completed: int, failed: int, lease_seconds: int
+    ) -> Optional[bool]:
+        """Publish how far the runner has got, refreshing the lease on the way.
+
+        The progress row doubles as the heartbeat: while the runner makes
+        progress the lease stays alive, and a runner that stops writing stops
+        holding the batch. Conditional on the lease: when another runner took
+        the batch over after an expired lease, this caller must stop touching
+        the row instead of clobbering the new holder's counters and lease.
+
+        Returns whether a cancel is pending, or ``None`` when this runner no
+        longer holds the batch.
+        """
         row = self.session.execute(
             text(
                 """
                 UPDATE batch_objects
-                SET completed_requests = :completed, failed_requests = :failed, updated_at = :now
-                WHERE id = :id
+                SET completed_requests = :completed, failed_requests = :failed,
+                    lease_expires_at = :now + make_interval(secs => :lease),
+                    updated_at = :now
+                WHERE id = :id AND runner_id = :runner
                 RETURNING cancel_requested
                 """
             ),
             {
                 "id": int(batch_object_id),
+                "runner": str(runner_id),
                 "completed": int(completed),
                 "failed": int(failed),
+                "lease": int(lease_seconds),
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         ).fetchone()
         self.session.commit()
-        return bool(row[0]) if row else False
+        return bool(row[0]) if row else None
 
     def finish_local_batch(
         self,
@@ -2828,6 +2953,8 @@ class DBManager:
                     error_file_id = COALESCE(:error_file_id, error_file_id),
                     completed_requests = COALESCE(:completed, completed_requests),
                     failed_requests = COALESCE(:failed, failed_requests),
+                    runner_id = NULL,
+                    lease_expires_at = NULL,
                     finished_at = :now,
                     settled_at = :now,
                     updated_at = :now
@@ -2866,6 +2993,53 @@ class DBManager:
             {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
         )
         self.session.commit()
+
+    def save_local_batch_lines(self, batch_object_id: int, rows: List[Dict[str, Any]]) -> None:
+        """Persist finished request lines of a Logos-run batch as its checkpoint.
+
+        One durable write per finished line, keyed by its custom_id, so a
+        resumed batch knows exactly which lines are done and can skip them —
+        including the result row the output file will carry for them.
+        """
+        if not rows:
+            return
+        params: Dict[str, Any] = {}
+        for index, row in enumerate(rows):
+            params[f"id_{index}"] = int(batch_object_id)
+            params[f"cid_{index}"] = row["custom_id"]
+            params[f"row_{index}"] = _json_for_jsonb(row["row"])
+            params[f"now_{index}"] = datetime.datetime.now(datetime.timezone.utc)
+        self.session.execute(
+            text(
+                """
+                INSERT INTO batch_line_results (batch_object_id, custom_id, row, finished_at)
+                VALUES
+                """
+                + ", ".join(f"(:id_{i}, :cid_{i}, CAST(:row_{i} AS JSONB), :now_{i})" for i in range(len(rows)))
+                + """
+                ON CONFLICT (batch_object_id, custom_id)
+                DO UPDATE SET row = EXCLUDED.row, finished_at = EXCLUDED.finished_at
+                """
+            ),
+            params,
+        )
+        self.session.commit()
+
+    def get_local_batch_lines(self, batch_object_id: int) -> Dict[str, Dict[str, Any]]:
+        """The batch's checkpoint: custom_id → the result row already written.
+
+        A resumed batch runs only the lines missing here.
+        """
+        rows = self.session.execute(
+            text(
+                """
+                SELECT custom_id, row FROM batch_line_results
+                WHERE batch_object_id = :id
+                """
+            ),
+            {"id": int(batch_object_id)},
+        ).mappings()
+        return {row["custom_id"]: row["row"] for row in rows.all()}
 
     def get_api_key_by_id(self, api_key_id: int) -> Optional[Dict[str, Any]]:
         """One active api key by id, in the shape ``authenticate_api_key`` uses.
@@ -2970,15 +3144,34 @@ class DBManager:
                          service_tier, result_status, error_message)
                     VALUES """
                     + ", ".join(values_sql)
-                    + " RETURNING id"
+                    + " RETURNING id, request_id"
                 ),
                 params,
             ).fetchall()
-            log_ids = [int(record[0]) for record in inserted]
+            # The rows come back keyed by the request_id they were inserted
+            # with, not by position: a multi-row INSERT ... RETURNING does not
+            # guarantee that the returned order matches the VALUES order, and
+            # a positional zip could attach one line's usage tokens to another
+            # line's log row — settling the cost against the wrong request.
+            log_ids_by_request: Dict[str, int] = {}
+            orphaned_ids: List[int] = []
+            for log_id, request_id in ((int(record[0]), record[1]) for record in inserted):
+                if request_id is None:
+                    orphaned_ids.append(log_id)
+                else:
+                    log_ids_by_request[str(request_id)] = log_id
+            log_ids = list(log_ids_by_request.values()) + orphaned_ids
 
             usage_values = []
             usage_params: Dict[str, Any] = {}
-            for index, (log_id, row) in enumerate(zip(log_ids, chunk)):
+            for index, row in enumerate(chunk):
+                request_id = row.get("request_id")
+                if request_id is not None:
+                    log_id = log_ids_by_request.get(str(request_id))
+                else:
+                    # A row without a request id has no identity to match on;
+                    # it takes the next id the insert returned without one.
+                    log_id = orphaned_ids.pop(0) if orphaned_ids else log_ids[index]
                 for token_type, token_count in (row.get("usage") or {}).items():
                     if not isinstance(token_count, int) or isinstance(token_count, bool) or token_count <= 0:
                         continue

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2542,8 +2542,14 @@ class DBManager:
         when the provider later shows it cannot batch one of them, the batch
         that named them is the evidence, and this list is what still says which
         models the file asked for.
+
+        An id is globally unique — a client supplies the id without the
+        provider that minted it, so one id may not name two objects. A row
+        another provider already holds therefore makes the upsert a no-op,
+        which this reports as an error; the caller then removes the provider
+        object again instead of letting the collision stand.
         """
-        self.session.execute(
+        result = self.session.execute(
             text(
                 """
                 INSERT INTO batch_objects
@@ -2551,16 +2557,16 @@ class DBManager:
                      input_file_id, status, models, created_at, updated_at)
                 VALUES (:kind, :upstream_id, :provider_id, :api_key_id, :team_id, :user_id,
                         :input_file_id, :status, CAST(:models AS JSONB), :now, :now)
-                -- The conflict target must mirror the uq_batch_objects_upstream
-                -- index expression (COALESCE, not the bare column: a Logos-run
-                -- object has no provider, and NULLs would compare as distinct) —
-                -- a bare-column target does not match an expression index and
-                -- the statement fails outright in PostgreSQL.
-                ON CONFLICT (COALESCE(provider_id, 0), kind, upstream_id)
+                -- The upsert only takes the row of the provider that minted
+                -- the id: when another provider already holds it the DO
+                -- UPDATE matches nothing (rowcount 0), and the caller turns
+                -- that into the unrecorded-ownership error.
+                ON CONFLICT (kind, upstream_id)
                 DO UPDATE SET status = COALESCE(EXCLUDED.status, batch_objects.status),
                               input_file_id = COALESCE(EXCLUDED.input_file_id, batch_objects.input_file_id),
                               models = COALESCE(EXCLUDED.models, batch_objects.models),
                               updated_at = EXCLUDED.updated_at
+                WHERE COALESCE(batch_objects.provider_id, 0) = COALESCE(EXCLUDED.provider_id, 0)
                 """
             ),
             {
@@ -2576,14 +2582,17 @@ class DBManager:
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         )
+        if result.rowcount == 0:
+            raise RuntimeError(f"batch object id {upstream_id!r} is already held by another provider")
         self.session.commit()
 
     def get_batch_object(self, kind: str, upstream_id: str) -> Optional[Dict[str, Any]]:
         """The ownership row for one id, or None when Logos never minted it.
 
-        Keyed by the id alone: a caller supplies an id, not a provider, and
-        this row is what says where the object lives — or that Logos runs it
-        itself.
+        The id is globally unique (one row per kind, across providers and
+        Logos itself), so the lookup is unambiguous: a caller supplies an id,
+        not a provider, and this row is what says where the object lives — or
+        that Logos runs it itself.
         """
         row = (
             self.session.execute(

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2551,7 +2551,12 @@ class DBManager:
                      input_file_id, status, models, created_at, updated_at)
                 VALUES (:kind, :upstream_id, :provider_id, :api_key_id, :team_id, :user_id,
                         :input_file_id, :status, CAST(:models AS JSONB), :now, :now)
-                ON CONFLICT (provider_id, kind, upstream_id)
+                -- The conflict target must mirror the uq_batch_objects_upstream
+                -- index expression (COALESCE, not the bare column: a Logos-run
+                -- object has no provider, and NULLs would compare as distinct) —
+                -- a bare-column target does not match an expression index and
+                -- the statement fails outright in PostgreSQL.
+                ON CONFLICT (COALESCE(provider_id, 0), kind, upstream_id)
                 DO UPDATE SET status = COALESCE(EXCLUDED.status, batch_objects.status),
                               input_file_id = COALESCE(EXCLUDED.input_file_id, batch_objects.input_file_id),
                               models = COALESCE(EXCLUDED.models, batch_objects.models),
@@ -2653,31 +2658,62 @@ class DBManager:
         )
         self.session.commit()
 
-    def claim_batch_for_settlement(self, batch_object_id: int) -> bool:
-        """Latch a batch for metering; False when someone else already did.
+    def claim_batch_for_settlement(self, batch_object_id: int, lease_seconds: int = 1800) -> bool:
+        """Take the settlement lease on a finished batch; False when held.
 
         The client's own poll and the reconciler can reach a finished batch at
         the same time. The conditional update makes the winner exclusive, so
         the output file is billed exactly once.
+
+        The claim is a *lease*, not the ``settled_at`` stamp: the stamp only
+        goes on once the usage rows are durably written. A settlement that
+        dies between the two (the process exits, the task is cancelled) must
+        stay retryable — stamping first would put the batch out of the
+        reconciler's reach forever and its cost with it. The lease expires on
+        its own, which is the recovery; the usage write itself is idempotent,
+        so a lease that lapses mid-settlement cannot double-bill.
         """
         result = self.session.execute(
             text(
                 """
                 UPDATE batch_objects
-                SET settled_at = :now, updated_at = :now
+                SET settlement_lease_expires_at = :now + make_interval(secs => :lease), updated_at = :now
                 WHERE id = :id AND settled_at IS NULL
+                  AND (settlement_lease_expires_at IS NULL OR settlement_lease_expires_at <= :now)
                 """
             ),
-            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
+            {
+                "id": int(batch_object_id),
+                "lease": int(lease_seconds),
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
         )
         self.session.commit()
         return bool(result.rowcount)
 
     def release_batch_settlement(self, batch_object_id: int) -> None:
-        """Undo a settlement latch whose metering failed, so it is retried."""
+        """Give up a settlement lease whose metering failed, so it is retried now."""
         self.session.execute(
-            text("UPDATE batch_objects SET settled_at = NULL WHERE id = :id"),
+            text("UPDATE batch_objects SET settlement_lease_expires_at = NULL WHERE id = :id AND settled_at IS NULL"),
             {"id": int(batch_object_id)},
+        )
+        self.session.commit()
+
+    def mark_batch_settled(self, batch_object_id: int) -> None:
+        """Stamp a batch settled, once its usage rows are durably written.
+
+        Only from here on does the reconciler leave the batch alone; whatever
+        was written before this point is either idempotent or already skipped.
+        """
+        self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET settled_at = :now, settlement_lease_expires_at = NULL, updated_at = :now
+                WHERE id = :id
+                """
+            ),
+            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
         )
         self.session.commit()
 
@@ -2931,20 +2967,26 @@ class DBManager:
     def finish_local_batch(
         self,
         batch_object_id: int,
+        runner_id: str,
         *,
         status: str,
         output_file_id: Optional[str] = None,
         error_file_id: Optional[str] = None,
         completed: Optional[int] = None,
         failed: Optional[int] = None,
-    ) -> None:
+    ) -> bool:
         """Close out a Logos-run batch.
 
         ``settled_at`` is stamped here: its requests went through the ordinary
         pipeline and were metered one by one as they ran, so there is nothing
         left for the settlement pass to book.
+
+        Conditional on the lease like every other runner write: a runner whose
+        lease lapsed must not finalize a batch another runner is running, or
+        the new holder's in-flight lines would end in a batch that reports
+        "completed" without them.
         """
-        self.session.execute(
+        result = self.session.execute(
             text(
                 """
                 UPDATE batch_objects
@@ -2958,11 +3000,12 @@ class DBManager:
                     finished_at = :now,
                     settled_at = :now,
                     updated_at = :now
-                WHERE id = :id
+                WHERE id = :id AND runner_id = :runner
                 """
             ),
             {
                 "id": int(batch_object_id),
+                "runner": str(runner_id),
                 "status": status,
                 "output_file_id": output_file_id,
                 "error_file_id": error_file_id,
@@ -2972,11 +3015,32 @@ class DBManager:
             },
         )
         self.session.commit()
+        return bool(result.rowcount)
 
     def delete_batch_object(self, batch_object_id: int) -> None:
         """Drop a Logos-held object and its bytes."""
         self.session.execute(text("DELETE FROM batch_objects WHERE id = :id"), {"id": int(batch_object_id)})
         self.session.commit()
+
+    def count_nonterminal_batches_for_input_file(self, input_file_id: str) -> int:
+        """How many Logos-run batches not yet finished still read this file.
+
+        The runner loads the input's bytes when it starts, not when the batch
+        is created, so deleting the file a validating or in-progress batch
+        references would strand that batch: it would find no content and fail
+        one it was accepted to run.
+        """
+        row = self.session.execute(
+            text(
+                """
+                SELECT count(*) FROM batch_objects
+                WHERE kind = 'batch' AND execution = 'logos' AND input_file_id = :file_id
+                  AND status IN ('validating', 'in_progress', 'cancelling')
+                """
+            ),
+            {"file_id": str(input_file_id)},
+        ).fetchone()
+        return int(row[0]) if row else 0
 
     def request_local_batch_cancel(self, batch_object_id: int) -> None:
         """Ask the runner to stop before its next request line."""
@@ -2994,16 +3058,22 @@ class DBManager:
         )
         self.session.commit()
 
-    def save_local_batch_lines(self, batch_object_id: int, rows: List[Dict[str, Any]]) -> None:
+    def save_local_batch_lines(self, batch_object_id: int, runner_id: str, rows: List[Dict[str, Any]]) -> None:
         """Persist finished request lines of a Logos-run batch as its checkpoint.
 
         One durable write per finished line, keyed by its custom_id, so a
         resumed batch knows exactly which lines are done and can skip them —
         including the result row the output file will carry for them.
+
+        The update half is conditional on the batch still naming ``runner_id``
+        as its holder: a runner whose lease lapsed and who is deposed must not
+        overwrite the result row the new holder wrote for the same line. A new
+        line's insert is left unconditional on purpose — that line ran and was
+        billed, and the new holder should resume past it, not replay it.
         """
         if not rows:
             return
-        params: Dict[str, Any] = {}
+        params: Dict[str, Any] = {"runner": str(runner_id)}
         for index, row in enumerate(rows):
             params[f"id_{index}"] = int(batch_object_id)
             params[f"cid_{index}"] = row["custom_id"]
@@ -3019,6 +3089,8 @@ class DBManager:
                 + """
                 ON CONFLICT (batch_object_id, custom_id)
                 DO UPDATE SET row = EXCLUDED.row, finished_at = EXCLUDED.finished_at
+                WHERE (SELECT runner_id FROM batch_objects
+                       WHERE id = batch_line_results.batch_object_id) = :runner
                 """
             ),
             params,
@@ -3101,7 +3173,13 @@ class DBManager:
         when no batch rate is configured for the model, so an unpriced batch is
         over- rather than under-charged.
 
-        Returns the number of rows written.
+        Idempotent per row: each row's ``request_id`` is scoped to its batch
+        and unique in ``log_entry``, so a settlement that is retried after a
+        partial commit (a chunk committed before the process died) skips the
+        rows the earlier attempt already booked instead of colliding with the
+        unique index and stalling the batch forever.
+
+        Returns the number of rows written by this call.
         """
         if not rows:
             return 0
@@ -3144,7 +3222,12 @@ class DBManager:
                          service_tier, result_status, error_message)
                     VALUES """
                     + ", ".join(values_sql)
-                    + " RETURNING id, request_id"
+                    + """
+                    -- A row whose request_id the ledger already holds was
+                    -- committed by an earlier attempt of this same settlement
+                    -- (the chunks commit before the batch is marked settled);
+                    -- it is skipped, not an error.
+                    ON CONFLICT (request_id) DO NOTHING RETURNING id, request_id"""
                 ),
                 params,
             ).fetchall()
@@ -3153,6 +3236,8 @@ class DBManager:
             # guarantee that the returned order matches the VALUES order, and
             # a positional zip could attach one line's usage tokens to another
             # line's log row — settling the cost against the wrong request.
+            # A row an earlier attempt of this settlement already committed is
+            # not among the returned ids at all — and is not a failure.
             log_ids_by_request: Dict[str, int] = {}
             orphaned_ids: List[int] = []
             for log_id, request_id in ((int(record[0]), record[1]) for record in inserted):
@@ -3168,6 +3253,10 @@ class DBManager:
                 request_id = row.get("request_id")
                 if request_id is not None:
                     log_id = log_ids_by_request.get(str(request_id))
+                    if log_id is None:
+                        # Already booked by an earlier attempt of this
+                        # settlement: its tokens went in with the row.
+                        continue
                 else:
                     # A row without a request id has no identity to match on;
                     # it takes the next id the insert returned without one.

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2596,7 +2596,7 @@ class DBManager:
                 """
                 SELECT id, upstream_id, provider_id, api_key_id, team_id, user_id, status
                 FROM batch_objects
-                WHERE kind = 'batch' AND settled_at IS NULL
+                WHERE kind = 'batch' AND settled_at IS NULL AND execution = 'provider'
                 ORDER BY created_at
                 LIMIT :limit
                 """
@@ -2772,7 +2772,8 @@ class DBManager:
                 """
                 SELECT id, upstream_id, input_file_id, endpoint, api_key_id, team_id, user_id, status
                 FROM batch_objects
-                WHERE kind = 'batch' AND execution = 'logos' AND status IN ('validating', 'in_progress')
+                WHERE kind = 'batch' AND execution = 'logos'
+                  AND status IN ('validating', 'in_progress', 'cancelling')
                 ORDER BY created_at
                 LIMIT :limit
                 """

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2668,9 +2668,11 @@ class DBManager:
 
         The listing is served from this record, not from the provider, so the
         fields it cannot render — the result file a terminal answer names and
-        the running request counts — must be stored with the status.
-        ``COALESCE`` keeps what an earlier poll stored when a later answer
-        omits a field.
+        the running request counts — must be stored with the status. The
+        counts travel under the nested ``request_counts`` object the provider
+        reports progress in (the older flat fields are accepted as a
+        fallback). ``COALESCE`` keeps what an earlier poll stored when a
+        later answer omits a field.
         """
         if not isinstance(body, dict):
             return
@@ -2679,11 +2681,20 @@ class DBManager:
             value = body.get(field)
             return value if isinstance(value, str) and value else None
 
-        def _count(field: str) -> Optional[int]:
-            value = body.get(field)
+        def _count(source: Dict[str, Any], field: str) -> Optional[int]:
+            value = source.get(field)
             if isinstance(value, bool) or not isinstance(value, int):
                 return None
             return max(value, 0)
+
+        counts = body.get("request_counts")
+        if not isinstance(counts, dict):
+            # The older Batch API shape reports the same three numbers flat.
+            counts = {
+                "total": body.get("total_requests"),
+                "completed": body.get("completed_requests"),
+                "failed": body.get("failed_requests"),
+            }
 
         status = body.get("status")
         if not isinstance(status, str):
@@ -2707,9 +2718,9 @@ class DBManager:
                 "status": status,
                 "output_file_id": _text("output_file_id"),
                 "error_file_id": _text("error_file_id"),
-                "total_requests": _count("total_requests"),
-                "completed_requests": _count("completed_requests"),
-                "failed_requests": _count("failed_requests"),
+                "total_requests": _count(counts, "total"),
+                "completed_requests": _count(counts, "completed"),
+                "failed_requests": _count(counts, "failed"),
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         )

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2262,6 +2262,761 @@ class DBManager:
         rows = self.session.execute(sql, {"api_key_id": api_key_id}).mappings().all()
         return [cast(Deployment, dict(row)) for row in rows]
 
+    def get_batch_provider_candidates(self, api_key_id: int) -> list[Dict[str, Any]]:
+        """Cloud providers the api key may use, as Batch API forward targets.
+
+        Provider-level rather than model-level: a batch-creation body carries
+        no ``model``, so model links are not part of its routing — the
+        effective-provider resolution (per-key permissions when the key opts
+        into custom permissions, the team's otherwise) is the whole of it.
+        ``logosnode`` providers are excluded: worker nodes serve no Batch API.
+
+        ``api_key`` mirrors the inference forward's credential resolution
+        (``get_auth_info_to_deployment``): a provider-level key, or the key of
+        one of its model links when only those are filled in. ``supports_batch``
+        is the cached probe result — NULL when the provider was never probed,
+        which the resolver treats as "ask the upstream now".
+        """
+        sql = text(
+            """
+                   WITH key_info AS (
+                            SELECT ak.id AS aki,
+                                   ak.team_id AS tid,
+                                   ak.use_custom_permissions AS custom
+                            FROM api_keys ak
+                            WHERE ak.id = :api_key_id
+                                AND ak.is_active = true
+                        ),
+                        effective_providers AS (
+                            SELECT akpp.provider_id
+                            FROM api_key_provider_permissions akpp, key_info ki
+                            WHERE akpp.api_key_id = ki.aki AND ki.custom = true
+                            UNION
+                            SELECT tpp.provider_id
+                            FROM team_provider_permissions tpp, key_info ki
+                            WHERE tpp.team_id = ki.tid AND ki.custom = false
+                        )
+                   SELECT p.id,
+                          p.name,
+                          p.base_url,
+                          p.cloud_provider_type,
+                          p.auth_name,
+                          p.auth_format,
+                          COALESCE(
+                              NULLIF(p.api_key, ''),
+                              (SELECT NULLIF(mp.api_key, '')
+                               FROM model_provider mp
+                               WHERE mp.provider_id = p.id AND NULLIF(mp.api_key, '') IS NOT NULL
+                               ORDER BY mp.id
+                               LIMIT 1)
+                          ) AS api_key,
+                          pbc.supports_batch,
+                          pbc.checked_at AS capability_checked_at
+                   FROM providers p
+                        JOIN effective_providers ep ON p.id = ep.provider_id
+                        LEFT JOIN provider_batch_capability pbc ON pbc.provider_id = p.id
+                   WHERE p.provider_type = 'cloud'
+                     AND COALESCE(NULLIF(TRIM(p.base_url), ''), NULL) IS NOT NULL
+                   ORDER BY p.id
+                   """
+        )
+        rows = self.session.execute(sql, {"api_key_id": int(api_key_id)}).mappings().all()
+        return [dict(row) for row in rows]
+
+    def get_batch_provider(self, provider_id: int) -> Optional[Dict[str, Any]]:
+        """One provider's Batch API forward inputs, outside any key's scope.
+
+        The settlement path runs long after the request that created the batch,
+        so it addresses the provider by id rather than through the caller's
+        permissions.
+        """
+        row = (
+            self.session.execute(
+                text(
+                    """
+                SELECT p.id,
+                       p.name,
+                       p.base_url,
+                       p.cloud_provider_type,
+                       p.auth_name,
+                       p.auth_format,
+                       COALESCE(
+                           NULLIF(p.api_key, ''),
+                           (SELECT NULLIF(mp.api_key, '')
+                            FROM model_provider mp
+                            WHERE mp.provider_id = p.id AND NULLIF(mp.api_key, '') IS NOT NULL
+                            ORDER BY mp.id
+                            LIMIT 1)
+                       ) AS api_key
+                FROM providers p
+                WHERE p.id = :provider_id
+                """
+                ),
+                {"provider_id": int(provider_id)},
+            )
+            .mappings()
+            .first()
+        )
+        return dict(row) if row else None
+
+    def record_provider_batch_capability(self, provider_id: int, supports_batch: bool, detail: str = "") -> None:
+        """Cache what a Batch API probe found for one provider."""
+        self.session.execute(
+            text(
+                """
+                INSERT INTO provider_batch_capability (provider_id, supports_batch, detail, checked_at)
+                VALUES (:pid, :supports, :detail, :now)
+                ON CONFLICT (provider_id)
+                DO UPDATE SET supports_batch = EXCLUDED.supports_batch,
+                              detail = EXCLUDED.detail,
+                              checked_at = EXCLUDED.checked_at
+                """
+            ),
+            {
+                "pid": int(provider_id),
+                "supports": bool(supports_batch),
+                "detail": (detail or "")[:500],
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
+    def get_batch_model_deployments(self, api_key_id: int, provider_id: Optional[int] = None) -> list[Dict[str, Any]]:
+        """The models this key may run, with the provider that serves each.
+
+        A batch input file names a model per line, so the uploader needs both
+        halves of the answer: which models the key may run at all (to refuse
+        the rest) and where each of them can run (to decide whether the whole
+        file can go to one provider's Batch API, or has to be executed here).
+        On Azure the request body names the *deployment*, which the endpoint
+        carries.
+
+        Passing ``provider_id`` narrows the answer to one provider.
+        """
+        scope = "WHERE mp.provider_id = :provider_id" if provider_id is not None else ""
+        sql = text(
+            f"""
+                   WITH key_info AS (
+                            SELECT ak.id AS aki,
+                                   ak.team_id AS tid,
+                                   ak.use_custom_permissions AS custom
+                            FROM api_keys ak
+                            WHERE ak.id = :api_key_id AND ak.is_active = true
+                        ),
+                        effective_models AS (
+                            SELECT akmp.model_id
+                            FROM api_key_model_permissions akmp, key_info ki
+                            WHERE akmp.api_key_id = ki.aki AND ki.custom = true
+                            UNION
+                            SELECT tmp.model_id
+                            FROM team_model_permissions tmp, key_info ki
+                            WHERE tmp.team_id = ki.tid AND ki.custom = false
+                        ),
+                        effective_providers AS (
+                            SELECT akpp.provider_id
+                            FROM api_key_provider_permissions akpp, key_info ki
+                            WHERE akpp.api_key_id = ki.aki AND ki.custom = true
+                            UNION
+                            SELECT tpp.provider_id
+                            FROM team_provider_permissions tpp, key_info ki
+                            WHERE tpp.team_id = ki.tid AND ki.custom = false
+                        )
+                   SELECT m.id AS model_id,
+                          m.name AS model_name,
+                          mp.endpoint AS endpoint,
+                          p.id AS provider_id,
+                          p.provider_type AS provider_type,
+                          p.cloud_provider_type AS cloud_provider_type
+                   FROM models m
+                        JOIN model_provider mp ON mp.model_id = m.id
+                        JOIN providers p ON p.id = mp.provider_id
+                        JOIN effective_models em ON em.model_id = m.id
+                        JOIN effective_providers ep ON ep.provider_id = p.id
+                   {scope}
+                   ORDER BY m.name, p.id
+                   """
+        )
+        params: Dict[str, Any] = {"api_key_id": int(api_key_id)}
+        if provider_id is not None:
+            params["provider_id"] = int(provider_id)
+        return [dict(row) for row in self.session.execute(sql, params).mappings().all()]
+
+    def get_provider_model_deployments(self, provider_id: int) -> list[Dict[str, Any]]:
+        """Every model link of a provider, permissions aside.
+
+        The settlement path needs the reverse of the upload's translation: an
+        output row names the deployment the provider ran, which has to map back
+        to the Logos model whose prices apply. It runs after the fact, outside
+        any key's permission scope, so it reads the full link table.
+        """
+        rows = self.session.execute(
+            text(
+                """
+                SELECT m.id AS model_id, m.name AS model_name, mp.endpoint AS endpoint
+                FROM model_provider mp
+                     JOIN models m ON m.id = mp.model_id
+                WHERE mp.provider_id = :provider_id
+                ORDER BY m.name
+                """
+            ),
+            {"provider_id": int(provider_id)},
+        ).mappings()
+        return [dict(row) for row in rows.all()]
+
+    def register_batch_object(
+        self,
+        *,
+        kind: str,
+        upstream_id: str,
+        provider_id: int,
+        api_key_id: Optional[int],
+        team_id: Optional[int],
+        user_id: Optional[int],
+        input_file_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        """Record who owns an object the provider just minted."""
+        self.session.execute(
+            text(
+                """
+                INSERT INTO batch_objects
+                    (kind, upstream_id, provider_id, api_key_id, team_id, user_id,
+                     input_file_id, status, created_at, updated_at)
+                VALUES (:kind, :upstream_id, :provider_id, :api_key_id, :team_id, :user_id,
+                        :input_file_id, :status, :now, :now)
+                ON CONFLICT (provider_id, kind, upstream_id)
+                DO UPDATE SET status = COALESCE(EXCLUDED.status, batch_objects.status),
+                              input_file_id = COALESCE(EXCLUDED.input_file_id, batch_objects.input_file_id),
+                              updated_at = EXCLUDED.updated_at
+                """
+            ),
+            {
+                "kind": kind,
+                "upstream_id": upstream_id,
+                "provider_id": int(provider_id),
+                "api_key_id": api_key_id,
+                "team_id": team_id,
+                "user_id": user_id,
+                "input_file_id": input_file_id,
+                "status": status,
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
+    def get_batch_object(self, kind: str, upstream_id: str) -> Optional[Dict[str, Any]]:
+        """The ownership row for one id, or None when Logos never minted it.
+
+        Keyed by the id alone: a caller supplies an id, not a provider, and
+        this row is what says where the object lives — or that Logos runs it
+        itself.
+        """
+        row = (
+            self.session.execute(
+                text("SELECT * FROM batch_objects WHERE kind = :kind AND upstream_id = :upstream_id"),
+                {"kind": kind, "upstream_id": upstream_id},
+            )
+            .mappings()
+            .first()
+        )
+        return dict(row) if row else None
+
+    def list_batch_objects_for_team(self, team_id: Optional[int], kind: str, limit: int = 100) -> list[Dict[str, Any]]:
+        """The team's own batch objects of one kind, newest first.
+
+        Listings are answered from here rather than by forwarding to the
+        provider: the shared upstream credential sees every team's objects, and
+        Logos minted all of its own, so its own record is both the safe answer
+        and the complete one — it covers batches it ran itself, which no
+        provider knows about.
+        """
+        row_set = self.session.execute(
+            text(
+                """
+                SELECT * FROM batch_objects
+                WHERE kind = :kind AND team_id IS NOT DISTINCT FROM :team_id
+                ORDER BY created_at DESC
+                LIMIT :limit
+                """
+            ),
+            {"kind": kind, "team_id": team_id, "limit": int(limit)},
+        ).mappings()
+        return [dict(row) for row in row_set.all()]
+
+    def update_batch_object_status(self, upstream_id: str, status: Optional[str]) -> None:
+        """Store the status a poll just reported for a batch."""
+        self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET status = COALESCE(:status, status), updated_at = :now
+                WHERE kind = 'batch' AND upstream_id = :upstream_id
+                """
+            ),
+            {
+                "upstream_id": upstream_id,
+                "status": status,
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
+    def claim_batch_for_settlement(self, batch_object_id: int) -> bool:
+        """Latch a batch for metering; False when someone else already did.
+
+        The client's own poll and the reconciler can reach a finished batch at
+        the same time. The conditional update makes the winner exclusive, so
+        the output file is billed exactly once.
+        """
+        result = self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET settled_at = :now, updated_at = :now
+                WHERE id = :id AND settled_at IS NULL
+                """
+            ),
+            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
+        )
+        self.session.commit()
+        return bool(result.rowcount)
+
+    def release_batch_settlement(self, batch_object_id: int) -> None:
+        """Undo a settlement latch whose metering failed, so it is retried."""
+        self.session.execute(
+            text("UPDATE batch_objects SET settled_at = NULL WHERE id = :id"),
+            {"id": int(batch_object_id)},
+        )
+        self.session.commit()
+
+    def get_unsettled_batches(self, limit: int = 50) -> list[Dict[str, Any]]:
+        """Batches whose usage has not been booked yet, oldest first."""
+        rows = self.session.execute(
+            text(
+                """
+                SELECT id, upstream_id, provider_id, api_key_id, team_id, user_id, status
+                FROM batch_objects
+                WHERE kind = 'batch' AND settled_at IS NULL
+                ORDER BY created_at
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        ).mappings()
+        return [dict(row) for row in rows.all()]
+
+    # ---- Batches Logos runs itself -------------------------------------
+
+    def store_local_batch_file(
+        self,
+        *,
+        upstream_id: str,
+        content: bytes,
+        filename: str,
+        api_key_id: Optional[int],
+        team_id: Optional[int],
+        user_id: Optional[int],
+        purpose: str = "batch",
+    ) -> int:
+        """Keep a file Logos runs a batch from (or wrote results to).
+
+        A forwarded batch leaves its files at the provider; a Logos-run one has
+        nowhere else to put them, and the UI has to hand the results back to a
+        browser.
+        """
+        row = self.session.execute(
+            text(
+                """
+                INSERT INTO batch_objects
+                    (kind, upstream_id, execution, api_key_id, team_id, user_id,
+                     filename, size_bytes, status, created_at, updated_at)
+                VALUES ('file', :upstream_id, 'logos', :api_key_id, :team_id, :user_id,
+                        :filename, :size_bytes, :purpose, :now, :now)
+                RETURNING id
+                """
+            ),
+            {
+                "upstream_id": upstream_id,
+                "api_key_id": api_key_id,
+                "team_id": team_id,
+                "user_id": user_id,
+                "filename": filename,
+                "size_bytes": len(content),
+                "purpose": purpose,
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        ).fetchone()
+        object_id = int(row[0])
+        self.session.execute(
+            text("INSERT INTO batch_file_contents (batch_object_id, content) VALUES (:id, :content)"),
+            {"id": object_id, "content": content},
+        )
+        self.session.commit()
+        return object_id
+
+    def get_local_batch_file_content(self, batch_object_id: int) -> Optional[bytes]:
+        """The stored bytes of a Logos-held file."""
+        row = self.session.execute(
+            text("SELECT content FROM batch_file_contents WHERE batch_object_id = :id"),
+            {"id": int(batch_object_id)},
+        ).fetchone()
+        if row is None:
+            return None
+        content = row[0]
+        return bytes(content) if content is not None else None
+
+    def create_local_batch(
+        self,
+        *,
+        upstream_id: str,
+        input_file_id: str,
+        endpoint: str,
+        completion_window: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        total_requests: int,
+        api_key_id: Optional[int],
+        team_id: Optional[int],
+        user_id: Optional[int],
+    ) -> int:
+        """Record a batch Logos will execute itself, ready for the runner."""
+        row = self.session.execute(
+            text(
+                """
+                INSERT INTO batch_objects
+                    (kind, upstream_id, execution, api_key_id, team_id, user_id,
+                     input_file_id, endpoint, completion_window, request_metadata,
+                     total_requests, status, created_at, updated_at)
+                VALUES ('batch', :upstream_id, 'logos', :api_key_id, :team_id, :user_id,
+                        :input_file_id, :endpoint, :completion_window, CAST(:metadata AS JSONB),
+                        :total, 'validating', :now, :now)
+                RETURNING id
+                """
+            ),
+            {
+                "upstream_id": upstream_id,
+                "api_key_id": api_key_id,
+                "team_id": team_id,
+                "user_id": user_id,
+                "input_file_id": input_file_id,
+                "endpoint": endpoint,
+                "completion_window": completion_window,
+                "metadata": _json_for_jsonb(metadata) if metadata else None,
+                "total": int(total_requests),
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        ).fetchone()
+        self.session.commit()
+        return int(row[0])
+
+    def get_local_batch(self, upstream_id: str) -> Optional[Dict[str, Any]]:
+        """One Logos-run batch by the id its client holds."""
+        row = (
+            self.session.execute(
+                text(
+                    """
+                SELECT * FROM batch_objects
+                WHERE kind = 'batch' AND execution = 'logos' AND upstream_id = :upstream_id
+                """
+                ),
+                {"upstream_id": upstream_id},
+            )
+            .mappings()
+            .first()
+        )
+        return dict(row) if row else None
+
+    def get_local_object_by_upstream_id(self, kind: str, upstream_id: str) -> Optional[Dict[str, Any]]:
+        """One Logos-held file or batch, whatever its state."""
+        row = (
+            self.session.execute(
+                text(
+                    """
+                SELECT * FROM batch_objects
+                WHERE kind = :kind AND execution = 'logos' AND upstream_id = :upstream_id
+                """
+                ),
+                {"kind": kind, "upstream_id": upstream_id},
+            )
+            .mappings()
+            .first()
+        )
+        return dict(row) if row else None
+
+    def claim_local_batch(self, batch_object_id: int) -> bool:
+        """Move a queued batch to in_progress; False when another runner won it.
+
+        Conditional on the status, so two orchestrator processes cannot run the
+        same file twice.
+        """
+        result = self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET status = 'in_progress', started_at = COALESCE(started_at, :now), updated_at = :now
+                WHERE id = :id AND kind = 'batch' AND execution = 'logos' AND status = 'validating'
+                """
+            ),
+            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
+        )
+        self.session.commit()
+        return bool(result.rowcount)
+
+    def get_runnable_local_batches(self, limit: int = 20) -> list[Dict[str, Any]]:
+        """Queued Logos-run batches, oldest first.
+
+        ``in_progress`` rows are included so a batch whose runner died with the
+        process is picked up again after a restart instead of hanging forever.
+        """
+        rows = self.session.execute(
+            text(
+                """
+                SELECT id, upstream_id, input_file_id, endpoint, api_key_id, team_id, user_id, status
+                FROM batch_objects
+                WHERE kind = 'batch' AND execution = 'logos' AND status IN ('validating', 'in_progress')
+                ORDER BY created_at
+                LIMIT :limit
+                """
+            ),
+            {"limit": int(limit)},
+        ).mappings()
+        return [dict(row) for row in rows.all()]
+
+    def update_local_batch_progress(self, batch_object_id: int, completed: int, failed: int) -> bool:
+        """Publish how far the runner has got, and report a pending cancel."""
+        row = self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET completed_requests = :completed, failed_requests = :failed, updated_at = :now
+                WHERE id = :id
+                RETURNING cancel_requested
+                """
+            ),
+            {
+                "id": int(batch_object_id),
+                "completed": int(completed),
+                "failed": int(failed),
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        ).fetchone()
+        self.session.commit()
+        return bool(row[0]) if row else False
+
+    def finish_local_batch(
+        self,
+        batch_object_id: int,
+        *,
+        status: str,
+        output_file_id: Optional[str] = None,
+        error_file_id: Optional[str] = None,
+        completed: Optional[int] = None,
+        failed: Optional[int] = None,
+    ) -> None:
+        """Close out a Logos-run batch.
+
+        ``settled_at`` is stamped here: its requests went through the ordinary
+        pipeline and were metered one by one as they ran, so there is nothing
+        left for the settlement pass to book.
+        """
+        self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET status = :status,
+                    output_file_id = COALESCE(:output_file_id, output_file_id),
+                    error_file_id = COALESCE(:error_file_id, error_file_id),
+                    completed_requests = COALESCE(:completed, completed_requests),
+                    failed_requests = COALESCE(:failed, failed_requests),
+                    finished_at = :now,
+                    settled_at = :now,
+                    updated_at = :now
+                WHERE id = :id
+                """
+            ),
+            {
+                "id": int(batch_object_id),
+                "status": status,
+                "output_file_id": output_file_id,
+                "error_file_id": error_file_id,
+                "completed": completed,
+                "failed": failed,
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
+    def delete_batch_object(self, batch_object_id: int) -> None:
+        """Drop a Logos-held object and its bytes."""
+        self.session.execute(text("DELETE FROM batch_objects WHERE id = :id"), {"id": int(batch_object_id)})
+        self.session.commit()
+
+    def request_local_batch_cancel(self, batch_object_id: int) -> None:
+        """Ask the runner to stop before its next request line."""
+        self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET cancel_requested = true,
+                    status = CASE WHEN status IN ('validating', 'in_progress') THEN 'cancelling' ELSE status END,
+                    updated_at = :now
+                WHERE id = :id
+                """
+            ),
+            {"id": int(batch_object_id), "now": datetime.datetime.now(datetime.timezone.utc)},
+        )
+        self.session.commit()
+
+    def get_api_key_by_id(self, api_key_id: int) -> Optional[Dict[str, Any]]:
+        """One active api key by id, in the shape ``authenticate_api_key`` uses.
+
+        The local batch runner acts for the key that submitted the batch long
+        after its request is gone, so it rebuilds the auth context from here.
+        """
+        row = (
+            self.session.execute(
+                text(
+                    """
+                SELECT ak.id, ak.key_value, ak.name, ak.key_type, ak.team_id, ak.user_id,
+                       ak.environment, ak.log, ak.settings, ak.default_priority
+                FROM api_keys ak
+                WHERE ak.id = :api_key_id AND ak.is_active = true
+                """
+                ),
+                {"api_key_id": int(api_key_id)},
+            )
+            .mappings()
+            .first()
+        )
+        return dict(row) if row else None
+
+    def get_api_key_logging_context(self, api_key_id: int) -> Dict[str, Any]:
+        """The environment and privacy level a key's log rows are written with.
+
+        The batch settlement runs long after the request that created the
+        batch, so it cannot take these off an AuthContext and reads them back
+        from the key instead.
+        """
+        row = (
+            self.session.execute(
+                text("SELECT environment, log FROM api_keys WHERE id = :api_key_id"),
+                {"api_key_id": int(api_key_id)},
+            )
+            .mappings()
+            .first()
+        )
+        if not row:
+            return {"environment": None, "log_level": "BILLING"}
+        log_level = row["log"]
+        if hasattr(log_level, "value"):
+            log_level = log_level.value
+        return {"environment": row["environment"], "log_level": log_level or "BILLING"}
+
+    def record_batch_usage(self, rows: list[Dict[str, Any]], chunk_size: int = 500) -> int:
+        """Book one finished batch request per row into the usage ledger.
+
+        A batch result file holds what would otherwise have been thousands of
+        individual proxied requests, so each row becomes an ordinary
+        ``log_entry`` with its own usage — that is what makes batch spend show
+        up in the same budget, statistics and export surfaces as everything
+        else. Rows are written in chunks (one multi-row INSERT each) because a
+        single batch can carry tens of thousands of them.
+
+        ``service_tier='batch'`` is what makes the price lookup pick the
+        provider's discounted batch rate; it falls back to the standard price
+        when no batch rate is configured for the model, so an unpriced batch is
+        over- rather than under-charged.
+
+        Returns the number of rows written.
+        """
+        if not rows:
+            return 0
+
+        type_ids: Dict[str, int] = {}
+        written = 0
+        for start in range(0, len(rows), max(1, chunk_size)):
+            chunk = rows[start : start + max(1, chunk_size)]
+            values_sql = []
+            params: Dict[str, Any] = {}
+            for index, row in enumerate(chunk):
+                values_sql.append(
+                    f"(:ts_{index}, :ts_{index}, :aki_{index}, :tid_{index}, :uid_{index}, :env_{index}, "
+                    f"CAST(:privacy_{index} AS logging_enum), :pid_{index}, :mid_{index}, :rid_{index}, "
+                    f":tier_{index}, CAST(:status_{index} AS result_status_enum), :err_{index})"
+                )
+                params.update(
+                    {
+                        f"ts_{index}": row["timestamp"],
+                        f"aki_{index}": row.get("api_key_id"),
+                        f"tid_{index}": row.get("team_id"),
+                        f"uid_{index}": row.get("user_id"),
+                        f"env_{index}": row.get("environment"),
+                        f"privacy_{index}": row.get("privacy_level") or "BILLING",
+                        f"pid_{index}": row.get("provider_id"),
+                        f"mid_{index}": row.get("model_id"),
+                        f"rid_{index}": row.get("request_id"),
+                        f"tier_{index}": row.get("service_tier") or "batch",
+                        f"status_{index}": row.get("result_status") or "success",
+                        f"err_{index}": row.get("error_message"),
+                    }
+                )
+
+            inserted = self.session.execute(
+                text(
+                    """
+                    INSERT INTO log_entry
+                        (timestamp_request, timestamp_response, api_key_id, team_id, user_id,
+                         environment, privacy_level, provider_id, model_id, request_id,
+                         service_tier, result_status, error_message)
+                    VALUES """
+                    + ", ".join(values_sql)
+                    + " RETURNING id"
+                ),
+                params,
+            ).fetchall()
+            log_ids = [int(record[0]) for record in inserted]
+
+            usage_values = []
+            usage_params: Dict[str, Any] = {}
+            for index, (log_id, row) in enumerate(zip(log_ids, chunk)):
+                for token_type, token_count in (row.get("usage") or {}).items():
+                    if not isinstance(token_count, int) or isinstance(token_count, bool) or token_count <= 0:
+                        continue
+                    if token_type not in type_ids:
+                        result, _ = self.add_token_type(token_type, "")
+                        if "error" in result:
+                            continue
+                        type_ids[token_type] = result["token-type-id"]
+                    slot = len(usage_values)
+                    usage_values.append(f"(:log_{slot}, :type_{slot}, :count_{slot})")
+                    usage_params[f"log_{slot}"] = log_id
+                    usage_params[f"type_{slot}"] = type_ids[token_type]
+                    usage_params[f"count_{slot}"] = token_count
+
+            if usage_values:
+                self.session.execute(
+                    text(
+                        "INSERT INTO usage_tokens (log_entry_id, type_id, token_count) VALUES "
+                        + ", ".join(usage_values)
+                        + " ON CONFLICT (log_entry_id, type_id) DO UPDATE SET token_count = EXCLUDED.token_count"
+                    ),
+                    usage_params,
+                )
+            self.session.commit()
+
+            # Same pricing path as an ordinary finalisation, so a batch row is
+            # priced by the one function that prices everything else.
+            try:
+                self.session.execute(
+                    text(_SETTLED_COST_SNAPSHOT_SQL.format(where_clause="le.id = ANY(:log_ids)")),
+                    {"log_ids": log_ids},
+                )
+                self.session.commit()
+            except Exception as exc:  # noqa: BLE001 - snapshot must not lose the usage rows
+                self.session.rollback()
+                logger.warning("settled-cost snapshot failed for %d batch rows: %s", len(log_ids), exc)
+            written += len(log_ids)
+        return written
+
     # ADMIN ONLY
     def get_all_deployments(self) -> list[Deployment]:
         """

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2641,7 +2641,12 @@ class DBManager:
         return [dict(row) for row in row_set.all()]
 
     def update_batch_object_status(self, upstream_id: str, status: Optional[str]) -> None:
-        """Store the status a poll just reported for a batch."""
+        """Store the status a poll just reported for a batch.
+
+        A missing status only stamps the check (``updated_at``): the
+        unsettled-batches window leads with the least recently checked, and a
+        check that could not run must rotate its batch to the back of it.
+        """
         self.session.execute(
             text(
                 """
@@ -2653,6 +2658,58 @@ class DBManager:
             {
                 "upstream_id": upstream_id,
                 "status": status,
+                "now": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
+        self.session.commit()
+
+    def record_batch_provider_state(self, upstream_id: str, body: Dict[str, Any]) -> None:
+        """Sync the state a provider answer reports for one of Logos' batches.
+
+        The listing is served from this record, not from the provider, so the
+        fields it cannot render — the result file a terminal answer names and
+        the running request counts — must be stored with the status.
+        ``COALESCE`` keeps what an earlier poll stored when a later answer
+        omits a field.
+        """
+        if not isinstance(body, dict):
+            return
+
+        def _text(field: str) -> Optional[str]:
+            value = body.get(field)
+            return value if isinstance(value, str) and value else None
+
+        def _count(field: str) -> Optional[int]:
+            value = body.get(field)
+            if isinstance(value, bool) or not isinstance(value, int):
+                return None
+            return max(value, 0)
+
+        status = body.get("status")
+        if not isinstance(status, str):
+            status = None
+        self.session.execute(
+            text(
+                """
+                UPDATE batch_objects
+                SET status = COALESCE(:status, status),
+                    output_file_id = COALESCE(:output_file_id, output_file_id),
+                    error_file_id = COALESCE(:error_file_id, error_file_id),
+                    total_requests = COALESCE(:total_requests, total_requests),
+                    completed_requests = COALESCE(:completed_requests, completed_requests),
+                    failed_requests = COALESCE(:failed_requests, failed_requests),
+                    updated_at = :now
+                WHERE kind = 'batch' AND upstream_id = :upstream_id
+                """
+            ),
+            {
+                "upstream_id": upstream_id,
+                "status": status,
+                "output_file_id": _text("output_file_id"),
+                "error_file_id": _text("error_file_id"),
+                "total_requests": _count("total_requests"),
+                "completed_requests": _count("completed_requests"),
+                "failed_requests": _count("failed_requests"),
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         )
@@ -2718,14 +2775,20 @@ class DBManager:
         self.session.commit()
 
     def get_unsettled_batches(self, limit: int = 50) -> list[Dict[str, Any]]:
-        """Batches whose usage has not been booked yet, oldest first."""
+        """Batches whose usage has not been booked yet, least recently checked first.
+
+        The least recently checked lead the window, not the oldest created:
+        the reconciler stamps every batch it has looked at, so one that is
+        still moving at the provider rotates to the back and a queue of fifty
+        that never finish cannot starve the batches behind them.
+        """
         rows = self.session.execute(
             text(
                 """
                 SELECT id, upstream_id, provider_id, api_key_id, team_id, user_id, status
                 FROM batch_objects
                 WHERE kind = 'batch' AND settled_at IS NULL AND execution = 'provider'
-                ORDER BY created_at
+                ORDER BY updated_at
                 LIMIT :limit
                 """
             ),

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmanager.py
@@ -2535,6 +2535,7 @@ class DBManager:
         input_file_id: Optional[str] = None,
         status: Optional[str] = None,
         models: Optional[List[str]] = None,
+        provider_object_id: Optional[str] = None,
     ) -> None:
         """Record who owns an object the provider just minted.
 
@@ -2542,6 +2543,11 @@ class DBManager:
         when the provider later shows it cannot batch one of them, the batch
         that named them is the evidence, and this list is what still says which
         models the file asked for.
+
+        ``provider_object_id`` is the object's own id at the provider, when
+        ``upstream_id`` is a Logos-facing name instead: result files are
+        exposed under Logos's ids, and the download forward resolves back to
+        the provider's through this column.
 
         An id is globally unique — a client supplies the id without the
         provider that minted it, so one id may not name two objects. A row
@@ -2554,9 +2560,9 @@ class DBManager:
                 """
                 INSERT INTO batch_objects
                     (kind, upstream_id, provider_id, api_key_id, team_id, user_id,
-                     input_file_id, status, models, created_at, updated_at)
+                     input_file_id, status, models, provider_object_id, created_at, updated_at)
                 VALUES (:kind, :upstream_id, :provider_id, :api_key_id, :team_id, :user_id,
-                        :input_file_id, :status, CAST(:models AS JSONB), :now, :now)
+                        :input_file_id, :status, CAST(:models AS JSONB), :provider_object_id, :now, :now)
                 -- The upsert only takes the row of the provider that minted
                 -- the id: when another provider already holds it the DO
                 -- UPDATE matches nothing (rowcount 0), and the caller turns
@@ -2565,6 +2571,8 @@ class DBManager:
                 DO UPDATE SET status = COALESCE(EXCLUDED.status, batch_objects.status),
                               input_file_id = COALESCE(EXCLUDED.input_file_id, batch_objects.input_file_id),
                               models = COALESCE(EXCLUDED.models, batch_objects.models),
+                              provider_object_id = COALESCE(EXCLUDED.provider_object_id,
+                                                            batch_objects.provider_object_id),
                               updated_at = EXCLUDED.updated_at
                 WHERE COALESCE(batch_objects.provider_id, 0) = COALESCE(EXCLUDED.provider_id, 0)
                 """
@@ -2579,6 +2587,7 @@ class DBManager:
                 "input_file_id": input_file_id,
                 "status": status,
                 "models": _json_for_jsonb(models) if models else None,
+                "provider_object_id": provider_object_id,
                 "now": datetime.datetime.now(datetime.timezone.utc),
             },
         )

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
@@ -407,6 +407,16 @@ class BatchObject(Base):
     completed_requests = Column(Integer, nullable=False, default=0)
     failed_requests = Column(Integer, nullable=False, default=0)
     cancel_requested = Column(Boolean, nullable=False, default=False)
+    # The Logos model names a batch input file asks for, as uploaded. When a
+    # forwarded batch turns out that the provider cannot batch one of them,
+    # this is what gets marked as not batch-eligible on that provider.
+    models = Column(JSON)
+    # Lease of the runner currently executing a Logos-run batch: which process
+    # holds it, and until when. A row whose lease is expired (or empty) is
+    # recoverable, so a batch whose runner died is picked up again — but a
+    # batch another live process is running is not.
+    runner_id = Column(Text)
+    lease_expires_at = Column(TIMESTAMP(timezone=True))
     started_at = Column(TIMESTAMP(timezone=True))
     finished_at = Column(TIMESTAMP(timezone=True))
     created_at = Column(
@@ -451,6 +461,64 @@ class ProviderBatchCapability(Base):
     supports_batch = Column(Boolean, nullable=False, default=False)
     detail = Column(Text)
     checked_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+class ProviderModelBatchEligibility(Base):
+    """Per-model Batch eligibility on one provider, as learned from the provider.
+
+    Serving a model and serving it *for batch* are two different things: an
+    Azure resource answers its Batch API with a Global-Batch deployment for
+    each model it offers for that, and a model that only exists as a Standard
+    deployment cannot be batched there no matter how capable the resource
+    looks. The Batch API does not publish a model list for its batch endpoint,
+    so the knowledge is learned from the provider's own refusals (a batch
+    creation or a failed batch naming the unsupported model) and tracked here —
+    one row per model, with the detail of what the provider said.
+
+    Absence means "unknown", which routes to the provider as before (its error
+    is then passed through and can teach this table); an ``eligible = false``
+    row is what moves the batch to Logos execution. Rows expire after a TTL so
+    a model the provider adds to Batch later is picked up automatically, at the
+    price of one more failed batch.
+    """
+
+    __tablename__ = "provider_model_batch_eligibility"
+    __table_args__ = (UniqueConstraint("provider_id", "model_id", name="uq_provider_model_batch_eligibility"),)
+
+    id = Column(BigInteger, primary_key=True)
+    provider_id = Column(Integer, ForeignKey("providers.id", ondelete="CASCADE"), nullable=False)
+    model_id = Column(Integer, ForeignKey("models.id", ondelete="CASCADE"), nullable=False)
+    eligible = Column(Boolean, nullable=False, default=False)
+    detail = Column(Text)
+    checked_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+class BatchLineResult(Base):
+    """One finished request line of a Logos-run batch, keyed by its custom_id.
+
+    The runner persists each line's result as it completes, so a batch whose
+    runner died (or was redeployed) is resumed from the checkpoint rather than
+    replayed from line zero — the finished lines were already sent through the
+    pipeline and already billed, and running them again would bill them twice.
+    The result file itself is only written when the batch finishes; this table
+    is what makes "finished" resumable.
+    """
+
+    __tablename__ = "batch_line_results"
+    __table_args__ = (UniqueConstraint("batch_object_id", "custom_id", name="uq_batch_line_results"),)
+
+    batch_object_id = Column(BigInteger, ForeignKey("batch_objects.id", ondelete="CASCADE"), primary_key=True)
+    custom_id = Column(Text, primary_key=True)
+    row = Column(JSON, nullable=False)
+    finished_at = Column(
         TIMESTAMP(timezone=True),
         nullable=False,
         default=lambda: datetime.datetime.now(datetime.timezone.utc),

--- a/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbmodules.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    LargeBinary,
     Numeric,
     String,
     Text,
@@ -363,4 +364,94 @@ class LatencyObservation(Base):
         nullable=False,
         default=lambda: datetime.datetime.now(datetime.timezone.utc),
         onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+class BatchObject(Base):
+    """A file or batch that lives at the provider, and the team that owns it.
+
+    The Batch API hands the client an upstream id it uses for hours after the
+    request that created it. Logos forwards those calls with a provider
+    credential shared by every key allowed to use that provider, so ownership
+    has to be recorded here — otherwise any such key could poll, cancel or
+    delete another team's batch and download its output file.
+
+    ``settled_at`` is the billing latch: a terminal batch is metered exactly
+    once, when its output rows are read.
+    """
+
+    __tablename__ = "batch_objects"
+    __table_args__ = (UniqueConstraint("provider_id", "kind", "upstream_id", name="uq_batch_objects_upstream"),)
+
+    id = Column(BigInteger, primary_key=True)
+    kind = Column(Text, nullable=False)  # "file" | "batch"
+    upstream_id = Column(Text, nullable=False)
+    # NULL for a batch Logos runs itself: each of its lines picks its own
+    # provider, so the batch as a whole belongs to none.
+    provider_id = Column(Integer, ForeignKey("providers.id", ondelete="CASCADE"))
+    execution = Column(Text, nullable=False, server_default="provider")  # "provider" | "logos"
+    api_key_id = Column(Integer, ForeignKey("api_keys.id"))
+    team_id = Column(Integer, ForeignKey("teams.id"))
+    user_id = Column(Integer, ForeignKey("users.id"))
+    input_file_id = Column(Text)
+    status = Column(Text)
+    settled_at = Column(TIMESTAMP(timezone=True))
+    filename = Column(Text)
+    size_bytes = Column(BigInteger)
+    endpoint = Column(Text)
+    completion_window = Column(Text)
+    request_metadata = Column(JSON)
+    output_file_id = Column(Text)
+    error_file_id = Column(Text)
+    total_requests = Column(Integer, nullable=False, default=0)
+    completed_requests = Column(Integer, nullable=False, default=0)
+    failed_requests = Column(Integer, nullable=False, default=0)
+    cancel_requested = Column(Boolean, nullable=False, default=False)
+    started_at = Column(TIMESTAMP(timezone=True))
+    finished_at = Column(TIMESTAMP(timezone=True))
+    created_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        onupdate=lambda: datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+class BatchFileContent(Base):
+    """The bytes of a file Logos holds itself.
+
+    A forwarded batch keeps its files at the provider; a Logos-run one has
+    nowhere else to put them. Separate from ``batch_objects`` so a listing does
+    not drag megabytes of JSONL with it.
+    """
+
+    __tablename__ = "batch_file_contents"
+
+    batch_object_id = Column(BigInteger, ForeignKey("batch_objects.id", ondelete="CASCADE"), primary_key=True)
+    content = Column(LargeBinary, nullable=False)
+
+
+class ProviderBatchCapability(Base):
+    """Whether a provider's Batch API answers, as last probed.
+
+    A cloud provider is not automatically a batch target: an OpenAI-shaped
+    resource can be a self-hosted inference endpoint that serves chat and
+    nothing else. The answer is a property of the upstream, so it is probed
+    and cached rather than configured — a hand-set flag would go stale.
+    """
+
+    __tablename__ = "provider_batch_capability"
+
+    provider_id = Column(Integer, ForeignKey("providers.id", ondelete="CASCADE"), primary_key=True)
+    supports_batch = Column(Boolean, nullable=False, default=False)
+    detail = Column(Text)
+    checked_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
     )

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -26,6 +26,8 @@ from grpclocal import model_pb2_grpc
 from grpclocal.grpc_server import LogosServicer
 from logos.anthropic_compat import UpstreamDialect, stream_translator, translate_error, translate_response
 from logos.auth import AuthContext, authenticate_api_key
+from logos.batch_api import batch_reconciler_loop, handle_batch_api_request
+from logos.batch_local import local_batch_runner_loop
 from logos.benchmarks.guidellm_runner import (
     BENCHMARK_JOB_HEADER,
     BENCHMARK_PHASE_HEADER,
@@ -33,6 +35,7 @@ from logos.benchmarks.guidellm_runner import (
     BENCHMARK_TOKEN_HEADER,
     benchmark_affinity_token,
 )
+from logos.billing.budget import check_monthly_budget
 from logos.billing.finalize import finalize_billing_inputs
 from logos.capacity.calibration_orchestrator import CalibrationConfig, CalibrationOrchestrator
 from logos.capacity.capacity_planner import CapacityPlanner
@@ -74,6 +77,7 @@ from logos.queue.priority_queue import PriorityQueueManager
 from logos.request_content import (
     force_non_streaming_payload,
     is_audio_upload_path,
+    is_batch_api_path,
     is_multipart_payload,
     is_whisper_payload,
     metered_whisper_response_format,
@@ -113,6 +117,10 @@ from logos.timeouts import (
 
 logger = logging.getLogger("LogosLogger")
 _grpc_server = None
+# Settles batches that finished while nobody polled them (see logos.batch_api),
+# and runs the batches Logos executes itself (see logos.batch_local).
+_batch_reconciler_task = None
+_local_batch_runner_task = None
 _background_tasks: Set[asyncio.Task] = set()
 _benchmark_tasks: Set[asyncio.Task] = set()
 _benchmark_tasks_by_job: dict[int, asyncio.Task] = {}
@@ -783,9 +791,22 @@ async def lifespan(app: FastAPI):
     _grpc_server.add_insecure_port("[::]:50051")
     await _grpc_server.start()
 
+    # A client may fire a batch and never poll it to completion. Without this
+    # pass its cost would never be booked, so the ledger would understate what
+    # the provider actually charged.
+    global _batch_reconciler_task, _local_batch_runner_task
+    _batch_reconciler_task = asyncio.create_task(batch_reconciler_loop())
+    # Batches Logos runs itself: started here, and picked up again after a
+    # restart that interrupted one mid-file.
+    _local_batch_runner_task = asyncio.create_task(local_batch_runner_loop())
+
     yield
 
     # Shutdown logic
+    for batch_task in (_batch_reconciler_task, _local_batch_runner_task):
+        if batch_task:
+            batch_task.cancel()
+            await asyncio.gather(batch_task, return_exceptions=True)
     benchmark_tasks = list(_benchmark_tasks)
     for task in benchmark_tasks:
         task.cancel()
@@ -3346,6 +3367,12 @@ async def handle_sync_request(path: str, request: Request):
     priority is derived from the authenticated API key's default_priority
     (falling back to the policy-level priority inside the pipeline).
     """
+    # Batch API operations (file uploads, batch jobs) carry no model to
+    # classify or schedule, so they bypass the per-request pipeline and are
+    # forwarded to a Batch-capable cloud provider the key may use.
+    if is_batch_api_path(path):
+        return await handle_batch_api_request(request)
+
     # Authenticate with profile-based auth (REQUIRED for v1/openai/jobs endpoints)
     headers, auth, body, client_ip, log_id = await auth_parse_log(request, use_profile_auth=True)
     request_id = secrets.token_urlsafe(16)
@@ -3512,46 +3539,13 @@ async def auth_parse_log(request: Request, use_profile_auth: bool = False):
     return headers, None, body, client_ip, None
 
 
-def _check_budget_if_cloud(db: DBManager, auth: "AuthContext", is_cloud: bool, month_start: str) -> None:
-    """
-    Raise HTTPException(402) if this key/team is over its monthly budget.
-
-    Only cloud usage is metered (logosnode/local providers have no configured
-    token pricing in token_prices, so they always cost $0), so this is a
-    no-op when the request that actually got scheduled isn't routing to a
-    cloud provider at all. Called post-scheduling (see _execute_resource_mode)
-    with the real resolved provider type, not a guess from the permission list --
-    that's what lets this be exact for mixed cloud+local keys instead of only
-    for pure-type ones.
-    """
-    if not is_cloud:
-        return
-
-    key_type = getattr(auth, "key_type", "user")
-
-    if key_type == "application":
-        app_budget_limit = db.get_api_key_budget_limit(auth.api_key_id)
-        if app_budget_limit is not None:
-            app_used = db.get_api_key_budget_usage(auth.api_key_id, month_start)
-            if app_used >= app_budget_limit:
-                raise HTTPException(status_code=402, detail="Application monthly budget exceeded.")
-    else:
-        if auth.team_id is not None:
-            team_info = db.get_team(auth.team_id)
-            if team_info and team_info.get("team_monthly_budget_micro_cents"):
-                team_limit = team_info["team_monthly_budget_micro_cents"]
-                team_used = db.get_team_budget_usage(auth.team_id, month_start)
-                if team_used >= team_limit:
-                    raise HTTPException(status_code=402, detail="Team monthly budget exceeded. Contact your admin.")
-
-        personal_limit = db.get_api_key_budget_limit(auth.api_key_id)
-        if personal_limit is not None:
-            personal_used = db.get_api_key_budget_usage(auth.api_key_id, month_start)
-            if personal_used >= personal_limit:
-                raise HTTPException(status_code=402, detail="Personal monthly budget exceeded.")
+# The budget guard lives in logos.billing.budget so the Batch API can apply the
+# same limits without importing main (which imports it). Kept bound here under
+# its original name: it is called above and patched by name in the tests.
+_check_budget_if_cloud = check_monthly_budget
 
 
-async def submit_job_request(path: str, request: Request) -> JSONResponse:
+async def submit_job_request(path: str, request: Request) -> Response:
     """
     Accept a proxy request, persist it as a job, and launch async processing (poll for result via /jobs/{id}).
 
@@ -3560,11 +3554,17 @@ async def submit_job_request(path: str, request: Request) -> JSONResponse:
         request: Incoming FastAPI request containing headers/body.
 
     Returns:
-        202 Accepted with job id and status URL.
+        202 Accepted with job id and status URL — or the provider's
+        Batch API response when the path is a batch operation.
 
     Raises:
         HTTPException(400/401) on invalid payload or auth.
     """
+    # Same dispatch as the sync path: batch operations never become Logos
+    # jobs, they are forwarded to the provider's Batch API.
+    if is_batch_api_path(path):
+        return await handle_batch_api_request(request)
+
     # Auth with full context + initial logging
     headers, auth, json_data, client_ip, log_id = await auth_parse_log(request, use_profile_auth=True)
 

--- a/logos/logos-orchestrator/src/logos/request_content.py
+++ b/logos/logos-orchestrator/src/logos/request_content.py
@@ -23,11 +23,21 @@ MULTIPART_PAYLOAD_KEY = "_logos_multipart"
 MAX_AUDIO_UPLOAD_BYTES = int(os.getenv("LOGOS_MAX_AUDIO_UPLOAD_BYTES", str(25 * 1024 * 1024)))
 MAX_AUDIO_FORM_FIELD_BYTES = int(os.getenv("LOGOS_MAX_AUDIO_FORM_FIELD_BYTES", str(64 * 1024)))
 MAX_AUDIO_REQUEST_BYTES = int(os.getenv("LOGOS_MAX_AUDIO_REQUEST_BYTES", str(MAX_AUDIO_UPLOAD_BYTES + 5 * 1024 * 1024)))
+# Batch file uploads are forwarded to the provider as-is (no base64 copy in
+# the payload), so the file bytes are the whole memory budget. Batch JSONLs
+# are larger than audio files, hence the wider default; both stay tunable.
+MAX_BATCH_FILE_BYTES = int(os.getenv("LOGOS_MAX_BATCH_FILE_BYTES", str(50 * 1024 * 1024)))
+MAX_BATCH_REQUEST_BYTES = int(os.getenv("LOGOS_MAX_BATCH_REQUEST_BYTES", str(MAX_BATCH_FILE_BYTES + 1024 * 1024)))
 _AUDIO_UPLOAD_OPERATIONS = frozenset({"audio/transcriptions", "audio/translations"})
 _METERED_WHISPER_RESPONSE_FORMATS = frozenset({"json", "text", "srt", "vtt"})
 
+# Inbound prefixes under which the OpenAI-shaped API is mirrored. ``jobs/``
+# is the async-job mirror (itself versioned), ``openai/`` the legacy mirror,
+# and v1/ v2/ the version segments (v1 OpenAI, v2 Cohere).
+_PROXY_PREFIXES = ("jobs/", "openai/", "v1/", "v2/")
 
-class _AudioRequestTooLarge(MultiPartException):
+
+class _MultipartRequestTooLarge(MultiPartException):
     """Signal an over-limit stream through Starlette's multipart cleanup path."""
 
 
@@ -35,13 +45,55 @@ def _audio_request_limit_detail() -> str:
     return f"Audio request exceeds the {MAX_AUDIO_REQUEST_BYTES}-byte request limit"
 
 
-def is_audio_upload_path(path: str) -> bool:
-    """Return whether an inbound path addresses an audio file-upload API."""
+def _batch_request_limit_detail() -> str:
+    return f"Batch file upload exceeds the {MAX_BATCH_REQUEST_BYTES}-byte request limit"
+
+
+def strip_proxy_prefixes(path: str) -> str:
+    """Strip the inbound proxy prefixes (jobs/, openai/, v1/, v2/) from a path.
+
+    A path can carry at most one of each, and they nest (``jobs/v1/...``), so
+    the prefixes are peeled in order until none matches.
+    """
     normalized = (path or "").strip("/")
-    for prefix in ("jobs/", "openai/", "v1/", "v2/"):
+    for prefix in _PROXY_PREFIXES:
         if normalized.startswith(prefix):
             normalized = normalized[len(prefix) :]
-    return normalized in _AUDIO_UPLOAD_OPERATIONS
+    return normalized
+
+
+def is_audio_upload_path(path: str) -> bool:
+    """Return whether an inbound path addresses an audio file-upload API."""
+    return strip_proxy_prefixes(path) in _AUDIO_UPLOAD_OPERATIONS
+
+
+_BATCH_API_OPERATIONS = frozenset({"batches", "files"})
+
+
+def is_batch_api_path(path: str) -> bool:
+    """Return whether an inbound path addresses the OpenAI Batch API.
+
+    The Batch API is the OpenAI ``v1`` surface (``/v1/files`` for batch file
+    uploads, ``/v1/batches`` for the batch job lifecycle) and its ``openai/``
+    and ``jobs/`` mirrors (which can nest, ``jobs/openai/v1/...``). The
+    version segment is optional after the mirrors because the ``openai/`` and
+    ``jobs/`` catch-alls re-prefix the path with ``v1/`` before dispatch.
+    The ``v2`` (Cohere) mirror has no batch routes and never matches.
+    """
+    normalized = (path or "").strip("/")
+    changed = True
+    while changed:
+        changed = False
+        for prefix in ("jobs/", "openai/"):
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix) :]
+                changed = True
+                break
+    if normalized.startswith("v2/"):
+        return False
+    if normalized.startswith("v1/"):
+        normalized = normalized[len("v1/") :]
+    return normalized.split("/", 1)[0] in _BATCH_API_OPERATIONS
 
 
 def is_multipart_payload(payload: object) -> bool:
@@ -64,7 +116,7 @@ async def parse_audio_upload(request: Request) -> Dict[str, Any]:
             detail="Audio transcription requests require multipart/form-data",
         )
 
-    limited_request = _request_with_size_limit(request)
+    limited_request = _request_with_size_limit(request, MAX_AUDIO_REQUEST_BYTES, _audio_request_limit_detail())
     form: FormData | None = None
     try:
         form = await limited_request.form(
@@ -73,7 +125,7 @@ async def parse_audio_upload(request: Request) -> Dict[str, Any]:
             max_part_size=MAX_AUDIO_FORM_FIELD_BYTES,
         )
         return await _encode_form_data(form)
-    except _AudioRequestTooLarge as exc:
+    except _MultipartRequestTooLarge as exc:
         raise HTTPException(status_code=413, detail=exc.message) from exc
     except StarletteHTTPException as exc:
         if exc.detail == _audio_request_limit_detail():
@@ -86,15 +138,15 @@ async def parse_audio_upload(request: Request) -> Dict[str, Any]:
             await form.close()
 
 
-def _request_with_size_limit(request: Request) -> Request:
-    """Return a request whose receive channel enforces the multipart body limit."""
+def _request_with_size_limit(request: Request, limit: int, detail: str) -> Request:
+    """Return a request whose receive channel enforces a multipart body limit."""
     content_length = request.headers.get("content-length")
     if content_length:
         try:
-            if int(content_length) > MAX_AUDIO_REQUEST_BYTES:
+            if int(content_length) > limit:
                 raise HTTPException(
                     status_code=413,
-                    detail=_audio_request_limit_detail(),
+                    detail=detail,
                 )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail="Invalid Content-Length header") from exc
@@ -107,8 +159,8 @@ def _request_with_size_limit(request: Request) -> Request:
         message = await original_receive()
         if message.get("type") == "http.request":
             received += len(message.get("body", b""))
-            if received > MAX_AUDIO_REQUEST_BYTES:
-                raise _AudioRequestTooLarge(_audio_request_limit_detail())
+            if received > limit:
+                raise _MultipartRequestTooLarge(detail)
         return message
 
     return Request(request.scope, limited_receive)
@@ -158,6 +210,92 @@ def _validate_audio_upload(payload: Dict[str, Any]) -> None:
     files = multipart["files"]
     if len(files) != 1 or files[0].get("field_name") != "file":
         raise HTTPException(status_code=400, detail="Audio transcription requests require a 'file' upload")
+
+
+async def parse_batch_file_upload(request: Request) -> Dict[str, Any]:
+    """Parse and validate an OpenAI-compatible batch file upload.
+
+    Unlike audio uploads the parsed file is *not* base64-encoded into the
+    JSON payload — the batch forwarder hands the raw bytes to the provider's
+    Files API over HTTP. Returns
+    ``{"purpose", "metadata", "file": {"filename", "content_type", "bytes"}}``.
+
+    Only ``purpose="batch"`` is accepted: Logos serves the Files API as the
+    Batch API's input/output channel, not as a general-purpose file store.
+    """
+    content_type = request.headers.get("content-type", "")
+    if not content_type.lower().startswith("multipart/form-data"):
+        raise HTTPException(
+            status_code=415,
+            detail="Batch file uploads require multipart/form-data",
+        )
+
+    limited_request = _request_with_size_limit(request, MAX_BATCH_REQUEST_BYTES, _batch_request_limit_detail())
+    form: FormData | None = None
+    try:
+        # max_part_size stays uncapped: the whole-upload limit is enforced on
+        # the receive channel and the file is checked while it is read.
+        form = await limited_request.form(max_files=1, max_fields=8)
+        return await _encode_batch_form_data(form)
+    except _MultipartRequestTooLarge as exc:
+        raise HTTPException(status_code=413, detail=exc.message) from exc
+    except StarletteHTTPException as exc:
+        if exc.detail == _batch_request_limit_detail():
+            raise HTTPException(status_code=413, detail=exc.detail) from exc
+        raise
+    except (MultiPartException, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid multipart form data: {exc}") from exc
+    finally:
+        if form is not None:
+            await form.close()
+
+
+async def _encode_batch_form_data(form: FormData) -> Dict[str, Any]:
+    files: list[dict[str, Any]] = []
+    fields: dict[str, str] = {}
+
+    for name, value in form.multi_items():
+        if isinstance(value, UploadFile):
+            if files:
+                raise HTTPException(status_code=400, detail="Batch file uploads accept exactly one file")
+            content = bytearray()
+            while chunk := await value.read(1024 * 1024):
+                content.extend(chunk)
+                if len(content) > MAX_BATCH_FILE_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Batch file exceeds the {MAX_BATCH_FILE_BYTES}-byte upload limit",
+                    )
+            files.append(
+                {
+                    "field_name": name,
+                    "filename": value.filename or "batch.jsonl",
+                    "content_type": value.content_type or "application/octet-stream",
+                    "bytes": bytes(content),
+                }
+            )
+            continue
+
+        fields[str(name)] = str(value)
+
+    if not files or files[0]["field_name"] != "file":
+        raise HTTPException(status_code=400, detail="Batch file uploads require a 'file' part")
+    purpose = (fields.get("purpose") or "").strip()
+    if purpose != "batch":
+        raise HTTPException(
+            status_code=400,
+            detail="Only purpose 'batch' is supported for file uploads through Logos",
+        )
+    file = files[0]
+    return {
+        "purpose": purpose,
+        "metadata": fields.get("metadata"),
+        "file": {
+            "filename": file["filename"],
+            "content_type": file["content_type"],
+            "bytes": file["bytes"],
+        },
+    }
 
 
 def set_payload_field(payload: Dict[str, Any], name: str, value: Any) -> Dict[str, Any]:

--- a/logos/logos-orchestrator/src/logos/routers/internal.py
+++ b/logos/logos-orchestrator/src/logos/routers/internal.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 import logos.main as _main
 from logos.auth import AuthContext
+from logos.batch_credential import issue_batch_credential
 from logos.benchmarks.guidellm_runner import BENCHMARK_JOB_HEADER
 from logos.benchmarks.guidellm_runner import DATASET as BENCHMARK_DATASET
 from logos.benchmarks.guidellm_runner import (
@@ -271,6 +272,33 @@ async def internal_live_streams(request: Request):
     """
     _require_internal_secret(request)
     return {"streams": _live_streams.snapshot()}
+
+
+@router.post("/internal/batch_credentials", tags=["admin"])
+async def internal_batch_credentials(request: Request):
+    """A scoped credential for the batch proxy, in place of the user's key.
+
+    The Spring webservice proxies the UI's batch pages to the Batch API as
+    the caller's own key. The user's key is a long-lived secret and the
+    internal hop is plain HTTP in the shipped setup, so the webservice names
+    the key by id here (its ownership check already ran) and gets back a
+    short-lived credential bound to that one key. That credential — not the
+    key value — is what travels to the Batch API.
+    """
+    _require_internal_secret(request, disabled_detail="Internal batch credential endpoint disabled")
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+    api_key_id = body.get("api_key_id") if isinstance(body, dict) else None
+    if isinstance(api_key_id, bool) or not isinstance(api_key_id, int):
+        raise HTTPException(status_code=400, detail="A batch credential needs an integer 'api_key_id'.")
+    with DBManager() as db:
+        row = db.get_api_key_by_id(api_key_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No such active API key: {api_key_id}.")
+    credential, expires_in = issue_batch_credential(api_key_id)
+    return {"credential": credential, "expires_in": expires_in}
 
 
 # How often the live-stream SSE connection checks for a changed snapshot. The

--- a/logos/logos-orchestrator/src/logos/routers/user_facing.py
+++ b/logos/logos-orchestrator/src/logos/routers/user_facing.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse, Response
 
 import logos.main as _main
 from logos.auth import authenticate_api_key
+from logos.batch_api import handle_batch_api_request
 from logos.dbutils.dbmanager import DBManager
 from logos.dbutils.dbmodules import JobStatus
 from logos.errors import coerce_upstream_error
@@ -311,6 +312,44 @@ async def create_audio_transcription(request: Request):
 async def create_audio_translation(request: Request):
     """Transcribe and translate an uploaded audio file into English."""
     return await handle_sync_request("v1/audio/translations", request)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Batch API (files + batches)
+#
+# Registered ahead of the POST-only catch-alls, which cannot answer the GET and
+# DELETE half of the lifecycle. Every operation is served by
+# logos.batch_api.handle_batch_api_request: authenticate, authorise, forward to
+# the provider's Batch API, account for the result.
+# ---------------------------------------------------------------------------
+
+_BATCH_API_ROUTES = (
+    ("POST", "files"),
+    ("GET", "files"),
+    ("GET", "files/{file_id}"),
+    ("GET", "files/{file_id}/content"),
+    ("DELETE", "files/{file_id}"),
+    ("POST", "batches"),
+    ("GET", "batches"),
+    ("GET", "batches/{batch_id}"),
+    ("POST", "batches/{batch_id}/cancel"),
+)
+
+
+async def _batch_api_route(request: Request):
+    """Serve one Batch API operation under any proxy prefix."""
+    return await handle_batch_api_request(request)
+
+
+for _batch_prefix in ("v1", "openai", "jobs/v1", "jobs/openai"):
+    for _batch_method, _batch_path in _BATCH_API_ROUTES:
+        router.add_api_route(
+            f"/{_batch_prefix}/{_batch_path}",
+            _batch_api_route,
+            methods=[_batch_method],
+            tags=["batch"],
+            include_in_schema=_batch_prefix == "v1",
+        )
 
 
 @router.post("/v1/{path:path}", tags=["user-facing"])

--- a/logos/logos-orchestrator/tests/conftest.py
+++ b/logos/logos-orchestrator/tests/conftest.py
@@ -205,6 +205,7 @@ sa = _make_module(
         "Float": _noop,
         "Boolean": _noop,
         "Numeric": _noop,
+        "LargeBinary": _noop,
         "Enum": _noop,
         "JSON": _noop,
         "TIMESTAMP": _noop,

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -441,3 +441,50 @@ def test_a_refusal_is_recorded_per_model_and_truncated():
     assert (params["pid"], params["mid"]) == (7, 25)
     assert len(params["detail"]) == 500
     assert isinstance(params["now"], datetime.datetime)
+
+
+def test_a_provider_answer_syncs_the_fields_the_listing_cannot_render():
+    # The listing is served from the ownership row, not from the provider, so
+    # the result file and the running counts must be stored with the status.
+    db = _db()
+    db.record_batch_provider_state(
+        "batch_1",
+        {
+            "status": "completed",
+            "output_file_id": "file-out",
+            "error_file_id": "file-err",
+            "total_requests": 2,
+            "completed_requests": 1,
+            "failed_requests": 1,
+        },
+    )
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["upstream_id"] == "batch_1"
+    assert params["status"] == "completed"
+    assert (params["output_file_id"], params["error_file_id"]) == ("file-out", "file-err")
+    assert (params["total_requests"], params["completed_requests"], params["failed_requests"]) == (2, 1, 1)
+
+
+def test_a_provider_answer_without_the_fields_binds_nulls_not_empty_values():
+    # The statement's COALESCE is what keeps an earlier poll's result file
+    # when a later answer omits it: the bound values are the nulls.
+    db = _db()
+    db.record_batch_provider_state("batch_1", {"status": "in_progress"})
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["status"] == "in_progress"
+    assert params["output_file_id"] is None
+    assert params["error_file_id"] is None
+    assert params["total_requests"] is None
+    assert params["completed_requests"] is None
+    assert params["failed_requests"] is None
+
+
+def test_a_non_numeric_provider_count_is_not_bound_as_a_count():
+    db = _db()
+    db.record_batch_provider_state("batch_1", {"total_requests": "a lot", "completed_requests": True})
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["total_requests"] is None
+    assert params["completed_requests"] is None

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -296,6 +296,26 @@ def test_registering_a_file_keeps_the_models_it_names():
     assert _params_of(db.session.execute.call_args)["models"] is None
 
 
+def test_a_registration_whose_id_another_provider_holds_is_refused():
+    # A fresh insert and an upsert of the same provider's row each touch
+    # exactly one row. A DO UPDATE that matches none means another provider
+    # already holds the id: the registration must fail closed — so the caller
+    # removes the provider object again — rather than overwrite or silently
+    # skip.
+    db = _db()
+    db.session.execute.return_value = MagicMock(rowcount=0)
+    with pytest.raises(RuntimeError, match="already held by another provider"):
+        db.register_batch_object(
+            kind="file", upstream_id="file-abc", provider_id=7, api_key_id=11, team_id=12, user_id=13
+        )
+    db.session.commit.assert_not_called()
+
+    # The same-provider upsert commits as before.
+    db.session.execute.return_value = MagicMock(rowcount=1)
+    db.register_batch_object(kind="file", upstream_id="file-abc", provider_id=7, api_key_id=11, team_id=12, user_id=13)
+    db.session.commit.assert_called_once()
+
+
 def test_the_registration_conflict_target_matches_the_migrated_index():
     # The unique index on batch_objects is on a COALESCE *expression*, not the
     # bare columns, and PostgreSQL can only infer an expression index when the

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -453,9 +453,8 @@ def test_a_provider_answer_syncs_the_fields_the_listing_cannot_render():
             "status": "completed",
             "output_file_id": "file-out",
             "error_file_id": "file-err",
-            "total_requests": 2,
-            "completed_requests": 1,
-            "failed_requests": 1,
+            # The shape the provider reports progress in: a nested object.
+            "request_counts": {"total": 2, "completed": 1, "failed": 1},
         },
     )
 
@@ -481,9 +480,17 @@ def test_a_provider_answer_without_the_fields_binds_nulls_not_empty_values():
     assert params["failed_requests"] is None
 
 
+def test_the_older_flat_count_fields_are_accepted_as_a_fallback():
+    db = _db()
+    db.record_batch_provider_state("batch_1", {"total_requests": 2, "completed_requests": 1, "failed_requests": 1})
+
+    params = _params_of(db.session.execute.call_args)
+    assert (params["total_requests"], params["completed_requests"], params["failed_requests"]) == (2, 1, 1)
+
+
 def test_a_non_numeric_provider_count_is_not_bound_as_a_count():
     db = _db()
-    db.record_batch_provider_state("batch_1", {"total_requests": "a lot", "completed_requests": True})
+    db.record_batch_provider_state("batch_1", {"request_counts": {"total": "a lot", "completed": True}})
 
     params = _params_of(db.session.execute.call_args)
     assert params["total_requests"] is None

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -12,7 +12,10 @@ statement — these assert on the bound parameters and the call structure.)
 from __future__ import annotations
 
 import datetime
+import json
 from unittest.mock import MagicMock
+
+import pytest
 
 from logos import DBManager
 from logos.dbutils import dbmanager
@@ -51,7 +54,7 @@ def test_a_failed_settlement_is_released_for_a_retry():
 
 def test_batch_usage_is_written_and_then_priced_by_the_shared_snapshot():
     db = _db()
-    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,), (102,)])
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101, None), (102, None)])
     db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
 
     written = db.record_batch_usage(
@@ -71,7 +74,7 @@ def test_batch_usage_is_written_and_then_priced_by_the_shared_snapshot():
 
 def test_batch_rows_default_to_the_batch_service_tier():
     db = _db()
-    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101, None)])
     db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
 
     db.record_batch_usage([{"timestamp": _now(), "usage": {}}])
@@ -86,7 +89,7 @@ def test_batch_rows_default_to_the_batch_service_tier():
 
 def test_an_owner_is_carried_onto_every_row():
     db = _db()
-    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101, None)])
     db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
 
     db.record_batch_usage(
@@ -111,7 +114,7 @@ def test_an_owner_is_carried_onto_every_row():
 
 def test_zero_and_boolean_token_counts_are_not_billed():
     db = _db()
-    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101, None)])
     db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
 
     db.record_batch_usage(
@@ -124,7 +127,7 @@ def test_zero_and_boolean_token_counts_are_not_billed():
 
 def test_rows_are_written_in_chunks():
     db = _db()
-    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101, None)])
     db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
 
     # A single batch can carry tens of thousands of results; they must not go
@@ -144,7 +147,7 @@ def test_no_rows_writes_nothing():
 def test_a_snapshot_failure_does_not_lose_the_usage_rows():
     db = _db()
     db.session.execute.side_effect = [
-        MagicMock(fetchall=lambda: [(101,)]),
+        MagicMock(fetchall=lambda: [(101, None)]),
         MagicMock(),
         RuntimeError("logos_price_usage failed"),
     ]
@@ -164,8 +167,28 @@ def test_ownership_and_listing_queries_are_scoped():
     assert db.get_batch_object("file", "file-abc") is None
     assert _params_of(db.session.execute.call_args) == {"kind": "file", "upstream_id": "file-abc"}
 
-    db.list_batch_objects_for_team(12, "batch")
-    assert _params_of(db.session.execute.call_args) == {"kind": "batch", "team_id": 12, "limit": 100}
+
+@pytest.mark.parametrize(
+    ("team_id", "user_id", "api_key_id", "expected_params"),
+    [
+        # A team sees the team's objects.
+        (12, 13, 11, {"kind": "batch", "team_id": 12, "limit": 100}),
+        # A team-less key sees only its own user's objects — never the objects
+        # of another unteamed user, which a "team_id IS NULL" scope would leak.
+        (None, 13, 11, {"kind": "batch", "user_id": 13, "limit": 100}),
+        # A key without a user falls back to the key itself.
+        (None, None, 11, {"kind": "batch", "api_key_id": 11, "limit": 100}),
+    ],
+)
+def test_listing_is_scoped_by_the_callers_principal(team_id, user_id, api_key_id, expected_params):
+    db = _db()
+    db.session.execute.return_value.mappings.return_value.all.return_value = []
+
+    db.list_batch_objects_for_principal("batch", team_id, user_id, api_key_id)
+
+    # Exactly one of the three scope parameters is bound — the one naming the
+    # caller's principal — so the WHERE clause can only match that principal's rows.
+    assert _params_of(db.session.execute.call_args) == expected_params
 
 
 def test_capability_is_cached_per_provider_with_a_timestamp():
@@ -182,3 +205,153 @@ def test_the_snapshot_statement_the_batch_path_reuses_is_the_shared_one():
     # the same statement.
     assert "logos_price_usage" in dbmanager._SETTLED_COST_SNAPSHOT_SQL
     assert "{where_clause}" in dbmanager._SETTLED_COST_SNAPSHOT_SQL
+
+
+def test_usage_tokens_follow_the_request_id_not_the_insert_order():
+    # A multi-row INSERT ... RETURNING does not promise its rows back in the
+    # order they went in; the usage tokens must attach by request_id or one
+    # line's tokens could be priced as another line's.
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(102, "b"), (101, "a")])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    db.record_batch_usage(
+        [
+            {"timestamp": _now(), "request_id": "a", "usage": {"total_tokens": 7}},
+            {"timestamp": _now(), "request_id": "b", "usage": {"total_tokens": 3}},
+        ]
+    )
+
+    calls = db.session.execute.call_args_list
+    # Row "a" was returned second (id 101), row "b" first (id 102) — the usage
+    # insert still puts 7 tokens on 101 and 3 on 102.
+    usage_params = _params_of(calls[1])
+    assert (usage_params["log_0"], usage_params["count_0"]) == (101, 7)
+    assert (usage_params["log_1"], usage_params["count_1"]) == (102, 3)
+
+
+def test_registering_a_file_keeps_the_models_it_names():
+    db = _db()
+    db.register_batch_object(
+        kind="file",
+        upstream_id="file-abc",
+        provider_id=7,
+        api_key_id=11,
+        team_id=12,
+        user_id=13,
+        models=["gpt-4.1", "gpt-4o"],
+    )
+
+    params = _params_of(db.session.execute.call_args)
+    assert json.loads(params["models"]) == ["gpt-4.1", "gpt-4o"]
+
+    # A row that names no models stores NULL, and the upsert keeps what is
+    # already there rather than blanking it.
+    db.session.execute.reset_mock()
+    db.register_batch_object(
+        kind="batch", upstream_id="batch-abc", provider_id=7, api_key_id=11, team_id=12, user_id=13
+    )
+    assert _params_of(db.session.execute.call_args)["models"] is None
+
+
+def test_claiming_a_local_batch_stamps_the_runner_and_the_lease():
+    db = _db()
+    db.session.execute.return_value = MagicMock(rowcount=1)
+    assert db.claim_local_batch(5, "runner-1", 600) is True
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["id"] == 5
+    assert params["runner"] == "runner-1"
+    assert params["lease"] == 600
+    assert isinstance(params["now"], datetime.datetime)
+
+    # A live lease (or a terminal batch) leaves the update unmatched.
+    db.session.execute.return_value = MagicMock(rowcount=0)
+    assert db.claim_local_batch(5, "runner-1", 600) is False
+
+
+def test_progress_updates_are_conditional_on_still_holding_the_batch():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchone=lambda: (True,))
+    assert db.update_local_batch_progress(5, "runner-1", 3, 1, 600) is True
+
+    params = _params_of(db.session.execute.call_args)
+    assert (params["id"], params["runner"]) == (5, "runner-1")
+    assert (params["completed"], params["failed"]) == (3, 1)
+
+    # No cancel pending -> False; the row no longer belongs to this runner
+    # (another one took it over after the lease lapsed) -> None, which the
+    # runner treats as "stop, do not write an output file".
+    db.session.execute.return_value = MagicMock(fetchone=lambda: (False,))
+    assert db.update_local_batch_progress(5, "runner-1", 4, 1, 600) is False
+    db.session.execute.return_value = MagicMock()
+    db.session.execute.return_value.fetchone.return_value = None
+    assert db.update_local_batch_progress(5, "runner-1", 4, 1, 600) is None
+
+
+def test_finishing_a_local_batch_releases_the_runner():
+    db = _db()
+    db.finish_local_batch(5, status="completed", output_file_id="file-out", completed=9, failed=1)
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["id"] == 5
+    assert params["status"] == "completed"
+    assert params["output_file_id"] == "file-out"
+    assert (params["completed"], params["failed"]) == (9, 1)
+
+
+def test_line_checkpoints_are_upserted_per_line():
+    db = _db()
+    db.save_local_batch_lines(
+        5,
+        [
+            {"custom_id": "q-1", "row": {"status_code": 200}},
+            {"custom_id": "q-2", "row": {"status_code": 500}},
+        ],
+    )
+
+    params = _params_of(db.session.execute.call_args)
+    assert (params["id_0"], params["cid_0"]) == (5, "q-1")
+    assert json.loads(params["row_0"]) == {"status_code": 200}
+    assert (params["id_1"], params["cid_1"]) == (5, "q-2")
+
+    # Nothing finished -> nothing to write.
+    db.session.execute.reset_mock()
+    db.save_local_batch_lines(5, [])
+    db.session.execute.assert_not_called()
+
+
+def test_the_checkpoint_reads_back_by_custom_id():
+    db = _db()
+    db.session.execute.return_value.mappings.return_value.all.return_value = [
+        {"custom_id": "q-1", "row": {"status_code": 200}},
+        {"custom_id": "q-2", "row": {"status_code": 500}},
+    ]
+
+    assert db.get_local_batch_lines(5) == {
+        "q-1": {"status_code": 200},
+        "q-2": {"status_code": 500},
+    }
+    assert _params_of(db.session.execute.call_args) == {"id": 5}
+
+
+def test_eligibility_rows_are_read_back_within_the_ttl():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(25,), (26,)])
+
+    assert db.get_batch_model_ineligibility(7) == {25, 26}
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["pid"] == 7
+    assert isinstance(params["now"], datetime.datetime)
+    assert params["ttl"] == dbmanager.BATCH_MODEL_ELIGIBILITY_TTL_DAYS
+
+
+def test_a_refusal_is_recorded_per_model_and_truncated():
+    db = _db()
+    db.record_model_batch_ineligibility(7, 25, "x" * 600)
+
+    params = _params_of(db.session.execute.call_args)
+    assert (params["pid"], params["mid"]) == (7, 25)
+    assert len(params["detail"]) == 500
+    assert isinstance(params["now"], datetime.datetime)

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -12,7 +12,9 @@ statement — these assert on the bound parameters and the call structure.)
 from __future__ import annotations
 
 import datetime
+import inspect
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,6 +42,13 @@ def test_settlement_latch_reports_whether_this_caller_won_it():
     db.session.execute.return_value = MagicMock(rowcount=1)
     assert db.claim_batch_for_settlement(77) is True
 
+    # The claim is a lease, not the settled_at stamp: a settlement that dies
+    # before the ledger write must stay retryable, so the claim carries an
+    # expiry and touches no settled column at all.
+    params = _params_of(db.session.execute.call_args)
+    assert params["id"] == 77
+    assert params["lease"] == 1800
+
     # The client's own poll and the reconciler can both reach a finished batch;
     # the conditional UPDATE lets only one of them bill it.
     db.session.execute.return_value = MagicMock(rowcount=0)
@@ -50,6 +59,15 @@ def test_a_failed_settlement_is_released_for_a_retry():
     db = _db()
     db.release_batch_settlement(77)
     assert _params_of(db.session.execute.call_args) == {"id": 77}
+
+
+def test_settling_a_batch_stamps_it_and_clears_the_lease():
+    db = _db()
+    db.mark_batch_settled(77)
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["id"] == 77
+    assert isinstance(params["now"], datetime.datetime)
 
 
 def test_batch_usage_is_written_and_then_priced_by_the_shared_snapshot():
@@ -230,6 +248,30 @@ def test_usage_tokens_follow_the_request_id_not_the_insert_order():
     assert (usage_params["log_1"], usage_params["count_1"]) == (102, 3)
 
 
+def test_a_settlement_retry_skips_rows_the_ledger_already_holds():
+    # The chunks commit before the batch is marked settled, so a settlement
+    # retried after a partial commit re-inserts rows that are already booked.
+    # They are skipped on the unique request_id, not an error: no second token
+    # write, no snapshot over the old rows, and only the new rows are counted.
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(102, "batch-5-b")])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    written = db.record_batch_usage(
+        [
+            {"timestamp": _now(), "request_id": "batch-5-a", "usage": {"total_tokens": 7}},
+            {"timestamp": _now(), "request_id": "batch-5-b", "usage": {"total_tokens": 3}},
+        ]
+    )
+
+    assert written == 1
+    calls = db.session.execute.call_args_list
+    usage_params = _params_of(calls[1])
+    assert (usage_params["log_0"], usage_params["count_0"]) == (102, 3)
+    assert "log_1" not in usage_params
+    assert _params_of(calls[2]) == {"log_ids": [102]}
+
+
 def test_registering_a_file_keeps_the_models_it_names():
     db = _db()
     db.register_batch_object(
@@ -252,6 +294,37 @@ def test_registering_a_file_keeps_the_models_it_names():
         kind="batch", upstream_id="batch-abc", provider_id=7, api_key_id=11, team_id=12, user_id=13
     )
     assert _params_of(db.session.execute.call_args)["models"] is None
+
+
+def test_the_registration_conflict_target_matches_the_migrated_index():
+    # The unique index on batch_objects is on a COALESCE *expression*, not the
+    # bare columns, and PostgreSQL can only infer an expression index when the
+    # ON CONFLICT target repeats the expression exactly. A bare-column target
+    # does not match and the statement fails outright — which would turn every
+    # provider upload into a 502. This keeps the two sides in lockstep; the
+    # unit environment stubs the SQL away, so the migration file is the check.
+    migration = (
+        Path(dbmanager.__file__).parents[4]
+        / "logos-webservice"
+        / "src"
+        / "main"
+        / "resources"
+        / "liquibase"
+        / "changelog"
+        / "031_batch_api.xml"
+    )
+    lines = migration.read_text(encoding="utf-8").splitlines()
+    index_lines = [
+        lines[index + 1]
+        for index, line in enumerate(lines)
+        if "CREATE" in line and "uq_batch_objects_upstream" in line and index + 1 < len(lines)
+    ]
+    assert len(index_lines) == 1
+    assert "ON batch_objects(" in index_lines[0]
+    expression = index_lines[0].split("ON batch_objects(", 1)[1].rstrip(");").strip()
+
+    source = inspect.getsource(DBManager.register_batch_object)
+    assert f"ON CONFLICT ({expression})" in source
 
 
 def test_claiming_a_local_batch_stamps_the_runner_and_the_lease():
@@ -289,21 +362,31 @@ def test_progress_updates_are_conditional_on_still_holding_the_batch():
     assert db.update_local_batch_progress(5, "runner-1", 4, 1, 600) is None
 
 
-def test_finishing_a_local_batch_releases_the_runner():
+def test_finishing_a_local_batch_requires_still_holding_the_lease():
     db = _db()
-    db.finish_local_batch(5, status="completed", output_file_id="file-out", completed=9, failed=1)
+    db.session.execute.return_value = MagicMock(rowcount=1)
+    assert (
+        db.finish_local_batch(5, "runner-1", status="completed", output_file_id="file-out", completed=9, failed=1)
+        is True
+    )
 
     params = _params_of(db.session.execute.call_args)
-    assert params["id"] == 5
+    assert (params["id"], params["runner"]) == (5, "runner-1")
     assert params["status"] == "completed"
     assert params["output_file_id"] == "file-out"
     assert (params["completed"], params["failed"]) == (9, 1)
+
+    # A runner whose lease lapsed must not finalize the batch the new holder
+    # is running.
+    db.session.execute.return_value = MagicMock(rowcount=0)
+    assert db.finish_local_batch(5, "runner-1", status="completed") is False
 
 
 def test_line_checkpoints_are_upserted_per_line():
     db = _db()
     db.save_local_batch_lines(
         5,
+        "runner-1",
         [
             {"custom_id": "q-1", "row": {"status_code": 200}},
             {"custom_id": "q-2", "row": {"status_code": 500}},
@@ -314,10 +397,13 @@ def test_line_checkpoints_are_upserted_per_line():
     assert (params["id_0"], params["cid_0"]) == (5, "q-1")
     assert json.loads(params["row_0"]) == {"status_code": 200}
     assert (params["id_1"], params["cid_1"]) == (5, "q-2")
+    # The update half is bound to the holder: a deposed runner's write must not
+    # overwrite the new holder's rows for the same lines.
+    assert params["runner"] == "runner-1"
 
     # Nothing finished -> nothing to write.
     db.session.execute.reset_mock()
-    db.save_local_batch_lines(5, [])
+    db.save_local_batch_lines(5, "runner-1", [])
     db.session.execute.assert_not_called()
 
 

--- a/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
+++ b/logos/logos-orchestrator/tests/unit/dbutils/test_batch_object_queries.py
@@ -1,0 +1,184 @@
+"""The queries behind Batch API ownership and settlement.
+
+Two properties are load-bearing and invisible from the HTTP tests: the
+settlement latch is conditional, so a finished batch is billed once no matter
+whether the client's poll or the reconciler gets there first, and a batch's
+usage rows are priced by the same snapshot statement as every other request.
+
+(The unit-test environment stubs SQLAlchemy, so ``text()`` yields no inspectable
+statement — these assert on the bound parameters and the call structure.)
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock
+
+from logos import DBManager
+from logos.dbutils import dbmanager
+
+
+def _db():
+    db = DBManager.__new__(DBManager)
+    db.session = MagicMock()
+    return db
+
+
+def _params_of(call):
+    return call.args[1] if len(call.args) > 1 else {}
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def test_settlement_latch_reports_whether_this_caller_won_it():
+    db = _db()
+    db.session.execute.return_value = MagicMock(rowcount=1)
+    assert db.claim_batch_for_settlement(77) is True
+
+    # The client's own poll and the reconciler can both reach a finished batch;
+    # the conditional UPDATE lets only one of them bill it.
+    db.session.execute.return_value = MagicMock(rowcount=0)
+    assert db.claim_batch_for_settlement(77) is False
+
+
+def test_a_failed_settlement_is_released_for_a_retry():
+    db = _db()
+    db.release_batch_settlement(77)
+    assert _params_of(db.session.execute.call_args) == {"id": 77}
+
+
+def test_batch_usage_is_written_and_then_priced_by_the_shared_snapshot():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,), (102,)])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    written = db.record_batch_usage(
+        [
+            {"timestamp": _now(), "usage": {"prompt_tokens": 10}},
+            {"timestamp": _now(), "usage": {"completion_tokens": 5}},
+        ]
+    )
+
+    assert written == 2
+    calls = db.session.execute.call_args_list
+    assert len(calls) == 3  # log_entry rows, usage rows, cost snapshot
+    # The snapshot runs over exactly the rows just written, through the same
+    # statement an ordinary finalisation uses.
+    assert _params_of(calls[2]) == {"log_ids": [101, 102]}
+
+
+def test_batch_rows_default_to_the_batch_service_tier():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    db.record_batch_usage([{"timestamp": _now(), "usage": {}}])
+
+    params = _params_of(db.session.execute.call_args_list[0])
+    # 'batch' is what makes the price lookup pick the provider's batch rate;
+    # without a batch rate it falls back to the standard one.
+    assert params["tier_0"] == "batch"
+    assert params["status_0"] == "success"
+    assert params["privacy_0"] == "BILLING"
+
+
+def test_an_owner_is_carried_onto_every_row():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    db.record_batch_usage(
+        [
+            {
+                "timestamp": _now(),
+                "api_key_id": 11,
+                "team_id": 12,
+                "user_id": 13,
+                "provider_id": 7,
+                "model_id": 25,
+                "request_id": "custom-1",
+                "usage": {},
+            }
+        ]
+    )
+
+    params = _params_of(db.session.execute.call_args_list[0])
+    assert (params["aki_0"], params["tid_0"], params["uid_0"]) == (11, 12, 13)
+    assert (params["pid_0"], params["mid_0"], params["rid_0"]) == (7, 25, "custom-1")
+
+
+def test_zero_and_boolean_token_counts_are_not_billed():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    db.record_batch_usage(
+        [{"timestamp": _now(), "usage": {"prompt_tokens": 0, "completion_tokens": True, "total_tokens": 7}}]
+    )
+
+    usage_params = _params_of(db.session.execute.call_args_list[1])
+    assert usage_params == {"log_0": 101, "type_0": 1, "count_0": 7}
+
+
+def test_rows_are_written_in_chunks():
+    db = _db()
+    db.session.execute.return_value = MagicMock(fetchall=lambda: [(101,)])
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    # A single batch can carry tens of thousands of results; they must not go
+    # into one statement.
+    written = db.record_batch_usage([{"timestamp": _now(), "usage": {"total_tokens": 1}}] * 3, chunk_size=1)
+
+    assert written == 3
+    assert len([c for c in db.session.execute.call_args_list if "log_ids" in _params_of(c)]) == 3
+
+
+def test_no_rows_writes_nothing():
+    db = _db()
+    assert db.record_batch_usage([]) == 0
+    db.session.execute.assert_not_called()
+
+
+def test_a_snapshot_failure_does_not_lose_the_usage_rows():
+    db = _db()
+    db.session.execute.side_effect = [
+        MagicMock(fetchall=lambda: [(101,)]),
+        MagicMock(),
+        RuntimeError("logos_price_usage failed"),
+    ]
+    db.add_token_type = lambda name, description="": ({"token-type-id": 1}, 200)
+
+    assert db.record_batch_usage([{"timestamp": _now(), "usage": {"total_tokens": 7}}]) == 1
+    assert "rollback" in [c[0] for c in db.session.mock_calls]
+
+
+def test_ownership_and_listing_queries_are_scoped():
+    db = _db()
+    db.session.execute.return_value.mappings.return_value.first.return_value = None
+    db.session.execute.return_value.mappings.return_value.all.return_value = []
+
+    # Keyed by the id alone: a caller supplies an id, not a provider, and the
+    # row is what says whether the object lives at a provider or here.
+    assert db.get_batch_object("file", "file-abc") is None
+    assert _params_of(db.session.execute.call_args) == {"kind": "file", "upstream_id": "file-abc"}
+
+    db.list_batch_objects_for_team(12, "batch")
+    assert _params_of(db.session.execute.call_args) == {"kind": "batch", "team_id": 12, "limit": 100}
+
+
+def test_capability_is_cached_per_provider_with_a_timestamp():
+    db = _db()
+    db.record_provider_batch_capability(7, False, "HTTP 404")
+
+    params = _params_of(db.session.execute.call_args)
+    assert params["pid"] == 7 and params["supports"] is False and params["detail"] == "HTTP 404"
+    assert isinstance(params["now"], datetime.datetime)
+
+
+def test_the_snapshot_statement_the_batch_path_reuses_is_the_shared_one():
+    # Guards against the pricing being inlined a second time: both paths format
+    # the same statement.
+    assert "logos_price_usage" in dbmanager._SETTLED_COST_SNAPSHOT_SQL
+    assert "{where_clause}" in dbmanager._SETTLED_COST_SNAPSHOT_SQL

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1258,6 +1258,61 @@ def test_result_file_ids_are_deterministic_and_distinguish_the_providers():
     assert batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out").startswith("file-lg-")
 
 
+def _mapped_result_file_db():
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    output_id = batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out")
+    db.register_batch_object(
+        kind="file",
+        upstream_id=output_id,
+        provider_id=OPENAI_PROVIDER["id"],
+        api_key_id=11,
+        team_id=OWN_TEAM,
+        user_id=13,
+        provider_object_id="file-out",
+    )
+    return db, output_id
+
+
+def test_a_mapped_result_file_metadata_returns_the_exposed_id(monkeypatch):
+    # The forward addresses the provider by its own id, but the answer must
+    # come back named by the id the client holds: reusing a returned raw
+    # provider id for the download or the deletion would 404, because
+    # ownership is keyed by the Logos id.
+    db, output_id = _mapped_result_file_db()
+    seen = _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(
+            200, json={"id": "file-out", "object": "file", "filename": "results.jsonl", "bytes": 42}
+        ),
+    )
+
+    meta = client.get(f"/v1/files/{output_id}")
+
+    assert meta.status_code == 200
+    assert meta.json()["id"] == output_id
+    assert meta.json()["filename"] == "results.jsonl"
+    assert str(seen[0].url) == "https://api.openai.com/v1/files/file-out"
+
+
+def test_a_mapped_result_file_deletion_returns_the_exposed_id(monkeypatch):
+    db, output_id = _mapped_result_file_db()
+    seen = _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(200, json={"id": "file-out", "object": "file", "deleted": True}),
+    )
+
+    deleted = client.delete(f"/v1/files/{output_id}")
+
+    assert deleted.status_code == 200
+    assert deleted.json()["id"] == output_id
+    assert deleted.json()["deleted"] is True
+    assert str(seen[0].url) == "https://api.openai.com/v1/files/file-out"
+    # The provider's file is gone, so Logos's own bookkeeping follows.
+    assert db.owned.get(("file", output_id)) is None
+
+
 def test_an_unfinished_batch_is_not_settled(monkeypatch):
     db = _FakeDB(
         [OPENAI_PROVIDER],

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1421,7 +1421,7 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
     executed = []
 
     async def fake_execute(path, headers, body, client_ip, auth, log_id):
-        executed.append((path, body["model"], auth.default_priority))
+        executed.append((path, body["model"], auth.default_priority, log_id))
         return {"status_code": 200, "data": {"model": body["model"], "usage": {"prompt_tokens": 5}}}
 
     stored = {}
@@ -1459,6 +1459,10 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
         def update_local_batch_progress(self, object_id, completed, failed):
             return False
 
+        def log_usage(self, **kwargs):
+            stored.setdefault("logged", []).append(kwargs)
+            return {"log-id": 500 + len(stored["logged"])}, 200
+
         def store_local_batch_file(self, **kwargs):
             stored.update(kwargs)
             return 1
@@ -1485,9 +1489,15 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
     )
 
     assert written and written.startswith("file-")
-    assert [name for _, name, _ in executed] == ["qwen3-32b", "qwen3-32b"]
+    assert [name for _, name, _, _ in executed] == ["qwen3-32b", "qwen3-32b"]
     # The key's own priority is 10 (HIGH); batch work runs at LOW regardless.
-    assert {priority for _, _, priority in executed} == {batch_local.LOCAL_BATCH_PRIORITY}
+    assert {priority for _, _, priority, _ in executed} == {batch_local.LOCAL_BATCH_PRIORITY}
+    # Each line opens its own usage-log row: that is what the pipeline writes
+    # the response's tokens onto, so without it the work would cost money and
+    # never reach the ledger.
+    assert len(stored["logged"]) == 2
+    assert {log_id for _, _, _, log_id in executed} == {501, 502}
+    assert stored["logged"][0]["api_key_id"] == 11
     assert stored["finish"]["status"] == "completed"
     assert stored["finish"]["completed"] == 2
     assert stored["finish"]["failed"] == 0

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1150,14 +1150,18 @@ def test_a_provider_batch_listing_carries_what_the_last_poll_saw(monkeypatch):
     )
     monkeypatch.setattr(batch_api, "_schedule_settlement", lambda *args: None)
 
-    assert client.get("/v1/batches/batch_p").status_code == 200  # the poll that stores the state
+    poll = client.get("/v1/batches/batch_p")
+    assert poll.status_code == 200  # the poll that stores the state
+    # The answer, like the stored state, carries Logos's ids for the result
+    # files — the ids the client downloads with, not the provider's.
+    assert poll.json()["output_file_id"] == batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out")
 
     listed = client.get("/v1/batches")
     assert listed.status_code == 200
     entry = listed.json()["data"][0]
     assert entry["status"] == "completed"
-    assert entry["output_file_id"] == "file-out"
-    assert entry["error_file_id"] == "file-err"
+    assert entry["output_file_id"] == batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out")
+    assert entry["error_file_id"] == batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-err")
     assert entry["request_counts"] == {"total": 2, "completed": 1, "failed": 1}
 
 
@@ -1185,6 +1189,10 @@ def test_a_poll_registers_the_result_file_the_provider_minted(monkeypatch):
     # credential: it shows up in the provider's file list for every key that
     # may use the provider. Without an ownership row of its own, the batch
     # owner's result download would be a 404 while a stranger's would work.
+    # The provider's file ids are only unique at that provider, and the client
+    # names a file without naming the provider — so the row is keyed by a
+    # Logos id derived from the pair, and the provider's id is kept on the
+    # row for the download forward.
     db = _FakeDB(
         [OPENAI_PROVIDER],
         OPENAI_DEPLOYMENTS,
@@ -1205,17 +1213,49 @@ def test_a_poll_registers_the_result_file_the_provider_minted(monkeypatch):
     )
     monkeypatch.setattr(batch_api, "_schedule_settlement", lambda *args: None)
 
+    poll = client.get("/v1/batches/batch_1")
+    assert poll.status_code == 200
+
+    output_id = batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out")
+    error_id = batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-err")
+    # The answer and the stored batch state carry the Logos ids...
+    assert (poll.json()["output_file_id"], poll.json()["error_file_id"]) == (output_id, error_id)
+    assert db.owned[("batch", "batch_1")]["output_file_id"] == output_id
+
+    # ...and the ownership rows map each one back to the provider's id.
+    file_rows = {row["upstream_id"]: row for (kind, _), row in db.owned.items() if kind == "file"}
+    assert set(file_rows) == {output_id, error_id}
+    assert file_rows[output_id]["provider_object_id"] == "file-out"
+    assert file_rows[error_id]["provider_object_id"] == "file-err"
+    assert all(row["team_id"] == OWN_TEAM for row in file_rows.values())
+
+    # A repeated poll of the finished batch mints the same ids and upserts
+    # the same rows — the mapping never grows with the number of polls.
     assert client.get("/v1/batches/batch_1").status_code == 200
-
     file_rows = [row for (kind, _), row in db.owned.items() if kind == "file"]
-    assert {row["upstream_id"] for row in file_rows} == {"file-out", "file-err"}
-    assert all(row["team_id"] == OWN_TEAM for row in file_rows)
+    assert len(file_rows) == 2
 
-    # And the owner can now download the result through the files route.
-    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, content=b'{"custom_id": "one"}\n'))
-    download = client.get("/v1/files/file-out/content")
+    # And the owner downloads the result through the files route, which
+    # addresses the provider by its own id.
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, content=b'{"custom_id": "one"}\n'))
+    download = client.get(f"/v1/files/{output_id}/content")
     assert download.status_code == 200
     assert download.content == b'{"custom_id": "one"}\n'
+    assert str(seen[0].url) == "https://api.openai.com/v1/files/file-out/content"
+
+
+def test_result_file_ids_are_deterministic_and_distinguish_the_providers():
+    # The same provider and file id must always yield the same Logos id, so a
+    # repeated poll upserts the one row; two providers minting the same file
+    # id must yield two different ones, so one team's result can never be
+    # reached through the other's id.
+    assert batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out") == batch_api._logos_result_file_id(
+        OPENAI_PROVIDER, "file-out"
+    )
+    assert batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out") != batch_api._logos_result_file_id(
+        AZURE_PROVIDER, "file-out"
+    )
+    assert batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out").startswith("file-lg-")
 
 
 def test_an_unfinished_batch_is_not_settled(monkeypatch):
@@ -1470,12 +1510,17 @@ class _SettlingDB:
         self.settled = 0
         self.rows = []
         self.booked = set()
+        self.registered = []
 
     def __enter__(self):
         return self
 
     def __exit__(self, *exc):
         return False
+
+    def register_batch_object(self, **kwargs):
+        # The settlement path only stores state; recording the call is enough.
+        self.registered.append(kwargs)
 
     def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
         self.claims += 1
@@ -1685,6 +1730,9 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
         def record_batch_provider_state(self, upstream_id, body):
             settling.rows.append(("state", upstream_id, body.get("status")))
 
+        def register_batch_object(self, **kwargs):
+            return settling.register_batch_object(**kwargs)
+
         def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
             return settling.claim_batch_for_settlement(batch_object_id, lease_seconds)
 
@@ -1715,6 +1763,12 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
     assert await reconcile_batches_once() == 2
     assert ("state", "batch_1", "completed") in settling.rows
     assert settling.settled == 1
+    # The reconciler stores the state under Logos's id, too, and the mapping
+    # row keeps the provider's for the download — the settlement above took
+    # the provider's own answer, so it billed from the right file.
+    (file_row,) = settling.registered
+    assert file_row["upstream_id"] == batch_api._logos_result_file_id(OPENAI_PROVIDER, "file-out")
+    assert file_row["provider_object_id"] == "file-out"
 
 
 @pytest.mark.asyncio

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -930,6 +930,37 @@ def test_a_key_that_lost_the_provider_cannot_run_its_file_at_the_provider(monkey
     assert seen == []
 
 
+def test_a_model_available_only_on_another_provider_does_not_authorise_the_stored_one(monkeypatch):
+    # The link on the stored provider was removed; the same model is still
+    # permitted through a second provider. That does not authorise spending
+    # the stored provider's shared credential on a model its link no longer
+    # serves — the re-check is scoped to the provider the file lives on.
+    second_provider = {
+        **OPENAI_PROVIDER,
+        "id": 9,
+        "name": "openai-two",
+        "base_url": "https://api.second.example.com/v1",
+        "api_key": "sk-second",
+    }
+    second_deployment = {**OPENAI_DEPLOYMENTS[0], "provider_id": 9}
+    db = _FakeDB(
+        [OPENAI_PROVIDER, second_provider],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+        key_permissions={11: {"providers": [OPENAI_PROVIDER, second_provider], "deployments": [second_deployment]}},
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1"}))
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "model_not_permitted"
+    assert seen == []
+
+
 def test_a_key_over_budget_cannot_start_a_batch(monkeypatch):
     db = _FakeDB(
         [OPENAI_PROVIDER],
@@ -2223,6 +2254,55 @@ def test_a_local_batch_line_must_be_a_post(monkeypatch):
     upload = client.post(
         "/v1/files",
         files={"file": ("batch.jsonl", _jsonl(get_line), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    assert upload.status_code == 200
+    file_id = upload.json()["id"]
+
+    created = client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "invalid_batch_line"
+    assert db.local_batches == {}
+
+
+def test_a_local_batch_requires_an_explicit_endpoint(monkeypatch):
+    # The endpoint is what the batch object advertises; a default would let a
+    # file's lines run under an endpoint nobody asked for.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    file_id = upload.json()["id"]
+
+    created = client.post("/v1/batches", json={"input_file_id": file_id, "completion_window": "24h"})
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "invalid_request_error"
+    assert db.local_batches == {}
+
+
+def test_a_local_batch_line_requires_an_explicit_method(monkeypatch):
+    # The runner would treat an unmarked line as a POST; the contract says so
+    # explicitly instead, so a line without a method is refused.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    line = {
+        "custom_id": "one",
+        "url": "/v1/chat/completions",
+        "body": {"model": "qwen3-32b", "messages": [{"role": "user", "content": "hi"}]},
+    }
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(line), "application/jsonl")},
         data={"purpose": "batch"},
     )
     assert upload.status_code == 200

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1552,3 +1552,117 @@ def test_a_local_batch_object_looks_like_a_providers(monkeypatch):
     assert rendered["request_counts"] == {"total": 3, "completed": 2, "failed": 1}
     assert rendered["completed_at"] == int(now.timestamp())
     assert rendered["metadata"] == {"run": "bench"}
+
+
+def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch):
+    # The cancel moves a queued batch to 'cancelling'; without the runner
+    # picking that state up it would sit there forever.
+    finished = {}
+
+    class _CancelDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, object_id):
+            raise AssertionError("a cancelling batch is not claimed as new work")
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return {
+                "id": 11,
+                "key_value": "lg-test",
+                "name": "k",
+                "key_type": "user",
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "environment": "test",
+                "log": "BILLING",
+                "settings": {},
+                "default_priority": 1,
+            }
+
+        def update_local_batch_progress(self, object_id, completed, failed):
+            return True  # a cancel is pending
+
+        def store_local_batch_file(self, **kwargs):
+            return 1
+
+        def finish_local_batch(self, object_id, **kwargs):
+            finished.update(kwargs)
+
+    monkeypatch.setattr(batch_local, "DBManager", _CancelDB)
+
+    asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2001,
+                "upstream_id": "batch_c",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "cancelling",
+            }
+        )
+    )
+
+    assert finished["status"] == "cancelled"
+    assert finished["completed"] == 0
+
+
+def test_a_batch_already_running_here_is_not_started_again(monkeypatch):
+    # The runner loop re-offers in_progress rows (so a batch interrupted by a
+    # restart resumes), which would otherwise start a second run of one this
+    # process is already working through.
+    claimed = []
+
+    class _ClaimDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, object_id):
+            claimed.append(object_id)
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return None
+
+        def get_local_batch_file_content(self, object_id):
+            return None
+
+        def finish_local_batch(self, object_id, **kwargs):
+            pass
+
+    monkeypatch.setattr(batch_local, "DBManager", _ClaimDB)
+    row = {
+        "id": 2002,
+        "upstream_id": "batch_d",
+        "input_file_id": "file-in",
+        "api_key_id": 11,
+        "team_id": OWN_TEAM,
+        "user_id": 13,
+        "status": "validating",
+    }
+
+    batch_local._running.add(2002)
+    try:
+        assert asyncio.run(batch_local.run_local_batch(row)) is None
+        assert claimed == []  # it never reached the database claim
+    finally:
+        batch_local._running.discard(2002)
+
+    # With the guard clear it runs — and the claim is what decides across
+    # processes.
+    asyncio.run(batch_local.run_local_batch(row))
+    assert claimed == [2002]

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -621,6 +621,19 @@ class _FakeDB:
     def update_batch_object_status(self, upstream_id, status):
         self.status_updates.append((upstream_id, status))
 
+    def record_batch_provider_state(self, upstream_id, body):
+        # The production sync stores the status and the result fields the
+        # answer carries on the ownership row the listing renders.
+        status = body.get("status") if isinstance(body, dict) else None
+        self.status_updates.append((upstream_id, status))
+        row = self.owned.get(("batch", upstream_id))
+        if row is not None and isinstance(body, dict):
+            if isinstance(status, str):
+                row["status"] = status
+            for field in ("output_file_id", "error_file_id", "total_requests", "completed_requests", "failed_requests"):
+                if body.get(field) is not None:
+                    row[field] = body[field]
+
     def delete_batch_object(self, batch_object_id):
         self.deleted.append(batch_object_id)
         for key, row in list(self.owned.items()):
@@ -980,6 +993,45 @@ def test_a_listing_is_answered_from_logos_own_record(monkeypatch):
     assert [item["id"] for item in resp.json()["data"]] == ["batch_mine"]
     assert resp.json()["data"][0]["status"] == "completed"
     assert seen == []
+
+
+def test_a_provider_batch_listing_carries_what_the_last_poll_saw(monkeypatch):
+    # The listing does not ask the provider for each row — it renders what
+    # the last poll stored. A provider batch that finished must therefore
+    # show its result file and its counts, or a client polling only the
+    # listing can neither offer the download nor the progress.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_p"): _remote(77, OWN_TEAM, upstream_id="batch_p", status="in_progress")},
+    )
+    _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(
+            200,
+            json={
+                "id": "batch_p",
+                "status": "completed",
+                "output_file_id": "file-out",
+                "error_file_id": "file-err",
+                "total_requests": 2,
+                "completed_requests": 1,
+                "failed_requests": 1,
+            },
+        ),
+    )
+    monkeypatch.setattr(batch_api, "_schedule_settlement", lambda *args: None)
+
+    assert client.get("/v1/batches/batch_p").status_code == 200  # the poll that stores the state
+
+    listed = client.get("/v1/batches")
+    assert listed.status_code == 200
+    entry = listed.json()["data"][0]
+    assert entry["status"] == "completed"
+    assert entry["output_file_id"] == "file-out"
+    assert entry["error_file_id"] == "file-err"
+    assert entry["request_counts"] == {"total": 2, "completed": 1, "failed": 1}
 
 
 def test_polling_records_the_status_and_settles_a_finished_batch(monkeypatch):
@@ -1347,6 +1399,48 @@ def _files_upstream(request):
     return httpx.Response(404, json={"error": "no such file"})
 
 
+class _StarvedWindow:
+    """The unsettled-batches window, shaped as the query returns it: the
+    least recently checked first, capped at the limit.
+
+    ``PROVIDERLESS`` is the provider id of the batch whose provider row is
+    gone — the check on that one cannot run at all.
+    """
+
+    PROVIDERLESS = 999
+
+    def __init__(self, count):
+        self.providerless = set()
+        self.rotated = set()
+        self.seen = set()
+        self.stamp = count
+        self.stamps = {f"batch_{n}": n for n in range(1, count + 1)}
+
+    def touched(self, upstream_id):
+        # What the check stamp is, without the upstream call having happened.
+        self.stamp += 1
+        self.stamps[upstream_id] = self.stamp
+
+    def checked(self, upstream_id):
+        self.seen.add(upstream_id)
+        self.touched(upstream_id)
+
+    def take(self, limit):
+        due = sorted(self.stamps, key=lambda upstream_id: self.stamps[upstream_id])[:limit]
+        return [
+            {
+                "id": 100 + int(upstream_id.split("_", 1)[1]),
+                "upstream_id": upstream_id,
+                "provider_id": self.PROVIDERLESS if upstream_id in self.providerless else 7,
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "in_progress",
+            }
+            for upstream_id in due
+        ]
+
+
 @pytest.mark.asyncio
 async def test_settlement_books_one_usage_row_per_result(monkeypatch):
     db = _SettlingDB()
@@ -1461,8 +1555,8 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
         def get_batch_provider(self, provider_id):
             return OPENAI_PROVIDER
 
-        def update_batch_object_status(self, upstream_id, status):
-            settling.rows.append(("status", upstream_id, status))
+        def record_batch_provider_state(self, upstream_id, body):
+            settling.rows.append(("state", upstream_id, body.get("status")))
 
         def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
             return settling.claim_batch_for_settlement(batch_object_id, lease_seconds)
@@ -1492,7 +1586,85 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
     monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(upstream)))
 
     assert await reconcile_batches_once() == 2
-    assert ("status", "batch_1", "completed") in settling.rows
+    assert ("state", "batch_1", "completed") in settling.rows
+    assert settling.settled == 1
+
+
+@pytest.mark.asyncio
+async def test_the_reconciler_does_not_starve_later_batches_behind_the_first_fifty(monkeypatch):
+    # The window is the least recently checked fifty. A queue of batches that
+    # is still moving at the provider must rotate to the back after its check
+    # — and so must one whose check cannot run — or the batch behind the
+    # first fifty is never looked at and never settled.
+    settling = _SettlingDB()
+    window = _StarvedWindow(51)  # one batch behind the window
+    window.providerless.add("batch_7")
+
+    class _ReconcileDB(_SettlingDB):
+        def get_unsettled_batches(self, limit=50):
+            return window.take(limit)
+
+        def get_batch_provider(self, provider_id):
+            return None if provider_id == window.PROVIDERLESS else OPENAI_PROVIDER
+
+        def record_batch_provider_state(self, upstream_id, body):
+            window.checked(upstream_id)
+            settling.rows.append(("state", upstream_id, body.get("status")))
+
+        def update_batch_object_status(self, upstream_id, status):
+            assert status is None  # a rotation is a pure stamp
+            window.rotated.add(upstream_id)
+            window.touched(upstream_id)
+
+        def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
+            return settling.claim_batch_for_settlement(batch_object_id, lease_seconds)
+
+        def release_batch_settlement(self, batch_object_id):
+            settling.release_batch_settlement(batch_object_id)
+
+        def mark_batch_settled(self, batch_object_id):
+            settling.mark_batch_settled(batch_object_id)
+
+        def get_api_key_logging_context(self, api_key_id):
+            return settling.get_api_key_logging_context(api_key_id)
+
+        def get_provider_model_deployments(self, provider_id):
+            return settling.get_provider_model_deployments(provider_id)
+
+        def record_batch_usage(self, rows, chunk_size=500):
+            return settling.record_batch_usage(rows)
+
+    monkeypatch.setattr(batch_api, "DBManager", _ReconcileDB)
+
+    def upstream(request):
+        if request.url.path.startswith("/v1/batches/"):
+            number = int(request.url.path.rsplit("/", 1)[1].split("_", 1)[1])
+            if number == 51:  # the one behind the window is already finished
+                return httpx.Response(
+                    200,
+                    json={
+                        "id": "batch_51",
+                        "status": "completed",
+                        "output_file_id": "file-out",
+                        "input_file_id": "file-in",
+                    },
+                )
+            return httpx.Response(200, json={"id": f"batch_{number}", "status": "in_progress"})
+        return _files_upstream(request)
+
+    monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(upstream)))
+
+    assert await reconcile_batches_once() == 0
+    # The first pass looked at the first fifty — batch_51 is behind them,
+    # and batch_7's check could not run at all (its provider row is gone).
+    assert "batch_51" not in window.seen
+    assert window.rotated == {"batch_7"}
+    assert settling.settled == 0
+
+    # What was looked at rotated to the back, so the second pass reaches the
+    # finished batch that the first one could not see.
+    assert await reconcile_batches_once() == 2
+    assert "batch_51" in window.seen
     assert settling.settled == 1
 
 
@@ -1788,6 +1960,35 @@ def test_a_named_provider_keeps_the_refused_creation_refused(monkeypatch):
     assert resp.status_code == 400
     assert db.local_batches == {}
     assert db.stored_files == {}
+    assert [request.method for request in seen] == ["POST"]
+
+
+def test_a_refusal_that_is_not_a_model_error_is_not_rerun_locally(monkeypatch):
+    # The rerun answers "the provider cannot batch this model", nothing else:
+    # a quota or a window error is the provider's own answer, and converting
+    # it into a successful local batch would hide it from the caller.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+
+    def upstream(request):
+        return httpx.Response(400, json={"error": {"message": "You exceeded your current quota."}})
+
+    seen = _patch_env(monkeypatch, db, upstream)
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 400
+    assert db.local_batches == {}
+    assert db.stored_files == {}
+    # The refusal neither taught the routing (it is not a model error) nor
+    # reran the job: the creation went out once, and nothing else happened.
+    assert db.eligibility_records == []
     assert [request.method for request in seen] == ["POST"]
 
 

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -516,6 +517,11 @@ class _FakeDB:
         self.deployments = deployments
         self.owned = dict(owned or {})
         self.budget_error = budget_error
+        # The registration retries run on the shared session: without a
+        # rollback between attempts the second attempt would raise
+        # PendingRollbackError instead of retrying, so the retry path touches
+        # it and the tests can see that it happened.
+        self.session = MagicMock()
         self.registered = []
         self.status_updates = []
         self.stored_files = {}
@@ -555,7 +561,9 @@ class _FakeDB:
         return self.owned.get((kind, upstream_id))
 
     def register_batch_object(self, **kwargs):
-        if self.fail_registration:
+        # True fails every registration; a kind fails only that one, so a test
+        # can keep the file row while breaking the batch row.
+        if self.fail_registration and self.fail_registration in (True, kwargs.get("kind")):
             raise RuntimeError("the database is down")
         self.registered.append(kwargs)
         self.owned[(kwargs["kind"], kwargs["upstream_id"])] = {
@@ -593,14 +601,31 @@ class _FakeDB:
     def get_provider_model_deployments(self, provider_id):
         return [row for row in self.deployments if int(row["provider_id"]) == int(provider_id)]
 
-    def claim_batch_for_settlement(self, batch_object_id):
+    def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
         return False  # the settlement tests drive the latch themselves
+
+    def release_batch_settlement(self, batch_object_id):
+        pass
+
+    def mark_batch_settled(self, batch_object_id):
+        pass
+
+    def count_nonterminal_batches_for_input_file(self, input_file_id):
+        states = {"validating", "in_progress", "cancelling"}
+        return sum(
+            1
+            for row in self.local_batches.values()
+            if row["input_file_id"] == input_file_id and row["status"] in states
+        )
 
     def update_batch_object_status(self, upstream_id, status):
         self.status_updates.append((upstream_id, status))
 
     def delete_batch_object(self, batch_object_id):
         self.deleted.append(batch_object_id)
+        for key, row in list(self.owned.items()):
+            if row.get("id") == batch_object_id:
+                del self.owned[key]
 
     # locally held objects
     def store_local_batch_file(self, *, upstream_id, content, filename, api_key_id, team_id, user_id, purpose="batch"):
@@ -1047,6 +1072,48 @@ def test_file_content_comes_back_as_raw_bytes(monkeypatch):
     assert resp.content == payload
 
 
+def test_a_deleted_provider_file_leaves_no_ownership_row_behind(monkeypatch):
+    # The provider's delete is forwarded, and a success means the object is
+    # gone there: keeping the row would park a dead id in the listing, and a
+    # later creation naming it would pass the local ownership check only to
+    # fail upstream.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+    )
+    seen = _patch_env(
+        monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-own", "object": "file", "deleted": True})
+    )
+
+    resp = client.delete("/v1/files/file-own")
+
+    assert resp.status_code == 200
+    assert [request.method for request in seen] == ["DELETE"]
+    assert db.deleted == [5]
+
+    # The listing, answered from Logos's own record, no longer shows it.
+    listed = client.get("/v1/files")
+    assert listed.json()["data"] == []
+
+
+def test_a_failed_provider_delete_keeps_the_ownership_row(monkeypatch):
+    # The other side of the same coin: the file is only gone from Logos's
+    # books when the provider says it is gone.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+    )
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(500))
+
+    resp = client.delete("/v1/files/file-own")
+
+    assert resp.status_code == 500
+    assert db.deleted == []
+    assert client.get("/v1/files").json()["data"] != []
+
+
 def test_an_upstream_error_is_passed_through_and_logged(monkeypatch):
     db = _FakeDB(
         [OPENAI_PROVIDER],
@@ -1090,6 +1157,37 @@ def test_an_unrecordable_upload_is_removed_upstream_and_reported(monkeypatch):
     # The provider object is gone again: minted, then deleted.
     assert [request.method for request in seen] == ["POST", "DELETE"]
     assert str(seen[-1].url).endswith("/v1/files/file-abc")
+    # Every failed attempt on the shared session was rolled back before the
+    # next one ran, so the retries actually retried the write instead of
+    # raising PendingRollbackError.
+    assert db.session.rollback.call_count == 3
+
+
+def test_an_unrecordable_batch_creation_is_cancelled_upstream_and_reported(monkeypatch):
+    # The batch equivalent of the upload case above — with one difference that
+    # matters: the Batch API has no delete. A job that is minted and left
+    # unowned would keep running on the shared credential, so the only
+    # cleanup is the cancel the API does have.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+    )
+    db.fail_registration = "batch"  # the file row stays, the batch row does not
+    seen = _patch_env(
+        monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1", "status": "validating"})
+    )
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["code"] == "batch_ownership_unrecorded"
+    # Minted, then stopped — with a cancel, because a DELETE would 405.
+    assert [request.method for request in seen] == ["POST", "POST"]
+    assert str(seen[-1].url).endswith("/v1/batches/batch_1/cancel")
 
 
 def test_an_unreachable_upstream_is_a_502(monkeypatch):
@@ -1185,11 +1283,14 @@ INPUT_FILE = _jsonl(_line("one"), _line("two"))
 
 
 class _SettlingDB:
-    def __init__(self, claimable=True):
+    def __init__(self, claimable=True, fail_record_once=False):
         self.claimable = claimable
+        self.fail_record_once = fail_record_once
         self.claims = 0
         self.released = 0
+        self.settled = 0
         self.rows = []
+        self.booked = set()
 
     def __enter__(self):
         return self
@@ -1197,12 +1298,15 @@ class _SettlingDB:
     def __exit__(self, *exc):
         return False
 
-    def claim_batch_for_settlement(self, batch_object_id):
+    def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
         self.claims += 1
         return self.claimable
 
     def release_batch_settlement(self, batch_object_id):
         self.released += 1
+
+    def mark_batch_settled(self, batch_object_id):
+        self.settled += 1
 
     def get_api_key_logging_context(self, api_key_id):
         return {"environment": "test", "log_level": "BILLING"}
@@ -1217,8 +1321,22 @@ class _SettlingDB:
         ]
 
     def record_batch_usage(self, rows, chunk_size=500):
-        self.rows.extend(rows)
-        return len(rows)
+        # Models the ledger's ON CONFLICT (request_id) DO NOTHING: a row an
+        # earlier attempt of the same settlement already booked is skipped,
+        # and only the newly written rows are counted.
+        written = 0
+        for row in rows:
+            if row["request_id"] in self.booked:
+                continue
+            self.booked.add(row["request_id"])
+            self.rows.append(row)
+            written += 1
+        if self.fail_record_once:
+            # The chunks committed and then the process died: the rows are in
+            # the ledger, but the batch was never stamped settled.
+            self.fail_record_once = False
+            raise RuntimeError("the ledger connection dropped")
+        return written
 
 
 def _files_upstream(request):
@@ -1245,6 +1363,7 @@ async def test_settlement_books_one_usage_row_per_result(monkeypatch):
     )
 
     assert written == 2
+    assert db.settled == 1  # stamped only after the rows were written
     ok, failed = db.rows
     assert ok["usage"]["prompt_tokens"] == 120
     assert ok["usage"]["completion_tokens"] == 30
@@ -1254,6 +1373,9 @@ async def test_settlement_books_one_usage_row_per_result(monkeypatch):
     assert ok["result_status"] == "success"
     assert failed["result_status"] == "error"
     assert "context length" in failed["error_message"]
+    # Scoped to this batch, from the line's own custom_id: that stable id is
+    # what makes a retried settlement skip the rows it already booked.
+    assert (ok["request_id"], failed["request_id"]) == ("batch-77-one", "batch-77-two")
 
 
 @pytest.mark.asyncio
@@ -1270,11 +1392,14 @@ async def test_a_batch_is_settled_only_once(monkeypatch):
 
     assert written == 0
     assert db.rows == []
+    assert db.settled == 0
 
 
 @pytest.mark.asyncio
-async def test_an_unreadable_result_file_releases_the_latch(monkeypatch):
+async def test_an_unreadable_result_file_releases_the_lease(monkeypatch):
     # Otherwise a transient failure would drop a whole batch's cost silently.
+    # The lease, not a settled stamp, is what is released: the batch must stay
+    # claimable for the retry.
     db = _SettlingDB()
     monkeypatch.setattr(batch_api, "DBManager", lambda: db)
     monkeypatch.setattr(
@@ -1289,6 +1414,30 @@ async def test_an_unreadable_result_file_releases_the_latch(monkeypatch):
 
     assert written == 0
     assert db.released == 1
+    assert db.settled == 0
+
+
+@pytest.mark.asyncio
+async def test_a_settlement_retry_books_the_rows_only_once(monkeypatch):
+    # The usage chunks commit before the batch is stamped settled, so a
+    # settlement that dies in between is retried with the rows already in the
+    # ledger: the retry skips them on their stable request id, bills nothing
+    # twice, and is what finally stamps the batch.
+    db = _SettlingDB(fail_record_once=True)
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(
+        batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(_files_upstream))
+    )
+    owner = {"id": 77, "api_key_id": 11, "team_id": OWN_TEAM, "user_id": 13, "upstream_id": "batch_1"}
+    batch_body = {"status": "completed", "output_file_id": "file-out", "input_file_id": "file-in"}
+
+    assert await settle_batch(OPENAI_PROVIDER, owner, batch_body) == 0
+    assert db.released == 1 and db.settled == 0
+    assert len(db.rows) == 2  # the partial commit made it into the ledger
+
+    assert await settle_batch(OPENAI_PROVIDER, owner, batch_body) == 0  # nothing new to book
+    assert len(db.rows) == 2  # ... and nothing was booked twice
+    assert db.settled == 1
 
 
 @pytest.mark.asyncio
@@ -1315,8 +1464,14 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
         def update_batch_object_status(self, upstream_id, status):
             settling.rows.append(("status", upstream_id, status))
 
-        def claim_batch_for_settlement(self, batch_object_id):
-            return settling.claim_batch_for_settlement(batch_object_id)
+        def claim_batch_for_settlement(self, batch_object_id, lease_seconds=1800):
+            return settling.claim_batch_for_settlement(batch_object_id, lease_seconds)
+
+        def release_batch_settlement(self, batch_object_id):
+            settling.release_batch_settlement(batch_object_id)
+
+        def mark_batch_settled(self, batch_object_id):
+            settling.mark_batch_settled(batch_object_id)
 
         def get_api_key_logging_context(self, api_key_id):
             return settling.get_api_key_logging_context(api_key_id)
@@ -1338,6 +1493,7 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
 
     assert await reconcile_batches_once() == 2
     assert ("status", "batch_1", "completed") in settling.rows
+    assert settling.settled == 1
 
 
 @pytest.mark.asyncio
@@ -1555,7 +1711,83 @@ def test_a_refused_creation_teaches_the_next_file_to_run_in_logos(monkeypatch):
     )
     assert upload.status_code == 200
     assert upload.json()["logos_execution"] == "logos"
-    # The learned routing kept the file out of the provider entirely.
+    # The learned routing kept the file out of the provider entirely. The GET
+    # is the in-request rerun's attempt to pull the input back from the
+    # provider, which this canned upstream also refuses — so the refusal stays
+    # the answer here, and the rerun is covered by its own test.
+    assert [request.method for request in seen] == ["POST", "GET"]
+
+
+def test_a_refused_auto_creation_is_rerun_locally_on_the_first_request(monkeypatch):
+    # Auto mode means "forward when that can work". A creation the provider
+    # refused with a model-availability error has just said it cannot, so the
+    # same input is pulled back from the provider and run here: the first
+    # request still ends in a batch, and no second upload is needed.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+    started = []
+    monkeypatch.setattr(batch_api, "_start_local_batch", lambda row: started.append(row["upstream_id"]))
+
+    def upstream(request):
+        if request.url.path.endswith("/files/file-own/content"):
+            return httpx.Response(200, content=_jsonl(_line("one"), _line("two")))
+        return httpx.Response(
+            400, json={"error": {"message": "The model 'gpt-4.1' is not supported on the batch SKU."}}
+        )
+
+    seen = _patch_env(monkeypatch, db, upstream)
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "batch"
+    assert body["logos_execution"] == "logos"
+    assert body["request_counts"]["total"] == 2
+    # The input was stored here under a fresh id, named after the provider's file.
+    assert body["input_file_id"].startswith("file-")
+    assert db.stored_files[body["input_file_id"]][0]["filename"] == "file-own_rerun.jsonl"
+    assert started == [body["id"]]
+    # The refusal taught the routing alongside the rerun: the model is marked,
+    # so the next upload of it stays local without another refusal.
+    assert [record[:2] for record in db.eligibility_records] == [(7, 25)]
+    # The creation went out once, and the input came back once.
+    assert [request.method for request in seen] == ["POST", "GET"]
+
+
+def test_a_named_provider_keeps_the_refused_creation_refused(monkeypatch):
+    # The rerun is what "auto" promises. A provider the client named was
+    # demanded, not suggested: its refusal is the answer, unrerun.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+
+    def upstream(request):
+        if request.url.path.endswith("/files/file-own/content"):
+            return httpx.Response(200, content=_jsonl(_line("one")))
+        return httpx.Response(
+            400, json={"error": {"message": "The model 'gpt-4.1' is not supported on the batch SKU."}}
+        )
+
+    seen = _patch_env(monkeypatch, db, upstream)
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+        headers={batch_api.BATCH_PROVIDER_HEADER: "openai"},
+    )
+
+    assert resp.status_code == 400
+    assert db.local_batches == {}
+    assert db.stored_files == {}
     assert [request.method for request in seen] == ["POST"]
 
 
@@ -1679,6 +1911,37 @@ def test_a_local_result_file_is_downloaded_through_the_files_route(monkeypatch):
     assert seen == []
 
 
+def test_an_input_file_is_not_deletable_while_a_batch_still_runs_on_it(monkeypatch):
+    # The runner reads the input's bytes when it starts the batch, not when
+    # the batch is created. A delete in between would strand the batch:
+    # accepted to run, then finding no content. So the delete waits for
+    # terminal.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+    monkeypatch.setattr(batch_api, "_start_local_batch", lambda row: None)  # keep it nonterminal
+
+    file_id = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    ).json()["id"]
+    client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    refused = client.delete(f"/v1/files/{file_id}")
+    assert refused.status_code == 409
+    assert refused.json()["error"]["code"] == "batch_input_file_in_use"
+
+    # Every referencing batch terminal -> the same delete goes through.
+    batch_row = next(row for row in db.local_batches.values() if row["input_file_id"] == file_id)
+    batch_row["status"] = "completed"
+    allowed = client.delete(f"/v1/files/{file_id}")
+    assert allowed.status_code == 200
+    assert allowed.json()["deleted"] is True
+
+
 def test_another_teams_local_object_is_a_404(monkeypatch):
     db = _FakeDB(
         [OPENAI_PROVIDER],
@@ -1739,8 +2002,9 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
         def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
             return False
 
-        def save_local_batch_lines(self, object_id, rows):
+        def save_local_batch_lines(self, object_id, runner_id, rows):
             stored.setdefault("checkpoints", []).extend(rows)
+            stored.setdefault("checkpoint_runners", []).append(runner_id)
 
         def log_usage(self, **kwargs):
             stored.setdefault("logged", []).append(kwargs)
@@ -1750,8 +2014,9 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
             stored.update(kwargs)
             return 1
 
-        def finish_local_batch(self, object_id, **kwargs):
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
             stored["finish"] = kwargs
+            return True
 
     monkeypatch.setattr(batch_local, "DBManager", _RunnerDB)
     monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
@@ -1792,6 +2057,9 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
     # Every finished line is checkpointed durably: on a restart that is what
     # tells the runner which lines must not run (and bill) a second time.
     assert {checkpoint["custom_id"] for checkpoint in stored["checkpoints"]} == {"a", "b"}
+    # The checkpoint write is bound to this holder: a runner deposed mid-batch
+    # must not overwrite the rows the new holder wrote for the same lines.
+    assert set(stored["checkpoint_runners"]) == {batch_local.RUNNER_ID}
     # The claim is the cross-process guard, and it carries this process' id
     # and the lease the other processes will wait on.
     assert stored["claims"] == [(2000, batch_local.RUNNER_ID, batch_local.LOCAL_BATCH_LEASE_TTL_S)]
@@ -1850,8 +2118,9 @@ def test_a_resumed_batch_skips_the_lines_already_checkpointed(monkeypatch):
         def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
             return False
 
-        def save_local_batch_lines(self, object_id, rows):
+        def save_local_batch_lines(self, object_id, runner_id, rows):
             stored.setdefault("checkpoints", []).extend(rows)
+            stored.setdefault("checkpoint_runners", []).append(runner_id)
 
         def log_usage(self, **kwargs):
             stored.setdefault("logged", []).append(kwargs)
@@ -1861,8 +2130,9 @@ def test_a_resumed_batch_skips_the_lines_already_checkpointed(monkeypatch):
             stored.update(kwargs)
             return 1
 
-        def finish_local_batch(self, object_id, **kwargs):
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
             stored["finish"] = kwargs
+            return True
 
     monkeypatch.setattr(batch_local, "DBManager", _ResumeDB)
     monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
@@ -1930,7 +2200,7 @@ def test_a_lost_lease_stops_the_runner_without_writing_results(monkeypatch):
         def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
             return None  # another runner took the batch over
 
-        def save_local_batch_lines(self, object_id, rows):
+        def save_local_batch_lines(self, object_id, runner_id, rows):
             stored.setdefault("checkpoints", []).extend(rows)
 
         def log_usage(self, **kwargs):
@@ -1940,8 +2210,9 @@ def test_a_lost_lease_stops_the_runner_without_writing_results(monkeypatch):
             stored.update(kwargs)
             return 1
 
-        def finish_local_batch(self, object_id, **kwargs):
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
             stored["finish"] = kwargs
+            return True
 
     monkeypatch.setattr(batch_local, "DBManager", _LostLeaseDB)
     monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
@@ -1963,6 +2234,90 @@ def test_a_lost_lease_stops_the_runner_without_writing_results(monkeypatch):
 
     assert result is None  # no output file id: this runner wrote nothing
     assert executed == []
+    assert "finish" not in stored
+    assert "content" not in stored
+
+
+def test_a_lease_lost_mid_chunk_cancels_the_lines_and_writes_nothing(monkeypatch):
+    # A single line can run longer than the whole lease, so the heartbeat
+    # refreshes it in chunks. When the heartbeat finds the lease gone, the
+    # in-flight lines are cancelled — the new holder will run them, and a
+    # cancelled line must not bill for the half it already spent — and this
+    # runner checkpoints nothing and finalizes nothing.
+    monkeypatch.setattr(batch_local, "LOCAL_BATCH_LEASE_TTL_S", 0.6)  # heartbeat every 0.2 s
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        await asyncio.sleep(0.5)  # longer than the heartbeat interval
+        executed.append(1)
+        return {"status_code": 200, "data": {}}
+
+    stored = {}
+
+    class _MidChunkDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, object_id, runner_id, lease_seconds):
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"), _local_line("b"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return _runner_key_row()
+
+        def get_local_batch_lines(self, object_id):
+            return {}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
+            # The write before the chunk still holds the lease; the heartbeat
+            # mid-chunk finds it gone. Counted in the closure: every
+            # ``with DBManager()`` opens a fresh instance.
+            stored["progress_calls"] = stored.get("progress_calls", 0) + 1
+            return False if stored["progress_calls"] == 1 else None
+
+        def save_local_batch_lines(self, object_id, runner_id, rows):
+            stored.setdefault("checkpoints", []).extend(rows)
+
+        def log_usage(self, **kwargs):
+            return {"log-id": 700}, 200
+
+        def store_local_batch_file(self, **kwargs):
+            stored.update(kwargs)
+            return 1
+
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
+            stored["finish"] = kwargs
+            return True
+
+    monkeypatch.setattr(batch_local, "DBManager", _MidChunkDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    result = asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2005,
+                "upstream_id": "batch_m",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "in_progress",
+            }
+        )
+    )
+
+    assert result is None
+    assert executed == []  # the lines were cancelled before they finished
+    assert "checkpoints" not in stored
     assert "finish" not in stored
     assert "content" not in stored
 
@@ -2101,8 +2456,9 @@ def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch
         def store_local_batch_file(self, **kwargs):
             return 1
 
-        def finish_local_batch(self, object_id, **kwargs):
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
             finished.update(kwargs)
+            return True
 
     monkeypatch.setattr(batch_local, "DBManager", _CancelDB)
 
@@ -2148,7 +2504,7 @@ def test_a_batch_already_running_here_is_not_started_again(monkeypatch):
         def get_local_batch_file_content(self, object_id):
             return None
 
-        def finish_local_batch(self, object_id, **kwargs):
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
             pass
 
     monkeypatch.setattr(batch_local, "DBManager", _ClaimDB)

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -572,6 +572,12 @@ class _FakeDB:
         if self.fail_registration and self.fail_registration in (True, kwargs.get("kind")):
             raise RuntimeError("the database is down")
         self.registered.append(kwargs)
+        # Mirrors the production upsert: a row another provider already holds
+        # makes the DO UPDATE a no-op, which the registration reports as a
+        # failure rather than an overwrite.
+        existing = self.owned.get((kwargs["kind"], kwargs["upstream_id"]))
+        if existing is not None and int(existing.get("provider_id") or 0) != int(kwargs.get("provider_id") or 0):
+            raise RuntimeError("batch object id is already held by another provider")
         self.owned[(kwargs["kind"], kwargs["upstream_id"])] = {
             "id": 1,
             "team_id": kwargs["team_id"],
@@ -809,6 +815,32 @@ def test_file_upload_forwards_the_rewritten_file_and_records_ownership(monkeypat
     ]
     assert db.log_usage_kwargs["input_payload"]["requests"] == 1
     assert db.finalization["result_status"] == "success"
+
+
+def test_an_id_already_held_by_another_provider_is_not_reused(monkeypatch):
+    # A client supplies the id without the provider that minted it, so one id
+    # may not name objects at two providers: the registration is refused, the
+    # colliding object is removed from the provider again, and the first row
+    # stays exactly where it was.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-abc"): _remote(5, OWN_TEAM, provider_id=8)},
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["code"] == "batch_ownership_unrecorded"
+    assert db.owned[("file", "file-abc")]["provider_id"] == 8
+    # The colliding object is gone from the provider again, so it lingers
+    # nowhere: the upload went out once, its cleanup delete once.
+    assert [request.method for request in seen] == ["POST", "DELETE"]
 
 
 def test_an_unpermitted_model_never_reaches_the_upstream(monkeypatch):

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -623,16 +623,27 @@ class _FakeDB:
 
     def record_batch_provider_state(self, upstream_id, body):
         # The production sync stores the status and the result fields the
-        # answer carries on the ownership row the listing renders.
+        # answer carries on the ownership row the listing renders: the
+        # counts come from the nested request_counts object.
         status = body.get("status") if isinstance(body, dict) else None
         self.status_updates.append((upstream_id, status))
         row = self.owned.get(("batch", upstream_id))
         if row is not None and isinstance(body, dict):
             if isinstance(status, str):
                 row["status"] = status
-            for field in ("output_file_id", "error_file_id", "total_requests", "completed_requests", "failed_requests"):
+            for field in ("output_file_id", "error_file_id"):
                 if body.get(field) is not None:
                     row[field] = body[field]
+            counts = body.get("request_counts")
+            if isinstance(counts, dict):
+                for column, field in (
+                    ("total_requests", "total"),
+                    ("completed_requests", "completed"),
+                    ("failed_requests", "failed"),
+                ):
+                    value = counts.get(field)
+                    if isinstance(value, int) and not isinstance(value, bool):
+                        row[column] = value
 
     def delete_batch_object(self, batch_object_id):
         self.deleted.append(batch_object_id)
@@ -740,7 +751,7 @@ def _patch_env(monkeypatch, db, upstream, auth=None):
         seen.append(request)
         return upstream(request)
 
-    monkeypatch.setattr(batch_api, "authenticate_api_key", lambda headers: auth or _auth())
+    monkeypatch.setattr(batch_api, "authenticate_batch_api_key", lambda headers: auth or _auth())
     monkeypatch.setattr(batch_api, "DBManager", lambda: db)
     monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)))
     return seen
@@ -1015,9 +1026,8 @@ def test_a_provider_batch_listing_carries_what_the_last_poll_saw(monkeypatch):
                 "status": "completed",
                 "output_file_id": "file-out",
                 "error_file_id": "file-err",
-                "total_requests": 2,
-                "completed_requests": 1,
-                "failed_requests": 1,
+                # The shape the provider reports progress in.
+                "request_counts": {"total": 2, "completed": 1, "failed": 1},
             },
         ),
     )
@@ -1267,7 +1277,7 @@ def test_an_unauthenticated_request_never_reaches_the_upstream(monkeypatch):
     def reject(headers):
         raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
 
-    monkeypatch.setattr(batch_api, "authenticate_api_key", reject)
+    monkeypatch.setattr(batch_api, "authenticate_batch_api_key", reject)
 
     resp = client.post("/v1/batches", json={"input_file_id": "file-own"})
 
@@ -2507,6 +2517,92 @@ def test_a_lease_lost_mid_chunk_cancels_the_lines_and_writes_nothing(monkeypatch
             {
                 "id": 2005,
                 "upstream_id": "batch_m",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "in_progress",
+            }
+        )
+    )
+
+    assert result is None
+    assert executed == []  # the lines were cancelled before they finished
+    assert "checkpoints" not in stored
+    assert "finish" not in stored
+    assert "content" not in stored
+
+
+def test_a_heartbeat_that_fails_cancels_the_lines_and_writes_nothing(monkeypatch):
+    # The heartbeat fails closed, not just on a lost lease but when the check
+    # itself cannot run: a runner that cannot confirm its lease cannot keep
+    # it, so it cancels the in-flight lines and stops — the batch resumes
+    # from its checkpoint under whoever claims it next, and this one
+    # checkpoints nothing and finalizes nothing.
+    monkeypatch.setattr(batch_local, "LOCAL_BATCH_LEASE_TTL_S", 0.6)  # heartbeat every 0.2 s
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        await asyncio.sleep(0.5)  # longer than the heartbeat interval
+        executed.append(1)
+        return {"status_code": 200, "data": {}}
+
+    stored = {}
+
+    class _HeartbeatFailsDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, object_id, runner_id, lease_seconds):
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"), _local_line("b"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return _runner_key_row()
+
+        def get_local_batch_lines(self, object_id):
+            return {}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
+            # The write before the chunk still runs; the heartbeat mid-chunk
+            # hits a database that is gone. Counted in the closure: every
+            # ``with DBManager()`` opens a fresh instance.
+            stored["progress_calls"] = stored.get("progress_calls", 0) + 1
+            if stored["progress_calls"] == 1:
+                return False
+            raise RuntimeError("the ledger connection dropped")
+
+        def save_local_batch_lines(self, object_id, runner_id, rows):
+            stored.setdefault("checkpoints", []).extend(rows)
+
+        def log_usage(self, **kwargs):
+            return {"log-id": 700}, 200
+
+        def store_local_batch_file(self, **kwargs):
+            stored.update(kwargs)
+            return 1
+
+        def finish_local_batch(self, object_id, runner_id, **kwargs):
+            stored["finish"] = kwargs
+            return True
+
+    monkeypatch.setattr(batch_local, "DBManager", _HeartbeatFailsDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    result = asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2006,
+                "upstream_id": "batch_hb",
                 "input_file_id": "file-in",
                 "api_key_id": 11,
                 "team_id": OWN_TEAM,

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1340,6 +1340,67 @@ async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
     assert ("status", "batch_1", "completed") in settling.rows
 
 
+@pytest.mark.asyncio
+async def test_a_failed_batch_nobody_polled_teaches_the_next_file_to_run_in_logos(monkeypatch):
+    # A batch the client never polls is the reconciler's to find, and its
+    # failure must teach the routing there as well as on the client's own
+    # poll: the unsettled-batches query does not carry the input file id, so
+    # the learning takes it from the provider's answer.
+    class _ReconcileDB(_FakeDB):
+        def get_unsettled_batches(self, limit=50):
+            # Shaped as the query selects it: no input_file_id.
+            return [
+                {
+                    "id": 77,
+                    "upstream_id": "batch_1",
+                    "provider_id": 7,
+                    "api_key_id": 11,
+                    "team_id": OWN_TEAM,
+                    "user_id": 13,
+                    "status": "in_progress",
+                }
+            ]
+
+    db = _ReconcileDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-in"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+
+    def upstream(request):
+        if request.url.path.endswith("/batches/batch_1"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "batch_1",
+                    "status": "failed",
+                    "input_file_id": "file-in",
+                    "error": {"message": "The model 'gpt-4.1' is not supported on the batch SKU."},
+                },
+            )
+        return httpx.Response(404, json={"error": "no such object"})
+
+    monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(upstream)))
+
+    await reconcile_batches_once()
+
+    # The failure named the model, so only that model is recorded — and the
+    # record is what the next upload reads.
+    assert [record[:2] for record in db.eligibility_records] == [(7, 25)]
+
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    assert upload.status_code == 200
+    assert upload.json()["logos_execution"] == "logos"
+    # The learned routing kept the file out of the provider entirely.
+    assert seen == []
+
+
 def test_a_dated_model_name_falls_back_to_the_configured_model():
     index = {"gpt-4.1": 25, "gpt-41": 25, "gpt-4.1-mini": 24}
     assert batch_api._model_id_for(index, "gpt-4.1-2025-04-14") == 25

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -512,11 +512,15 @@ def test_too_many_request_lines_are_refused(monkeypatch):
 class _FakeDB:
     """One fake DBManager shared by every ``with DBManager()`` in a request."""
 
-    def __init__(self, providers, deployments, owned=None, budget_error=None):
+    def __init__(self, providers, deployments, owned=None, budget_error=None, key_permissions=None):
         self.providers = providers
         self.deployments = deployments
         self.owned = dict(owned or {})
         self.budget_error = budget_error
+        # api_key_id -> the narrower answer its effective permissions yield.
+        # A key not named here keeps the shared one, like a key whose
+        # permissions the fixture did not touch.
+        self.key_permissions = dict(key_permissions or {})
         # The registration retries run on the shared session: without a
         # rollback between attempts the second attempt would raise
         # PendingRollbackError instead of retrying, so the retry path touches
@@ -542,7 +546,8 @@ class _FakeDB:
 
     # resolution
     def get_batch_provider_candidates(self, api_key_id):
-        return list(self.providers)
+        scoped = self.key_permissions.get(int(api_key_id))
+        return list(scoped["providers"]) if scoped else list(self.providers)
 
     def record_provider_batch_capability(self, provider_id, supports, detail=""):
         pass
@@ -551,7 +556,8 @@ class _FakeDB:
         return next((p for p in self.providers if int(p["id"]) == int(provider_id)), None)
 
     def get_batch_model_deployments(self, api_key_id, provider_id=None):
-        rows = list(self.deployments)
+        scoped = self.key_permissions.get(int(api_key_id))
+        rows = list(scoped["deployments"]) if scoped else list(self.deployments)
         if provider_id is None:
             return rows
         return [row for row in rows if int(row["provider_id"]) == int(provider_id)]
@@ -874,6 +880,54 @@ def test_batch_creation_registers_the_new_batch(monkeypatch):
     assert db.registered[0]["kind"] == "batch"
     assert db.registered[0]["upstream_id"] == "batch_1"
     assert db.registered[0]["team_id"] == OWN_TEAM
+
+
+def test_a_narrower_team_key_cannot_run_a_wider_key_s_file_at_the_provider(monkeypatch):
+    # Ownership is the team's, the permission is the key's: the wide key
+    # uploaded a file that also names a model the narrow team key may not
+    # run. The creation is refused before the shared provider credential is
+    # asked to run what the creating key no longer may.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1", "gpt-4o"])},
+        key_permissions={22: {"providers": [OPENAI_PROVIDER], "deployments": OPENAI_DEPLOYMENTS}},
+    )
+    seen = _patch_env(
+        monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1"}), auth=_auth(api_key_id=22)
+    )
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "model_not_permitted"
+    assert "gpt-4o" in resp.json()["error"]["message"]
+    assert seen == []
+
+
+def test_a_key_that_lost_the_provider_cannot_run_its_file_at_the_provider(monkeypatch):
+    # The upload key's provider link is revoked after the upload: the team
+    # still owns the file, but the key may no longer spend the shared
+    # credential on it, so the creation is refused rather than forwarded.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+        key_permissions={11: {"providers": [], "deployments": []}},
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1"}))
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "batch_provider_not_authorized"
+    assert seen == []
 
 
 def test_a_key_over_budget_cannot_start_a_batch(monkeypatch):
@@ -2079,6 +2133,141 @@ def test_a_local_batch_is_created_and_reported_in_the_openai_shape(monkeypatch):
     assert started == [body["id"]]
 
 
+def test_a_local_batch_must_match_the_endpoint_of_its_lines(monkeypatch):
+    # The runner would execute the lines' own urls while the batch advertised
+    # the other endpoint; a provider-run batch is refused for that mismatch,
+    # so is a local one.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+    monkeypatch.setattr(batch_api, "_start_local_batch", lambda row: None)
+
+    embedding = {
+        "custom_id": "one",
+        "method": "POST",
+        "url": "/v1/embeddings",
+        "body": {"model": "qwen3-32b", "input": "hi"},
+    }
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(embedding), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    assert upload.status_code == 200
+    file_id = upload.json()["id"]
+
+    created = client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "invalid_batch_line"
+    assert db.local_batches == {}
+
+
+@pytest.mark.parametrize("window", ["48h", None])
+def test_a_local_batch_requires_the_one_supported_window(monkeypatch, window):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    file_id = upload.json()["id"]
+    body = {"input_file_id": file_id, "endpoint": "/v1/chat/completions"}
+    if window is not None:
+        body["completion_window"] = window
+
+    created = client.post("/v1/batches", json=body)
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "invalid_request_error"
+    assert db.local_batches == {}
+
+
+def test_a_local_batch_requires_a_supported_endpoint(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    file_id = upload.json()["id"]
+
+    created = client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/audio/transcriptions", "completion_window": "24h"},
+    )
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "unsupported_batch_endpoint"
+    assert db.local_batches == {}
+
+
+def test_a_local_batch_line_must_be_a_post(monkeypatch):
+    # The upload does not look at the method, and the runner would ignore it
+    # too: a non-POST line is not a batch request, so the creation refuses it.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    get_line = {
+        "custom_id": "one",
+        "method": "GET",
+        "url": "/v1/chat/completions",
+        "body": {"model": "qwen3-32b", "messages": [{"role": "user", "content": "hi"}]},
+    }
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(get_line), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    assert upload.status_code == 200
+    file_id = upload.json()["id"]
+
+    created = client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert created.status_code == 400
+    assert created.json()["error"]["code"] == "invalid_batch_line"
+    assert db.local_batches == {}
+
+
+def test_a_rerun_whose_lines_do_not_match_the_endpoint_stays_refused(monkeypatch):
+    # The rerun is the alternative to the provider's refusal, not a rewrite
+    # of the contract: lines that do not call the requested endpoint leave
+    # the refusal standing instead of starting a lying batch.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+
+    def upstream(request):
+        if request.url.path.endswith("/files/file-own/content"):
+            return httpx.Response(200, content=_jsonl(_line("one")))
+        return httpx.Response(
+            400, json={"error": {"message": "The model 'gpt-4.1' is not supported on the batch SKU."}}
+        )
+
+    seen = _patch_env(monkeypatch, db, upstream)
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/embeddings", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 400
+    assert db.local_batches == {}
+    assert db.stored_files == {}
+    assert [request.method for request in seen] == ["POST", "GET"]
+
+
 def test_a_local_batch_is_polled_and_cancelled_through_the_same_routes(monkeypatch):
     db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
     seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
@@ -2089,7 +2278,10 @@ def test_a_local_batch_is_polled_and_cancelled_through_the_same_routes(monkeypat
         files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
         data={"purpose": "batch"},
     )
-    batch_id = client.post("/v1/batches", json={"input_file_id": upload.json()["id"]}).json()["id"]
+    batch_id = client.post(
+        "/v1/batches",
+        json={"input_file_id": upload.json()["id"], "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    ).json()["id"]
 
     polled = client.get(f"/v1/batches/{batch_id}")
     assert polled.status_code == 200

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -524,6 +524,9 @@ class _FakeDB:
         self.cancelled = []
         self.log_usage_kwargs = None
         self.finalization = None
+        self.ineligible = {}
+        self.eligibility_records = []
+        self.fail_registration = False
 
     def __enter__(self):
         return self
@@ -552,6 +555,8 @@ class _FakeDB:
         return self.owned.get((kind, upstream_id))
 
     def register_batch_object(self, **kwargs):
+        if self.fail_registration:
+            raise RuntimeError("the database is down")
         self.registered.append(kwargs)
         self.owned[(kwargs["kind"], kwargs["upstream_id"])] = {
             "id": 1,
@@ -561,8 +566,35 @@ class _FakeDB:
             **kwargs,
         }
 
-    def list_batch_objects_for_team(self, team_id, kind, limit=100):
-        return [row for key, row in self.owned.items() if key[0] == kind and row.get("team_id") == team_id]
+    def list_batch_objects_for_principal(self, kind, team_id, user_id, api_key_id, limit=100):
+        rows = []
+        for key, row in self.owned.items():
+            if key[0] != kind:
+                continue
+            if team_id is not None:
+                matches = row.get("team_id") == team_id
+            elif user_id is not None:
+                # A team-less key sees only its own user's objects — the same
+                # predicate the database query uses.
+                matches = row.get("team_id") is None and row.get("user_id") == user_id
+            else:
+                matches = row.get("api_key_id") == api_key_id
+            if matches:
+                rows.append(row)
+        return rows
+
+    def get_batch_model_ineligibility(self, provider_id):
+        return set(self.ineligible.get(int(provider_id), set()))
+
+    def record_model_batch_ineligibility(self, provider_id, model_id, detail=""):
+        self.eligibility_records.append((int(provider_id), int(model_id), detail))
+        self.ineligible.setdefault(int(provider_id), set()).add(int(model_id))
+
+    def get_provider_model_deployments(self, provider_id):
+        return [row for row in self.deployments if int(row["provider_id"]) == int(provider_id)]
+
+    def claim_batch_for_settlement(self, batch_object_id):
+        return False  # the settlement tests drive the latch themselves
 
     def update_batch_object_status(self, upstream_id, status):
         self.status_updates.append((upstream_id, status))
@@ -715,6 +747,9 @@ def test_file_upload_forwards_the_rewritten_file_and_records_ownership(monkeypat
             "api_key_id": 11,
             "team_id": OWN_TEAM,
             "user_id": 13,
+            # The models the file names are kept on the row: a later refusal
+            # by the provider is the evidence for which model to mark.
+            "models": ["gpt-4.1"],
         }
     ]
     assert db.log_usage_kwargs["input_payload"]["requests"] == 1
@@ -850,6 +885,57 @@ def test_an_id_logos_never_minted_is_a_404(monkeypatch):
     assert seen == []
 
 
+def test_a_team_less_key_cannot_reach_another_users_objects(monkeypatch):
+    # Both keys are team-less, so their objects carry team_id = NULL. A scope
+    # on "team_id IS NULL" would make every personal key on the instance the
+    # owner of every other one's batches; the user, then the key, is what
+    # separates them.
+    personal = {
+        "id": 5,
+        "team_id": None,
+        "user_id": 13,
+        "api_key_id": 21,
+        "provider_id": 7,
+        "execution": "provider",
+        "settled_at": None,
+        "created_at": datetime.now(timezone.utc),
+    }
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS, owned={("batch", "batch_p"): personal})
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "leaked"}))
+    stranger = SimpleNamespace(
+        key_value="lg-other",
+        api_key_id=22,
+        api_key_name="other-key",
+        key_type="user",
+        team_id=None,
+        user_id=14,
+        environment="test",
+        log_level="BILLING",
+        settings={},
+        default_priority=0,
+    )
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "leaked"}), auth=stranger)
+
+    # Another unteamed user is answered exactly like an unknown id, and the
+    # listing shows none of that user's objects either.
+    assert client.get("/v1/batches/batch_p").status_code == 404
+    listed = client.get("/v1/batches")
+    assert listed.status_code == 200
+    assert listed.json()["data"] == []
+    assert seen == []
+
+    # The owning user (team-less like the object) reaches it.
+    _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(200, json={"id": "batch_p", "status": "in_progress"}),
+        auth=_auth(api_key_id=21, team_id=None),
+    )
+    resp = client.get("/v1/batches/batch_p")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "batch_p"
+
+
 def test_a_listing_is_answered_from_logos_own_record(monkeypatch):
     # Not forwarded: the shared upstream credential sees every team's objects,
     # and Logos knows about the batches it ran itself, which no provider does.
@@ -888,6 +974,44 @@ def test_polling_records_the_status_and_settles_a_finished_batch(monkeypatch):
     assert resp.status_code == 200
     assert db.status_updates == [("batch_1", "completed")]
     assert settled == [(77, "completed")]
+
+
+def test_a_poll_registers_the_result_file_the_provider_minted(monkeypatch):
+    # The provider mints the output (and error) file under the shared
+    # credential: it shows up in the provider's file list for every key that
+    # may use the provider. Without an ownership row of its own, the batch
+    # owner's result download would be a 404 while a stranger's would work.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_1"): _remote(77, OWN_TEAM)},
+    )
+    _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(
+            200,
+            json={
+                "id": "batch_1",
+                "status": "completed",
+                "output_file_id": "file-out",
+                "error_file_id": "file-err",
+            },
+        ),
+    )
+    monkeypatch.setattr(batch_api, "_schedule_settlement", lambda *args: None)
+
+    assert client.get("/v1/batches/batch_1").status_code == 200
+
+    file_rows = [row for (kind, _), row in db.owned.items() if kind == "file"]
+    assert {row["upstream_id"] for row in file_rows} == {"file-out", "file-err"}
+    assert all(row["team_id"] == OWN_TEAM for row in file_rows)
+
+    # And the owner can now download the result through the files route.
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, content=b'{"custom_id": "one"}\n'))
+    download = client.get("/v1/files/file-out/content")
+    assert download.status_code == 200
+    assert download.content == b'{"custom_id": "one"}\n'
 
 
 def test_an_unfinished_batch_is_not_settled(monkeypatch):
@@ -944,6 +1068,28 @@ def test_an_upstream_error_is_passed_through_and_logged(monkeypatch):
     assert resp.json()["error"]["message"] == "input file is empty"
     assert db.finalization["result_status"] == "error"
     assert "input file is empty" in db.finalization["error_message"]
+
+
+def test_an_unrecordable_upload_is_removed_upstream_and_reported(monkeypatch):
+    # The provider has the file but nobody at Logos knows who owns it: with
+    # the shared credential that object is reachable by every key. Rather
+    # than return success for an unowned object, Logos removes it again and
+    # says so.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    db.fail_registration = True
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["code"] == "batch_ownership_unrecorded"
+    # The provider object is gone again: minted, then deleted.
+    assert [request.method for request in seen] == ["POST", "DELETE"]
+    assert str(seen[-1].url).endswith("/v1/files/file-abc")
 
 
 def test_an_unreachable_upstream_is_a_502(monkeypatch):
@@ -1283,6 +1429,75 @@ def test_a_cloud_model_its_provider_cannot_batch_is_run_by_logos(monkeypatch):
     assert seen == []
 
 
+def test_a_model_the_provider_refused_before_runs_in_logos(monkeypatch):
+    # The model is hosted on the batch-capable provider — through a Standard
+    # deployment — but a refusal recorded before marked it as not batchable
+    # there. Hosting alone must not qualify it: forwarding would just fail
+    # the batch the same way it failed before.
+    hosted_but_not_batchable = [
+        {
+            "model_id": 92,
+            "model_name": "gpt-5.6-luna",
+            "endpoint": "https://res.openai.azure.com/openai/deployments/gpt-5.6-luna/responses",
+            "provider_id": 8,  # the batch-capable provider itself
+            "provider_type": "cloud",
+            "cloud_provider_type": "azure",
+        }
+    ]
+    db = _FakeDB([AZURE_PROVIDER], AZURE_DEPLOYMENTS + hosted_but_not_batchable)
+    db.ineligible[8] = {92}
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line(model="gpt-5.6-luna")), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["logos_execution"] == "logos"
+    assert seen == []
+
+
+def test_a_refused_creation_teaches_the_next_file_to_run_in_logos(monkeypatch):
+    # The provider does not publish which of its models it offers for batch,
+    # so its refusal is the only source: a creation refused for the model
+    # records it, and the same file uploaded again is routed to Logos instead
+    # of failing the same way.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM, models=["gpt-4.1"])},
+    )
+    seen = _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(
+            400, json={"error": {"message": "The model 'gpt-4.1' is not supported on the batch SKU."}}
+        ),
+    )
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 400
+    # The refusal named the model, so only that model is recorded — and the
+    # record is what the next upload reads.
+    assert [record[:2] for record in db.eligibility_records] == [(7, 25)]
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    assert upload.status_code == 200
+    assert upload.json()["logos_execution"] == "logos"
+    # The learned routing kept the file out of the provider entirely.
+    assert [request.method for request in seen] == ["POST"]
+
+
 def test_the_execution_header_forces_a_local_run(monkeypatch):
     db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
     seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
@@ -1433,7 +1648,8 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
         def __exit__(self, *exc):
             return False
 
-        def claim_local_batch(self, batch_object_id):
+        def claim_local_batch(self, batch_object_id, runner_id, lease_seconds):
+            stored.setdefault("claims", []).append((batch_object_id, runner_id, lease_seconds))
             return True
 
         def get_local_object_by_upstream_id(self, kind, upstream_id):
@@ -1456,8 +1672,14 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
                 "default_priority": 10,
             }
 
-        def update_local_batch_progress(self, object_id, completed, failed):
+        def get_local_batch_lines(self, object_id):
+            return {}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
             return False
+
+        def save_local_batch_lines(self, object_id, rows):
+            stored.setdefault("checkpoints", []).extend(rows)
 
         def log_usage(self, **kwargs):
             stored.setdefault("logged", []).append(kwargs)
@@ -1506,6 +1728,195 @@ def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
     assert row["custom_id"] == "a"
     assert row["response"]["status_code"] == 200
     assert row["error"] is None
+    # Every finished line is checkpointed durably: on a restart that is what
+    # tells the runner which lines must not run (and bill) a second time.
+    assert {checkpoint["custom_id"] for checkpoint in stored["checkpoints"]} == {"a", "b"}
+    # The claim is the cross-process guard, and it carries this process' id
+    # and the lease the other processes will wait on.
+    assert stored["claims"] == [(2000, batch_local.RUNNER_ID, batch_local.LOCAL_BATCH_LEASE_TTL_S)]
+
+
+def _runner_key_row(default_priority=1):
+    return {
+        "id": 11,
+        "key_value": "lg-test",
+        "name": "k",
+        "key_type": "user",
+        "team_id": OWN_TEAM,
+        "user_id": 13,
+        "environment": "test",
+        "log": "BILLING",
+        "settings": {},
+        "default_priority": default_priority,
+    }
+
+
+def test_a_resumed_batch_skips_the_lines_already_checkpointed(monkeypatch):
+    # A restart must not re-run (and re-bill) the lines the previous pass
+    # finished: they are read back from the checkpoint, and only the missing
+    # lines go through the pipeline.
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        executed.append(body["model"])
+        return {"status_code": 200, "data": {"usage": {"prompt_tokens": 5}}}
+
+    stored = {}
+    done = batch_local._result_row(_local_line("a"), {"status_code": 200, "data": {"usage": {"prompt_tokens": 5}}})[0]
+
+    class _ResumeDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, batch_object_id, runner_id, lease_seconds):
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"), _local_line("b"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return _runner_key_row()
+
+        def get_local_batch_lines(self, object_id):
+            return {"a": done}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
+            return False
+
+        def save_local_batch_lines(self, object_id, rows):
+            stored.setdefault("checkpoints", []).extend(rows)
+
+        def log_usage(self, **kwargs):
+            stored.setdefault("logged", []).append(kwargs)
+            return {"log-id": 500 + len(stored["logged"])}, 200
+
+        def store_local_batch_file(self, **kwargs):
+            stored.update(kwargs)
+            return 1
+
+        def finish_local_batch(self, object_id, **kwargs):
+            stored["finish"] = kwargs
+
+    monkeypatch.setattr(batch_local, "DBManager", _ResumeDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2003,
+                "upstream_id": "batch_r",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "in_progress",  # left behind by a dead runner
+            }
+        )
+    )
+
+    assert len(executed) == 1  # only the line without a checkpoint ran
+    assert len(stored["logged"]) == 1  # ... and was the only one billed
+    assert stored["finish"]["completed"] == 2
+    assert stored["finish"]["failed"] == 0
+    # The output file carries both rows, in input order — the resumed one
+    # from the checkpoint, the fresh one from this run.
+    output = [json.loads(line) for line in stored["content"].splitlines()]
+    assert [row["custom_id"] for row in output] == ["a", "b"]
+    assert output[0] == done
+
+
+def test_a_lost_lease_stops_the_runner_without_writing_results(monkeypatch):
+    # A progress write that says "you no longer hold this batch" must stop the
+    # runner before the next line: the new holder resumes from the checkpoints
+    # already written, and two finishers would write two result files.
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        executed.append(1)
+        return {"status_code": 200, "data": {}}
+
+    stored = {}
+
+    class _LostLeaseDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, batch_object_id, runner_id, lease_seconds):
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"), _local_line("b"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return _runner_key_row()
+
+        def get_local_batch_lines(self, object_id):
+            return {}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
+            return None  # another runner took the batch over
+
+        def save_local_batch_lines(self, object_id, rows):
+            stored.setdefault("checkpoints", []).extend(rows)
+
+        def log_usage(self, **kwargs):
+            return {"log-id": 600}, 200
+
+        def store_local_batch_file(self, **kwargs):
+            stored.update(kwargs)
+            return 1
+
+        def finish_local_batch(self, object_id, **kwargs):
+            stored["finish"] = kwargs
+
+    monkeypatch.setattr(batch_local, "DBManager", _LostLeaseDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    result = asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2004,
+                "upstream_id": "batch_l",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "in_progress",
+            }
+        )
+    )
+
+    assert result is None  # no output file id: this runner wrote nothing
+    assert executed == []
+    assert "finish" not in stored
+    assert "content" not in stored
+
+
+class _LineLogDB:
+    """The minimum of a database a single line needs: its usage-log row."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def log_usage(self, **kwargs):
+        return {"log-id": 600}, 200
 
 
 def test_a_failing_line_is_reported_without_stopping_the_batch(monkeypatch):
@@ -1514,6 +1925,7 @@ def test_a_failing_line_is_reported_without_stopping_the_batch(monkeypatch):
             raise RuntimeError("upstream exploded")
         return {"status_code": 400, "data": {"error": {"message": "context length exceeded"}}}
 
+    monkeypatch.setattr(batch_local, "DBManager", _LineLogDB)
     monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
     monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
 
@@ -1522,6 +1934,31 @@ def test_a_failing_line_is_reported_without_stopping_the_batch(monkeypatch):
     assert failed is True
     assert row["error"]["code"] == "400"
     assert "context length" in row["error"]["message"]
+
+
+def test_a_line_without_a_log_row_is_refused_not_run_unbilled(monkeypatch):
+    # Without the log row the pipeline would run the request and bill nothing,
+    # so the line is refused instead of run — the batch reports it as failed.
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        executed.append(body)
+        return {"status_code": 200, "data": {}}
+
+    class _BrokenLogDB(_LineLogDB):
+        def log_usage(self, **kwargs):
+            raise RuntimeError("the ledger is down")
+
+    monkeypatch.setattr(batch_local, "DBManager", _BrokenLogDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    row, failed = asyncio.run(batch_local._run_line(_local_line("a"), _auth(), {}, asyncio.Semaphore(1)))
+
+    assert failed is True
+    assert row["response"]["status_code"] == 500
+    assert "could not be started" in row["error"]["message"]
+    assert executed == []  # no unbilled request may reach the provider
 
 
 def test_a_local_batch_object_looks_like_a_providers(monkeypatch):
@@ -1556,7 +1993,11 @@ def test_a_local_batch_object_looks_like_a_providers(monkeypatch):
 
 def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch):
     # The cancel moves a queued batch to 'cancelling'; without the runner
-    # picking that state up it would sit there forever.
+    # picking that state up it would sit there forever. 'cancelling' goes
+    # through the same lease claim as every other state: the claim is what
+    # makes the takeover exclusive, and the pending cancel is read off the
+    # first progress write.
+    claimed = []
     finished = {}
 
     class _CancelDB:
@@ -1566,8 +2007,9 @@ def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch
         def __exit__(self, *exc):
             return False
 
-        def claim_local_batch(self, object_id):
-            raise AssertionError("a cancelling batch is not claimed as new work")
+        def claim_local_batch(self, object_id, runner_id, lease_seconds):
+            claimed.append(object_id)
+            return True
 
         def get_local_object_by_upstream_id(self, kind, upstream_id):
             return {"id": 1000}
@@ -1589,7 +2031,10 @@ def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch
                 "default_priority": 1,
             }
 
-        def update_local_batch_progress(self, object_id, completed, failed):
+        def get_local_batch_lines(self, object_id):
+            return {}
+
+        def update_local_batch_progress(self, object_id, runner_id, completed, failed, lease_seconds):
             return True  # a cancel is pending
 
         def store_local_batch_file(self, **kwargs):
@@ -1614,6 +2059,7 @@ def test_a_cancel_before_the_runner_started_still_finishes_the_batch(monkeypatch
         )
     )
 
+    assert claimed == [2001]  # taken over like any other queued batch
     assert finished["status"] == "cancelled"
     assert finished["completed"] == 0
 
@@ -1631,7 +2077,7 @@ def test_a_batch_already_running_here_is_not_started_again(monkeypatch):
         def __exit__(self, *exc):
             return False
 
-        def claim_local_batch(self, object_id):
+        def claim_local_batch(self, object_id, runner_id, lease_seconds):
             claimed.append(object_id)
             return True
 

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_api.py
@@ -1,0 +1,1544 @@
+"""The OpenAI Batch API, served by forwarding to a provider that has one.
+
+Logos hands the job to the provider's batch endpoint — that is where the
+provider's batch rate applies — and keeps the three things a proxy exists for:
+the key's model permissions are enforced on every request line of the input
+file, the ids the provider mints are owned by the team that created them, and a
+finished batch's usage is booked into the same ledger as everything else.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import logos as main
+from logos import batch_api, batch_local
+from logos.batch_api import (
+    BATCH_PROVIDER_HEADER,
+    BatchOperation,
+    batch_operation_url,
+    batch_provider_headers,
+    parse_batch_api_path,
+    reconcile_batches_once,
+    resolve_batch_provider,
+    settle_batch,
+    validate_and_rewrite_batch_input,
+)
+from logos.request_content import is_batch_api_path
+
+OPENAI_PROVIDER = {
+    "id": 7,
+    "name": "openai",
+    "base_url": "https://api.openai.com/v1",
+    "cloud_provider_type": "openai",
+    "auth_name": "Authorization",
+    "auth_format": "Bearer {}",
+    "api_key": "sk-test",
+    "supports_batch": True,
+    "capability_checked_at": datetime.now(timezone.utc),
+}
+
+AZURE_PROVIDER = {
+    "id": 8,
+    "name": "azure",
+    "base_url": "https://res.openai.azure.com/openai/deployments/",
+    "cloud_provider_type": "azure",
+    "auth_name": "api-key",
+    "auth_format": "{}",
+    "api_key": "az-key",
+    "supports_batch": True,
+    "capability_checked_at": datetime.now(timezone.utc),
+}
+
+# What the key may run, as get_batch_model_deployments returns it.
+OPENAI_DEPLOYMENTS = [
+    {
+        "model_id": 25,
+        "model_name": "gpt-4.1",
+        "endpoint": "https://api.openai.com/v1/chat/completions",
+        "provider_id": 7,
+        "provider_type": "cloud",
+        "cloud_provider_type": "openai",
+    },
+]
+AZURE_DEPLOYMENTS = [
+    {
+        "model_id": 25,
+        "model_name": "gpt-4.1",
+        "endpoint": (
+            "https://res.openai.azure.com/openai/deployments/gpt-41/chat/completions?api-version=2025-01-01-preview"
+        ),
+        "provider_id": 8,
+        "provider_type": "cloud",
+        "cloud_provider_type": "azure",
+    },
+]
+
+# A model only a worker node serves: no provider Batch API can run it, so a
+# batch that names it is executed by Logos itself.
+LOCAL_DEPLOYMENTS = [
+    {
+        "model_id": 40,
+        "model_name": "qwen3-32b",
+        "endpoint": None,
+        "provider_id": 15,
+        "provider_type": "logosnode",
+        "cloud_provider_type": None,
+    },
+]
+
+client = TestClient(main.app, raise_server_exceptions=False)
+
+OWN_TEAM = 12
+OTHER_TEAM = 99
+
+
+def _auth(api_key_id=11, team_id=OWN_TEAM):
+    return SimpleNamespace(
+        key_value="lg-test",
+        api_key_id=api_key_id,
+        api_key_name="test-key",
+        key_type="user",
+        team_id=team_id,
+        user_id=13,
+        environment="test",
+        log_level="BILLING",
+        settings={},
+        default_priority=0,
+    )
+
+
+def _remote(object_id, team_id, **extra):
+    """An ownership row for an object that lives at the provider."""
+    return {
+        "id": object_id,
+        "team_id": team_id,
+        "provider_id": 7,
+        "execution": "provider",
+        "settled_at": None,
+        "created_at": datetime.now(timezone.utc),
+        **extra,
+    }
+
+
+def _line(custom_id="one", model="gpt-4.1", url="/v1/chat/completions", body=None):
+    payload = {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+    return {"custom_id": custom_id, "method": "POST", "url": url, "body": body if body is not None else payload}
+
+
+def _jsonl(*lines):
+    return ("\n".join(json.dumps(line) for line in lines) + "\n").encode()
+
+
+# ---------------------------------------------------------------------------
+# is_batch_api_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "v1/batches",
+        "v1/batches/batch_123",
+        "v1/batches/batch_123/cancel",
+        "v1/files",
+        "v1/files/file_123",
+        "v1/files/file_123/content",
+        "/v1/batches",
+        "openai/batches",
+        "openai/files",
+        "openai/v1/batches",
+        "openai/v1/files/file_123/content",
+        "jobs/v1/batches",
+        "jobs/v1/files",
+        "jobs/openai/v1/batches",
+    ],
+)
+def test_is_batch_api_path_recognises_batch_operations(path):
+    assert is_batch_api_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "v1/chat/completions",
+        "v1/completions",
+        "v1/embeddings",
+        "v1/responses",
+        "v1/audio/transcriptions",
+        "v1/models",
+        "v1/files_backup",
+        "v1/mybatches",
+        "v1/batch",
+        # The v2 (Cohere) mirror has no batch routes.
+        "v2/batches",
+        "v2/files",
+        "jobs/v2/batches",
+        "v2/embed",
+        "pooling",
+        "",
+        None,
+    ],
+)
+def test_is_batch_api_path_ignores_regular_operations(path):
+    assert not is_batch_api_path(path)
+
+
+# ---------------------------------------------------------------------------
+# parse_batch_api_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "expected"),
+    [
+        ("v1/files", "POST", ("files", None, None, True)),
+        ("v1/files", "GET", ("files", None, None, False)),
+        ("v1/files/file_1", "GET", ("files", "file_1", None, False)),
+        ("v1/files/file_1", "DELETE", ("files", "file_1", None, False)),
+        ("v1/files/file_1/content", "GET", ("files", "file_1", "content", False)),
+        ("v1/batches", "POST", ("batches", None, None, False)),
+        ("v1/batches", "GET", ("batches", None, None, False)),
+        ("v1/batches/batch_1", "GET", ("batches", "batch_1", None, False)),
+        ("v1/batches/batch_1/cancel", "POST", ("batches", "batch_1", "cancel", False)),
+        ("openai/v1/files/file_1/content", "GET", ("files", "file_1", "content", False)),
+        ("jobs/v1/batches/batch_1/cancel", "POST", ("batches", "batch_1", "cancel", False)),
+        ("jobs/openai/v1/files", "POST", ("files", None, None, True)),
+    ],
+)
+def test_parse_batch_api_path_recovers_the_operation(path, method, expected):
+    op = parse_batch_api_path(path, method=method)
+    assert op is not None
+    resource, resource_id, suboperation, is_upload = expected
+    assert (op.resource, op.resource_id, op.suboperation, op.is_file_upload) == (
+        resource,
+        resource_id,
+        suboperation,
+        is_upload,
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "v1/batches/batch_1/unknown",
+        "v1/files/file_1/unknown",
+        "v1/batches/batch_1/cancel/extra",
+        "v1/batch",
+        "v1/chat/completions",
+        "",
+        None,
+    ],
+)
+def test_parse_batch_api_path_rejects_non_batch_shapes(path):
+    assert parse_batch_api_path(path) is None
+
+
+def test_mirrored_paths_are_normalised_to_the_canonical_version():
+    # The mirrors are inbound spellings only; a provider whose base_url has no
+    # version segment must still be addressed at /v1/....
+    for path in ("openai/files", "jobs/openai/files", "openai/v1/files", "jobs/v1/files"):
+        assert parse_batch_api_path(path, method="POST").path == "v1/files"
+
+
+# ---------------------------------------------------------------------------
+# Upstream URL and header construction
+# ---------------------------------------------------------------------------
+
+
+def test_generic_provider_url_dedups_the_version_prefix():
+    op = parse_batch_api_path("v1/files/file_1/content", method="GET")
+    assert batch_operation_url(OPENAI_PROVIDER, op) == "https://api.openai.com/v1/files/file_1/content"
+
+
+def test_generic_provider_url_keeps_the_version_when_the_base_lacks_it():
+    provider = {**OPENAI_PROVIDER, "base_url": "https://proxy.example.com"}
+    for path in ("v1/batches/batch_1/cancel", "openai/batches/batch_1/cancel", "jobs/openai/batches/batch_1/cancel"):
+        op = parse_batch_api_path(path, method="POST")
+        assert batch_operation_url(provider, op) == "https://proxy.example.com/v1/batches/batch_1/cancel"
+
+
+def test_generic_provider_url_forwards_the_query_verbatim():
+    op = parse_batch_api_path("v1/batches", method="GET", query="after=batch_1&limit=5")
+    assert batch_operation_url(OPENAI_PROVIDER, op) == "https://api.openai.com/v1/batches?after=batch_1&limit=5"
+
+
+def test_provider_without_a_base_url_is_a_502():
+    provider = {**OPENAI_PROVIDER, "base_url": "  "}
+    with pytest.raises(HTTPException) as exc:
+        batch_operation_url(provider, parse_batch_api_path("v1/batches", method="POST"))
+    assert exc.value.status_code == 502
+
+
+def test_azure_batch_is_addressed_on_the_v1_surface():
+    # Verified against a live resource: the dated data-plane version that first
+    # served /openai/batches is long gone (2024-02-01 answers 404), while the
+    # /openai/v1 surface serves them and carries the newer models.
+    op = parse_batch_api_path("v1/batches", method="POST")
+    assert batch_operation_url(AZURE_PROVIDER, op) == "https://res.openai.azure.com/openai/v1/batches"
+
+
+def test_azure_batch_query_is_forwarded():
+    op = parse_batch_api_path("v1/batches", method="GET", query="limit=5")
+    assert batch_operation_url(AZURE_PROVIDER, op) == "https://res.openai.azure.com/openai/v1/batches?limit=5"
+
+
+def test_azure_batch_api_version_override_uses_the_dated_route(monkeypatch):
+    monkeypatch.setattr(batch_api, "AZURE_BATCH_API_VERSION", "2024-10-21")
+    op = parse_batch_api_path("v1/files/file_1/content", method="GET")
+    assert batch_operation_url(AZURE_PROVIDER, op) == (
+        "https://res.openai.azure.com/openai/files/file_1/content?api-version=2024-10-21"
+    )
+
+
+def test_azure_batch_api_version_override_keeps_a_client_supplied_version(monkeypatch):
+    monkeypatch.setattr(batch_api, "AZURE_BATCH_API_VERSION", "2024-10-21")
+    op = parse_batch_api_path("v1/batches", method="GET", query="api-version=2025-04-01-preview")
+    assert batch_operation_url(AZURE_PROVIDER, op) == (
+        "https://res.openai.azure.com/openai/batches?api-version=2025-04-01-preview"
+    )
+
+
+def test_azure_provider_uses_the_resource_api_key_header():
+    assert batch_provider_headers(AZURE_PROVIDER) == {"api-key": "az-key"}
+
+
+def test_azure_provider_without_a_key_is_a_502():
+    with pytest.raises(HTTPException) as exc:
+        batch_provider_headers({**AZURE_PROVIDER, "api_key": None})
+    assert exc.value.status_code == 502
+
+
+def test_generic_provider_uses_its_stored_auth_format():
+    assert batch_provider_headers(OPENAI_PROVIDER) == {"Authorization": "Bearer sk-test"}
+
+
+def test_keyless_upstream_gets_no_auth_header():
+    assert batch_provider_headers({**OPENAI_PROVIDER, "api_key": None}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Provider resolution and capability
+# ---------------------------------------------------------------------------
+
+
+class _ResolvingDB:
+    def __init__(self, providers):
+        self.providers = providers
+        self.recorded = []
+
+    def get_batch_provider_candidates(self, api_key_id):
+        return list(self.providers)
+
+    def record_provider_batch_capability(self, provider_id, supports, detail=""):
+        self.recorded.append((provider_id, supports, detail))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_resolution_without_candidates_keeps_the_501():
+    with pytest.raises(HTTPException) as exc:
+        await resolve_batch_provider(_auth(), {}, _ResolvingDB([]))
+    assert exc.value.status_code == 501
+    assert exc.value.detail["error"]["code"] == "batch_api_not_supported"
+
+
+@pytest.mark.asyncio
+async def test_single_candidate_is_selected_implicitly():
+    assert await resolve_batch_provider(_auth(), {}, _ResolvingDB([AZURE_PROVIDER])) is AZURE_PROVIDER
+
+
+@pytest.mark.asyncio
+async def test_multiple_candidates_require_the_provider_header():
+    with pytest.raises(HTTPException) as exc:
+        await resolve_batch_provider(_auth(), {}, _ResolvingDB([OPENAI_PROVIDER, AZURE_PROVIDER]))
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"]["code"] == "multiple_batch_providers"
+
+
+@pytest.mark.asyncio
+async def test_provider_header_is_read_case_insensitively():
+    # Starlette lowercases header names, so a case-sensitive lookup would make
+    # explicit selection impossible over HTTP while passing a dict-based test.
+    db = _ResolvingDB([OPENAI_PROVIDER, AZURE_PROVIDER])
+    for spelling in (BATCH_PROVIDER_HEADER, BATCH_PROVIDER_HEADER.lower(), BATCH_PROVIDER_HEADER.upper()):
+        assert await resolve_batch_provider(_auth(), {spelling: "openai"}, db) is OPENAI_PROVIDER
+    assert await resolve_batch_provider(_auth(), {"x-logos-provider": "8"}, db) is AZURE_PROVIDER
+
+
+@pytest.mark.asyncio
+async def test_header_naming_an_unauthorized_provider_is_a_403():
+    with pytest.raises(HTTPException) as exc:
+        await resolve_batch_provider(_auth(), {"x-logos-provider": "elsewhere"}, _ResolvingDB([OPENAI_PROVIDER]))
+    assert exc.value.status_code == 403
+    assert exc.value.detail["error"]["code"] == "batch_provider_not_authorized"
+
+
+@pytest.mark.asyncio
+async def test_a_provider_without_a_batch_api_is_not_a_candidate(monkeypatch):
+    # A self-hosted OpenAI-shaped inference endpoint serves chat and nothing
+    # else. Counting it as a batch target would make the choice ambiguous for
+    # every key that may also use it, and send jobs where they 404.
+    inference_only = {
+        **OPENAI_PROVIDER,
+        "id": 26,
+        "name": "morpheus",
+        "base_url": "https://morpheus.example.com/api/v1",
+        "supports_batch": None,
+        "capability_checked_at": None,
+    }
+    db = _ResolvingDB([AZURE_PROVIDER, inference_only])
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+
+    def probe(request):
+        assert "morpheus" in str(request.url)
+        return httpx.Response(404, json={"error": "not found"})
+
+    monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(probe)))
+
+    assert await resolve_batch_provider(_auth(), {}, db) is AZURE_PROVIDER
+    assert db.recorded == [(26, False, "HTTP 404")]
+
+
+@pytest.mark.asyncio
+async def test_a_stale_capability_is_reprobed(monkeypatch):
+    stale = {
+        **OPENAI_PROVIDER,
+        "supports_batch": False,
+        "capability_checked_at": datetime.now(timezone.utc) - timedelta(days=30),
+    }
+    db = _ResolvingDB([stale])
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(
+        batch_api,
+        "_http_client",
+        lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"data": []}))
+        ),
+    )
+
+    assert await resolve_batch_provider(_auth(), {}, db) is stale
+    assert db.recorded == [(7, True, "")]
+
+
+# ---------------------------------------------------------------------------
+# Input file validation
+# ---------------------------------------------------------------------------
+
+
+def test_a_permitted_model_is_rewritten_to_the_azure_deployment():
+    content, counts = validate_and_rewrite_batch_input(_jsonl(_line()), AZURE_PROVIDER, AZURE_DEPLOYMENTS)
+    line = json.loads(content.splitlines()[0])
+    assert line["body"]["model"] == "gpt-41"
+    assert line["url"] == "/chat/completions"
+    assert counts == {25: 1}
+
+
+def test_a_generic_provider_keeps_the_model_and_versioned_url():
+    content, counts = validate_and_rewrite_batch_input(_jsonl(_line()), OPENAI_PROVIDER, OPENAI_DEPLOYMENTS)
+    line = json.loads(content.splitlines()[0])
+    assert line["body"]["model"] == "gpt-4.1"
+    assert line["url"] == "/v1/chat/completions"
+    assert counts == {25: 1}
+
+
+def test_a_model_the_key_may_not_use_is_refused():
+    # Provider permission alone does not authorise what the batch runs: each
+    # line picks its own model, and the shared upstream credential would run it.
+    with pytest.raises(HTTPException) as exc:
+        validate_and_rewrite_batch_input(_jsonl(_line(model="gpt-5.6-luna")), AZURE_PROVIDER, AZURE_DEPLOYMENTS)
+    assert exc.value.status_code == 403
+    assert exc.value.detail["error"]["code"] == "model_not_permitted"
+    assert "gpt-5.6-luna" in exc.value.detail["error"]["message"]
+
+
+def test_an_unsupported_request_endpoint_is_refused():
+    with pytest.raises(HTTPException) as exc:
+        validate_and_rewrite_batch_input(_jsonl(_line(url="/v1/files")), OPENAI_PROVIDER, OPENAI_DEPLOYMENTS)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"]["code"] == "unsupported_batch_endpoint"
+
+
+@pytest.mark.parametrize(
+    ("content", "code"),
+    [
+        (b"not json\n", "invalid_batch_line"),
+        (b'["a list"]\n', "invalid_batch_line"),
+        (b'{"method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4.1"}}\n', "invalid_batch_line"),
+        (b'{"custom_id": "a", "url": "/v1/chat/completions"}\n', "invalid_batch_line"),
+        (b"\n \n", "empty_batch_file"),
+    ],
+)
+def test_malformed_request_lines_are_refused(content, code):
+    with pytest.raises(HTTPException) as exc:
+        validate_and_rewrite_batch_input(content, OPENAI_PROVIDER, OPENAI_DEPLOYMENTS)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"]["code"] == code
+
+
+def test_a_repeated_custom_id_is_refused():
+    with pytest.raises(HTTPException) as exc:
+        validate_and_rewrite_batch_input(_jsonl(_line("same"), _line("same")), OPENAI_PROVIDER, OPENAI_DEPLOYMENTS)
+    assert exc.value.status_code == 400
+    assert "same" in exc.value.detail["error"]["message"]
+
+
+def test_too_many_request_lines_are_refused(monkeypatch):
+    monkeypatch.setattr(batch_api, "MAX_BATCH_REQUESTS", 2)
+    with pytest.raises(HTTPException) as exc:
+        validate_and_rewrite_batch_input(
+            _jsonl(_line("a"), _line("b"), _line("c")), OPENAI_PROVIDER, OPENAI_DEPLOYMENTS
+        )
+    assert exc.value.detail["error"]["code"] == "batch_file_too_many_requests"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end forward through the app
+# ---------------------------------------------------------------------------
+
+
+class _FakeDB:
+    """One fake DBManager shared by every ``with DBManager()`` in a request."""
+
+    def __init__(self, providers, deployments, owned=None, budget_error=None):
+        self.providers = providers
+        self.deployments = deployments
+        self.owned = dict(owned or {})
+        self.budget_error = budget_error
+        self.registered = []
+        self.status_updates = []
+        self.stored_files = {}
+        self.local_batches = {}
+        self.deleted = []
+        self.cancelled = []
+        self.log_usage_kwargs = None
+        self.finalization = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    # resolution
+    def get_batch_provider_candidates(self, api_key_id):
+        return list(self.providers)
+
+    def record_provider_batch_capability(self, provider_id, supports, detail=""):
+        pass
+
+    def get_batch_provider(self, provider_id):
+        return next((p for p in self.providers if int(p["id"]) == int(provider_id)), None)
+
+    def get_batch_model_deployments(self, api_key_id, provider_id=None):
+        rows = list(self.deployments)
+        if provider_id is None:
+            return rows
+        return [row for row in rows if int(row["provider_id"]) == int(provider_id)]
+
+    # ownership
+    def get_batch_object(self, kind, upstream_id):
+        return self.owned.get((kind, upstream_id))
+
+    def register_batch_object(self, **kwargs):
+        self.registered.append(kwargs)
+        self.owned[(kwargs["kind"], kwargs["upstream_id"])] = {
+            "id": 1,
+            "team_id": kwargs["team_id"],
+            "settled_at": None,
+            "execution": "provider",
+            **kwargs,
+        }
+
+    def list_batch_objects_for_team(self, team_id, kind, limit=100):
+        return [row for key, row in self.owned.items() if key[0] == kind and row.get("team_id") == team_id]
+
+    def update_batch_object_status(self, upstream_id, status):
+        self.status_updates.append((upstream_id, status))
+
+    def delete_batch_object(self, batch_object_id):
+        self.deleted.append(batch_object_id)
+
+    # locally held objects
+    def store_local_batch_file(self, *, upstream_id, content, filename, api_key_id, team_id, user_id, purpose="batch"):
+        row = {
+            "id": 1000 + len(self.stored_files),
+            "kind": "file",
+            "execution": "logos",
+            "upstream_id": upstream_id,
+            "filename": filename,
+            "size_bytes": len(content),
+            "status": purpose,
+            "team_id": team_id,
+            "api_key_id": api_key_id,
+            "user_id": user_id,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self.stored_files[upstream_id] = (row, content)
+        self.owned[("file", upstream_id)] = row
+        return row["id"]
+
+    def get_local_object_by_upstream_id(self, kind, upstream_id):
+        if kind == "file" and upstream_id in self.stored_files:
+            return self.stored_files[upstream_id][0]
+        return self.local_batches.get(upstream_id)
+
+    def get_local_batch_file_content(self, batch_object_id):
+        for row, content in self.stored_files.values():
+            if row["id"] == batch_object_id:
+                return content
+        return None
+
+    def create_local_batch(
+        self,
+        *,
+        upstream_id,
+        input_file_id,
+        endpoint,
+        completion_window,
+        metadata,
+        total_requests,
+        api_key_id,
+        team_id,
+        user_id,
+    ):
+        row = {
+            "id": 2000 + len(self.local_batches),
+            "kind": "batch",
+            "execution": "logos",
+            "upstream_id": upstream_id,
+            "input_file_id": input_file_id,
+            "endpoint": endpoint,
+            "completion_window": completion_window,
+            "request_metadata": metadata,
+            "total_requests": total_requests,
+            "completed_requests": 0,
+            "failed_requests": 0,
+            "status": "validating",
+            "team_id": team_id,
+            "api_key_id": api_key_id,
+            "user_id": user_id,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self.local_batches[upstream_id] = row
+        self.owned[("batch", upstream_id)] = row
+        return row["id"]
+
+    def get_local_batch(self, upstream_id):
+        return self.local_batches.get(upstream_id)
+
+    def request_local_batch_cancel(self, batch_object_id):
+        self.cancelled.append(batch_object_id)
+        for row in self.local_batches.values():
+            if row["id"] == batch_object_id:
+                row["status"] = "cancelling"
+
+    # logging + budget
+    def log_usage(self, **kwargs):
+        self.log_usage_kwargs = kwargs
+        return {"log-id": 42}, 200
+
+    def update_log_entry_metrics(self, **kwargs):
+        self.finalization = kwargs
+
+    def get_api_key_budget_limit(self, api_key_id):
+        return 100 if self.budget_error else None
+
+    def get_api_key_budget_usage(self, api_key_id, month_start):
+        return 500 if self.budget_error else 0
+
+    def get_team(self, team_id):
+        return None
+
+
+def _patch_env(monkeypatch, db, upstream, auth=None):
+    """Point the Batch API at a fake DB, a canned upstream and a fixed key."""
+    seen = []
+
+    def handler(request):
+        seen.append(request)
+        return upstream(request)
+
+    monkeypatch.setattr(batch_api, "authenticate_api_key", lambda headers: auth or _auth())
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+    return seen
+
+
+def test_batch_routes_are_registered_before_the_catch_alls():
+    operations = (
+        "files",
+        "batches",
+        "files/{file_id}",
+        "files/{file_id}/content",
+        "batches/{batch_id}",
+        "batches/{batch_id}/cancel",
+    )
+    paths = [route.path for route in main.app.routes]
+    for prefix in ("v1", "openai", "jobs/v1", "jobs/openai"):
+        for operation in operations:
+            assert f"/{prefix}/{operation}" in paths, f"missing route /{prefix}/{operation}"
+        assert paths.index(f"/{prefix}/files") < paths.index(f"/{prefix}/{{path:path}}")
+        assert paths.index(f"/{prefix}/batches") < paths.index(f"/{prefix}/{{path:path}}")
+
+
+def test_file_upload_forwards_the_rewritten_file_and_records_ownership(monkeypatch):
+    db = _FakeDB([AZURE_PROVIDER], AZURE_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc", "object": "file"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 200
+    assert str(seen[0].url) == "https://res.openai.azure.com/openai/v1/files"
+    # The model name the client used is translated to the Azure deployment.
+    assert b'"model": "gpt-41"' in seen[0].content
+    assert db.registered == [
+        {
+            "kind": "file",
+            "upstream_id": "file-abc",
+            "provider_id": 8,
+            "api_key_id": 11,
+            "team_id": OWN_TEAM,
+            "user_id": 13,
+        }
+    ]
+    assert db.log_usage_kwargs["input_payload"]["requests"] == 1
+    assert db.finalization["result_status"] == "success"
+
+
+def test_an_unpermitted_model_never_reaches_the_upstream(monkeypatch):
+    db = _FakeDB([AZURE_PROVIDER], AZURE_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line(model="gpt-5.6-luna")), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "model_not_permitted"
+    assert seen == []
+
+
+def test_only_purpose_batch_is_accepted(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("data.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "fine-tune"},
+    )
+
+    assert resp.status_code == 400
+    assert seen == []
+
+
+def test_batch_creation_requires_an_input_file_the_team_owns(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-someone-else"): _remote(5, OTHER_TEAM)},
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1"}))
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-someone-else", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 404
+    assert seen == []
+
+
+def test_batch_creation_registers_the_new_batch(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+    )
+    body = {"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"}
+    seen = _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(
+            200, json={"id": "batch_1", "status": "validating", "input_file_id": "file-own"}
+        ),
+    )
+
+    resp = client.post("/v1/batches", json=body)
+
+    assert resp.status_code == 200
+    assert seen[0].method == "POST"
+    assert json.loads(seen[0].content) == body
+    assert db.registered[0]["kind"] == "batch"
+    assert db.registered[0]["upstream_id"] == "batch_1"
+    assert db.registered[0]["team_id"] == OWN_TEAM
+
+
+def test_a_key_over_budget_cannot_start_a_batch(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+        budget_error=True,
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1"}))
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 402
+    assert seen == []
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/v1/batches/batch_other"),
+        ("POST", "/v1/batches/batch_other/cancel"),
+        ("GET", "/v1/files/file_other"),
+        ("GET", "/v1/files/file_other/content"),
+        ("DELETE", "/v1/files/file_other"),
+    ],
+)
+def test_another_teams_object_is_indistinguishable_from_a_missing_one(monkeypatch, method, path):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={
+            ("batch", "batch_other"): _remote(5, OTHER_TEAM),
+            ("file", "file_other"): _remote(6, OTHER_TEAM),
+        },
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "leaked"}))
+
+    resp = client.request(method, path)
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "not_found"
+    # Nothing was asked of the provider, so the shared credential never touched
+    # another team's object.
+    assert seen == []
+
+
+def test_an_id_logos_never_minted_is_a_404(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_x"}))
+
+    resp = client.get("/v1/batches/batch_x")
+
+    assert resp.status_code == 404
+    assert seen == []
+
+
+def test_a_listing_is_answered_from_logos_own_record(monkeypatch):
+    # Not forwarded: the shared upstream credential sees every team's objects,
+    # and Logos knows about the batches it ran itself, which no provider does.
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={
+            ("batch", "batch_mine"): _remote(1, OWN_TEAM, upstream_id="batch_mine", status="completed"),
+            ("batch", "batch_theirs"): _remote(2, OTHER_TEAM, upstream_id="batch_theirs"),
+        },
+    )
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"data": [{"id": "leaked"}]}))
+
+    resp = client.get("/v1/batches")
+
+    assert resp.status_code == 200
+    assert [item["id"] for item in resp.json()["data"]] == ["batch_mine"]
+    assert resp.json()["data"][0]["status"] == "completed"
+    assert seen == []
+
+
+def test_polling_records_the_status_and_settles_a_finished_batch(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_1"): _remote(77, OWN_TEAM)},
+    )
+    finished = {"id": "batch_1", "status": "completed", "output_file_id": "file-out"}
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json=finished))
+
+    settled = []
+    monkeypatch.setattr(batch_api, "_schedule_settlement", lambda p, o, b: settled.append((o["id"], b["status"])))
+
+    resp = client.get("/v1/batches/batch_1")
+
+    assert resp.status_code == 200
+    assert db.status_updates == [("batch_1", "completed")]
+    assert settled == [(77, "completed")]
+
+
+def test_an_unfinished_batch_is_not_settled(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_1"): _remote(77, OWN_TEAM)},
+    )
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1", "status": "in_progress"}))
+    settled = []
+    monkeypatch.setattr(batch_api, "_schedule_settlement", lambda p, o, b: settled.append(o))
+
+    assert client.get("/v1/batches/batch_1").status_code == 200
+    assert settled == []
+
+
+def test_file_content_comes_back_as_raw_bytes(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-out"): _remote(3, OWN_TEAM)},
+    )
+    payload = b'{"custom_id": "one", "response": {"status_code": 200}}\n'
+    _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(200, content=payload, headers={"content-type": "application/jsonl"}),
+    )
+
+    resp = client.get("/v1/files/file-out/content")
+
+    assert resp.status_code == 200
+    assert resp.content == payload
+
+
+def test_an_upstream_error_is_passed_through_and_logged(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("file", "file-own"): _remote(5, OWN_TEAM)},
+    )
+    _patch_env(
+        monkeypatch,
+        db,
+        lambda request: httpx.Response(400, json={"error": {"message": "input file is empty", "type": "invalid"}}),
+    )
+
+    resp = client.post(
+        "/v1/batches",
+        json={"input_file_id": "file-own", "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["message"] == "input file is empty"
+    assert db.finalization["result_status"] == "error"
+    assert "input file is empty" in db.finalization["error_message"]
+
+
+def test_an_unreachable_upstream_is_a_502(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+
+    def boom(request):
+        raise httpx.ConnectError("refused", request=request)
+
+    _patch_env(monkeypatch, db, boom)
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["code"] == "batch_upstream_unreachable"
+
+
+def test_an_unauthenticated_request_never_reaches_the_upstream(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    def reject(headers):
+        raise HTTPException(status_code=401, detail="Invalid or inactive logos key")
+
+    monkeypatch.setattr(batch_api, "authenticate_api_key", reject)
+
+    resp = client.post("/v1/batches", json={"input_file_id": "file-own"})
+
+    assert resp.status_code == 401
+    assert seen == []
+    assert db.log_usage_kwargs is None
+
+
+def test_the_mirrors_reach_the_same_forward(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_1"): _remote(7, OWN_TEAM)},
+    )
+    seen = _patch_env(
+        monkeypatch, db, lambda request: httpx.Response(200, json={"id": "batch_1", "status": "in_progress"})
+    )
+
+    for prefix in ("/v1", "/openai", "/jobs/v1", "/jobs/openai"):
+        assert client.get(f"{prefix}/batches/batch_1").status_code == 200
+    assert {str(request.url) for request in seen} == {"https://api.openai.com/v1/batches/batch_1"}
+
+
+def test_credentials_are_not_sent_over_an_insecure_transport(monkeypatch):
+    db = _FakeDB([{**OPENAI_PROVIDER, "base_url": "http://plain.example.com/v1"}], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 502
+    assert seen == []
+
+
+# ---------------------------------------------------------------------------
+# Settlement
+# ---------------------------------------------------------------------------
+
+
+OUTPUT_FILE = (
+    json.dumps(
+        {
+            "custom_id": "one",
+            "response": {
+                "status_code": 200,
+                "body": {"model": "gpt-4.1-2025-04-14", "usage": {"prompt_tokens": 120, "completion_tokens": 30}},
+            },
+        }
+    )
+    + "\n"
+    + json.dumps(
+        {
+            "custom_id": "two",
+            "error": {"message": "context length exceeded"},
+            "response": {"status_code": 400, "body": {"model": "gpt-4.1"}},
+        }
+    )
+    + "\n"
+).encode()
+
+INPUT_FILE = _jsonl(_line("one"), _line("two"))
+
+
+class _SettlingDB:
+    def __init__(self, claimable=True):
+        self.claimable = claimable
+        self.claims = 0
+        self.released = 0
+        self.rows = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def claim_batch_for_settlement(self, batch_object_id):
+        self.claims += 1
+        return self.claimable
+
+    def release_batch_settlement(self, batch_object_id):
+        self.released += 1
+
+    def get_api_key_logging_context(self, api_key_id):
+        return {"environment": "test", "log_level": "BILLING"}
+
+    def get_provider_model_deployments(self, provider_id):
+        return [
+            {
+                "model_id": 25,
+                "model_name": "gpt-4.1",
+                "endpoint": "https://api.openai.com/v1/chat/completions",
+            }
+        ]
+
+    def record_batch_usage(self, rows, chunk_size=500):
+        self.rows.extend(rows)
+        return len(rows)
+
+
+def _files_upstream(request):
+    if request.url.path.endswith("/file-out/content"):
+        return httpx.Response(200, content=OUTPUT_FILE)
+    if request.url.path.endswith("/file-in/content"):
+        return httpx.Response(200, content=INPUT_FILE)
+    return httpx.Response(404, json={"error": "no such file"})
+
+
+@pytest.mark.asyncio
+async def test_settlement_books_one_usage_row_per_result(monkeypatch):
+    db = _SettlingDB()
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(
+        batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(_files_upstream))
+    )
+
+    owner = {"id": 77, "api_key_id": 11, "team_id": OWN_TEAM, "user_id": 13, "upstream_id": "batch_1"}
+    written = await settle_batch(
+        OPENAI_PROVIDER,
+        owner,
+        {"status": "completed", "output_file_id": "file-out", "input_file_id": "file-in"},
+    )
+
+    assert written == 2
+    ok, failed = db.rows
+    assert ok["usage"]["prompt_tokens"] == 120
+    assert ok["usage"]["completion_tokens"] == 30
+    assert ok["model_id"] == 25  # the dated model name maps back to the model
+    assert ok["service_tier"] == "batch"  # what makes the batch rate apply
+    assert ok["team_id"] == OWN_TEAM
+    assert ok["result_status"] == "success"
+    assert failed["result_status"] == "error"
+    assert "context length" in failed["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_a_batch_is_settled_only_once(monkeypatch):
+    db = _SettlingDB(claimable=False)
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(
+        batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(_files_upstream))
+    )
+
+    written = await settle_batch(
+        OPENAI_PROVIDER, {"id": 77, "api_key_id": 11, "team_id": OWN_TEAM}, {"output_file_id": "file-out"}
+    )
+
+    assert written == 0
+    assert db.rows == []
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_result_file_releases_the_latch(monkeypatch):
+    # Otherwise a transient failure would drop a whole batch's cost silently.
+    db = _SettlingDB()
+    monkeypatch.setattr(batch_api, "DBManager", lambda: db)
+    monkeypatch.setattr(
+        batch_api,
+        "_http_client",
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(lambda request: httpx.Response(500))),
+    )
+
+    written = await settle_batch(
+        OPENAI_PROVIDER, {"id": 77, "api_key_id": 11, "team_id": OWN_TEAM}, {"output_file_id": "file-out"}
+    )
+
+    assert written == 0
+    assert db.released == 1
+
+
+@pytest.mark.asyncio
+async def test_the_reconciler_settles_a_batch_nobody_polled(monkeypatch):
+    settling = _SettlingDB()
+
+    class _ReconcileDB(_SettlingDB):
+        def get_unsettled_batches(self, limit=50):
+            return [
+                {
+                    "id": 77,
+                    "upstream_id": "batch_1",
+                    "provider_id": 7,
+                    "api_key_id": 11,
+                    "team_id": OWN_TEAM,
+                    "user_id": 13,
+                    "status": "in_progress",
+                }
+            ]
+
+        def get_batch_provider(self, provider_id):
+            return OPENAI_PROVIDER
+
+        def update_batch_object_status(self, upstream_id, status):
+            settling.rows.append(("status", upstream_id, status))
+
+        def claim_batch_for_settlement(self, batch_object_id):
+            return settling.claim_batch_for_settlement(batch_object_id)
+
+        def get_api_key_logging_context(self, api_key_id):
+            return settling.get_api_key_logging_context(api_key_id)
+
+        def get_provider_model_deployments(self, provider_id):
+            return settling.get_provider_model_deployments(provider_id)
+
+        def record_batch_usage(self, rows, chunk_size=500):
+            return settling.record_batch_usage(rows)
+
+    monkeypatch.setattr(batch_api, "DBManager", _ReconcileDB)
+
+    def upstream(request):
+        if request.url.path.endswith("/batches/batch_1"):
+            return httpx.Response(200, json={"id": "batch_1", "status": "completed", "output_file_id": "file-out"})
+        return _files_upstream(request)
+
+    monkeypatch.setattr(batch_api, "_http_client", lambda: httpx.AsyncClient(transport=httpx.MockTransport(upstream)))
+
+    assert await reconcile_batches_once() == 2
+    assert ("status", "batch_1", "completed") in settling.rows
+
+
+def test_a_dated_model_name_falls_back_to_the_configured_model():
+    index = {"gpt-4.1": 25, "gpt-41": 25, "gpt-4.1-mini": 24}
+    assert batch_api._model_id_for(index, "gpt-4.1-2025-04-14") == 25
+    assert batch_api._model_id_for(index, "gpt-4.1-mini-2025-04-14") == 24
+    assert batch_api._model_id_for(index, "gpt-41") == 25
+    assert batch_api._model_id_for(index, "something-else") is None
+    assert batch_api._model_id_for(index, None) is None
+
+
+def test_a_result_row_without_a_model_falls_back_to_the_input_file():
+    rows = batch_api._usage_rows_from_output(
+        json.dumps({"custom_id": "one", "error": {"message": "boom"}}).encode() + b"\n",
+        {"api_key_id": 11, "team_id": OWN_TEAM, "user_id": 13},
+        OPENAI_PROVIDER,
+        {"gpt-4.1": 25},
+        {"one": "gpt-4.1"},
+        {"environment": "test", "log_level": "BILLING"},
+    )
+    assert rows[0]["model_id"] == 25
+    assert rows[0]["result_status"] == "error"
+
+
+def test_the_batch_operation_dataclass_knows_its_shapes():
+    upload = BatchOperation(resource="files", method="POST", path="v1/files")
+    assert upload.is_file_upload and not upload.is_batch_creation and not upload.is_listing
+    creation = BatchOperation(resource="batches", method="POST", path="v1/batches")
+    assert creation.is_batch_creation and not creation.is_file_upload
+    listing = BatchOperation(resource="batches", method="GET", path="v1/batches")
+    assert listing.is_listing
+
+
+# ---------------------------------------------------------------------------
+# Batches Logos runs itself
+# ---------------------------------------------------------------------------
+
+
+def _local_line(custom_id="one", model="qwen3-32b"):
+    return _line(custom_id, model=model)
+
+
+def test_a_model_only_a_worker_node_serves_is_run_by_logos(monkeypatch):
+    # A worker node has no Batch API at all, so there is nothing to forward to;
+    # the batch becomes low-priority requests here instead of a 501.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "file"
+    assert body["id"].startswith("file-")
+    assert body["logos_execution"] == "logos"
+    assert seen == []  # nothing was uploaded to a provider
+    assert db.log_usage_kwargs["input_payload"]["execution"] == "logos"
+
+
+def test_a_cloud_model_its_provider_cannot_batch_is_run_by_logos(monkeypatch):
+    # Exactly the gpt-5.6 case: the model is served on the provider, but not on
+    # its Batch API, so the file names a model the provider's batch endpoint
+    # would reject. Running it here keeps the same client working.
+    unbatchable = [
+        {
+            "model_id": 92,
+            "model_name": "gpt-5.6-luna",
+            "endpoint": "https://res.openai.azure.com/openai/deployments/gpt-5.6-luna/responses",
+            "provider_id": 99,  # a provider the key may use but which is not batch-capable
+            "provider_type": "cloud",
+            "cloud_provider_type": "azure",
+        }
+    ]
+    db = _FakeDB([AZURE_PROVIDER], AZURE_DEPLOYMENTS + unbatchable)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line(model="gpt-5.6-luna")), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["logos_execution"] == "logos"
+    assert seen == []
+
+
+def test_the_execution_header_forces_a_local_run(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+        headers={batch_api.BATCH_EXECUTION_HEADER: "logos"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["logos_execution"] == "logos"
+    assert seen == []
+
+
+def test_forwarding_is_preferred_when_the_provider_can_run_it(monkeypatch):
+    # The provider's batch endpoint is where the discount is, so 'auto' only
+    # falls back to a local run when forwarding cannot work.
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "file-abc"
+    assert len(seen) == 1
+
+
+def test_demanding_a_provider_that_cannot_run_the_model_is_an_error(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "file-abc"}))
+
+    resp = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+        headers={batch_api.BATCH_EXECUTION_HEADER: "provider"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "model_not_available_for_batch"
+    assert seen == []
+
+
+def test_a_local_batch_is_created_and_reported_in_the_openai_shape(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+    started = []
+    monkeypatch.setattr(batch_api, "_start_local_batch", lambda row: started.append(row["upstream_id"]))
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line("a"), _local_line("b")), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    file_id = upload.json()["id"]
+
+    created = client.post(
+        "/v1/batches",
+        json={"input_file_id": file_id, "endpoint": "/v1/chat/completions", "completion_window": "24h"},
+    )
+
+    assert created.status_code == 200
+    body = created.json()
+    assert body["object"] == "batch"
+    assert body["status"] == "validating"
+    assert body["input_file_id"] == file_id
+    assert body["request_counts"] == {"total": 2, "completed": 0, "failed": 0}
+    # Started immediately rather than waiting for the next poll of the runner.
+    assert started == [body["id"]]
+
+
+def test_a_local_batch_is_polled_and_cancelled_through_the_same_routes(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+    monkeypatch.setattr(batch_api, "_start_local_batch", lambda row: None)
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", _jsonl(_local_line()), "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    batch_id = client.post("/v1/batches", json={"input_file_id": upload.json()["id"]}).json()["id"]
+
+    polled = client.get(f"/v1/batches/{batch_id}")
+    assert polled.status_code == 200
+    assert polled.json()["id"] == batch_id
+
+    cancelled = client.post(f"/v1/batches/{batch_id}/cancel")
+    assert cancelled.status_code == 200
+    assert cancelled.json()["status"] == "cancelling"
+    assert db.cancelled  # the runner stops before its next line
+    assert seen == []  # no provider was ever involved
+
+
+def test_a_local_result_file_is_downloaded_through_the_files_route(monkeypatch):
+    db = _FakeDB([OPENAI_PROVIDER], OPENAI_DEPLOYMENTS + LOCAL_DEPLOYMENTS)
+    seen = _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+    content = _jsonl(_local_line())
+
+    upload = client.post(
+        "/v1/files",
+        files={"file": ("batch.jsonl", content, "application/jsonl")},
+        data={"purpose": "batch"},
+    )
+    file_id = upload.json()["id"]
+
+    downloaded = client.get(f"/v1/files/{file_id}/content")
+
+    assert downloaded.status_code == 200
+    # The stored file is the validated one, so it round-trips as JSONL.
+    assert json.loads(downloaded.content.splitlines()[0])["custom_id"] == "one"
+    assert seen == []
+
+
+def test_another_teams_local_object_is_a_404(monkeypatch):
+    db = _FakeDB(
+        [OPENAI_PROVIDER],
+        OPENAI_DEPLOYMENTS,
+        owned={("batch", "batch_local"): {"id": 9, "team_id": OTHER_TEAM, "execution": "logos"}},
+    )
+    _patch_env(monkeypatch, db, lambda request: httpx.Response(200, json={"id": "unused"}))
+
+    assert client.get("/v1/batches/batch_local").status_code == 404
+
+
+def test_a_local_batch_runs_its_lines_as_low_priority_requests(monkeypatch):
+    # Each line goes through the ordinary pipeline, so it is authorised, routed,
+    # logged and metered like any other request — which is why a Logos-run batch
+    # needs no settlement pass.
+    executed = []
+
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        executed.append((path, body["model"], auth.default_priority))
+        return {"status_code": 200, "data": {"model": body["model"], "usage": {"prompt_tokens": 5}}}
+
+    stored = {}
+
+    class _RunnerDB:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def claim_local_batch(self, batch_object_id):
+            return True
+
+        def get_local_object_by_upstream_id(self, kind, upstream_id):
+            return {"id": 1000}
+
+        def get_local_batch_file_content(self, object_id):
+            return _jsonl(_local_line("a"), _local_line("b"))
+
+        def get_api_key_by_id(self, api_key_id):
+            return {
+                "id": 11,
+                "key_value": "lg-test",
+                "name": "k",
+                "key_type": "user",
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "environment": "test",
+                "log": "BILLING",
+                "settings": {},
+                "default_priority": 10,
+            }
+
+        def update_local_batch_progress(self, object_id, completed, failed):
+            return False
+
+        def store_local_batch_file(self, **kwargs):
+            stored.update(kwargs)
+            return 1
+
+        def finish_local_batch(self, object_id, **kwargs):
+            stored["finish"] = kwargs
+
+    monkeypatch.setattr(batch_local, "DBManager", _RunnerDB)
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    written = asyncio.run(
+        batch_local.run_local_batch(
+            {
+                "id": 2000,
+                "upstream_id": "batch_x",
+                "input_file_id": "file-in",
+                "api_key_id": 11,
+                "team_id": OWN_TEAM,
+                "user_id": 13,
+                "status": "validating",
+            }
+        )
+    )
+
+    assert written and written.startswith("file-")
+    assert [name for _, name, _ in executed] == ["qwen3-32b", "qwen3-32b"]
+    # The key's own priority is 10 (HIGH); batch work runs at LOW regardless.
+    assert {priority for _, _, priority in executed} == {batch_local.LOCAL_BATCH_PRIORITY}
+    assert stored["finish"]["status"] == "completed"
+    assert stored["finish"]["completed"] == 2
+    assert stored["finish"]["failed"] == 0
+    # The result file is the OpenAI batch output shape.
+    row = json.loads(stored["content"].splitlines()[0])
+    assert row["custom_id"] == "a"
+    assert row["response"]["status_code"] == 200
+    assert row["error"] is None
+
+
+def test_a_failing_line_is_reported_without_stopping_the_batch(monkeypatch):
+    async def fake_execute(path, headers, body, client_ip, auth, log_id):
+        if body.get("custom") == "boom":
+            raise RuntimeError("upstream exploded")
+        return {"status_code": 400, "data": {"error": {"message": "context length exceeded"}}}
+
+    monkeypatch.setitem(__import__("sys").modules, "logos.main", main)
+    monkeypatch.setattr(main, "execute_proxy_job", fake_execute, raising=False)
+
+    row, failed = asyncio.run(batch_local._run_line(_local_line("a"), _auth(), {}, asyncio.Semaphore(1)))
+
+    assert failed is True
+    assert row["error"]["code"] == "400"
+    assert "context length" in row["error"]["message"]
+
+
+def test_a_local_batch_object_looks_like_a_providers(monkeypatch):
+    # A polling script must not be able to tell the two apart, or chaining one
+    # batch onto the last would need two clients.
+    now = datetime.now(timezone.utc)
+    rendered = batch_local.local_batch_object(
+        {
+            "upstream_id": "batch_x",
+            "endpoint": "/v1/chat/completions",
+            "input_file_id": "file-in",
+            "completion_window": "24h",
+            "status": "completed",
+            "output_file_id": "file-out",
+            "created_at": now,
+            "started_at": now,
+            "finished_at": now,
+            "total_requests": 3,
+            "completed_requests": 2,
+            "failed_requests": 1,
+            "request_metadata": {"run": "bench"},
+        }
+    )
+
+    assert rendered["object"] == "batch"
+    assert rendered["status"] == "completed"
+    assert rendered["output_file_id"] == "file-out"
+    assert rendered["request_counts"] == {"total": 3, "completed": 2, "failed": 1}
+    assert rendered["completed_at"] == int(now.timestamp())
+    assert rendered["metadata"] == {"run": "bench"}

--- a/logos/logos-orchestrator/tests/unit/main/test_batch_credential.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_batch_credential.py
@@ -1,0 +1,74 @@
+"""Scoped batch credentials: what the proxy sends instead of the user's key.
+
+The shipped setup reaches the orchestrator over plain HTTP, so the user's
+long-lived key value may not cross that hop. The credential is the substitute:
+bound to one key, short-lived, and verifiable without trusting the wire.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from logos import batch_credential
+
+
+@pytest.fixture
+def secret(monkeypatch):
+    monkeypatch.setenv("LOGOS_INTERNAL_SECRET", "internal-secret")
+
+
+def test_issue_and_resolve_round_trip(secret):
+    credential, ttl = batch_credential.issue_batch_credential(5)
+    assert ttl == batch_credential.BATCH_CREDENTIAL_TTL_S
+    assert credential.startswith(batch_credential.BATCH_CREDENTIAL_PREFIX)
+    assert batch_credential.resolve_batch_credential(credential) == 5
+
+
+def test_a_credential_only_works_with_the_same_secret(monkeypatch):
+    monkeypatch.setenv("LOGOS_INTERNAL_SECRET", "first")
+    credential, _ = batch_credential.issue_batch_credential(5)
+    monkeypatch.setenv("LOGOS_INTERNAL_SECRET", "second")
+    assert batch_credential.resolve_batch_credential(credential) is None
+
+
+def test_a_credential_stops_at_its_expiry(secret):
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=batch_credential.BATCH_CREDENTIAL_TTL_S + 10
+    )
+    credential, _ = batch_credential.issue_batch_credential(5, now=past)
+    assert batch_credential.resolve_batch_credential(credential) is None
+
+
+def test_a_credential_a_few_seconds_old_is_still_live(secret):
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
+    credential, _ = batch_credential.issue_batch_credential(5, now=past)
+    assert batch_credential.resolve_batch_credential(credential) == 5
+
+
+def test_two_credentials_for_one_key_are_distinct(secret):
+    a, _ = batch_credential.issue_batch_credential(5)
+    b, _ = batch_credential.issue_batch_credential(5)
+    assert a != b  # the nonce keeps the two hand-outs distinguishable
+
+
+def test_a_tampered_credential_does_not_resolve(secret):
+    credential, _ = batch_credential.issue_batch_credential(5)
+    prefix, signature = credential.rsplit(".", 1)
+    flipped = ("A" if signature[0] != "A" else "B") + signature[1:]
+    assert batch_credential.resolve_batch_credential(prefix + flipped) is None
+
+
+def test_values_that_are_not_credentials_resolve_to_none(secret):
+    assert batch_credential.resolve_batch_credential("lg-plain-key") is None
+    assert batch_credential.resolve_batch_credential(batch_credential.BATCH_CREDENTIAL_PREFIX + "garbage") is None
+    assert batch_credential.resolve_batch_credential("") is None
+    assert batch_credential.resolve_batch_credential(None) is None
+
+
+def test_without_a_secret_nothing_is_issued_or_verified(monkeypatch):
+    monkeypatch.delenv("LOGOS_INTERNAL_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        batch_credential.issue_batch_credential(5)
+    assert batch_credential.resolve_batch_credential("bc1.anything.else") is None

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_batch_credentials_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_batch_credentials_endpoint.py
@@ -1,0 +1,113 @@
+"""The /internal/batch_credentials endpoint.
+
+The Spring webservice names the key by id — its ownership check already ran
+against the caller — and gets back a short-lived credential bound to that one
+key. The user's key value never crosses the internal hop.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from logos import batch_credential
+from logos.routers import internal as main_mod
+
+KEY_ROW = {
+    "id": 5,
+    "key_value": "lg-5",
+    "name": "k",
+    "key_type": "application",
+    "team_id": 2,
+    "user_id": 3,
+    "environment": "prod",
+    "log": "BILLING",
+    "settings": None,
+    "default_priority": 1,
+}
+
+
+def _make_request(body: str, authorization: str = "") -> MagicMock:
+    request = MagicMock()
+    request.headers.get = lambda key, default="": authorization if key == "authorization" else default
+
+    async def _json():
+        return json.loads(body)
+
+    request.json = _json
+    return request
+
+
+class _KeyDB:
+    def __init__(self, row):
+        self.row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get_api_key_by_id(self, api_key_id):
+        return self.row if self.row is not None and self.row["id"] == api_key_id else None
+
+
+def _patch(monkeypatch, row):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "secret")
+    monkeypatch.setattr(main_mod, "DBManager", lambda: _KeyDB(row))
+    monkeypatch.setenv("LOGOS_INTERNAL_SECRET", "secret")
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_requires_the_internal_secret(monkeypatch):
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc:
+        await main_mod.internal_batch_credentials(_make_request('{"api_key_id": 5}'))
+    assert exc.value.status_code == 403
+
+    _patch(monkeypatch, None)
+    with pytest.raises(HTTPException) as exc:
+        await main_mod.internal_batch_credentials(_make_request('{"api_key_id": 5}', authorization="Bearer wrong"))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "{}",  # no id
+        '{"api_key_id": "5"}',  # not an int
+        '{"api_key_id": true}',  # a bool is an int in Python and not an id
+        "[5]",  # not an object
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_body_without_an_integer_key_id_is_a_400(monkeypatch, body):
+    _patch(monkeypatch, KEY_ROW)
+    with pytest.raises(HTTPException) as exc:
+        await main_mod.internal_batch_credentials(_make_request(body, authorization="Bearer secret"))
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_a_key_the_orchestrator_does_not_know_is_a_404(monkeypatch):
+    _patch(monkeypatch, None)
+    with pytest.raises(HTTPException) as exc:
+        await main_mod.internal_batch_credentials(_make_request('{"api_key_id": 5}', authorization="Bearer secret"))
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_the_credential_comes_back_bound_to_the_named_key(monkeypatch):
+    _patch(monkeypatch, KEY_ROW)
+
+    result = await main_mod.internal_batch_credentials(
+        _make_request('{"api_key_id": 5}', authorization="Bearer secret")
+    )
+
+    assert result["expires_in"] == batch_credential.BATCH_CREDENTIAL_TTL_S
+    # The answer is a credential, not the key: the value stays in the database.
+    assert "lg-5" not in result["credential"]
+    assert batch_credential.resolve_batch_credential(result["credential"]) == 5

--- a/logos/logos-orchestrator/tests/unit/test_auth.py
+++ b/logos/logos-orchestrator/tests/unit/test_auth.py
@@ -110,3 +110,66 @@ def test_authenticate_logos_key_shim_returns_key_and_api_key_id(monkeypatch):
 
     assert ctx.key_value == "lg-test-abc"
     assert ctx.api_key_id == 5
+
+
+class _CredentialDB:
+    """A database in which the header value is a credential, not a key value."""
+
+    def __init__(self, row):
+        self.row = row
+        self.seen_by_id = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get_api_key_by_value(self, key_value):
+        return None  # it is a credential, so the plain lookup finds nothing
+
+    def get_api_key_by_id(self, api_key_id):
+        self.seen_by_id = api_key_id
+        return self.row if self.row is not None and self.row["id"] == api_key_id else None
+
+
+def _patch_credential_db(monkeypatch, row):
+    from logos import batch_credential
+
+    fake = _CredentialDB(row)
+    monkeypatch.setattr(auth, "DBManager", lambda: fake)
+    monkeypatch.setenv("LOGOS_INTERNAL_SECRET", "internal")
+    credential, _ = batch_credential.issue_batch_credential(row["id"]) if row else (None, None)
+    return fake, credential
+
+
+def test_a_scoped_batch_credential_resolves_to_the_keys_own_row(monkeypatch):
+    # The proxy presents the credential in place of the key value; the
+    # context carries the key's own value, because the batch lines re-enter
+    # the pipeline as the key.
+    fake, credential = _patch_credential_db(monkeypatch, _api_key_row("lg-secret-value"))
+
+    ctx = auth.authenticate_api_key({"logos_key": credential})
+
+    assert fake.seen_by_id == 5
+    assert ctx.key_value == "lg-secret-value"
+    assert ctx.api_key_id == 5
+
+
+def test_a_dead_or_tampered_credential_is_a_401_like_any_bad_key(monkeypatch):
+    fake, credential = _patch_credential_db(monkeypatch, _api_key_row("lg-secret-value"))
+
+    # The key the credential names is gone (revoked after the hand-out): the
+    # row lookup is what kills it, at presentation time.
+    fake.row = None
+    with pytest.raises(HTTPException) as exc:
+        auth.authenticate_api_key({"logos_key": credential})
+    assert exc.value.status_code == 401
+
+    # A credential no one here signed: it never reaches the key lookup.
+    fake.row = _api_key_row("lg-secret-value")
+    fake.seen_by_id = None
+    with pytest.raises(HTTPException) as exc:
+        auth.authenticate_api_key({"logos_key": credential + "x"})
+    assert exc.value.status_code == 401
+    assert fake.seen_by_id is None

--- a/logos/logos-orchestrator/tests/unit/test_auth.py
+++ b/logos/logos-orchestrator/tests/unit/test_auth.py
@@ -149,9 +149,20 @@ def test_a_scoped_batch_credential_resolves_to_the_keys_own_row(monkeypatch):
     # the pipeline as the key.
     fake, credential = _patch_credential_db(monkeypatch, _api_key_row("lg-secret-value"))
 
-    ctx = auth.authenticate_api_key({"logos_key": credential})
+    ctx = auth.authenticate_batch_api_key({"logos_key": credential})
 
     assert fake.seen_by_id == 5
+    assert ctx.key_value == "lg-secret-value"
+    assert ctx.api_key_id == 5
+
+
+def test_the_batch_path_still_accepts_the_plain_key_value(monkeypatch):
+    # Scripts call the Batch API with the key itself; the credential is an
+    # addition for the internal proxy, not a replacement.
+    _patch_db(monkeypatch, _api_key_row("lg-secret-value"))
+
+    ctx = auth.authenticate_batch_api_key({"logos_key": "lg-secret-value"})
+
     assert ctx.key_value == "lg-secret-value"
     assert ctx.api_key_id == 5
 
@@ -163,13 +174,28 @@ def test_a_dead_or_tampered_credential_is_a_401_like_any_bad_key(monkeypatch):
     # row lookup is what kills it, at presentation time.
     fake.row = None
     with pytest.raises(HTTPException) as exc:
-        auth.authenticate_api_key({"logos_key": credential})
+        auth.authenticate_batch_api_key({"logos_key": credential})
     assert exc.value.status_code == 401
 
     # A credential no one here signed: it never reaches the key lookup.
     fake.row = _api_key_row("lg-secret-value")
     fake.seen_by_id = None
     with pytest.raises(HTTPException) as exc:
-        auth.authenticate_api_key({"logos_key": credential + "x"})
+        auth.authenticate_batch_api_key({"logos_key": credential + "x"})
     assert exc.value.status_code == 401
+    assert fake.seen_by_id is None
+
+
+def test_the_global_key_auth_refuses_a_batch_credential(monkeypatch):
+    # The credential is a batch-only bearer: every other route authenticates
+    # with key values alone, so it must 401 there — otherwise it would open
+    # ordinary inference (and, for an admin-owned key, the role-gated routes)
+    # for its whole TTL.
+    fake, credential = _patch_credential_db(monkeypatch, _api_key_row("lg-secret-value"))
+
+    with pytest.raises(HTTPException) as exc:
+        auth.authenticate_api_key({"logos_key": credential})
+
+    assert exc.value.status_code == 401
+    # It is not even resolved: the global path does not know about it.
     assert fake.seen_by_id is None

--- a/logos/logos-ui/src/app/app.routes.ts
+++ b/logos/logos-ui/src/app/app.routes.ts
@@ -29,6 +29,7 @@ export const routes: Routes = [
       { path: 'agents',         title: 'Agent Sessions · Logos',   data: { roles: ['logos_admin'] },                canActivate: [roleGuard], loadComponent: () => import('./features/agents/agents').then(m => m.Agents) },
       { path: 'my-workspace',    title: 'My Workspace · Logos',    canActivate: [hasKeysGuard], loadComponent: () => import('./features/my-workspace/my-workspace').then(m => m.MyWorkspace) },
       { path: 'ai-tools',        title: 'AI Tools · Logos',         canActivate: [hasKeysGuard], loadComponent: () => import('./features/ai-tools/ai-tools').then(m => m.AiTools) },
+      { path: 'batches',         title: 'Batches · Logos',          canActivate: [hasKeysGuard], loadComponent: () => import('./features/batches/batches').then(m => m.Batches) },
       { path: 'open-code',       redirectTo: 'ai-tools', pathMatch: 'full' },
       { path: 'claude-code',     redirectTo: 'ai-tools', pathMatch: 'full' },
       { path: 'no-access',       title: 'No Access · Logos',       loadComponent: () => import('./features/no-access/no-access').then(m => m.NoAccess) },

--- a/logos/logos-ui/src/app/core/layout/shell/shell.ts
+++ b/logos/logos-ui/src/app/core/layout/shell/shell.ts
@@ -117,7 +117,7 @@ export class Shell {
   navSections = computed<NavSection[]>(() => {
     const role = this.auth.role();
     if (!role) return [];
-    const keyGatedPaths = ['/my-workspace', '/ai-tools'];
+    const keyGatedPaths = ['/my-workspace', '/ai-tools', '/batches'];
     // Keys can outlive team membership (orphaned key after removal), so both
     // must hold; this mirrors hasKeysGuard, which is the actual access boundary.
     const hasTeams = (this.auth.currentUser()?.teams.length ?? 0) > 0;

--- a/logos/logos-ui/src/app/core/services/batch.service.ts
+++ b/logos/logos-ui/src/app/core/services/batch.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+/** One of the caller's API keys. A batch runs as exactly one of them. */
+export interface BatchKey {
+  id: number;
+  name: string;
+  team_id: number | null;
+  environment: string | null;
+}
+
+/** The OpenAI batch object, as Logos reports it for either execution path. */
+export interface BatchObject {
+  id: string;
+  object: string;
+  status: string;
+  endpoint: string | null;
+  input_file_id: string | null;
+  output_file_id: string | null;
+  created_at: number | null;
+  completed_at: number | null;
+  request_counts?: { total: number; completed: number; failed: number };
+  /** 'logos' when Logos ran the job itself, 'provider' when it was forwarded. */
+  logos_execution?: string;
+}
+
+/**
+ * The batch page's data access.
+ *
+ * Everything goes through the webservice, which forwards to the orchestrator's
+ * Batch API as the selected key — so the browser never handles a key value and
+ * the permission and ownership rules are the ones every batch gets.
+ */
+@Injectable({ providedIn: 'root' })
+export class BatchService {
+  private http = inject(HttpClient);
+
+  getKeys(): Promise<BatchKey[]> {
+    return firstValueFrom(this.http.get<BatchKey[]>('/api/logosdb/batches/keys'));
+  }
+
+  list(apiKeyId: number): Promise<{ data: BatchObject[] }> {
+    return firstValueFrom(
+      this.http.get<{ data: BatchObject[] }>('/api/logosdb/batches', { params: { apiKeyId } }),
+    );
+  }
+
+  get(apiKeyId: number, batchId: string): Promise<BatchObject> {
+    return firstValueFrom(
+      this.http.get<BatchObject>(`/api/logosdb/batches/${batchId}`, { params: { apiKeyId } }),
+    );
+  }
+
+  cancel(apiKeyId: number, batchId: string): Promise<BatchObject> {
+    return firstValueFrom(
+      this.http.post<BatchObject>(`/api/logosdb/batches/${batchId}/cancel`, null, {
+        params: { apiKeyId },
+      }),
+    );
+  }
+
+  create(
+    apiKeyId: number,
+    file: File,
+    endpoint: string,
+    execution: string,
+  ): Promise<BatchObject> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('apiKeyId', String(apiKeyId));
+    form.append('endpoint', endpoint);
+    form.append('execution', execution);
+    return firstValueFrom(this.http.post<BatchObject>('/api/logosdb/batches', form));
+  }
+
+  /** The result file, as a blob the browser can save. */
+  results(apiKeyId: number, batchId: string, outputFileId: string): Promise<Blob> {
+    return firstValueFrom(
+      this.http.get(`/api/logosdb/batches/${batchId}/results`, {
+        params: { apiKeyId, outputFileId },
+        responseType: 'blob',
+      }),
+    );
+  }
+}

--- a/logos/logos-ui/src/app/features/batches/batches.html
+++ b/logos/logos-ui/src/app/features/batches/batches.html
@@ -1,0 +1,108 @@
+<div class="batches">
+  <h1 class="page-title">Batches</h1>
+  <p class="page-subtitle">
+    Run many requests at once without waiting for them. Where a provider offers a batch endpoint
+    Logos hands the job over and you pay its batch rate; everything else — models served here, and
+    cloud models their provider does not offer for batch — Logos runs itself as low-priority
+    requests that fill whatever capacity interactive traffic leaves.
+  </p>
+
+  @if (keys().length === 0) {
+    <p class="empty">You need an active API key to run a batch.</p>
+  } @else {
+    <section class="card">
+      <h2>New batch</h2>
+
+      <label class="field">
+        <span>API key</span>
+        <select (change)="onKeyChange($any($event.target).value)">
+          @for (key of keys(); track key.id) {
+            <option [value]="key.id" [selected]="key.id === selectedKeyId()">{{ key.name }}</option>
+          }
+        </select>
+        <small>The batch runs as this key: its model permissions and its team's budget apply.</small>
+      </label>
+
+      <label class="field">
+        <span>Input file (.jsonl)</span>
+        <input type="file" accept=".jsonl,application/jsonl,text/plain" (change)="onFileSelected($event)" />
+        <small>
+          One request per line:
+          <code>{{ '{' }}"custom_id": "q-1", "method": "POST", "url": "/v1/chat/completions", "body": {{ '{' }}"model": "…", "messages": […]{{ '}' }}{{ '}' }}</code>
+        </small>
+      </label>
+
+      <label class="field">
+        <span>Endpoint</span>
+        <select (change)="endpoint.set($any($event.target).value)">
+          <option value="/v1/chat/completions">/v1/chat/completions</option>
+          <option value="/v1/responses">/v1/responses</option>
+          <option value="/v1/embeddings">/v1/embeddings</option>
+        </select>
+      </label>
+
+      <label class="field">
+        <span>Where it runs</span>
+        <select (change)="execution.set($any($event.target).value)">
+          <option value="auto">Automatic — use the provider's batch endpoint when it can</option>
+          <option value="logos">Run in Logos (low priority)</option>
+          <option value="provider">Provider only (fail if unavailable)</option>
+        </select>
+      </label>
+
+      <button class="primary" [disabled]="!file() || uploading()" (click)="submit()">
+        {{ uploading() ? 'Starting…' : 'Start batch' }}
+      </button>
+
+      @if (error()) {
+        <p class="error" role="alert">{{ error() }}</p>
+      }
+      @if (notice()) {
+        <p class="notice">{{ notice() }}</p>
+      }
+    </section>
+
+    <section class="card">
+      <div class="card-header">
+        <h2>Your batches</h2>
+        <button class="ghost" (click)="refresh()" [disabled]="loading()">Refresh</button>
+      </div>
+
+      @if (loading()) {
+        <p class="empty">Loading…</p>
+      } @else if (batches().length === 0) {
+        <p class="empty">No batches yet.</p>
+      } @else {
+        <table>
+          <thead>
+            <tr>
+              <th>Batch</th>
+              <th>Status</th>
+              <th>Progress</th>
+              <th>Runs on</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (batch of batches(); track batch.id) {
+              <tr>
+                <td class="mono">{{ batch.id }}</td>
+                <td><span class="status" [class]="'status-' + batch.status">{{ batch.status }}</span></td>
+                <td>{{ progressOf(batch) }}</td>
+                <td>{{ batch.logos_execution === 'logos' ? 'Logos' : 'Provider' }}</td>
+                <td class="actions">
+                  @if (batch.output_file_id) {
+                    <button class="ghost" (click)="download(batch)">Download results</button>
+                  }
+                  @if (!isTerminal(batch)) {
+                    <button class="ghost" (click)="cancel(batch)">Cancel</button>
+                  }
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      }
+    </section>
+  }
+</div>

--- a/logos/logos-ui/src/app/features/batches/batches.scss
+++ b/logos/logos-ui/src/app/features/batches/batches.scss
@@ -1,0 +1,152 @@
+@use 'styles/glass' as *;
+
+.batches {
+  padding: 36px 32px 48px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.batches .page-subtitle {
+  margin-bottom: 24px;
+  max-width: 68ch;
+}
+
+.card {
+  @include glass-card;
+  padding: 20px 24px;
+  margin-bottom: 24px;
+
+  h2 {
+    margin: 0 0 16px;
+    font-size: 1rem;
+  }
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.field {
+  display: block;
+  margin-bottom: 16px;
+
+  > span {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 500;
+  }
+
+  select,
+  input[type='file'] {
+    width: 100%;
+    max-width: 520px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgb(var(--color-outline-200) / var(--opacity-strong));
+    background: transparent;
+    color: inherit;
+  }
+
+  small {
+    display: block;
+    margin-top: 6px;
+    opacity: 0.75;
+
+    code {
+      // The example line is long on purpose; let it wrap rather than pushing
+      // the panel wider than the viewport.
+      overflow-wrap: anywhere;
+    }
+  }
+}
+
+button.primary {
+  padding: 9px 18px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  background: rgb(var(--color-primary-500));
+  color: #fff;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+button.ghost {
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-strong));
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    text-align: left;
+    padding: 8px 10px;
+    border-bottom: 1px solid rgb(var(--color-outline-200) / var(--opacity-subtle));
+  }
+
+  th {
+    font-weight: 500;
+    opacity: 0.75;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.status {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  border: 1px solid rgb(var(--color-outline-200) / var(--opacity-strong));
+}
+
+.status-completed {
+  border-color: rgb(var(--color-success-500) / var(--opacity-strong));
+}
+
+.status-failed,
+.status-expired {
+  border-color: rgb(var(--color-danger-500) / var(--opacity-strong));
+}
+
+.empty {
+  opacity: 0.7;
+}
+
+.error {
+  color: rgb(var(--color-danger-500));
+}
+
+.notice {
+  opacity: 0.85;
+}

--- a/logos/logos-ui/src/app/features/batches/batches.spec.ts
+++ b/logos/logos-ui/src/app/features/batches/batches.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { Batches } from './batches';
+import { BatchObject } from '../../core/services/batch.service';
+
+/**
+ * The page's own judgements: what counts as finished, and how much of a batch
+ * has been done. Both drive the poll loop and the buttons, so they are worth
+ * pinning down independently of the template.
+ */
+
+const batch = (overrides: Partial<BatchObject> = {}): BatchObject => ({
+  id: 'batch_1',
+  object: 'batch',
+  status: 'in_progress',
+  endpoint: '/v1/chat/completions',
+  input_file_id: 'file-in',
+  output_file_id: null,
+  created_at: 0,
+  completed_at: null,
+  ...overrides,
+});
+
+describe('Batches', () => {
+  let page: Batches;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    page = TestBed.runInInjectionContext(() => new Batches());
+  });
+
+  it('treats every state the job will not leave on its own as terminal', () => {
+    for (const status of ['completed', 'failed', 'expired', 'cancelled']) {
+      expect(page.isTerminal(batch({ status }))).toBe(true);
+    }
+    for (const status of ['validating', 'in_progress', 'cancelling', 'finalizing']) {
+      expect(page.isTerminal(batch({ status }))).toBe(false);
+    }
+  });
+
+  it('keeps polling only while something is still moving', () => {
+    page.batches.set([batch({ status: 'completed' }), batch({ id: 'b2', status: 'in_progress' })]);
+    expect(page.hasRunning()).toBe(true);
+
+    page.batches.set([batch({ status: 'completed' })]);
+    expect(page.hasRunning()).toBe(false);
+  });
+
+  it('counts failed requests as done, and says how many failed', () => {
+    expect(page.progressOf(batch({ request_counts: { total: 10, completed: 6, failed: 2 } })))
+      .toBe('8 / 10 (2 failed)');
+    expect(page.progressOf(batch({ request_counts: { total: 10, completed: 10, failed: 0 } })))
+      .toBe('10 / 10');
+    // A forwarded batch reports no counts until the provider does.
+    expect(page.progressOf(batch())).toBe('—');
+  });
+});

--- a/logos/logos-ui/src/app/features/batches/batches.ts
+++ b/logos/logos-ui/src/app/features/batches/batches.ts
@@ -92,12 +92,16 @@ export class Batches implements OnInit, OnDestroy {
     if (!quiet) this.loading.set(true);
     try {
       const response = await this.batchService.list(keyId);
+      // The key may have changed while the request was in flight; a stale
+      // answer must not replace the new key's list.
+      if (this.selectedKeyId() !== keyId) return;
       this.batches.set(response.data ?? []);
       this.error.set(null);
     } catch {
+      if (this.selectedKeyId() !== keyId) return;
       if (!quiet) this.error.set('Could not load your batches.');
     } finally {
-      this.loading.set(false);
+      if (this.selectedKeyId() === keyId) this.loading.set(false);
     }
   }
 

--- a/logos/logos-ui/src/app/features/batches/batches.ts
+++ b/logos/logos-ui/src/app/features/batches/batches.ts
@@ -1,0 +1,172 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BatchKey, BatchObject, BatchService } from '../../core/services/batch.service';
+
+/** Batch states the provider (or Logos) will not move away from on its own. */
+const TERMINAL = new Set(['completed', 'failed', 'expired', 'cancelled']);
+
+/**
+ * Start a batch, watch it run, take the results.
+ *
+ * Most batches are driven from a script — upload, poll every few minutes,
+ * chain the next one onto the result. This page is for the other half of the
+ * job: starting one without writing code, and seeing where a running one got
+ * to. It polls on the same cadence a script would, so a batch started here and
+ * a batch started from a terminal look identical.
+ */
+@Component({
+  selector: 'app-batches',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './batches.html',
+  styleUrl: './batches.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Batches implements OnInit, OnDestroy {
+  private batchService = inject(BatchService);
+
+  keys = signal<BatchKey[]>([]);
+  selectedKeyId = signal<number | null>(null);
+  batches = signal<BatchObject[]>([]);
+  loading = signal(false);
+  uploading = signal(false);
+  error = signal<string | null>(null);
+  notice = signal<string | null>(null);
+
+  file = signal<File | null>(null);
+  endpoint = signal('/v1/chat/completions');
+  execution = signal('auto');
+
+  /** A batch still moving is worth polling for; a finished one is not. */
+  hasRunning = computed(() => this.batches().some(batch => !TERMINAL.has(batch.status)));
+
+  private pollHandle: ReturnType<typeof setInterval> | null = null;
+
+  async ngOnInit(): Promise<void> {
+    try {
+      const keys = await this.batchService.getKeys();
+      this.keys.set(keys);
+      if (keys.length > 0) {
+        this.selectedKeyId.set(keys[0].id);
+        await this.refresh();
+      }
+    } catch {
+      this.error.set('Could not load your API keys.');
+    }
+    // A batch is minutes-to-hours work, so this is deliberately unhurried;
+    // it exists so an open tab keeps up, not to drive the workload.
+    this.pollHandle = setInterval(() => {
+      if (this.hasRunning()) {
+        void this.refresh(true);
+      }
+    }, 30_000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.pollHandle) {
+      clearInterval(this.pollHandle);
+    }
+  }
+
+  onKeyChange(value: string): void {
+    this.selectedKeyId.set(Number(value));
+    void this.refresh();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.file.set(input.files && input.files.length > 0 ? input.files[0] : null);
+  }
+
+  async refresh(quiet = false): Promise<void> {
+    const keyId = this.selectedKeyId();
+    if (keyId === null) return;
+    if (!quiet) this.loading.set(true);
+    try {
+      const response = await this.batchService.list(keyId);
+      this.batches.set(response.data ?? []);
+      this.error.set(null);
+    } catch {
+      if (!quiet) this.error.set('Could not load your batches.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async submit(): Promise<void> {
+    const keyId = this.selectedKeyId();
+    const file = this.file();
+    if (keyId === null || !file) return;
+
+    this.uploading.set(true);
+    this.error.set(null);
+    this.notice.set(null);
+    try {
+      const created = await this.batchService.create(keyId, file, this.endpoint(), this.execution());
+      this.notice.set(
+        created.logos_execution === 'logos'
+          ? `Batch ${created.id} queued — Logos runs it here as low-priority requests.`
+          : `Batch ${created.id} handed to the provider's batch endpoint.`,
+      );
+      this.file.set(null);
+      await this.refresh();
+    } catch (err: unknown) {
+      // The orchestrator's message names the offending line or model, which is
+      // the only useful thing to show here.
+      this.error.set(this.messageOf(err) ?? 'The batch could not be started.');
+    } finally {
+      this.uploading.set(false);
+    }
+  }
+
+  async cancel(batch: BatchObject): Promise<void> {
+    const keyId = this.selectedKeyId();
+    if (keyId === null) return;
+    try {
+      await this.batchService.cancel(keyId, batch.id);
+      await this.refresh();
+    } catch (err: unknown) {
+      this.error.set(this.messageOf(err) ?? 'The batch could not be cancelled.');
+    }
+  }
+
+  async download(batch: BatchObject): Promise<void> {
+    const keyId = this.selectedKeyId();
+    if (keyId === null || !batch.output_file_id) return;
+    try {
+      const blob = await this.batchService.results(keyId, batch.id, batch.output_file_id);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `${batch.id}_results.jsonl`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      this.error.set(this.messageOf(err) ?? 'The results could not be downloaded.');
+    }
+  }
+
+  progressOf(batch: BatchObject): string {
+    const counts = batch.request_counts;
+    if (!counts || !counts.total) return '—';
+    const done = counts.completed + counts.failed;
+    return `${done} / ${counts.total}${counts.failed ? ` (${counts.failed} failed)` : ''}`;
+  }
+
+  isTerminal(batch: BatchObject): boolean {
+    return TERMINAL.has(batch.status);
+  }
+
+  private messageOf(err: unknown): string | null {
+    const body = (err as { error?: { error?: { message?: string }; detail?: string } })?.error;
+    return body?.error?.message ?? body?.detail ?? null;
+  }
+}

--- a/logos/logos-ui/src/app/shared/constants/nav-items.ts
+++ b/logos/logos-ui/src/app/shared/constants/nav-items.ts
@@ -18,6 +18,7 @@ export const MENU_ITEMS: MenuItem[] = [
   // Personal (all roles)
   { label: 'My Workspace', path: '/my-workspace',  piIcon: 'objects-column', group: 'personal',   roles: ALL_ROLES },
   { label: 'AI Tools',    path: '/ai-tools',       piIcon: 'code',           group: 'personal',   roles: ALL_ROLES },
+  { label: 'Batches',     path: '/batches',        piIcon: 'layer-group',    group: 'personal',   roles: ALL_ROLES },
 ];
 
 export const HOME_ROUTE: Record<UserRole, string> = {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
@@ -41,16 +41,23 @@ public class RestTemplateConfig {
     }
 
     /**
-     * Template for the batch proxy, which sends the caller's own API key.
+     * Template for the batch proxy.
      *
-     * The key travels in a custom header (logos_key), and a redirect would
-     * carry it along: the connection resends the request headers onto the
-     * redirected request. The orchestrator answers every batch call
-     * directly, so redirects have no legitimate purpose here and are
-     * refused at the connection level — the 3xx comes back as the response,
-     * and the service turns it into an error instead of following it into
-     * wherever it points.
+     * A redirect would carry the request's credential along — the connection
+     * resends the request headers onto the redirected request. The
+     * orchestrator answers every batch call directly, so redirects have no
+     * legitimate purpose here and are refused at the connection level: the
+     * 3xx comes back as the response, and the service turns it into an error
+     * instead of following it into wherever it points.
+     *
+     * The read timeout matches the orchestrator's own budget for a batch
+     * operation, which is 300 s (a file upload there covers validation, a
+     * cold provider-capability probe, and the upstream upload): a legitimate
+     * slow operation must come back as the provider's own answer, not as a
+     * UI-facing 502 after the work started upstream.
      */
+    public static final int BATCH_READ_TIMEOUT_MS = 305_000;
+
     @Bean
     public RestTemplate batchRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
@@ -61,7 +68,7 @@ public class RestTemplateConfig {
             }
         };
         factory.setConnectTimeout(3_000);
-        factory.setReadTimeout(5_000);
+        factory.setReadTimeout(BATCH_READ_TIMEOUT_MS);
         return new RestTemplate(factory);
     }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/common/RestTemplateConfig.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.logos.logoswebservice.common;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -34,6 +37,31 @@ public class RestTemplateConfig {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(3_000);
         factory.setReadTimeout(130_000);
+        return new RestTemplate(factory);
+    }
+
+    /**
+     * Template for the batch proxy, which sends the caller's own API key.
+     *
+     * The key travels in a custom header (logos_key), and a redirect would
+     * carry it along: the connection resends the request headers onto the
+     * redirected request. The orchestrator answers every batch call
+     * directly, so redirects have no legitimate purpose here and are
+     * refused at the connection level — the 3xx comes back as the response,
+     * and the service turns it into an error instead of following it into
+     * wherever it points.
+     */
+    @Bean
+    public RestTemplate batchRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+                super.prepareConnection(connection, httpMethod);
+                connection.setInstanceFollowRedirects(false);
+            }
+        };
+        factory.setConnectTimeout(3_000);
+        factory.setReadTimeout(5_000);
         return new RestTemplate(factory);
     }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/PriceUpdaterService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/PriceUpdaterService.java
@@ -126,6 +126,9 @@ public class PriceUpdaterService {
     // <base>_priority / <base>_flex / <base>_scale / <base>_standard
     private static final Pattern MODE_SUFFIX =
         Pattern.compile("^(?<base>.+?)_(?<mode>priority|flex|scale|standard)$");
+    // <base>_batches — the provider's Batch API rate for the same quantity
+    private static final Pattern BATCH_SUFFIX =
+        Pattern.compile("^(?<base>.+?)_batches$");
     private static final Pattern DURATION_INTERVAL_SUFFIX =
         Pattern.compile("^input_cost_per_video_per_second_above_(?<seconds>8|15)s_interval$");
 
@@ -303,7 +306,19 @@ public class PriceUpdaterService {
                 }
                 continue;
             }
-            if (rawKey.contains("_batches") || rawKey.contains("_batch")) continue;
+            // <base>_batches is the provider's Batch API rate for that base
+            // quantity — the same dimension, priced for asynchronous work.
+            // Logos books batch result rows with service_tier 'batch', so the
+            // discounted rate is what prices them; a model whose catalogue
+            // entry carries none falls back to the standard rate rather than
+            // going unpriced.
+            String batchStripped = rawKey;
+            String batchTier = "default";
+            Matcher batch = BATCH_SUFFIX.matcher(rawKey);
+            if (batch.matches()) {
+                batchStripped = batch.group("base");
+                batchTier = "batch";
+            }
 
             Matcher durationInterval = DURATION_INTERVAL_SUFFIX.matcher(rawKey);
             if (durationInterval.matches()) {
@@ -315,14 +330,18 @@ public class PriceUpdaterService {
                 continue;
             }
 
-            String key = rawKey;
+            String key = batchStripped;
             long minContextTokens = 0L;
-            String serviceTier = "default";
+            String serviceTier = batchTier;
 
             Matcher mode = MODE_SUFFIX.matcher(key);
             if (mode.matches()) {
                 String m = mode.group("mode");
-                serviceTier = "standard".equals(m) ? "default" : m;
+                // A key cannot carry both a batch and a flex/priority rate;
+                // the batch tier wins if a catalogue ever spells one that way.
+                if ("default".equals(serviceTier)) {
+                    serviceTier = "standard".equals(m) ? "default" : m;
+                }
                 key = mode.group("base");
             }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
@@ -7,10 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.logos.logoswebservice.auth.AuthContext;
+import de.tum.cit.aet.logos.logoswebservice.common.ConflictException;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.AddProviderRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.ConnectModelProviderRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DisconnectModelProviderRequestDTO;
@@ -41,13 +43,16 @@ public class ProviderService {
     private final ProviderRepository providerRepository;
     private final ModelProviderRepository modelProviderRepository;
     private final OrchestratorNotificationService orchestratorNotificationService;
+    private final JdbcTemplate jdbc;
 
     public ProviderService(ProviderRepository providerRepository,
                            ModelProviderRepository modelProviderRepository,
-                           OrchestratorNotificationService orchestratorNotificationService) {
+                           OrchestratorNotificationService orchestratorNotificationService,
+                           JdbcTemplate jdbc) {
         this.providerRepository = providerRepository;
         this.modelProviderRepository = modelProviderRepository;
         this.orchestratorNotificationService = orchestratorNotificationService;
+        this.jdbc = jdbc;
     }
 
     public List<Map<String, Object>> getProviders(AuthContext auth) {
@@ -128,6 +133,20 @@ public class ProviderService {
     public Map<String, Object> deleteProvider(Integer providerId) {
         if (!providerRepository.existsById(providerId)) {
             throw new IllegalArgumentException("Provider not found: " + providerId);
+        }
+        // Deleting the provider cascades its batch_objects rows away. For a
+        // batch that still runs upstream — or finished there without its
+        // usage being booked yet — that would leave the job unreachable and
+        // its spend unbillable, so the deletion waits for it. Settled
+        // records are safe to cascade: the job is terminal and metered.
+        Long unsettled = jdbc.queryForObject(
+            "SELECT count(*) FROM batch_objects WHERE kind = 'batch' AND provider_id = ? AND settled_at IS NULL",
+            Long.class, providerId);
+        if (unsettled != null && unsettled > 0) {
+            throw new ConflictException(
+                "Provider " + providerId + " still has " + unsettled
+                    + " batch(es) running or not yet settled; they must finish and be metered "
+                    + "before the provider can be deleted.");
         }
         providerRepository.deleteById(providerId);
         orchestratorNotificationService.notifyRefresh(false);

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
@@ -134,6 +134,13 @@ public class ProviderService {
         if (!providerRepository.existsById(providerId)) {
             throw new IllegalArgumentException("Provider not found: " + providerId);
         }
+        // Lock the provider row before checking: inserting a batch_object
+        // takes a FOR KEY SHARE lock on the referenced row, so no concurrent
+        // registration can commit while the count and the delete run.
+        // Without it, a creation could land an unsettled batch between the
+        // count and the delete, and the cascade would erase its row while
+        // the upstream job keeps running.
+        jdbc.queryForObject("SELECT id FROM providers WHERE id = ? FOR UPDATE", Long.class, providerId);
         // Deleting the provider cascades its batch_objects rows away. For a
         // batch that still runs upstream — or finished there without its
         // usage being booked yet — that would leave the job unreachable and

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchController.java
@@ -1,0 +1,143 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.controller;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import de.tum.cit.aet.logos.logoswebservice.auth.AuthContext;
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.Role;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.BatchService;
+
+/**
+ * The batch page: upload a file, watch it run, download the results.
+ *
+ * Researchers mostly drive batches from a script, but somebody has to be able
+ * to start one without writing code and to see where it got to — that is what
+ * these endpoints are for. They are a thin forward to the orchestrator's Batch
+ * API, called as the key the user picked, so the permission, ownership and
+ * budget rules are the ones that apply to every other batch.
+ */
+@RestController
+public class BatchController {
+
+    private final BatchService batchService;
+
+    public BatchController(BatchService batchService) {
+        this.batchService = batchService;
+    }
+
+    /** The user's keys, for the picker: a batch runs as exactly one of them. */
+    @GetMapping("/logosdb/batches/keys")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> keys(@RequestAttribute("authContext") AuthContext auth) {
+        if (auth.userId() == null) {
+            return ResponseEntity.status(403).body(Map.of("detail", "No user context"));
+        }
+        return ResponseEntity.ok(batchService.keysForUser(auth.userId()));
+    }
+
+    @GetMapping("/logosdb/batches")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> list(@RequestParam("apiKeyId") int apiKeyId,
+                                  @RequestAttribute("authContext") AuthContext auth) {
+        return proxy(() -> batchService.listBatches(requireUser(auth), apiKeyId));
+    }
+
+    @GetMapping("/logosdb/batches/{batchId}")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> get(@PathVariable String batchId,
+                                 @RequestParam("apiKeyId") int apiKeyId,
+                                 @RequestAttribute("authContext") AuthContext auth) {
+        return proxy(() -> batchService.getBatch(requireUser(auth), apiKeyId, batchId));
+    }
+
+    @PostMapping("/logosdb/batches/{batchId}/cancel")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> cancel(@PathVariable String batchId,
+                                    @RequestParam("apiKeyId") int apiKeyId,
+                                    @RequestAttribute("authContext") AuthContext auth) {
+        return proxy(() -> batchService.cancelBatch(requireUser(auth), apiKeyId, batchId));
+    }
+
+    /**
+     * Download a finished batch's results.
+     *
+     * The file id comes from the batch object the caller just read; the
+     * orchestrator refuses one their team does not own, so this cannot be used
+     * to fish for other teams' output.
+     */
+    @GetMapping("/logosdb/batches/{batchId}/results")
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> results(@PathVariable String batchId,
+                                     @RequestParam("apiKeyId") int apiKeyId,
+                                     @RequestParam("outputFileId") String outputFileId,
+                                     @RequestAttribute("authContext") AuthContext auth) {
+        return proxy(() -> batchService.batchResults(requireUser(auth), apiKeyId, outputFileId),
+            "attachment; filename=\"" + batchId + "_results.jsonl\"");
+    }
+
+    @PostMapping(value = "/logosdb/batches", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyAuthority('" + Role.Names.LOGOS_ADMIN + "', '" + Role.Names.APP_ADMIN + "', '"
+        + Role.Names.APP_DEVELOPER + "')")
+    public ResponseEntity<?> create(@RequestParam("file") MultipartFile file,
+                                    @RequestParam("apiKeyId") int apiKeyId,
+                                    @RequestParam(value = "endpoint", required = false) String endpoint,
+                                    @RequestParam(value = "completionWindow", required = false) String window,
+                                    @RequestParam(value = "execution", required = false) String execution,
+                                    @RequestAttribute("authContext") AuthContext auth) {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("detail", "A batch needs a .jsonl file."));
+        }
+        byte[] content;
+        try {
+            content = file.getBytes();
+        } catch (IOException exc) {
+            return ResponseEntity.badRequest().body(Map.of("detail", "The upload could not be read."));
+        }
+        return proxy(() -> batchService.createBatch(requireUser(auth), apiKeyId,
+            file.getOriginalFilename(), content, endpoint, window, execution));
+    }
+
+    private int requireUser(AuthContext auth) {
+        if (auth.userId() == null) {
+            throw new BatchService.KeyNotOwnedException("No user context");
+        }
+        return auth.userId();
+    }
+
+    private ResponseEntity<?> proxy(java.util.function.Supplier<BatchService.ProxiedResponse> call) {
+        return proxy(call, null);
+    }
+
+    private ResponseEntity<?> proxy(java.util.function.Supplier<BatchService.ProxiedResponse> call,
+                                    String contentDisposition) {
+        try {
+            BatchService.ProxiedResponse response = call.get();
+            ResponseEntity.BodyBuilder builder = ResponseEntity.status(response.status());
+            if (response.contentType() != null) {
+                builder = builder.header("Content-Type", response.contentType());
+            }
+            if (contentDisposition != null) {
+                builder = builder.header("Content-Disposition", contentDisposition);
+            }
+            return builder.body(response.body());
+        } catch (BatchService.KeyNotOwnedException exc) {
+            return ResponseEntity.status(403).body(Map.of("detail", exc.getMessage()));
+        }
+    }
+}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchController.java
@@ -138,6 +138,10 @@ public class BatchController {
             return builder.body(response.body());
         } catch (BatchService.KeyNotOwnedException exc) {
             return ResponseEntity.status(403).body(Map.of("detail", exc.getMessage()));
+        } catch (BatchService.CredentialExchangeException exc) {
+            // The key is fine and owned; what failed is the exchange with the
+            // orchestrator — a deployment problem, not the caller's.
+            return ResponseEntity.status(502).body(Map.of("detail", exc.getMessage()));
         }
     }
 }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
@@ -36,12 +36,17 @@ import jakarta.annotation.PostConstruct;
  * ownership of the ids, the budget guard, the choice between forwarding to a
  * provider and running the job here — lives in the orchestrator's Batch API. A
  * second implementation in Java would be a second set of those rules to keep in
- * step, so this forwards to the same endpoints a script would call, with the
+ * step, so this forwards to the same endpoints a script would call, as the
  * API key the user picked in the UI.
  *
- * The key is the user's secret, so where it may travel is checked at startup
- * (HTTPS, or plain HTTP on loopback for local development) and the template
- * used never follows a redirect that could carry it to another authority.
+ * What travels there is not the key itself: the key is the user's long-lived
+ * secret, and the shipped setup reaches the orchestrator over plain HTTP. The
+ * key value stays in this process; the ownership check runs here, and the
+ * scoped credential the orchestrator hands back in exchange for the key's id
+ * (short-lived, bound to that one key) is what authenticates the calls. Where
+ * the credential may travel is checked at startup (HTTPS anywhere; plain HTTP
+ * on loopback, or against the internal service URL when the credential
+ * exchange is configured), and the template used never follows a redirect.
  */
 @Service
 public class BatchService {
@@ -54,17 +59,22 @@ public class BatchService {
     @Value("${logos.orchestrator.url:}")
     private String orchestratorUrl;
 
+    @Value("${logos.orchestrator.internal-secret:}")
+    private String internalSecret;
+
     public BatchService(@Qualifier("batchRestTemplate") RestTemplate restTemplate, ApiKeyRepository apiKeyRepository) {
         this.restTemplate = restTemplate;
         this.apiKeyRepository = apiKeyRepository;
     }
 
     /**
-     * The batch proxy sends the caller's API key to this URL on every call, so
-     * a URL that would put the key on the wire in cleartext is a
+     * The batch proxy sends the caller's scoped credential to this URL on
+     * every call, so a URL that would put it on the wire in cleartext is a
      * misconfiguration that should fail the deployment, not the request.
-     * HTTPS is fine anywhere; plain HTTP only on loopback, matching the
-     * orchestrator's own rule for credentials.
+     * HTTPS is fine anywhere; plain HTTP on loopback (local development) or
+     * against the internal service URL when the credential exchange is
+     * configured — that is the mechanism that keeps the user's raw key off
+     * the hop, which is what the internal URL is permitted for.
      */
     @PostConstruct
     void validateOrchestratorUrl() {
@@ -78,12 +88,22 @@ public class BatchService {
         String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
         String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
         boolean loopback = "localhost".equals(host) || "127.0.0.1".equals(host) || "::1".equals(host);
-        if ("https".equals(scheme) || ("http".equals(scheme) && loopback)) return;
+        boolean exchangeConfigured = internalSecret != null && !internalSecret.isBlank();
+        if ("https".equals(scheme)) return;
+        if ("http".equals(scheme) && (loopback || exchangeConfigured)) return;
         throw new IllegalStateException(
-            "The batch proxy sends the caller's API key to logos.orchestrator.url ("
+            "The batch proxy sends the caller's scoped credential to logos.orchestrator.url ("
                 + orchestratorUrl
-                + "), which is not HTTPS. Point it at an HTTPS endpoint (plain HTTP is only accepted on loopback) "
-                + "so the key does not travel in cleartext.");
+                + "), which is not HTTPS. Point it at an HTTPS endpoint — plain HTTP is only accepted on loopback, "
+                + "or against the internal service URL when logos.orchestrator.internal-secret is configured, "
+                + "which is what keeps the user's key value off the hop.");
+    }
+
+    /** Raised when the scoped credential could not be obtained from the orchestrator. */
+    public static class CredentialExchangeException extends RuntimeException {
+        public CredentialExchangeException(String message) {
+            super(message);
+        }
     }
 
     /** Raised when the caller may not act as the key they named. */
@@ -117,18 +137,39 @@ public class BatchService {
     }
 
     /**
-     * The key's secret, once the caller is confirmed to own it.
+     * The scoped credential for the key, once the caller is confirmed to own it.
      *
-     * The UI never sees this value: it names a key by id, and the ownership
-     * check here is what stops one user from submitting work as another's key.
+     * The key value never leaves this process: the UI names a key by id (the
+     * ownership check here is what stops one user from submitting work as
+     * another's key), and what is asked of the orchestrator is the key's id —
+     * answered with a short-lived credential bound to that one key. That
+     * credential, not the key, is what authenticates the batch calls.
      */
-    private String keyValueOwnedBy(int userId, int apiKeyId) {
+    private String batchCredentialOwnedBy(int userId, int apiKeyId) {
         ApiKey key = apiKeyRepository.findById(apiKeyId).orElse(null);
         if (key == null || !Boolean.TRUE.equals(key.getIsActive())
                 || key.getUserId() == null || key.getUserId() != userId) {
             throw new KeyNotOwnedException("This API key does not belong to you.");
         }
-        return key.getKeyValue();
+        if (internalSecret == null || internalSecret.isBlank()) {
+            throw new CredentialExchangeException(
+                "The batch proxy cannot exchange a credential for this key: "
+                    + "logos.orchestrator.internal-secret is not configured.");
+        }
+        Map<String, Object> body = Map.of("api_key_id", key.getId());
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + internalSecret);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ProxiedResponse exchanged =
+            exchange(HttpMethod.POST, "/internal/batch_credentials", new HttpEntity<>(body, headers));
+        if (exchanged.status() >= 400) {
+            throw new CredentialExchangeException("The orchestrator refused the credential for this key.");
+        }
+        String credential = readField(exchanged, "credential");
+        if (credential == null) {
+            throw new CredentialExchangeException("The orchestrator returned no batch credential.");
+        }
+        return credential;
     }
 
     public ProxiedResponse listBatches(int userId, int apiKeyId) {
@@ -157,7 +198,7 @@ public class BatchService {
      */
     public ProxiedResponse createBatch(int userId, int apiKeyId, String filename, byte[] content,
                                        String endpoint, String completionWindow, String execution) {
-        String keyValue = keyValueOwnedBy(userId, apiKeyId);
+        String credential = batchCredentialOwnedBy(userId, apiKeyId);
 
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
         ByteArrayResource file = new ByteArrayResource(content) {
@@ -169,13 +210,13 @@ public class BatchService {
         form.add("file", file);
         form.add("purpose", "batch");
 
-        HttpHeaders uploadHeaders = headers(keyValue, execution);
+        HttpHeaders uploadHeaders = headers(credential, execution);
         uploadHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
         ProxiedResponse uploaded = exchange(HttpMethod.POST, "/v1/files", new HttpEntity<>(form, uploadHeaders));
         if (uploaded.status() >= 400) {
             return uploaded;
         }
-        String fileId = readId(uploaded);
+        String fileId = readField(uploaded, "id");
         if (fileId == null) {
             return new ProxiedResponse(502, MediaType.APPLICATION_JSON_VALUE,
                 "{\"error\":{\"message\":\"The upload returned no file id.\"}}".getBytes(StandardCharsets.UTF_8));
@@ -187,23 +228,23 @@ public class BatchService {
         body.put("completion_window", completionWindow != null && !completionWindow.isBlank()
             ? completionWindow : "24h");
 
-        HttpHeaders createHeaders = headers(keyValue, execution);
+        HttpHeaders createHeaders = headers(credential, execution);
         createHeaders.setContentType(MediaType.APPLICATION_JSON);
         return exchange(HttpMethod.POST, "/v1/batches", new HttpEntity<>(body, createHeaders));
     }
 
     private ProxiedResponse call(int userId, int apiKeyId, HttpMethod method, String path,
                                  Object body, MediaType contentType) {
-        HttpHeaders requestHeaders = headers(keyValueOwnedBy(userId, apiKeyId), null);
+        HttpHeaders requestHeaders = headers(batchCredentialOwnedBy(userId, apiKeyId), null);
         if (contentType != null) {
             requestHeaders.setContentType(contentType);
         }
         return exchange(method, path, new HttpEntity<>(body, requestHeaders));
     }
 
-    private HttpHeaders headers(String keyValue, String execution) {
+    private HttpHeaders headers(String credential, String execution) {
         HttpHeaders requestHeaders = new HttpHeaders();
-        requestHeaders.set("logos_key", keyValue);
+        requestHeaders.set("logos_key", credential);
         if (execution != null && !execution.isBlank()) {
             requestHeaders.set("X-Logos-Batch-Execution", execution);
         }
@@ -245,10 +286,10 @@ public class BatchService {
         }
     }
 
-    /** The ``id`` of a JSON object response, without pulling in a parser. */
-    private String readId(ProxiedResponse response) {
+    /** A string field of a JSON object response, without pulling in a parser. */
+    private String readField(ProxiedResponse response, String field) {
         String body = new String(response.body(), StandardCharsets.UTF_8);
-        int marker = body.indexOf("\"id\"");
+        int marker = body.indexOf("\"" + field + "\"");
         if (marker < 0) {
             return null;
         }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
@@ -1,12 +1,15 @@
 package de.tum.cit.aet.logos.logoswebservice.operations.service;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
@@ -23,6 +26,8 @@ import org.springframework.web.client.RestTemplate;
 import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKey;
 import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
 
+import jakarta.annotation.PostConstruct;
+
 /**
  * The batch pages, served by talking to the orchestrator as the user's own key.
  *
@@ -33,6 +38,10 @@ import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository
  * second implementation in Java would be a second set of those rules to keep in
  * step, so this forwards to the same endpoints a script would call, with the
  * API key the user picked in the UI.
+ *
+ * The key is the user's secret, so where it may travel is checked at startup
+ * (HTTPS, or plain HTTP on loopback for local development) and the template
+ * used never follows a redirect that could carry it to another authority.
  */
 @Service
 public class BatchService {
@@ -45,9 +54,36 @@ public class BatchService {
     @Value("${logos.orchestrator.url:}")
     private String orchestratorUrl;
 
-    public BatchService(RestTemplate restTemplate, ApiKeyRepository apiKeyRepository) {
+    public BatchService(@Qualifier("batchRestTemplate") RestTemplate restTemplate, ApiKeyRepository apiKeyRepository) {
         this.restTemplate = restTemplate;
         this.apiKeyRepository = apiKeyRepository;
+    }
+
+    /**
+     * The batch proxy sends the caller's API key to this URL on every call, so
+     * a URL that would put the key on the wire in cleartext is a
+     * misconfiguration that should fail the deployment, not the request.
+     * HTTPS is fine anywhere; plain HTTP only on loopback, matching the
+     * orchestrator's own rule for credentials.
+     */
+    @PostConstruct
+    void validateOrchestratorUrl() {
+        if (orchestratorUrl.isBlank()) return;
+        URI uri;
+        try {
+            uri = URI.create(orchestratorUrl);
+        } catch (IllegalArgumentException exc) {
+            throw new IllegalStateException("logos.orchestrator.url is not a valid URL: " + orchestratorUrl, exc);
+        }
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+        boolean loopback = "localhost".equals(host) || "127.0.0.1".equals(host) || "::1".equals(host);
+        if ("https".equals(scheme) || ("http".equals(scheme) && loopback)) return;
+        throw new IllegalStateException(
+            "The batch proxy sends the caller's API key to logos.orchestrator.url ("
+                + orchestratorUrl
+                + "), which is not HTTPS. Point it at an HTTPS endpoint (plain HTTP is only accepted on loopback) "
+                + "so the key does not travel in cleartext.");
     }
 
     /** Raised when the caller may not act as the key they named. */
@@ -178,6 +214,17 @@ public class BatchService {
         String url = orchestratorUrl.replaceAll("/+$", "") + path;
         try {
             ResponseEntity<byte[]> response = restTemplate.exchange(url, method, entity, byte[].class);
+            if (response.getStatusCode().is3xxRedirection()) {
+                // The template never follows a redirect, and the request
+                // carries the caller's key — so a 3xx is an error to report,
+                // not a hop to take.
+                log.warn("batch proxy to {} answered with a redirect: {}", path, response.getStatusCode());
+                return new ProxiedResponse(
+                    502,
+                    MediaType.APPLICATION_JSON_VALUE,
+                    "{\"error\":{\"message\":\"The orchestrator answered with a redirect, which the batch proxy does not follow.\"}}"
+                        .getBytes(StandardCharsets.UTF_8));
+            }
             return new ProxiedResponse(
                 response.getStatusCode().value(),
                 response.getHeaders().getContentType() != null

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
@@ -228,7 +228,13 @@ public class BatchService {
         body.put("completion_window", completionWindow != null && !completionWindow.isBlank()
             ? completionWindow : "24h");
 
-        HttpHeaders createHeaders = headers(credential, execution);
+        // The upload may have spent most of the credential's life — the
+        // orchestrator's own budget for it is the same five minutes the
+        // credential gets — so the creation asks for a fresh exchange.
+        // Presenting the aged one would 401 after the file was already
+        // stored, leaving it behind with no batch to spend it on.
+        String createCredential = batchCredentialOwnedBy(userId, apiKeyId);
+        HttpHeaders createHeaders = headers(createCredential, execution);
         createHeaders.setContentType(MediaType.APPLICATION_JSON);
         return exchange(HttpMethod.POST, "/v1/batches", new HttpEntity<>(body, createHeaders));
     }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchService.java
@@ -1,0 +1,212 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKey;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
+
+/**
+ * The batch pages, served by talking to the orchestrator as the user's own key.
+ *
+ * The webservice deliberately does not write batch rows itself. Everything that
+ * makes a batch safe — the key's model permissions checked line by line, the
+ * ownership of the ids, the budget guard, the choice between forwarding to a
+ * provider and running the job here — lives in the orchestrator's Batch API. A
+ * second implementation in Java would be a second set of those rules to keep in
+ * step, so this forwards to the same endpoints a script would call, with the
+ * API key the user picked in the UI.
+ */
+@Service
+public class BatchService {
+
+    private static final Logger log = LoggerFactory.getLogger(BatchService.class);
+
+    private final RestTemplate restTemplate;
+    private final ApiKeyRepository apiKeyRepository;
+
+    @Value("${logos.orchestrator.url:}")
+    private String orchestratorUrl;
+
+    public BatchService(RestTemplate restTemplate, ApiKeyRepository apiKeyRepository) {
+        this.restTemplate = restTemplate;
+        this.apiKeyRepository = apiKeyRepository;
+    }
+
+    /** Raised when the caller may not act as the key they named. */
+    public static class KeyNotOwnedException extends RuntimeException {
+        public KeyNotOwnedException(String message) {
+            super(message);
+        }
+    }
+
+    /** An orchestrator answer, passed back to the browser as it came. */
+    public record ProxiedResponse(int status, String contentType, byte[] body) {
+    }
+
+    /**
+     * The user's active keys, as the batch page's key picker needs them.
+     *
+     * A batch runs as one key: its permissions decide which models the file may
+     * name and its team owns the resulting objects.
+     */
+    public List<Map<String, Object>> keysForUser(int userId) {
+        return apiKeyRepository.findByUserIdAndIsActiveTrueOrderByIdAsc(userId).stream()
+            .map(key -> {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("id", key.getId());
+                entry.put("name", key.getName());
+                entry.put("team_id", key.getTeamId());
+                entry.put("environment", key.getEnvironment());
+                return entry;
+            })
+            .toList();
+    }
+
+    /**
+     * The key's secret, once the caller is confirmed to own it.
+     *
+     * The UI never sees this value: it names a key by id, and the ownership
+     * check here is what stops one user from submitting work as another's key.
+     */
+    private String keyValueOwnedBy(int userId, int apiKeyId) {
+        ApiKey key = apiKeyRepository.findById(apiKeyId).orElse(null);
+        if (key == null || !Boolean.TRUE.equals(key.getIsActive())
+                || key.getUserId() == null || key.getUserId() != userId) {
+            throw new KeyNotOwnedException("This API key does not belong to you.");
+        }
+        return key.getKeyValue();
+    }
+
+    public ProxiedResponse listBatches(int userId, int apiKeyId) {
+        return call(userId, apiKeyId, HttpMethod.GET, "/v1/batches", null, null);
+    }
+
+    public ProxiedResponse getBatch(int userId, int apiKeyId, String batchId) {
+        return call(userId, apiKeyId, HttpMethod.GET, "/v1/batches/" + batchId, null, null);
+    }
+
+    public ProxiedResponse cancelBatch(int userId, int apiKeyId, String batchId) {
+        return call(userId, apiKeyId, HttpMethod.POST, "/v1/batches/" + batchId + "/cancel", null, null);
+    }
+
+    /** The result file of a finished batch, streamed back to the browser. */
+    public ProxiedResponse batchResults(int userId, int apiKeyId, String outputFileId) {
+        return call(userId, apiKeyId, HttpMethod.GET, "/v1/files/" + outputFileId + "/content", null, null);
+    }
+
+    /**
+     * Upload a JSONL file and start a batch from it.
+     *
+     * Two calls, exactly as a script would make them: the file first (which is
+     * where the per-line permission check happens and where Logos decides
+     * whether a provider can run this batch), then the batch itself.
+     */
+    public ProxiedResponse createBatch(int userId, int apiKeyId, String filename, byte[] content,
+                                       String endpoint, String completionWindow, String execution) {
+        String keyValue = keyValueOwnedBy(userId, apiKeyId);
+
+        MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+        ByteArrayResource file = new ByteArrayResource(content) {
+            @Override
+            public String getFilename() {
+                return filename != null && !filename.isBlank() ? filename : "batch.jsonl";
+            }
+        };
+        form.add("file", file);
+        form.add("purpose", "batch");
+
+        HttpHeaders uploadHeaders = headers(keyValue, execution);
+        uploadHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+        ProxiedResponse uploaded = exchange(HttpMethod.POST, "/v1/files", new HttpEntity<>(form, uploadHeaders));
+        if (uploaded.status() >= 400) {
+            return uploaded;
+        }
+        String fileId = readId(uploaded);
+        if (fileId == null) {
+            return new ProxiedResponse(502, MediaType.APPLICATION_JSON_VALUE,
+                "{\"error\":{\"message\":\"The upload returned no file id.\"}}".getBytes(StandardCharsets.UTF_8));
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("input_file_id", fileId);
+        body.put("endpoint", endpoint != null && !endpoint.isBlank() ? endpoint : "/v1/chat/completions");
+        body.put("completion_window", completionWindow != null && !completionWindow.isBlank()
+            ? completionWindow : "24h");
+
+        HttpHeaders createHeaders = headers(keyValue, execution);
+        createHeaders.setContentType(MediaType.APPLICATION_JSON);
+        return exchange(HttpMethod.POST, "/v1/batches", new HttpEntity<>(body, createHeaders));
+    }
+
+    private ProxiedResponse call(int userId, int apiKeyId, HttpMethod method, String path,
+                                 Object body, MediaType contentType) {
+        HttpHeaders requestHeaders = headers(keyValueOwnedBy(userId, apiKeyId), null);
+        if (contentType != null) {
+            requestHeaders.setContentType(contentType);
+        }
+        return exchange(method, path, new HttpEntity<>(body, requestHeaders));
+    }
+
+    private HttpHeaders headers(String keyValue, String execution) {
+        HttpHeaders requestHeaders = new HttpHeaders();
+        requestHeaders.set("logos_key", keyValue);
+        if (execution != null && !execution.isBlank()) {
+            requestHeaders.set("X-Logos-Batch-Execution", execution);
+        }
+        return requestHeaders;
+    }
+
+    private ProxiedResponse exchange(HttpMethod method, String path, HttpEntity<?> entity) {
+        String url = orchestratorUrl.replaceAll("/+$", "") + path;
+        try {
+            ResponseEntity<byte[]> response = restTemplate.exchange(url, method, entity, byte[].class);
+            return new ProxiedResponse(
+                response.getStatusCode().value(),
+                response.getHeaders().getContentType() != null
+                    ? response.getHeaders().getContentType().toString()
+                    : MediaType.APPLICATION_JSON_VALUE,
+                response.getBody() != null ? response.getBody() : new byte[0]);
+        } catch (HttpStatusCodeException exc) {
+            // The orchestrator's own error bodies are the useful ones (a line
+            // number, a model the key may not use), so they go straight back.
+            return new ProxiedResponse(
+                exc.getStatusCode().value(),
+                MediaType.APPLICATION_JSON_VALUE,
+                exc.getResponseBodyAsByteArray());
+        } catch (RuntimeException exc) {
+            log.warn("batch proxy to {} failed: {}", path, exc.toString());
+            return new ProxiedResponse(502, MediaType.APPLICATION_JSON_VALUE,
+                "{\"error\":{\"message\":\"The orchestrator is unreachable.\"}}".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /** The ``id`` of a JSON object response, without pulling in a parser. */
+    private String readId(ProxiedResponse response) {
+        String body = new String(response.body(), StandardCharsets.UTF_8);
+        int marker = body.indexOf("\"id\"");
+        if (marker < 0) {
+            return null;
+        }
+        int open = body.indexOf('"', body.indexOf(':', marker) + 1);
+        int close = open < 0 ? -1 : body.indexOf('"', open + 1);
+        return (open < 0 || close < 0) ? null : body.substring(open + 1, close);
+    }
+}

--- a/logos/logos-webservice/src/main/resources/application.properties
+++ b/logos/logos-webservice/src/main/resources/application.properties
@@ -10,6 +10,13 @@ server.port=8081
 logos.orchestrator.url=${LOGOS_ORCHESTRATOR_URL:}
 logos.orchestrator.internal-secret=${LOGOS_INTERNAL_SECRET:}
 
+# Batch uploads: the orchestrator caps a batch file at 50 MiB (and the whole
+# request at file + 1 MiB of form fields). Spring's default 1 MiB per-file
+# limit would reject the upload before the controller ever sees it, so the
+# two limits mirror the orchestrator's.
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=51MB
+
 # --- Keycloak / OAuth2 resource server ---
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_ISSUER_URI:http://localhost:8085/realms/tum}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_JWKS_URI:http://localhost:8085/realms/tum/protocol/openid-connect/certs}

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
@@ -119,12 +119,14 @@
 
     <changeSet id="031-batch-objects-indexes" author="wasnertobias">
         <sql><![CDATA[
-            -- The lookup every lifecycle call makes: id + provider → owner.
-            -- COALESCE, not the bare column: a Logos-run object has no
-            -- provider, and NULLs would compare as distinct and let the same
-            -- id be minted twice.
+            -- The lookup every lifecycle call makes: id → owner. The id is
+            -- unique across providers and Logos itself, because a client
+            -- supplies the id without the provider that minted it: two rows
+            -- for one id would leave every later lifecycle call ambiguous.
+            -- The registration refuses a colliding id instead of storing a
+            -- second row, so the index is what enforces the contract.
             CREATE UNIQUE INDEX IF NOT EXISTS uq_batch_objects_upstream
-                ON batch_objects(COALESCE(provider_id, 0), kind, upstream_id);
+                ON batch_objects(kind, upstream_id);
 
             -- The reconciler's scan: forwarded batches that still owe a
             -- settlement. A Logos-run batch meters itself request by request.

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
@@ -35,11 +35,22 @@
             <column name="kind" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <!-- The provider's own id (file-abc…, batch_abc…). Unique per
-                 provider: two upstreams may legitimately mint the same id. -->
+            <!-- The id the object is exposed under. For a result file that is
+                 Logos's own (the provider's file ids are only unique at that
+                 provider, and a client names the file without the provider):
+                 see provider_object_id. Otherwise the provider's own id,
+                 unique across providers by the uq_batch_objects_upstream
+                 index — a colliding registration is refused. -->
             <column name="upstream_id" type="TEXT">
                 <constraints nullable="false"/>
             </column>
+            <!-- The object's own id at the provider, when Logos exposes a
+                 different one: result files are minted by the provider, and
+                 their ids are only unique at that provider, so the row is
+                 keyed by Logos's id and the forward uses this one. NULL
+                 everywhere else — input files and local objects are exposed
+                 under the ids they carry. -->
+            <column name="provider_object_id" type="TEXT"/>
             <!-- Where the object lives. NULL for a batch Logos runs itself:
                  its lines are scheduled as ordinary low-priority requests and
                  each one picks its own provider, so the batch as a whole

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Who owns a file or batch that lives at the provider.
+
+         The Batch API is the one proxied surface whose objects outlive the
+         request that created them: a file id and a batch id are handed back to
+         the client and used for hours afterwards. Logos forwards those
+         operations with the provider credential shared by every key allowed to
+         use that provider, so without this table any such key could poll,
+         cancel or delete another team's batch — and download its output file,
+         which holds that team's prompts and completions.
+
+         Every lifecycle call therefore resolves the inbound id here first and
+         is answered with a 404 when the row belongs to another team, so an id
+         guessed or leaked from elsewhere is indistinguishable from one that
+         never existed.
+
+         settled_at is the billing latch: a completed batch is metered exactly
+         once, when its output file is read (see the batch reconciler). -->
+    <changeSet id="031-batch-objects" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="batch_objects"/></not>
+        </preConditions>
+        <createTable tableName="batch_objects">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="pk_batch_objects"/>
+            </column>
+            <!-- 'file' or 'batch' — the two object kinds the OpenAI Batch API
+                 hands out ids for. -->
+            <column name="kind" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <!-- The provider's own id (file-abc…, batch_abc…). Unique per
+                 provider: two upstreams may legitimately mint the same id. -->
+            <column name="upstream_id" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Where the object lives. NULL for a batch Logos runs itself:
+                 its lines are scheduled as ordinary low-priority requests and
+                 each one picks its own provider, so the batch as a whole
+                 belongs to none. -->
+            <column name="provider_id" type="INTEGER">
+                <constraints foreignKeyName="fk_batch_objects_provider"
+                             references="providers(id)"
+                             deleteCascade="true"/>
+            </column>
+            <!-- 'provider' (forwarded to an upstream Batch API) or 'logos'
+                 (executed here as low-priority requests). Local models have no
+                 upstream Batch API at all, and a cloud model can lack a batch
+                 deployment, so both need the same client-facing surface. -->
+            <column name="execution" type="TEXT" defaultValue="provider">
+                <constraints nullable="false"/>
+            </column>
+            <!-- The key that created the object. Kept for attribution; access
+                 is decided on team_id, matching how job results are scoped. -->
+            <column name="api_key_id" type="INTEGER">
+                <constraints foreignKeyName="fk_batch_objects_api_key"
+                             references="api_keys(id)"
+                             deleteCascade="false"/>
+            </column>
+            <column name="team_id" type="INTEGER">
+                <constraints foreignKeyName="fk_batch_objects_team"
+                             references="teams(id)"
+                             deleteCascade="false"/>
+            </column>
+            <column name="user_id" type="INTEGER">
+                <constraints foreignKeyName="fk_batch_objects_user"
+                             references="users(id)"
+                             deleteCascade="false"/>
+            </column>
+            <!-- For a batch: the input file it was created from, so the
+                 reconciler can attribute rows even when the client deleted
+                 its own bookkeeping. NULL for files. -->
+            <column name="input_file_id" type="TEXT"/>
+            <!-- Last status seen from the provider (validating, in_progress,
+                 completed, expired, cancelled, failed). NULL for files. -->
+            <column name="status" type="TEXT"/>
+            <!-- Set once the batch's usage has been booked into log_entry /
+                 usage_tokens. NULL means "not metered yet". A batch Logos ran
+                 itself is metered request by request as it runs, so it is
+                 stamped settled the moment it finishes. -->
+            <column name="settled_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <!-- The rest describes a Logos-run batch. Filled in for a forwarded
+                 one only where the provider's own object carries it. -->
+            <column name="filename" type="TEXT"/>
+            <column name="size_bytes" type="BIGINT"/>
+            <!-- The single operation every request line addresses, as the
+                 OpenAI batch object reports it. -->
+            <column name="endpoint" type="TEXT"/>
+            <column name="completion_window" type="TEXT"/>
+            <column name="request_metadata" type="JSONB"/>
+            <column name="output_file_id" type="TEXT"/>
+            <column name="error_file_id" type="TEXT"/>
+            <column name="total_requests" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="completed_requests" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="failed_requests" type="INTEGER" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <!-- A cancel arrives while the runner is mid-file; it stops before
+                 the next line rather than killing the one in flight. -->
+            <column name="cancel_requested" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="started_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="finished_at" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="batch_objects"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="031-batch-objects-indexes" author="wasnertobias">
+        <sql><![CDATA[
+            -- The lookup every lifecycle call makes: id + provider → owner.
+            -- COALESCE, not the bare column: a Logos-run object has no
+            -- provider, and NULLs would compare as distinct and let the same
+            -- id be minted twice.
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_batch_objects_upstream
+                ON batch_objects(COALESCE(provider_id, 0), kind, upstream_id);
+
+            -- The reconciler's scan: forwarded batches that still owe a
+            -- settlement. A Logos-run batch meters itself request by request.
+            CREATE INDEX IF NOT EXISTS idx_batch_objects_unsettled
+                ON batch_objects(kind, settled_at)
+                WHERE kind = 'batch' AND settled_at IS NULL AND execution = 'provider';
+
+            -- The local runner's scan: batches waiting to be executed here.
+            CREATE INDEX IF NOT EXISTS idx_batch_objects_runnable
+                ON batch_objects(status, created_at)
+                WHERE kind = 'batch' AND execution = 'logos';
+
+            -- Listing a team's own objects (GET /v1/batches, GET /v1/files).
+            CREATE INDEX IF NOT EXISTS idx_batch_objects_team
+                ON batch_objects(team_id, kind, created_at DESC);
+        ]]></sql>
+        <rollback>
+            <sql>
+                DROP INDEX IF EXISTS uq_batch_objects_upstream;
+                DROP INDEX IF EXISTS idx_batch_objects_unsettled;
+                DROP INDEX IF EXISTS idx_batch_objects_runnable;
+                DROP INDEX IF EXISTS idx_batch_objects_team;
+            </sql>
+        </rollback>
+    </changeSet>
+
+    <!-- The bytes of a file Logos holds itself.
+
+         A forwarded batch keeps its files at the provider; a Logos-run one has
+         nowhere else to put them, and the UI has to serve the result back to a
+         browser. They live in the shared database rather than on a container
+         volume so the webservice can read them without a second transport, and
+         so they survive a redeploy of the orchestrator. Separate table because
+         a listing must not drag megabytes of JSONL with it. -->
+    <changeSet id="031-batch-file-contents" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="batch_file_contents"/></not>
+        </preConditions>
+        <createTable tableName="batch_file_contents">
+            <column name="batch_object_id" type="BIGINT">
+                <constraints nullable="false"
+                             primaryKey="true"
+                             primaryKeyName="pk_batch_file_contents"
+                             foreignKeyName="fk_batch_file_contents_object"
+                             references="batch_objects(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="content" type="BYTEA">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="batch_file_contents"/>
+        </rollback>
+    </changeSet>
+
+    <!-- Whether a provider actually serves an OpenAI Batch API.
+
+         "Cloud provider" is not the same as "has a Batch API": an
+         OpenAI-shaped resource can be a self-hosted inference endpoint
+         (Hetzner, Morpheus) that serves /chat/completions and nothing else.
+         Treating those as batch targets would make the Batch API ambiguous for
+         every key that may also use them, and send jobs somewhere that 404s.
+
+         The answer is a fact about the upstream rather than an operator
+         preference, so it is probed (GET <base>/batches) and cached here
+         instead of being configured — a hand-set flag would go stale the day a
+         provider gains or loses the surface. checked_at drives the refresh;
+         detail keeps the reason a probe said no, for the admin who wonders. -->
+    <changeSet id="031-provider-batch-capability" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="provider_batch_capability"/></not>
+        </preConditions>
+        <createTable tableName="provider_batch_capability">
+            <column name="provider_id" type="INTEGER">
+                <constraints nullable="false"
+                             primaryKey="true"
+                             primaryKeyName="pk_provider_batch_capability"
+                             foreignKeyName="fk_provider_batch_capability_provider"
+                             references="providers(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="supports_batch" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="detail" type="TEXT"/>
+            <column name="checked_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="provider_batch_capability"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/031_batch_api.xml
@@ -56,23 +56,16 @@
             <column name="execution" type="TEXT" defaultValue="provider">
                 <constraints nullable="false"/>
             </column>
-            <!-- The key that created the object. Kept for attribution; access
-                 is decided on team_id, matching how job results are scoped. -->
-            <column name="api_key_id" type="INTEGER">
-                <constraints foreignKeyName="fk_batch_objects_api_key"
-                             references="api_keys(id)"
-                             deleteCascade="false"/>
-            </column>
-            <column name="team_id" type="INTEGER">
-                <constraints foreignKeyName="fk_batch_objects_team"
-                             references="teams(id)"
-                             deleteCascade="false"/>
-            </column>
-            <column name="user_id" type="INTEGER">
-                <constraints foreignKeyName="fk_batch_objects_user"
-                             references="users(id)"
-                             deleteCascade="false"/>
-            </column>
+            <!-- Attribution (key, team, user) lives on the raw-SQL foreign
+                 keys at the bottom of this file: SET NULL, not the default
+                 RESTRICT, because the existing deletion paths remove keys,
+                 users and teams physically and a retained batch must not
+                 keep them. The Liquibase XML of this version cannot express
+                 SET NULL on a column constraint, so they are raw SQL, like
+                 the 000 schema. The object survives its owners, unattributed. -->
+            <column name="api_key_id" type="INTEGER"/>
+            <column name="team_id" type="INTEGER"/>
+            <column name="user_id" type="INTEGER"/>
             <!-- For a batch: the input file it was created from, so the
                  reconciler can attribute rows even when the client deleted
                  its own bookkeeping. NULL for files. -->
@@ -147,9 +140,19 @@
             -- Listing a team's own objects (GET /v1/batches, GET /v1/files).
             CREATE INDEX IF NOT EXISTS idx_batch_objects_team
                 ON batch_objects(team_id, kind, created_at DESC);
+
+            -- The attribution foreign keys (see the column comments above).
+            ALTER TABLE batch_objects
+                ADD CONSTRAINT fk_batch_objects_api_key FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE SET NULL,
+                ADD CONSTRAINT fk_batch_objects_team FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE SET NULL,
+                ADD CONSTRAINT fk_batch_objects_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
         ]]></sql>
         <rollback>
             <sql>
+                ALTER TABLE batch_objects
+                    DROP CONSTRAINT IF EXISTS fk_batch_objects_api_key,
+                    DROP CONSTRAINT IF EXISTS fk_batch_objects_team,
+                    DROP CONSTRAINT IF EXISTS fk_batch_objects_user;
                 DROP INDEX IF EXISTS uq_batch_objects_upstream;
                 DROP INDEX IF EXISTS idx_batch_objects_unsettled;
                 DROP INDEX IF EXISTS idx_batch_objects_runnable;

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/032_batch_runner.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/032_batch_runner.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Runner lease on batch_objects.
+
+         A Logos-run batch whose process died mid-file is recovered by the next
+         pass of the runner, which deliberately re-offers in_progress rows.
+         Without a lease that recovery cannot tell "the runner is gone" from
+         "another replica is running it right now", so a second process picks
+         up a batch that is still active and runs — and bills — its lines a
+         second time. runner_id names the process that holds the batch, and
+         lease_expires_at is when its right to it runs out: a row is only
+         recoverable when the lease is missing or expired, and the holder
+         refreshes it as it makes progress. -->
+    <changeSet id="032-batch-runner-lease" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="batch_objects" columnName="runner_id"/></not>
+        </preConditions>
+        <addColumn tableName="batch_objects">
+            <column name="runner_id" type="TEXT"/>
+            <column name="lease_expires_at" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="batch_objects" columnName="lease_expires_at"/>
+            <dropColumn tableName="batch_objects" columnName="runner_id"/>
+        </rollback>
+    </changeSet>
+
+    <!-- The models a batch input file asks for, as uploaded.
+
+         A forwarded batch whose provider turns out not to batch one of its
+         models has to be marked as much *per model* — and at that point the
+         only thing that still says what the file wanted is this list. The
+         error text the provider sends is not trusted enough to name the model
+         on its own. -->
+    <changeSet id="032-batch-file-models" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="batch_objects" columnName="models"/></not>
+        </preConditions>
+        <addColumn tableName="batch_objects">
+            <column name="models" type="JSONB"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="batch_objects" columnName="models"/>
+        </rollback>
+    </changeSet>
+
+    <!-- Per-model Batch eligibility on one provider, learned from refusals.
+
+         Being a cloud provider that answers GET /batches is not the same as
+         batching a given model: on Azure each batchable model needs its own
+         Global-Batch deployment, and a model that only exists as a Standard
+         deployment cannot be batched there even though the resource serves the
+         Batch API. The provider does not publish its batch model list, so the
+         knowledge is learned from its own refusals (a batch creation refused
+         for the model, or a batch that finishes failed with the SKU error) and
+         tracked here. eligible=false is what moves that model's batches to
+         Logos execution; the absence of a row means "unknown" and keeps the
+         forwarding behaviour. detail keeps what the provider said, for the
+         admin who wants to know why a model is excluded. -->
+    <changeSet id="032-provider-model-batch-eligibility" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="provider_model_batch_eligibility"/></not>
+        </preConditions>
+        <createTable tableName="provider_model_batch_eligibility">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="pk_provider_model_batch_eligibility"/>
+            </column>
+            <column name="provider_id" type="INTEGER">
+                <constraints nullable="false"
+                             foreignKeyName="fk_pmb_eligibility_provider"
+                             references="providers(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="model_id" type="INTEGER">
+                <constraints nullable="false"
+                             foreignKeyName="fk_pmb_eligibility_model"
+                             references="models(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="eligible" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="detail" type="TEXT"/>
+            <column name="checked_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="provider_model_batch_eligibility"
+                             columnNames="provider_id, model_id"
+                             constraintName="uq_provider_model_batch_eligibility"/>
+        <rollback>
+            <dropTable tableName="provider_model_batch_eligibility"/>
+        </rollback>
+    </changeSet>
+
+    <!-- The finished request lines of a Logos-run batch, one row per custom_id.
+
+         The runner writes each line's result here as it completes. A batch
+         recovered after a restart resumes from this checkpoint instead of
+         replaying the file from line zero: the finished lines already went
+         through the ordinary pipeline and were billed once, and the result
+         file is only written when the batch finishes, so without a durable
+         per-line record there is nothing to resume from. The table is keyed by
+         the batch object and the line's custom_id, which the input-file
+         validation already guarantees to be unique per file. -->
+    <changeSet id="032-batch-line-results" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="batch_line_results"/></not>
+        </preConditions>
+        <createTable tableName="batch_line_results">
+            <column name="batch_object_id" type="BIGINT">
+                <constraints nullable="false"
+                             foreignKeyName="fk_batch_line_results_object"
+                             references="batch_objects(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="custom_id" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="row" type="JSONB">
+                <constraints nullable="false"/>
+            </column>
+            <column name="finished_at" type="TIMESTAMP WITH TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="batch_line_results"
+                       columnNames="batch_object_id, custom_id"
+                       constraintName="pk_batch_line_results"/>
+        <rollback>
+            <dropTable tableName="batch_line_results"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/033_batch_settlement.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/033_batch_settlement.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- The settlement lease on batch_objects.
+
+         A provider-run batch is metered when its output file is read: the
+         settlement downloads the file, books one usage row per request line,
+         and only then stamps settled_at. The claim that makes the settlement
+         exclusive (a client's poll and the reconciler can reach the batch at
+         the same time) is a lease, not the settled_at stamp itself: stamping
+         first would make a settlement that dies between the stamp and the
+         ledger write unretryable, and the batch's provider cost would be lost
+         with it. The lease expires on its own, which is the recovery, and the
+         ledger write is idempotent per row (request_id unique in log_entry),
+         so a lapsed lease cannot double-bill. -->
+    <changeSet id="033-batch-settlement-lease" author="wasnertobias">
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="batch_objects" columnName="settlement_lease_expires_at"/></not>
+        </preConditions>
+        <addColumn tableName="batch_objects">
+            <column name="settlement_lease_expires_at" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="batch_objects" columnName="settlement_lease_expires_at"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -35,5 +35,6 @@
     <include file="liquibase/changelog/029_rename_provider_snapshots.xml"/>
     <include file="liquibase/changelog/030_refuse_ollama_typed_providers.xml"/>
     <include file="liquibase/changelog/031_batch_api.xml"/>
+    <include file="liquibase/changelog/032_batch_runner.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -36,5 +36,6 @@
     <include file="liquibase/changelog/030_refuse_ollama_typed_providers.xml"/>
     <include file="liquibase/changelog/031_batch_api.xml"/>
     <include file="liquibase/changelog/032_batch_runner.xml"/>
+    <include file="liquibase/changelog/033_batch_settlement.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
+++ b/logos/logos-webservice/src/main/resources/liquibase/changelog/master.xml
@@ -34,5 +34,6 @@
     <include file="liquibase/changelog/028_log_entry_api_key_response_index.xml"/>
     <include file="liquibase/changelog/029_rename_provider_snapshots.xml"/>
     <include file="liquibase/changelog/030_refuse_ollama_typed_providers.xml"/>
+    <include file="liquibase/changelog/031_batch_api.xml"/>
 
 </databaseChangeLog>

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
@@ -1,5 +1,12 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 import de.tum.cit.aet.logos.logoswebservice.configuration.service.PriceUpdaterService;
@@ -40,6 +49,7 @@ class ProviderControllerTest {
 
     @Autowired MockMvc mvc;
     @Autowired JdbcTemplate jdbc;
+    @Autowired DataSource dataSource;
     @MockitoBean JwtDecoder jwtDecoder;
     // Mocked so the price refresh triggered by connect_model_provider does not
     // reach the live litellm catalog during tests.
@@ -196,6 +206,50 @@ class ProviderControllerTest {
             // The cascade removed the settled row with the provider, so this
             // only covers a failed run where the provider still exists.
             jdbc.update("DELETE FROM batch_objects WHERE upstream_id = 'batch_delete_settled'");
+        }
+    }
+
+    @Test
+    void deleteProvider_serializesWithAConcurrentBatchRegistration() throws Exception {
+        // The count alone has a window: a registration could commit its
+        // unsettled batch after the count returns zero and before the delete,
+        // and the cascade would then erase its row while the upstream job
+        // keeps running. The provider row lock closes the window — the
+        // registration's FK check waits on the delete, and once the
+        // registration is committed the count sees it and refuses.
+        CountDownLatch registrationInFlight = new CountDownLatch(1);
+        Thread inserter = new Thread(() -> {
+            try (Connection conn = dataSource.getConnection()) {
+                conn.setAutoCommit(false);
+                try (PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO batch_objects (kind, upstream_id, provider_id, team_id, execution, status, created_at, updated_at) "
+                        + "VALUES ('batch', 'batch_delete_race', 6001, 2001, 'provider', 'validating', now(), now())")) {
+                    ps.executeUpdate();
+                }
+                registrationInFlight.countDown();
+                // Hold the FK lock while the delete is in flight; only then
+                // commit, so the delete is forced to wait and see the batch.
+                Thread.sleep(1500);
+                conn.commit();
+            } catch (Exception ignored) {
+                // The thread must not kill the test on the way down.
+            }
+        });
+        inserter.start();
+        assertTrue(registrationInFlight.await(10, TimeUnit.SECONDS), "the concurrent registration did not start");
+        try {
+            mvc.perform(post("/logosdb/delete_provider")
+                    .with(TestJwt.logosAdmin())
+                    .contentType("application/json")
+                    .content("{\"provider_id\":6001}"))
+               .andExpect(status().isConflict());
+            // The provider survived with its batch: the ownership row (and
+            // with it the billing state) is intact.
+            assertEquals(1, jdbc.queryForObject(
+                "SELECT count(*) FROM batch_objects WHERE upstream_id = 'batch_delete_race'", Integer.class));
+        } finally {
+            inserter.join(15_000);
+            jdbc.update("DELETE FROM batch_objects WHERE upstream_id = 'batch_delete_race'");
         }
     }
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/ProviderControllerTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.logos.logoswebservice.configuration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -38,6 +39,7 @@ import de.tum.cit.aet.logos.logoswebservice.TestJwt;
 class ProviderControllerTest {
 
     @Autowired MockMvc mvc;
+    @Autowired JdbcTemplate jdbc;
     @MockitoBean JwtDecoder jwtDecoder;
     // Mocked so the price refresh triggered by connect_model_provider does not
     // reach the live litellm catalog during tests.
@@ -154,6 +156,47 @@ class ProviderControllerTest {
                 .content("{\"provider_id\":6001}"))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.result").value("Deleted Provider."));
+    }
+
+    @Test
+    void deleteProvider_refusedWhileABatchStillRunsOrOwesItsSettlement() throws Exception {
+        // The upstream job outlives the providers table: cascading the
+        // ownership row away would make it unreachable and its spend
+        // unbillable, so the deletion is refused until it is settled.
+        jdbc.update(
+            "INSERT INTO batch_objects (kind, upstream_id, provider_id, team_id, execution, status, created_at, updated_at) "
+                + "VALUES ('batch', 'batch_delete_guard', 6001, 2001, 'provider', 'in_progress', now(), now())");
+        try {
+            mvc.perform(post("/logosdb/delete_provider")
+                    .with(TestJwt.logosAdmin())
+                    .contentType("application/json")
+                    .content("{\"provider_id\":6001}"))
+               .andExpect(status().isConflict())
+               .andExpect(jsonPath("$.detail").value(containsString("not yet settled")));
+        } finally {
+            jdbc.update("DELETE FROM batch_objects WHERE upstream_id = 'batch_delete_guard'");
+        }
+    }
+
+    @Test
+    void deleteProvider_allowedOnceTheBatchesAreSettled() throws Exception {
+        // A terminal, metered batch is safe to cascade away with the
+        // provider: nothing runs on it any more and its spend is booked.
+        jdbc.update(
+            "INSERT INTO batch_objects (kind, upstream_id, provider_id, team_id, execution, status, settled_at, created_at, updated_at) "
+                + "VALUES ('batch', 'batch_delete_settled', 6001, 2001, 'provider', 'completed', now(), now(), now())");
+        try {
+            mvc.perform(post("/logosdb/delete_provider")
+                    .with(TestJwt.logosAdmin())
+                    .contentType("application/json")
+                    .content("{\"provider_id\":6001}"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.result").value("Deleted Provider."));
+        } finally {
+            // The cascade removed the settled row with the provider, so this
+            // only covers a failed run where the provider still exists.
+            jdbc.update("DELETE FROM batch_objects WHERE upstream_id = 'batch_delete_settled'");
+        }
     }
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/PriceUpdaterServiceTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/PriceUpdaterServiceTest.java
@@ -332,4 +332,31 @@ class PriceUpdaterServiceTest {
             new SavedPrice("billed_search_prompts", "request", 0, "default", Math.round(1.0e-3 * 1e11))
         );
     }
+
+    @Test
+    void batchKeysBecomeBatchTierRowsAlongsideTheStandardRate() {
+        // Batch result rows are booked with service_tier 'batch', so the
+        // provider's discounted rate has to reach token_prices under that tier
+        // rather than being dropped as an unknown key.
+        List<SavedPrice> rows = ingest(Map.of(
+            "input_cost_per_token", 2.0e-7,
+            "output_cost_per_token", 1.2e-6,
+            "input_cost_per_token_batches", 1.0e-7,
+            "output_cost_per_token_batches", 6.0e-7
+        ));
+        assertThat(rows).containsExactlyInAnyOrder(
+            new SavedPrice("billed_input_uncached", "token", 0, "default", Math.round(2.0e-7 * 1e11)),
+            new SavedPrice("billed_output_text", "token", 0, "default", Math.round(1.2e-6 * 1e11)),
+            new SavedPrice("billed_input_uncached", "token", 0, "batch", Math.round(1.0e-7 * 1e11)),
+            new SavedPrice("billed_output_text", "token", 0, "batch", Math.round(6.0e-7 * 1e11))
+        );
+    }
+
+    @Test
+    void aModelWithoutABatchRateGetsNoBatchRow() {
+        // The price lookup falls back to the standard rate, which over- rather
+        // than under-charges a batch whose model has no published batch price.
+        List<SavedPrice> rows = ingest(Map.of("input_cost_per_token", 2.0e-7));
+        assertThat(rows).noneMatch(row -> "batch".equals(row.tier()));
+    }
 }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchControllerUploadTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/controller/BatchControllerUploadTest.java
@@ -1,0 +1,78 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.controller;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
+import de.tum.cit.aet.logos.logoswebservice.TestJwt;
+import de.tum.cit.aet.logos.logoswebservice.operations.service.BatchService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The upload limit, end to end: Spring's default rejects a per-file upload
+ * above 1 MiB before the controller runs, while the orchestrator — whose
+ * 50 MiB cap is what the batch page documents — would accept it. The limits
+ * in application.properties mirror the orchestrator's; this pins them with a
+ * file the default would have refused.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestContainersConfig.class)
+@TestPropertySource(properties = {
+    "spring.liquibase.enabled=true",
+    "spring.liquibase.change-log=classpath:liquibase/changelog/master.xml",
+    "logos.auth.roles.logos-admin=itg-admin",
+    "logos.auth.roles.app-admin=chair-member",
+    "logos.auth.sync-debounce-minutes=5",
+    "logos.orchestrator.url=",
+    "logos.orchestrator.internal-secret="
+})
+@Sql(scripts = {"/sql/seed-identity.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"/sql/cleanup-identity.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class BatchControllerUploadTest {
+
+    @Autowired MockMvc mvc;
+    @MockitoBean JwtDecoder jwtDecoder;
+    @MockitoBean BatchService batchService;
+
+    @Test
+    void an_upload_larger_than_the_spring_default_reaches_the_service_intact() throws Exception {
+        byte[] content = new byte[2 * 1024 * 1024];
+        when(batchService.createBatch(anyInt(), anyInt(), anyString(), any(byte[].class), any(), any(), any()))
+            .thenReturn(new BatchService.ProxiedResponse(
+                200, "application/json", "{\"id\":\"batch_1\"}".getBytes(StandardCharsets.UTF_8)));
+
+        mvc.perform(multipart("/logosdb/batches")
+                .file(new MockMultipartFile("file", "batch.jsonl", "application/jsonl", content))
+                .param("apiKeyId", "3004")
+                .with(TestJwt.logosAdmin()))
+           .andExpect(status().isOk());
+
+        // The whole file made the round trip to the orchestrator call, not a
+        // truncated or rejected remnant of it.
+        ArgumentCaptor<byte[]> contentCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(batchService).createBatch(eq(1003), eq(3004), eq("batch.jsonl"), contentCaptor.capture(), any(), any(), any());
+        assertThat(contentCaptor.getValue()).hasSize(2 * 1024 * 1024);
+    }
+}

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchObjectOwnerDeletionTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchObjectOwnerDeletionTest.java
@@ -1,0 +1,83 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import de.tum.cit.aet.logos.logoswebservice.TestContainersConfig;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.TeamRepository;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Batch objects outlive their owners.
+ *
+ * The existing deletion paths remove API keys, users, and teams physically,
+ * and a batch object is a long-lived record of cost attribution — so its
+ * attribution foreign keys must let the owner go (SET NULL) instead of
+ * keeping it, or a single batch created days ago would make the deletion of
+ * the key, the user, or the team fail.
+ */
+@SpringBootTest
+@Import(TestContainersConfig.class)
+@TestPropertySource(properties = {
+    "spring.liquibase.enabled=true",
+    "spring.liquibase.change-log=classpath:liquibase/changelog/master.xml",
+    "logos.auth.roles.logos-admin=itg-admin",
+    "logos.auth.roles.app-admin=chair-member",
+    "logos.auth.sync-debounce-minutes=5",
+    "logos.orchestrator.url=",
+    "logos.orchestrator.internal-secret="
+})
+@Sql(scripts = {"/sql/seed-identity.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"/sql/cleanup-identity.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class BatchObjectOwnerDeletionTest {
+
+    @Autowired JdbcTemplate jdbc;
+    @Autowired ApiKeyRepository apiKeyRepository;
+    @Autowired TeamRepository teamRepository;
+    @Autowired UserRepository userRepository;
+    @MockitoBean JwtDecoder jwtDecoder;
+
+    @Test
+    void the_owners_of_a_batch_object_can_still_be_deleted() {
+        // One batch object attributed to all three owner kinds the deletion
+        // paths physically remove: the key that created it, the team it is
+        // scoped to, the user behind the key.
+        jdbc.update(
+            "INSERT INTO batch_objects (kind, upstream_id, execution, api_key_id, team_id, user_id, status)"
+                + " VALUES ('batch', 'batch_fk_test', 'logos', 3001, 2001, 1001, 'validating')");
+
+        apiKeyRepository.deleteById(3001);
+        Integer keyAttribution = jdbc.queryForObject(
+            "SELECT api_key_id FROM batch_objects WHERE upstream_id = 'batch_fk_test'", Integer.class);
+        assertThat(keyAttribution).isNull();
+
+        teamRepository.deleteById(2001);
+        Integer teamAttribution = jdbc.queryForObject(
+            "SELECT team_id FROM batch_objects WHERE upstream_id = 'batch_fk_test'", Integer.class);
+        assertThat(teamAttribution).isNull();
+
+        // The last owner goes through the repository the service uses after
+        // its managed-user guard.
+        userRepository.deleteById(1001);
+        Integer userAttribution = jdbc.queryForObject(
+            "SELECT user_id FROM batch_objects WHERE upstream_id = 'batch_fk_test'", Integer.class);
+        assertThat(userAttribution).isNull();
+
+        // The record of what cost what survives its owners, unattributed.
+        Integer remaining = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM batch_objects WHERE upstream_id = 'batch_fk_test'", Integer.class);
+        assertThat(remaining).isEqualTo(1);
+
+        jdbc.update("DELETE FROM batch_objects WHERE upstream_id = 'batch_fk_test'");
+    }
+}

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchServiceTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchServiceTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
@@ -120,6 +121,70 @@ class BatchServiceTest {
         // The raw key value is in neither request.
         assertThat(seenHeaders.values()).doesNotContain(RAW_KEY);
         assertThat(seenBodies.values()).noneSatisfy(body -> assertThat(body).contains(RAW_KEY));
+    }
+
+    @Test
+    void a_slow_upload_does_not_carry_its_aged_credential_into_the_creation() throws IOException {
+        // The upload may itself take most of the credential's life; the
+        // creation that follows it must present a fresh exchange, not the one
+        // the upload already aged out — or it 401s after the file was stored,
+        // leaving the file behind with no batch to spend it on.
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        AtomicInteger exchanges = new AtomicInteger();
+        Map<String, String> keys = new ConcurrentHashMap<>();
+        server.createContext("/internal/batch_credentials", exchange -> {
+            String credential = exchanges.getAndIncrement() == 0 ? "bc1.aged" : "bc1.fresh";
+            byte[] body = ("{\"credential\":\"" + credential + "\",\"expires_in\":300}").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/files", exchange -> {
+            keys.put("files-logos-key", exchange.getRequestHeaders().getFirst("logos_key"));
+            byte[] body = "{\"id\":\"file-1\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/batches", exchange -> {
+            keys.put("batches-logos-key", exchange.getRequestHeaders().getFirst("logos_key"));
+            // The credential the upload used is expired by the time the creation goes out.
+            if ("bc1.aged".equals(exchange.getRequestHeaders().getFirst("logos_key"))) {
+                byte[] body = "{\"error\":{\"message\":\"the credential is no longer valid\"}}"
+                    .getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(401, body.length);
+                exchange.getResponseBody().write(body);
+                exchange.close();
+                return;
+            }
+            byte[] body = "{\"id\":\"batch_1\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+        try {
+            ApiKeyRepository repository = mock(ApiKeyRepository.class);
+            ApiKey key = keyOwnedBy(1, 5);
+            when(repository.findById(5)).thenReturn(Optional.of(key));
+            BatchService service = service(new RestTemplateConfig().batchRestTemplate(), repository,
+                "http://127.0.0.1:" + server.getAddress().getPort(), "internal");
+
+            BatchService.ProxiedResponse response = service.createBatch(1, 5, "batch.jsonl",
+                "{\"custom_id\":\"one\"}".getBytes(StandardCharsets.UTF_8), "/v1/chat/completions", "24h", "auto");
+
+            assertThat(response.status()).isEqualTo(200);
+            // The upload carried the first exchange; the creation the fresh one.
+            assertThat(keys.get("files-logos-key")).isEqualTo("bc1.aged");
+            assertThat(keys.get("batches-logos-key")).isEqualTo("bc1.fresh");
+            assertThat(exchanges.get()).isEqualTo(2);
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchServiceTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/operations/service/BatchServiceTest.java
@@ -1,0 +1,194 @@
+package de.tum.cit.aet.logos.logoswebservice.operations.service;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import de.tum.cit.aet.logos.logoswebservice.common.RestTemplateConfig;
+import de.tum.cit.aet.logos.logoswebservice.identity.entity.ApiKey;
+import de.tum.cit.aet.logos.logoswebservice.identity.repository.ApiKeyRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The batch proxy authenticates with a scoped credential, not the user's
+ * key value: the key is a long-lived secret, and the shipped setup reaches
+ * the orchestrator over plain HTTP. These tests pin down what may travel —
+ * and what keeps the raw key out of every request.
+ */
+class BatchServiceTest {
+
+    private static final String RAW_KEY = "lg-raw-secret-value";
+    private static final String CREDENTIAL = "bc1.test-credential";
+
+    private HttpServer server;
+    private final Map<String, String> seenHeaders = new ConcurrentHashMap<>();
+    private final Map<String, String> seenBodies = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/internal/batch_credentials", exchange -> {
+            seenHeaders.put("internal-authorization", exchange.getRequestHeaders().getFirst("Authorization"));
+            seenBodies.put("internal", new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] body = ("{\"credential\":\"" + CREDENTIAL + "\",\"expires_in\":300}").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/batches", exchange -> {
+            // Longer than the old 5 s read timeout: a legitimate slow
+            // orchestrator answer (the upload there covers validation, a cold
+            // capability probe, and the provider upload) must not 502.
+            try {
+                Thread.sleep(6_000);
+            } catch (InterruptedException exc) {
+                Thread.currentThread().interrupt();
+            }
+            seenHeaders.put("batches-logos-key", exchange.getRequestHeaders().getFirst("logos_key"));
+            byte[] body = "{\"data\":[]}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private ApiKey keyOwnedBy(int userId, int keyId) {
+        ApiKey key = mock(ApiKey.class);
+        when(key.getId()).thenReturn(keyId);
+        when(key.getKeyValue()).thenReturn(RAW_KEY);
+        when(key.getIsActive()).thenReturn(true);
+        when(key.getUserId()).thenReturn(userId);
+        return key;
+    }
+
+    private BatchService service(RestTemplate restTemplate, ApiKeyRepository repository,
+                                 String orchestratorUrl, String internalSecret) {
+        BatchService service = new BatchService(restTemplate, repository);
+        ReflectionTestUtils.setField(service, "orchestratorUrl", orchestratorUrl);
+        ReflectionTestUtils.setField(service, "internalSecret", internalSecret);
+        return service;
+    }
+
+    @Test
+    void the_raw_key_never_leaves_the_process_and_a_slow_answer_is_not_cut_off() {
+        ApiKeyRepository repository = mock(ApiKeyRepository.class);
+        ApiKey key = keyOwnedBy(1, 5);
+        when(repository.findById(5)).thenReturn(Optional.of(key));
+        BatchService service = service(new RestTemplateConfig().batchRestTemplate(), repository,
+            "http://127.0.0.1:" + server.getAddress().getPort(), "internal");
+
+        BatchService.ProxiedResponse response = service.listBatches(1, 5);
+
+        assertThat(response.status()).isEqualTo(200);
+        // The Batch API call carries the exchanged credential — and only it.
+        assertThat(seenHeaders.get("batches-logos-key")).isEqualTo(CREDENTIAL);
+        // The exchange itself is secret-gated and names the key by id.
+        assertThat(seenHeaders.get("internal-authorization")).isEqualTo("Bearer internal");
+        assertThat(seenBodies.get("internal")).contains("\"api_key_id\":5");
+        // The raw key value is in neither request.
+        assertThat(seenHeaders.values()).doesNotContain(RAW_KEY);
+        assertThat(seenBodies.values()).noneSatisfy(body -> assertThat(body).contains(RAW_KEY));
+    }
+
+    @Test
+    void a_key_the_caller_does_not_own_is_rejected_before_any_orchestrator_call() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        ApiKeyRepository repository = mock(ApiKeyRepository.class);
+        ApiKey otherUsersKey = keyOwnedBy(2, 5);  // another user's key
+        when(repository.findById(5)).thenReturn(Optional.of(otherUsersKey));
+        BatchService service = service(restTemplate, repository, "http://127.0.0.1:1", "internal");
+
+        assertThatThrownBy(() -> service.listBatches(1, 5))
+            .isInstanceOf(BatchService.KeyNotOwnedException.class);
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void a_refused_exchange_is_an_exchange_error_not_a_proxied_answer() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(byte[].class)))
+            .thenReturn(ResponseEntity.status(HttpStatus.NOT_FOUND).body(new byte[0]));
+        ApiKeyRepository repository = mock(ApiKeyRepository.class);
+        ApiKey key = keyOwnedBy(1, 5);
+        when(repository.findById(5)).thenReturn(Optional.of(key));
+        BatchService service = service(restTemplate, repository, "http://127.0.0.1:1", "internal");
+
+        assertThatThrownBy(() -> service.listBatches(1, 5))
+            .isInstanceOf(BatchService.CredentialExchangeException.class);
+    }
+
+    @Test
+    void a_missing_internal_secret_is_an_exchange_error() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        ApiKeyRepository repository = mock(ApiKeyRepository.class);
+        ApiKey key = keyOwnedBy(1, 5);
+        when(repository.findById(5)).thenReturn(Optional.of(key));
+        BatchService service = service(restTemplate, repository, "http://127.0.0.1:1", "");
+
+        assertThatThrownBy(() -> service.listBatches(1, 5))
+            .isInstanceOf(BatchService.CredentialExchangeException.class);
+        verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void the_startup_validation_permits_the_internal_service_url_when_the_exchange_is_configured() {
+        // The value the shipped Compose files configure: plain HTTP, and not
+        // loopback. With the exchange configured, that is exactly what the
+        // URL is permitted for.
+        BatchService service = service(mock(RestTemplate.class), mock(ApiKeyRepository.class),
+            "http://logos-orchestrator:8080", "some-secret");
+
+        assertThatCode(service::validateOrchestratorUrl).doesNotThrowAnyException();
+    }
+
+    @Test
+    void the_startup_validation_still_refuses_a_cleartext_url_without_the_exchange() {
+        BatchService service = service(mock(RestTemplate.class), mock(ApiKeyRepository.class),
+            "http://logos-orchestrator:8080", "");
+
+        assertThatThrownBy(service::validateOrchestratorUrl).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void loopback_and_https_need_no_exchange_to_be_permitted() {
+        BatchService loopback = service(mock(RestTemplate.class), mock(ApiKeyRepository.class),
+            "http://localhost:8080", "");
+        assertThatCode(loopback::validateOrchestratorUrl).doesNotThrowAnyException();
+
+        BatchService https = service(mock(RestTemplate.class), mock(ApiKeyRepository.class),
+            "https://orchestrator.example.com", "");
+        assertThatCode(https::validateOrchestratorUrl).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Closes #932.

## The question, answered

**1.) Does Logos support batching?** It does now. Before this PR a batch
request died in `request_setup` with a misleading `404 No available model
deployments for model 'unknown'` — a batch body carries no `model` — and Azure
serves Batch at the resource level while the proxy only knew deployment-scoped
URLs.

**2.) Run-time guarantees (Azure).** `completion_window` must be `"24h"`, and
that is a *service goal, not a deadline*. Azure aims to finish inside 24 hours
but does not expire jobs that run longer; they continue until they complete or
you cancel, and cancelling bills the work already done.

**3.) Discount for the current flagship models (Azure).** 50% off Global
Standard — but only for models Azure actually offers on Batch. As of
2026-09-04 the Global Batch and Data Zone Batch availability tables stop at
`gpt-5.4` / `gpt-5.4-mini` (plus `gpt-5`, `gpt-5.1`, `o3`, `o3-mini`,
`o4-mini`, the `gpt-4.1` and `gpt-4o` families). **The GPT-5.5 and GPT-5.6
families — `gpt-5.6-luna` included — are not available for batch on Azure, so
there is no discount for them there today.** OpenAI direct does have one
($0.10/$0.60 per 1M vs $0.20/$1.20). Microsoft publishes no parity timeline.

Two operational prerequisites, both outside Logos: a *Global-Batch* deployment
has to exist on the resource for each model you want to batch (it is a separate
deployment type with its own quota — the production resource currently has 24
deployments, all Standard), and the model has to be offered for batch at all.

## What this adds

A batch runs in one of two places, decided when its input file is uploaded:

- **At the provider**, when a Batch-capable provider the key may use serves
  every model the file names. That is where the batch rate applies.
- **In Logos**, otherwise. A worker-node model has no upstream Batch API at
  all, and a cloud model can be missing from its provider's batch offering —
  which is precisely the luna case. Logos then schedules each request line
  through the ordinary pipeline at the **lowest queue priority**, so batch work
  fills whatever capacity interactive traffic leaves and finishes as fast as
  that allows.

Both answer the same routes, so a script uploads, polls every few minutes and
chains the next batch onto the last without knowing which path it got;
`logos_execution` on the batch object says which it was, and
`X-Logos-Batch-Execution` forces one. The day Azure adds luna to Batch, the
same file starts taking the discounted path with no client change.

**Governance.** Provider permission alone does not authorise what a batch runs,
so every request line is checked against the key's model permissions before the
file is accepted (and its model name rewritten to the Azure deployment id, so
clients keep using Logos names). File and batch ids are recorded with their
owning team: a lifecycle call for another team's id is answered exactly like
one that never existed — otherwise any key allowed to use the provider could
cancel a foreign batch or download its results, which hold that team's prompts
and completions. Listings come from Logos' own record rather than the
provider's, which sees everyone. A key already over budget cannot start one.

**Billing.** A finished forwarded batch has its result file read once and
booked as one usage row per line with `service_tier = 'batch'`, so the price
lookup picks the provider's batch rate — now imported from the catalogue's
`*_batches` keys, which `PriceUpdaterService` used to drop. A model without a
batch rate falls back to the standard one, so an unpriced batch is over- rather
than under-charged. The settlement latch is conditional, so the client's poll
and the background reconciler cannot bill the same batch twice. A Logos-run
batch needs none of this: its lines are ordinary metered requests.

**UI.** *Batches* under Personal: pick a key, upload a `.jsonl`, watch the
progress, download the results, cancel. The webservice forwards to the same
Batch API as the key you picked rather than writing batch rows itself, so there
is one set of rules, and the browser never sees a key value.

## Verification

- `pytest tests/unit`: **1727 passed**, 1 xfail (pre-existing).
- `mvn test` (webservice): **429 tests, 0 failures** — which also applies the
  new Liquibase changeset against a real database.
- `npm run build` (UI): clean.
- `pre-commit`: clean.
- Azure addressing checked against the production resource: `/openai/v1`
  serves the batch routes; `2024-02-01`, the version the previous revision
  defaulted to, answers **404**.

## What the previous revision got wrong

Worth recording, because all of it was invisible in CI:

- `request.url.query.decode(...)` — Starlette's `query` is `str`, so **every**
  batch request raised `AttributeError` and returned 500. All 18 end-to-end
  tests fail once the module can be imported at all.
- The test module could not be imported (`import logos.batch_api as batch_api`
  against the `logos/__init__` module swap), so **no batch test ever ran** in
  CI; the suite errored during collection.
- `X-Logos-Provider` was read case-sensitively from `dict(request.headers)`,
  which Starlette lowercases — explicit provider selection could never work.
- The Azure api-version default did not serve the batch routes.
- The `/openai/...` mirrors lost their `v1/` segment.
- Credentials were read from `providers.api_key` only, while the inference path
  resolves `COALESCE(model_provider.api_key, providers.api_key)`.
- Every cloud provider counted as batch-capable, which in production would have
  made the choice ambiguous for every key that may also use Hetzner or
  Morpheus. Capability is now probed and cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B26MKT8brqf7WQDLA7QmmZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible Batch API file and job operations.
  * Added automatic provider routing and Logos-managed local execution when needed.
  * Added batch validation, progress tracking, cancellation, result downloads, and usage logging.
  * Added a Batches page for creating and monitoring jobs.
  * Added support for batch-specific pricing and team-less personal API keys.

* **Documentation**
  * Added guidance for provider selection, model eligibility, Azure configuration, billing, limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->