### PR TITLE
`Logos`: Scrape a cloud provider's models when it is added, and fix the provider dialog's dropdowns

### DIFF
--- a/logos/logos-orchestrator/src/logos/anthropic_compat/chat_completions.py
+++ b/logos/logos-orchestrator/src/logos/anthropic_compat/chat_completions.py
@@ -25,7 +25,7 @@ from logos.anthropic_compat.common import (
     normalize_content,
     parse_arguments,
     stop_reason,
-    system_to_text,
+    system_and_messages,
     tool_result_text,
     usage_block,
     usage_extras,
@@ -56,15 +56,16 @@ def to_chat_completions(payload: Dict[str, Any], *, model_name: Optional[str] = 
 
     messages: List[Dict[str, Any]] = []
 
-    system = system_to_text(payload.get("system"))
+    # Any system turn the client inlined among the messages is folded into the
+    # prompt here, so exactly one system message is emitted and it leads.
+    system, conversation = system_and_messages(payload)
     if system:
         # Reasoning models replaced the system role with "developer"; o1 and
         # its successors reject a system-role message outright.
         messages.append({"role": "developer" if reasoning else "system", "content": system})
 
-    for message in payload.get("messages") or []:
-        if isinstance(message, dict):
-            messages.extend(_translate_message(message))
+    for message in conversation:
+        messages.extend(_translate_message(message))
 
     result: Dict[str, Any] = {
         "model": payload.get("model"),

--- a/logos/logos-orchestrator/src/logos/anthropic_compat/common.py
+++ b/logos/logos-orchestrator/src/logos/anthropic_compat/common.py
@@ -131,6 +131,42 @@ def system_to_text(system: Any) -> str:
     return "\n\n".join(part for part in parts if part)
 
 
+# Roles a client may put on a turn to mean "this is an instruction, not
+# something the user or the model said".
+_SYSTEM_ROLES = frozenset({"system", "developer"})
+
+
+def system_and_messages(payload: Dict[str, Any]) -> Tuple[str, List[Dict[str, Any]]]:
+    """The system prompt and the conversation, with inline system turns hoisted.
+
+    The Messages API defines two roles for ``messages`` — user and assistant —
+    and carries the system prompt in its own top-level field. Claude Code
+    nonetheless injects ``role: "system"`` turns mid-conversation, and
+    translating one literally puts a system message in the middle of a
+    chat/completions body. OpenAI tolerates that; a chat template does not, and
+    an upstream serving one answers "System message must be at the beginning."
+    with a 400 before the model sees the request.
+
+    Their text joins the system prompt in the order it appeared. That keeps the
+    instructions — dropping them would silently change what the model was told
+    — and leaves the remaining turns strictly alternating, which is what the
+    templates that reject a stray system message also tend to require. Turning
+    them into user turns would instead produce two user turns in a row.
+    """
+    system_parts = [system_to_text(payload.get("system"))]
+    conversation: List[Dict[str, Any]] = []
+    for message in payload.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        if str(message.get("role") or "").lower() in _SYSTEM_ROLES:
+            # Content here has the same string-or-text-blocks shape as the
+            # top-level system field, so it flattens the same way.
+            system_parts.append(system_to_text(message.get("content")))
+            continue
+        conversation.append(message)
+    return "\n\n".join(part for part in system_parts if part), conversation
+
+
 def image_data_url(block: Dict[str, Any]) -> Optional[str]:
     """Turn an Anthropic image block into a ``data:``/``https:`` URL.
 

--- a/logos/logos-orchestrator/src/logos/anthropic_compat/responses_api.py
+++ b/logos/logos-orchestrator/src/logos/anthropic_compat/responses_api.py
@@ -28,7 +28,7 @@ from logos.anthropic_compat.common import (
     new_message_id,
     normalize_content,
     parse_arguments,
-    system_to_text,
+    system_and_messages,
     tool_result_text,
     usage_block,
     usage_extras,
@@ -42,17 +42,19 @@ def to_responses(payload: Dict[str, Any]) -> Dict[str, Any]:
     dialect is only reached for reasoning deployments, which reject both, and
     Anthropic clients send a temperature on every request.
     """
+    # A system turn inlined among the messages belongs in ``instructions``,
+    # the Responses API's own home for it, not in the middle of the input.
+    instructions, conversation = system_and_messages(payload)
+
     items: List[Dict[str, Any]] = []
-    for message in payload.get("messages") or []:
-        if isinstance(message, dict):
-            items.extend(_translate_message(message))
+    for message in conversation:
+        items.extend(_translate_message(message))
 
     result: Dict[str, Any] = {
         "model": payload.get("model"),
         "input": items,
     }
 
-    instructions = system_to_text(payload.get("system"))
     if instructions:
         result["instructions"] = instructions
     if payload.get("max_tokens") is not None:

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -2265,6 +2265,11 @@ async def prometheus_metrics(request: Request):
 
 class _RefreshPipelineRequest(BaseModel):
     rebuild_classifier: bool = False
+    # Set by the webservice when a provider itself changed, as opposed to a
+    # model link or a permission. A newly added cloud provider has no models
+    # until its /v1/models listing is read, and that otherwise waits for the
+    # next interval tick — a quarter of an hour of an empty model list.
+    sync_cloud_models: bool = False
 
 
 @app.post("/internal/refresh_pipeline", tags=["admin"])
@@ -2281,8 +2286,19 @@ async def internal_refresh_pipeline(data: _RefreshPipelineRequest, request: Requ
         raise HTTPException(status_code=401, detail="Invalid or missing internal secret")
     if not _pipeline or not _logosnode_facade or not _azure_facade:
         raise HTTPException(status_code=503, detail="Pipeline not initialized")
-    logger.info("Pipeline refresh requested by Spring (rebuildClassifier=%s)", data.rebuild_classifier)
+    logger.info(
+        "Pipeline refresh requested by Spring (rebuildClassifier=%s, syncCloudModels=%s)",
+        data.rebuild_classifier,
+        data.sync_cloud_models,
+    )
     await refresh_pipeline_runtime_state(rebuild_model_classifier=data.rebuild_classifier)
+    if data.sync_cloud_models and _cloud_model_sync is not None:
+        # Scheduled, not awaited: the pass contacts every cloud upstream in
+        # turn and the webservice is blocked on this response, so one
+        # unreachable provider would stall a provider edit for a full request
+        # timeout. The pass refreshes runtime state itself once it finds
+        # something, so nothing is lost by returning first.
+        _cloud_model_sync.request_refresh()
     return {"status": "ok"}
 
 

--- a/logos/logos-orchestrator/src/logos/sdi/azure_deployment_sync.py
+++ b/logos/logos-orchestrator/src/logos/sdi/azure_deployment_sync.py
@@ -113,7 +113,24 @@ def _warn_if_not_an_azure_endpoint(provider: Dict[str, Any]) -> None:
     empty, with the Azure listing failure as the only hint. Say plainly which
     provider it is and what to change.
     """
-    host = urlsplit(provider.get("base_url") or "").hostname or ""
+    base_url = provider.get("base_url") or ""
+    try:
+        host = urlsplit(base_url).hostname or ""
+    except ValueError:
+        # A bracketed authority that is not a valid IPv6 literal — "https://[x"
+        # — raises rather than returning None. This runs before any provider is
+        # synced and outside the per-provider guard, so letting it escape would
+        # abort the whole pass, and the initial one is awaited inline by
+        # start(): a single malformed base_url would take orchestrator startup
+        # down with it. It is also its own kind of misconfiguration, so it is
+        # reported rather than swallowed.
+        logger.warning(
+            "Azure deployment sync: provider %s (%s) has an unparseable base_url %r; it cannot be queried",
+            provider.get("id"),
+            provider.get("name"),
+            base_url,
+        )
+        return
     if host.lower().rstrip(".").endswith("azure.com"):
         return
     logger.warning(

--- a/logos/logos-orchestrator/src/logos/sdi/azure_deployment_sync.py
+++ b/logos/logos-orchestrator/src/logos/sdi/azure_deployment_sync.py
@@ -104,6 +104,29 @@ def azure_host_from_base_url(base_url: str) -> str:
     return f"{parts.scheme}://{parts.netloc}"
 
 
+def _warn_if_not_an_azure_endpoint(provider: Dict[str, Any]) -> None:
+    """Point out a cloud provider that is typed 'azure' but is not one.
+
+    Such a provider is discovered by nobody: this sync queries the Azure
+    data-plane route it does not serve, and the generic ``/v1/models`` sync
+    skips everything typed 'azure' on purpose. The catalogue then just stays
+    empty, with the Azure listing failure as the only hint. Say plainly which
+    provider it is and what to change.
+    """
+    host = urlsplit(provider.get("base_url") or "").hostname or ""
+    if host.lower().rstrip(".").endswith("azure.com"):
+        return
+    logger.warning(
+        "Azure deployment sync: provider %s (%s) is typed 'azure' but its endpoint %r is not an Azure host. "
+        "Azure providers are excluded from the generic /v1/models sync, so this provider is discovered by "
+        "neither path and its model list will stay empty. Set its cloud provider type to the vendor it "
+        "actually is, or leave it unset for a plain OpenAI-compatible endpoint.",
+        provider.get("id"),
+        provider.get("name"),
+        provider.get("base_url"),
+    )
+
+
 def build_azure_endpoint(host: str, deployment_id: str, op: AzureOperation) -> str:
     """Build the per-model endpoint URL stored in the DB for a deployment.
 
@@ -224,6 +247,9 @@ class AzureDeploymentSyncService:
         if not providers:
             logger.debug("Azure deployment sync: no Azure providers configured")
             return
+
+        for provider in providers:
+            _warn_if_not_an_azure_endpoint(provider)
 
         # Track DB changes separately from new model rows: any link insert /
         # endpoint update / prune must refresh the runtime registry (so the

--- a/logos/logos-orchestrator/src/logos/sdi/cloud_model_sync.py
+++ b/logos/logos-orchestrator/src/logos/sdi/cloud_model_sync.py
@@ -178,6 +178,13 @@ class CloudModelSyncService:
         self._enabled = enabled
         self._on_models_changed = on_models_changed
         self._task: Optional[asyncio.Task] = None
+        self._refresh_task: Optional[asyncio.Task] = None
+        self._refresh_pending = False
+        # One pass at a time. The interval loop and an out-of-band refresh can
+        # otherwise overlap, and a pass rewrites model_provider and
+        # cloud_model_context per provider with delete-then-insert — two doing
+        # that at once race for the same rows.
+        self._pass_lock = asyncio.Lock()
 
     async def start(self) -> None:
         """Schedule the sync; returns immediately.
@@ -194,14 +201,49 @@ class CloudModelSyncService:
             return
         self._task = asyncio.create_task(self._loop())
 
-    async def stop(self) -> None:
-        if self._task is not None:
-            self._task.cancel()
+    def request_refresh(self) -> None:
+        """Sync now rather than at the next tick. Returns immediately.
+
+        Without this a provider added or edited through the UI stays invisible
+        until the interval comes round — up to 15 minutes of an operator
+        looking at an empty model list and concluding the sync is broken. The
+        webservice already announces every provider change, so the refresh hook
+        it calls is where a pass belongs.
+
+        Not awaited: the pass contacts every configured upstream in turn, and
+        the caller is an HTTP handler the webservice is blocked on, so a single
+        unreachable provider would hold it for a full request timeout. Requests
+        arriving while a pass runs collapse into one follow-up pass, so saving
+        a form five times costs one extra sync rather than five.
+        """
+        if not self._enabled:
+            return
+        if self._refresh_task is not None and not self._refresh_task.done():
+            self._refresh_pending = True
+            return
+        self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    async def _refresh_loop(self) -> None:
+        while True:
+            self._refresh_pending = False
             try:
-                await self._task
+                await self.run_once()
+            except Exception:  # noqa: BLE001
+                logger.exception("Cloud model sync: out-of-band refresh failed")
+            if not self._refresh_pending:
+                return
+
+    async def stop(self) -> None:
+        for attr in ("_task", "_refresh_task"):
+            task = getattr(self, attr)
+            if task is None:
+                continue
+            task.cancel()
+            try:
+                await task
             except asyncio.CancelledError:
                 pass
-            self._task = None
+            setattr(self, attr, None)
 
     async def _loop(self) -> None:
         while True:
@@ -213,6 +255,10 @@ class CloudModelSyncService:
 
     async def run_once(self) -> None:
         """Sync every eligible cloud provider once. Never raises."""
+        async with self._pass_lock:
+            await self._run_pass()
+
+    async def _run_pass(self) -> None:
         try:
             with DBManager() as db:
                 providers = db.get_cloud_sync_providers()

--- a/logos/logos-orchestrator/tests/unit/anthropic_compat/test_chat_completions.py
+++ b/logos/logos-orchestrator/tests/unit/anthropic_compat/test_chat_completions.py
@@ -666,3 +666,107 @@ def test_the_terminal_event_carries_the_settled_usage():
     # The native Messages path surfaces the cost; the translated one must too.
     assert usage["cost"] == 0.0042
     assert usage["cost_currency"] == "EUR"
+
+
+# ── inline system turns ─────────────────────────────────────────────────────
+#
+# Claude Code injects role:"system" turns among the messages, a role the
+# Messages API does not define for that field. Translating one literally put a
+# system message in the middle of the chat/completions body, and an upstream
+# rendering a chat template answered "System message must be at the beginning."
+# with a 400 — reproduced against Hetzner's inference API.
+
+
+def _roles(request):
+    return [message["role"] for message in request["messages"]]
+
+
+def test_an_inlined_system_turn_does_not_land_mid_conversation():
+    request = to_chat_completions(
+        {
+            "model": "Qwen3.8-27B",
+            "system": "You are Claude Code.",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "system", "content": "a reminder"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "user", "content": "second"},
+            ],
+        }
+    )
+
+    assert _roles(request) == ["system", "user", "assistant", "user"]
+
+
+def test_an_inlined_system_turn_keeps_its_instructions():
+    request = to_chat_completions(
+        {
+            "model": "Qwen3.8-27B",
+            "system": "You are Claude Code.",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "system", "content": "a reminder"},
+            ],
+        }
+    )
+
+    assert request["messages"][0]["content"] == "You are Claude Code.\n\na reminder"
+
+
+def test_inlined_system_turns_keep_the_order_they_appeared_in():
+    request = to_chat_completions(
+        {
+            "model": "Qwen3.8-27B",
+            "system": "base",
+            "messages": [
+                {"role": "system", "content": "first reminder"},
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": [{"type": "text", "text": "second reminder"}]},
+            ],
+        }
+    )
+
+    assert request["messages"][0]["content"] == "base\n\nfirst reminder\n\nsecond reminder"
+
+
+def test_an_inlined_system_turn_leads_even_without_a_top_level_system():
+    request = to_chat_completions(
+        {"model": "Qwen3.8-27B", "messages": [{"role": "user", "content": "hi"}, {"role": "system", "content": "r"}]}
+    )
+
+    assert _roles(request) == ["system", "user"]
+    assert request["messages"][0]["content"] == "r"
+
+
+def test_a_developer_turn_is_hoisted_too():
+    """Some clients spell the same thing 'developer'."""
+    request = to_chat_completions(
+        {"model": "Qwen3.8-27B", "messages": [{"role": "developer", "content": "r"}, {"role": "user", "content": "hi"}]}
+    )
+
+    assert _roles(request) == ["system", "user"]
+
+
+def test_a_reasoning_model_still_gets_the_developer_role():
+    request = to_chat_completions(
+        {"model": "gpt-5.1", "system": "base", "messages": [{"role": "system", "content": "r"}]}
+    )
+
+    assert request["messages"][0] == {"role": "developer", "content": "base\n\nr"}
+
+
+def test_the_conversation_alternates_the_way_a_chat_template_needs():
+    """The shape claude-logos actually sends: system turns every few turns."""
+    roles = ["user", "system", "assistant", "user", "assistant", "user", "system", "assistant", "user"]
+    request = to_chat_completions(
+        {
+            "model": "Qwen3.8-27B",
+            "system": "base",
+            "messages": [{"role": role, "content": role} for role in roles],
+        }
+    )
+
+    translated = _roles(request)
+    assert translated[0] == "system"
+    assert "system" not in translated[1:]
+    assert translated[1:] == ["user", "assistant", "user", "assistant", "user", "assistant", "user"]

--- a/logos/logos-orchestrator/tests/unit/anthropic_compat/test_responses_api.py
+++ b/logos/logos-orchestrator/tests/unit/anthropic_compat/test_responses_api.py
@@ -451,3 +451,21 @@ def test_the_terminal_event_carries_the_settled_usage():
     assert usage["cache_read_input_tokens"] == 500
     assert usage["cost"] == 0.0042
     assert usage["cost_currency"] == "EUR"
+
+
+def test_an_inlined_system_turn_becomes_instructions():
+    """The Responses API has its own home for it; the input list is not it."""
+    request = to_responses(
+        {
+            "model": "gpt-5.1",
+            "system": "base",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "system", "content": "a reminder"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        }
+    )
+
+    assert request["instructions"] == "base\n\na reminder"
+    assert [item["role"] for item in request["input"] if item["type"] == "message"] == ["user", "assistant"]

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_refresh_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_refresh_endpoint.py
@@ -88,3 +88,54 @@ async def test_calls_refresh_with_rebuild_true_when_requested(monkeypatch):
 
     assert result == {"status": "ok"}
     assert refresh_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_a_plain_refresh_does_not_rescrape_the_cloud_providers(monkeypatch):
+    """Model links and permissions change constantly; upstreams do not."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+
+    async def _fake_refresh(*, rebuild_model_classifier: bool = False):
+        pass
+
+    monkeypatch.setattr(main_mod, "refresh_pipeline_runtime_state", _fake_refresh)
+    sync = MagicMock()
+    monkeypatch.setattr(main_mod, "_cloud_model_sync", sync, raising=False)
+
+    await main_mod.internal_refresh_pipeline(_make_data(False), _make_request("Bearer correct-secret"))
+
+    sync.request_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_provider_change_rescrapes_the_cloud_providers(monkeypatch):
+    """A cloud provider added in the UI has no models until its listing is read."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+
+    async def _fake_refresh(*, rebuild_model_classifier: bool = False):
+        pass
+
+    monkeypatch.setattr(main_mod, "refresh_pipeline_runtime_state", _fake_refresh)
+    sync = MagicMock()
+    monkeypatch.setattr(main_mod, "_cloud_model_sync", sync, raising=False)
+
+    data = main_mod._RefreshPipelineRequest(sync_cloud_models=True)
+    result = await main_mod.internal_refresh_pipeline(data, _make_request("Bearer correct-secret"))
+
+    assert result == {"status": "ok"}
+    sync.request_refresh.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_a_provider_change_before_startup_completes_is_not_an_error(monkeypatch):
+    """The sync service is created late in startup; the hook must tolerate that."""
+    monkeypatch.setattr(main_mod, "_INTERNAL_SECRET", "correct-secret")
+
+    async def _fake_refresh(*, rebuild_model_classifier: bool = False):
+        pass
+
+    monkeypatch.setattr(main_mod, "refresh_pipeline_runtime_state", _fake_refresh)
+    monkeypatch.setattr(main_mod, "_cloud_model_sync", None, raising=False)
+
+    data = main_mod._RefreshPipelineRequest(sync_cloud_models=True)
+    assert await main_mod.internal_refresh_pipeline(data, _make_request("Bearer correct-secret")) == {"status": "ok"}

--- a/logos/logos-orchestrator/tests/unit/sdi/test_azure_deployment_sync.py
+++ b/logos/logos-orchestrator/tests/unit/sdi/test_azure_deployment_sync.py
@@ -2,6 +2,7 @@
 
 from logos.pipeline.ettft_estimator import ReadinessTier, estimate_ettft_azure
 from logos.sdi.azure_deployment_sync import (
+    _warn_if_not_an_azure_endpoint,
     azure_host_from_base_url,
     build_azure_endpoint,
     classify_azure_operation,
@@ -106,3 +107,42 @@ def test_synced_responses_model_is_schedulable():
     provider.register_model(model_id=42, model_name="gpt-5.1", deployment_name=deployment_name)
     capacity = provider.get_capacity_info(deployment_name)
     assert estimate_ettft_azure(capacity).tier == ReadinessTier.WARM
+
+
+# ── mislabelled provider diagnostics ────────────────────────────────────────
+#
+# A cloud provider typed 'azure' that is not one is discovered by nobody: this
+# sync queries a data-plane route it does not serve, and the generic
+# /v1/models sync skips everything typed 'azure' by design. The warning is the
+# only thing connecting the empty catalogue to its cause, so it must survive
+# every base_url an operator can type — it runs before any provider is synced
+# and outside the per-provider guard, and start() awaits the first pass inline.
+
+
+def test_an_azure_host_draws_no_warning(caplog):
+    _warn_if_not_an_azure_endpoint({"id": 1, "name": "prod", "base_url": HOST})
+    assert not caplog.records
+
+
+def test_a_subdomain_of_azure_is_still_azure(caplog):
+    # Azure OpenAI also answers on cognitiveservices.azure.com.
+    _warn_if_not_an_azure_endpoint(
+        {"id": 1, "name": "prod", "base_url": "https://x.cognitiveservices.azure.com/openai"}
+    )
+    assert not caplog.records
+
+
+def test_a_foreign_host_is_named(caplog):
+    _warn_if_not_an_azure_endpoint({"id": 25, "name": "Hetzner", "base_url": "https://inference.hetzner.com/api/v1"})
+    assert "25" in caplog.text and "Hetzner" in caplog.text
+
+
+def test_an_unparseable_base_url_warns_instead_of_raising(caplog):
+    """urlsplit().hostname raises on a bracketed authority that is not IPv6."""
+    _warn_if_not_an_azure_endpoint({"id": 3, "name": "typo", "base_url": "https://[not-an-ipv6"})
+    assert "unparseable" in caplog.text
+
+
+def test_a_missing_base_url_warns_instead_of_raising(caplog):
+    _warn_if_not_an_azure_endpoint({"id": 4, "name": "blank", "base_url": None})
+    assert caplog.records

--- a/logos/logos-orchestrator/tests/unit/sdi/test_cloud_model_sync.py
+++ b/logos/logos-orchestrator/tests/unit/sdi/test_cloud_model_sync.py
@@ -6,6 +6,7 @@ typed in by hand, and the context window an upstream reported was thrown away
 measured.
 """
 
+import asyncio
 from typing import Any, Dict, List
 
 import pytest
@@ -28,6 +29,12 @@ LOGOS_LISTING = {
         # A cloud model on the upstream: catalogued, but it reports no window.
         {"id": "gpt-4.1-nano", "object": "model", "owned_by": "logos"},
     ],
+}
+
+# A plain OpenAI-compatible vendor: no Logos ownership marker, no window.
+HETZNER_LISTING = {
+    "object": "list",
+    "data": [{"id": "Qwen/Qwen3.8-27B", "object": "model", "owned_by": "hetzner"}],
 }
 
 
@@ -424,3 +431,120 @@ async def test_an_anthropic_upstream_is_discovered_with_its_own_conventions(monk
     assert seen["headers"]["anthropic-version"]
     assert seen["headers"]["x-api-key"] == "sk-ant"
     assert "Authorization" not in seen["headers"]
+
+
+@pytest.mark.asyncio
+async def test_a_nested_api_version_is_not_duplicated(monkeypatch):
+    """Hetzner's inference API lives under /api/v1, not /v1."""
+    seen = {}
+    service = _run(
+        monkeypatch,
+        [_provider(cloud_provider_type=None, base_url="https://inference.hetzner.com/api/v1")],
+        lambda url, headers: seen.update(url=url, headers=headers) or HETZNER_LISTING,
+    )
+    await service.run_once()
+
+    assert seen["url"] == "https://inference.hetzner.com/api/v1/models"
+    assert seen["headers"]["Authorization"] == "Bearer lg-secret"
+    assert DummyDB.instances[-1].synced[4] == ["Qwen/Qwen3.8-27B"]
+
+
+@pytest.mark.asyncio
+async def test_an_untyped_upstream_is_not_mistaken_for_a_logos_instance(monkeypatch):
+    """Only an all-"logos" listing may set the type; a vendor's must not."""
+    service = _run(
+        monkeypatch,
+        [_provider(cloud_provider_type=None)],
+        lambda url, headers: HETZNER_LISTING,
+    )
+    await service.run_once()
+
+    assert DummyDB.instances[-1].types == {}
+
+
+# ── out-of-band refresh ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_syncs_without_waiting_for_the_interval(monkeypatch):
+    """A provider added through the UI must not wait 15 minutes to be scraped."""
+    service = _run(monkeypatch, [_provider()], lambda url, headers: LOGOS_LISTING)
+
+    service.request_refresh()
+    await service._refresh_task
+
+    assert DummyDB.instances[-1].synced[4]
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_does_nothing_while_disabled(monkeypatch):
+    service = _run(monkeypatch, [_provider()], lambda url, headers: LOGOS_LISTING)
+    service._enabled = False
+
+    service.request_refresh()
+
+    assert service._refresh_task is None
+    assert DummyDB.instances == []
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_edits_collapses_into_one_follow_up_pass(monkeypatch):
+    """Saving a form five times costs one extra sync, not five."""
+    passes = 0
+    release = asyncio.Event()
+
+    async def fetch(url, headers, client):  # noqa: ARG001
+        nonlocal passes
+        passes += 1
+        await release.wait()
+        return LOGOS_LISTING
+
+    service = _run(monkeypatch, [_provider()], lambda url, headers: LOGOS_LISTING)
+    monkeypatch.setattr(cloud_model_sync, "fetch_models", fetch)
+
+    service.request_refresh()
+    await asyncio.sleep(0)  # let the first pass reach the upstream and block
+    for _ in range(4):
+        service.request_refresh()
+
+    release.set()
+    await service._refresh_task
+
+    assert passes == 2
+
+
+@pytest.mark.asyncio
+async def test_two_passes_never_write_the_catalogue_concurrently(monkeypatch):
+    """The interval loop and an out-of-band refresh must not interleave."""
+    concurrent = 0
+    peak = 0
+
+    async def fetch(url, headers, client):  # noqa: ARG001
+        nonlocal concurrent, peak
+        concurrent += 1
+        peak = max(peak, concurrent)
+        await asyncio.sleep(0)
+        concurrent -= 1
+        return LOGOS_LISTING
+
+    service = _run(monkeypatch, [_provider()], lambda url, headers: LOGOS_LISTING)
+    monkeypatch.setattr(cloud_model_sync, "fetch_models", fetch)
+
+    await asyncio.gather(service.run_once(), service.run_once())
+
+    assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_a_refresh_still_in_flight(monkeypatch):
+    async def fetch(url, headers, client):  # noqa: ARG001
+        await asyncio.Event().wait()
+
+    service = _run(monkeypatch, [_provider()], lambda url, headers: LOGOS_LISTING)
+    monkeypatch.setattr(cloud_model_sync, "fetch_models", fetch)
+
+    service.request_refresh()
+    await asyncio.sleep(0)
+    await service.stop()
+
+    assert service._refresh_task is None

--- a/logos/logos-ui/src/app/core/layout/shell/shell.spec.ts
+++ b/logos/logos-ui/src/app/core/layout/shell/shell.spec.ts
@@ -151,7 +151,6 @@ describe('Shell', () => {
 
       expect(menuLabels()).toEqual(
         expect.arrayContaining([
-          'Dashboard',
           'Statistics',
           'Models',
           'Providers',

--- a/logos/logos-ui/src/app/features/providers/providers.spec.ts
+++ b/logos/logos-ui/src/app/features/providers/providers.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModelManagementService } from '../../core/services/model-management.service';
+import { ProviderManagementService } from '../../core/services/provider-management.service';
+import { AddProviderPayload, Provider, UpdateProviderPayload } from '../../shared/models/provider.model';
+import { Providers } from './providers';
+
+/**
+ * A cloud provider that is none of the named vendors — Hetzner, a vLLM
+ * gateway — is configured by leaving the cloud type unset. That is the
+ * configuration the generic machinery is built for: addressed at
+ * /v1/chat/completions with a plain bearer token, and discovered over
+ * GET /v1/models. The form used to make it unreachable: 'none' was filtered
+ * out of the cloud list, the field defaulted to 'azure', and 'azure' is the
+ * one type the /v1/models sync skips.
+ */
+
+const makeProvider = (overrides: Partial<Provider> = {}): Provider => ({
+  id: 7,
+  name: 'Hetzner',
+  base_url: 'https://inference.hetzner.com/api/v1',
+  api_key: 'hz-secret',
+  auth_name: '',
+  auth_format: '',
+  provider_type: 'cloud',
+  cloud_provider_type: null,
+  privacy_level: 'CLOUD_IN_EU_BY_EU_PROVIDER',
+  ...overrides,
+});
+
+describe('Providers', () => {
+  let fixture: ComponentFixture<Providers>;
+  let component: Providers;
+  let addProvider: ReturnType<typeof vi.fn>;
+  let updateProvider: ReturnType<typeof vi.fn>;
+
+  const optionValues = (options: { value: string }[]): string[] => options.map((o) => o.value);
+
+  beforeEach(async () => {
+    addProvider = vi.fn().mockResolvedValue({});
+    updateProvider = vi.fn().mockResolvedValue({});
+    const providerService = {
+      getProviders: vi.fn().mockResolvedValue([makeProvider()]),
+      addProvider,
+      updateProvider,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [Providers],
+      providers: [
+        { provide: ProviderManagementService, useValue: providerService },
+        { provide: ModelManagementService, useValue: { getModels: vi.fn().mockResolvedValue([]) } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(Providers);
+    component = fixture.componentInstance;
+    await component.fetchProviders();
+  });
+
+  describe('the cloud provider type field', () => {
+    it('offers an untyped option for a vendor that is not on the list', () => {
+      component.onAddProviderTypeChange('cloud');
+      expect(optionValues(component.addCloudProviderTypeOptions())).toContain('none');
+    });
+
+    it('does not default a new cloud provider to azure', async () => {
+      // Azure has its own control-plane discovery and is excluded from the
+      // /v1/models sync, so a provider saved on this default was scraped by
+      // neither path and stayed empty.
+      component.openAddDialog();
+      component.addName.set('Hetzner');
+      await component.submitAdd();
+
+      const payload = addProvider.mock.calls[0][0] as AddProviderPayload;
+      expect(payload.provider_type).toBe('cloud');
+      expect(payload.cloud_provider_type).toBeUndefined();
+    });
+
+    it('keeps a named vendor the operator picked', async () => {
+      component.openAddDialog();
+      component.addName.set('OpenAI');
+      component.addCloudProviderType.set('openai');
+      await component.submitAdd();
+
+      expect((addProvider.mock.calls[0][0] as AddProviderPayload).cloud_provider_type).toBe('openai');
+    });
+
+    it('does not relabel an untyped cloud provider as azure on edit', async () => {
+      // Merely opening the dialog and saving used to move the provider onto
+      // the Azure path, silently dropping it out of the sync it relied on.
+      component.openEditDialog(makeProvider());
+      expect(component.editCloudProviderType()).toBe('none');
+
+      await component.submitEdit();
+      expect((updateProvider.mock.calls[0][0] as UpdateProviderPayload).cloud_provider_type).toBe('none');
+    });
+
+    it('stays out of the way for a logosnode', () => {
+      component.onAddProviderTypeChange('logosnode');
+      expect(component.addProviderType()).toBe('logosnode');
+      expect(component.addCloudProviderType()).toBe('none');
+    });
+  });
+
+  describe('the provider type field', () => {
+    it('opens on cloud for a new provider', () => {
+      component.openAddDialog();
+      expect(component.addProviderType()).toBe('cloud');
+    });
+
+    it('opens on the type the provider actually has', () => {
+      component.openEditDialog(makeProvider({ provider_type: 'logosnode', privacy_level: 'LOCAL' }));
+      expect(component.editProviderType()).toBe('logosnode');
+    });
+
+    it('renders the dialog on the bound type, not on the first option', async () => {
+      // Regression for the app-select value binding: the dropdown read
+      // "logosnode" while the component state said "cloud", so the operator
+      // saw a provider type that was not the one being saved.
+      component.openAddDialog();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+      const typeSelect = Array.from(selects).find((s) =>
+        Array.from(s.options).some((o) => o.value === 'logosnode'),
+      );
+      expect(typeSelect?.value).toBe('cloud');
+    });
+  });
+});

--- a/logos/logos-ui/src/app/features/providers/providers.ts
+++ b/logos/logos-ui/src/app/features/providers/providers.ts
@@ -72,15 +72,30 @@ export class Providers implements OnInit {
 
   readonly providerTypeOptions: AppSelectOption[] = this.providerTypes.map((t) => ({ value: t, label: t }));
 
-  private readonly defaultCloudProviderType: CloudProviderType = 'azure';
+  // A cloud provider that is none of the named vendors — Hetzner, a vLLM
+  // gateway, any other OpenAI-compatible endpoint — is left untyped. That is
+  // not an omission: an untyped cloud provider is exactly the one the generic
+  // machinery handles, addressed at /v1/chat/completions with a plain
+  // "Authorization: Bearer" and discovered over GET /v1/models.
+  private readonly untypedCloudLabel = 'other (OpenAI-compatible)';
+
+  // Deliberately not 'azure'. Azure is the one type excluded from the generic
+  // /v1/models sync — it has its own control-plane discovery — so defaulting to
+  // it meant a provider saved without touching the field was scraped by
+  // neither path and silently stayed empty.
+  private readonly defaultCloudProviderType: CloudProviderType = 'none';
   private readonly defaultCloudPrivacyLevel: PrivacyLevel = 'CLOUD_IN_EU_BY_US_PROVIDER';
 
   private cloudProviderTypeOptionsFor(type: ProviderType): AppSelectOption[] {
-    const types =
-      type === 'logosnode'
-        ? this.cloudProviderTypes.filter((t) => t === 'none')
-        : this.cloudProviderTypes.filter((t) => t !== 'none');
-    return types.map((t) => ({ value: t, label: t }));
+    if (type === 'logosnode') {
+      // Never rendered — the field is hidden for a logosnode — but the value
+      // still has to resolve to something the backend maps to NULL.
+      return [{ value: 'none', label: 'none' }];
+    }
+    return [
+      { value: 'none', label: this.untypedCloudLabel },
+      ...this.cloudProviderTypes.filter((t) => t !== 'none').map((t) => ({ value: t, label: t })),
+    ];
   }
 
   private privacyLevelOptionsFor(type: ProviderType): AppSelectOption[] {
@@ -119,8 +134,12 @@ export class Providers implements OnInit {
       // dialog reopens or the type toggle is cycled.
       return { cloud: 'none', privacy: privacy === 'THIRD_PARTY_HARDWARE' ? privacy : 'LOCAL' };
     }
+    // 'none' is kept, not rewritten to a vendor. An untyped cloud provider is a
+    // legitimate configuration, and coercing it to 'azure' here meant merely
+    // opening the edit dialog on one and saving re-labelled it as Azure —
+    // which drops it out of the /v1/models sync it was relying on.
     return {
-      cloud: cloud === 'none' ? this.defaultCloudProviderType : cloud,
+      cloud,
       privacy: privacy === 'LOCAL' || privacy === 'THIRD_PARTY_HARDWARE' ? this.defaultCloudPrivacyLevel : privacy,
     };
   }

--- a/logos/logos-ui/src/app/shared/components/select/select.html
+++ b/logos/logos-ui/src/app/shared/components/select/select.html
@@ -1,17 +1,30 @@
 @if (collapseWhenSingle && options.length <= 1) {
   <span class="app-select__static">{{ selectedLabel }}</span>
 } @else {
+  <!--
+    Selection is expressed on the options, not as [value] on the <select>.
+    A binding on the <select> is applied before the @for has produced any
+    <option>, so the browser drops it and falls back to index 0 — the provider
+    dialog opened on "cloud" but read "logosnode". [selected] is evaluated when
+    each option is created, and again whenever the list is recomputed, so it
+    holds for both the first render and later updates.
+  -->
   <select
     class="app-select"
     [class.app-select--compact]="compact"
-    [value]="value ?? ''"
     [disabled]="disabled"
     [attr.id]="id ?? null"
     [attr.aria-label]="ariaLabel ?? null"
     (change)="onChange($event)"
   >
     @for (opt of options; track opt.value) {
-      <option [value]="opt.value" [disabled]="opt.disabled ?? false">{{ opt.label }}</option>
+      <option
+        [value]="opt.value"
+        [selected]="opt.value === (value ?? '')"
+        [disabled]="opt.disabled ?? false"
+      >
+        {{ opt.label }}
+      </option>
     }
   </select>
 }

--- a/logos/logos-ui/src/app/shared/components/select/select.spec.ts
+++ b/logos/logos-ui/src/app/shared/components/select/select.spec.ts
@@ -1,0 +1,77 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { AppSelectOption, SelectComponent } from './select';
+
+@Component({
+  standalone: true,
+  imports: [SelectComponent],
+  template: `<app-select
+    [options]="options()"
+    [value]="value()"
+    (valueChange)="value.set($any($event))"
+  />`,
+})
+class Host {
+  readonly options = signal<AppSelectOption[]>([
+    { value: 'logosnode', label: 'logosnode' },
+    { value: 'cloud', label: 'cloud' },
+  ]);
+  readonly value = signal<string | null>('cloud');
+}
+
+function nativeSelect(fixture: ComponentFixture<Host>): HTMLSelectElement {
+  return fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+}
+
+describe('SelectComponent', () => {
+  async function render(): Promise<ComponentFixture<Host>> {
+    await TestBed.configureTestingModule({ imports: [Host] }).compileComponents();
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('shows the bound value on first render, not the first option', async () => {
+    // Regression: the <select>'s own [value] binding runs before the @for has
+    // produced any <option>, so the assignment is dropped and the browser
+    // falls back to index 0. A provider dialog opened on "cloud" then read
+    // "logosnode" while the component state said otherwise.
+    const fixture = await render();
+    expect(nativeSelect(fixture).value).toBe('cloud');
+  });
+
+  it('follows the bound value when the parent changes it', async () => {
+    const fixture = await render();
+    fixture.componentInstance.value.set('logosnode');
+    fixture.detectChanges();
+    expect(nativeSelect(fixture).value).toBe('logosnode');
+  });
+
+  it('shows the bound value when the options arrive after it', async () => {
+    // The cloud-provider-type dropdown recomputes its options from the
+    // selected provider type, so a value can be bound before its option list.
+    await TestBed.configureTestingModule({ imports: [Host] }).compileComponents();
+    const fixture = TestBed.createComponent(Host);
+    fixture.componentInstance.options.set([]);
+    fixture.componentInstance.value.set('groq');
+    fixture.detectChanges();
+
+    fixture.componentInstance.options.set([
+      { value: 'azure', label: 'azure' },
+      { value: 'groq', label: 'groq' },
+    ]);
+    fixture.detectChanges();
+    expect(nativeSelect(fixture).value).toBe('groq');
+  });
+
+  it('emits the picked value', async () => {
+    const fixture = await render();
+    const select = nativeSelect(fixture);
+    select.value = 'logosnode';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()).toBe('logosnode');
+  });
+});

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/service/ProviderService.java
@@ -86,7 +86,10 @@ public class ProviderService {
         p.setApiKey(apiKey);
 
         p = providerRepository.save(p);
-        orchestratorNotificationService.notifyRefresh(false);
+        // A cloud provider is created empty: its models come from the orchestrator's
+        // /v1/models scrape. Ask for that pass now instead of leaving the operator
+        // looking at an empty list until the next interval tick.
+        orchestratorNotificationService.notifyRefresh(false, providerType == ProviderType.cloud);
 
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("result", "Created Provider.");
@@ -115,7 +118,9 @@ public class ProviderService {
             p.setPrivacyLevel(ThresholdLevel.valueOf(req.privacyLevel()));
         }
         providerRepository.save(p);
-        orchestratorNotificationService.notifyRefresh(false);
+        // Base URL, key and cloud type all change what the upstream lists, so a
+        // cloud provider is re-scraped on every edit.
+        orchestratorNotificationService.notifyRefresh(false, p.getProviderType() == ProviderType.cloud);
         return Map.of("result", "Updated Provider.");
     }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationService.java
@@ -4,11 +4,14 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -18,34 +21,66 @@ public class OrchestratorNotificationService {
 
     private final RestTemplate restTemplate;
 
+    /**
+     * This bean through its proxy. Every caller of {@link #notifyRefresh(boolean, boolean)} is
+     * inside a transaction, so the send has to be deferred to after the commit — and a deferred
+     * send is a plain method call from a callback, which would bypass the {@code @Async} proxy
+     * and put the HTTP round trip on the committing request thread. Going through the proxy
+     * keeps it off. Lazy by nature, so it does not close a circular dependency on itself.
+     */
+    private final ObjectProvider<OrchestratorNotificationService> self;
+
     @Value("${logos.orchestrator.url:}")
     private String orchestratorUrl;
 
     @Value("${logos.orchestrator.internal-secret:}")
     private String internalSecret;
 
-    public OrchestratorNotificationService(RestTemplate restTemplate) {
+    public OrchestratorNotificationService(RestTemplate restTemplate,
+                                           ObjectProvider<OrchestratorNotificationService> self) {
         this.restTemplate = restTemplate;
+        this.self = self;
     }
 
-    @Async
     public void notifyRefresh(boolean rebuildClassifier) {
         notifyRefresh(rebuildClassifier, false);
     }
 
     /**
-     * Announce a pipeline refresh to the orchestrator.
+     * Announce a pipeline refresh to the orchestrator, once the change being announced is
+     * actually visible.
+     *
+     * <p>Every caller runs inside a {@code @Transactional} service method, and the orchestrator
+     * answers by reading the database back. Sending before the commit is a race it loses on its
+     * own connection: it reads the rows as they were, and a provider that was just added is
+     * simply not there. The pass then reports nothing to do — the very symptom the cloud model
+     * sync exists to prevent. Deferring to {@code afterCommit} also means a rolled-back change
+     * announces nothing, which the immediate send got wrong in the other direction.
      *
      * @param rebuildClassifier whether the model classifier has to be rebuilt
-     * @param syncCloudModels   whether a cloud provider itself was added or changed. A new provider
-     *                          contributes no models until its {@code /v1/models} listing is read, and
-     *                          that otherwise waits for the orchestrator's 15-minute interval — long
-     *                          enough that an operator reads the empty list as a broken sync. The
-     *                          orchestrator schedules the pass and answers immediately, so this stays
-     *                          as cheap as a plain refresh.
+     * @param syncCloudModels   whether a cloud provider itself was added or changed. A new
+     *                          provider contributes no models until its {@code /v1/models}
+     *                          listing is read, and that otherwise waits for the orchestrator's
+     *                          15-minute interval — long enough that an operator reads the empty
+     *                          list as a broken sync. The orchestrator schedules the pass and
+     *                          answers immediately, so this stays as cheap as a plain refresh.
      */
-    @Async
     public void notifyRefresh(boolean rebuildClassifier, boolean syncCloudModels) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    self.getObject().sendRefresh(rebuildClassifier, syncCloudModels);
+                }
+            });
+            return;
+        }
+        // No transaction in progress: there is nothing to wait for.
+        self.getObject().sendRefresh(rebuildClassifier, syncCloudModels);
+    }
+
+    @Async
+    public void sendRefresh(boolean rebuildClassifier, boolean syncCloudModels) {
         if (orchestratorUrl.isBlank() || internalSecret.isBlank()) {
             return;
         }

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationService.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationService.java
@@ -30,6 +30,22 @@ public class OrchestratorNotificationService {
 
     @Async
     public void notifyRefresh(boolean rebuildClassifier) {
+        notifyRefresh(rebuildClassifier, false);
+    }
+
+    /**
+     * Announce a pipeline refresh to the orchestrator.
+     *
+     * @param rebuildClassifier whether the model classifier has to be rebuilt
+     * @param syncCloudModels   whether a cloud provider itself was added or changed. A new provider
+     *                          contributes no models until its {@code /v1/models} listing is read, and
+     *                          that otherwise waits for the orchestrator's 15-minute interval — long
+     *                          enough that an operator reads the empty list as a broken sync. The
+     *                          orchestrator schedules the pass and answers immediately, so this stays
+     *                          as cheap as a plain refresh.
+     */
+    @Async
+    public void notifyRefresh(boolean rebuildClassifier, boolean syncCloudModels) {
         if (orchestratorUrl.isBlank() || internalSecret.isBlank()) {
             return;
         }
@@ -38,7 +54,7 @@ public class OrchestratorNotificationService {
             headers.set("Authorization", "Bearer " + internalSecret);
             headers.set("Content-Type", "application/json");
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(
-                Map.of("rebuild_classifier", rebuildClassifier), headers
+                Map.of("rebuild_classifier", rebuildClassifier, "sync_cloud_models", syncCloudModels), headers
             );
             restTemplate.postForEntity(orchestratorUrl + "/internal/refresh_pipeline", request, Void.class);
         } catch (Exception e) {

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationServiceTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorNotificationServiceTest.java
@@ -1,0 +1,114 @@
+package de.tum.cit.aet.logos.logoswebservice.orchestrator;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The orchestrator answers a refresh by reading the database back. Announcing a change before
+ * its transaction commits is a race it loses on its own connection — it reads the rows as they
+ * were, finds nothing to do, and the operator is left with the empty model list the cloud model
+ * sync exists to prevent.
+ */
+class OrchestratorNotificationServiceTest {
+
+    private RestTemplate restTemplate;
+    private OrchestratorNotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        // The real bean resolves itself through the proxy so the send stays @Async. A unit test
+        // has no proxy, so it resolves to the instance itself and the send runs inline — which
+        // is what makes the ordering observable here.
+        service = new OrchestratorNotificationService(restTemplate, providerOf());
+        ReflectionTestUtils.setField(service, "orchestratorUrl", "http://orchestrator:8000");
+        ReflectionTestUtils.setField(service, "internalSecret", "s3cret");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    private ObjectProvider<OrchestratorNotificationService> providerOf() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<OrchestratorNotificationService> provider = mock(ObjectProvider.class);
+        org.mockito.Mockito.lenient().when(provider.getObject()).thenAnswer(invocation -> service);
+        return provider;
+    }
+
+    @Test
+    void sendsImmediatelyWhenNoTransactionIsInProgress() {
+        service.notifyRefresh(false, true);
+
+        verify(restTemplate).postForEntity(eq("http://orchestrator:8000/internal/refresh_pipeline"), any(), any());
+    }
+
+    @Test
+    void doesNotAnnounceAChangeThatHasNotCommittedYet() {
+        TransactionSynchronizationManager.initSynchronization();
+
+        service.notifyRefresh(false, true);
+
+        verify(restTemplate, never()).postForEntity(any(String.class), any(), any());
+    }
+
+    @Test
+    void announcesTheChangeOnceItsTransactionCommits() {
+        TransactionSynchronizationManager.initSynchronization();
+        service.notifyRefresh(false, true);
+
+        TransactionSynchronizationUtils.triggerAfterCommit();
+
+        ArgumentCaptor<HttpEntity<Map<String, Object>>> body = captor();
+        verify(restTemplate).postForEntity(
+            eq("http://orchestrator:8000/internal/refresh_pipeline"), body.capture(), any());
+        assertThat(body.getValue().getBody())
+            .containsEntry("sync_cloud_models", true)
+            .containsEntry("rebuild_classifier", false);
+    }
+
+    @Test
+    void announcesNothingWhenTheTransactionRollsBack() {
+        TransactionSynchronizationManager.initSynchronization();
+        service.notifyRefresh(true, false);
+
+        // afterCommit never runs for a rollback; only the completion callbacks do.
+        TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+        verify(restTemplate, never()).postForEntity(any(String.class), any(), any());
+    }
+
+    @Test
+    void staysQuietWhenNoOrchestratorIsConfigured() {
+        ReflectionTestUtils.setField(service, "orchestratorUrl", "");
+
+        service.notifyRefresh(false, true);
+
+        verify(restTemplate, never()).postForEntity(any(String.class), any(), any());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ArgumentCaptor<HttpEntity<Map<String, Object>>> captor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(HttpEntity.class);
+    }
+}


### PR DESCRIPTION
## Summary

Two things reported against `logos-prod` after adding Hetzner as a cloud provider: the provider contributed no models, and the provider dialog showed a provider type that was not the one being saved.

### 1. Nothing scrapes a provider when it is added

`CloudModelSyncService` runs on startup and every 15 minutes, and nothing else triggers it. A cloud provider added through the UI therefore contributes no models until the next tick — long enough that an operator reads the empty list as a broken sync. Hetzner is configured correctly: `models_url` turns its documented base URL `https://inference.hetzner.com/api/v1` into `https://inference.hetzner.com/api/v1/models` without duplicating the version, and a plain `Authorization: Bearer` is what it wants. It just had not been asked yet.

The webservice already announces every provider change over `/internal/refresh_pipeline`, but the hook only refreshed runtime state. It now carries `sync_cloud_models`, set when the provider itself was added or edited (not for a model link or a permission — those change constantly, upstreams do not), and the orchestrator schedules a `/v1/models` pass.

Scheduled, not awaited: the pass contacts every configured upstream in turn, and the webservice is blocked on the response, so one unreachable provider would stall a provider edit for a full request timeout. The pass refreshes runtime state itself once it finds something.

Two things fall out of running a pass off the interval:

- **Passes are serialised.** A pass rewrites `model_provider` and `cloud_model_context` per provider with delete-then-insert; the interval loop and an out-of-band refresh would otherwise race for the same rows.
- **A burst of edits collapses.** Requests arriving while a pass runs become one follow-up pass, so saving a form five times costs one extra sync rather than five.

### 2. A cloud provider that is none of the named vendors cannot be configured

`'none'` was filtered out of the cloud list, so a vendor that is not one of azure/openai/anthropic/gemini/bedrock/deepseek/groq/logos — Hetzner, a vLLM gateway, any other OpenAI-compatible endpoint — had to be mislabelled. The field defaulted to **`azure`**, and `azure` is the one type `get_cloud_sync_providers` excludes, because Azure has its own control-plane discovery (that call yields the deployment id and api-version a URL needs, none of which `/v1/models` reports). A provider saved on that default is scraped by **neither** path and stays empty, with nothing in the log connecting the two.

Not what happened here — this provider was typed `openai`, which is functionally identical to untyped (same bearer default, same `chat/completions` dialect) — but it is the same footgun one field over.

- The cloud list now offers the untyped option first, labelled `other (OpenAI-compatible)`, and it is the default for a new cloud provider.
- `coercedForType` keeps `'none'` instead of rewriting it to `'azure'`. Opening the edit dialog on an untyped cloud provider and saving used to relabel it as Azure — silently dropping it out of the sync it was relying on.
- The Azure sync now names an `azure`-typed provider whose endpoint is not an Azure host, and says what to change, instead of leaving the empty catalogue as the only symptom.

### 3. `app-select` never applied its value

The `[value]` binding on the `<select>` runs before the `@for` has produced any `<option>`, so the browser drops the assignment and falls back to index 0. The provider dialog opened reading **`logosnode`** while `addProviderType()` was `'cloud'` — which is why the "Cloud Provider" field was still (correctly, per state) rendered next to a dropdown that said otherwise. On edit, a provider genuinely set to cloud read `logosnode` for the same reason.

Selection moved onto the options, where it is evaluated once each one exists and again whenever the list is recomputed. This affects **every** dropdown in the app whose value is not the first option; it went unnoticed where the default happens to be first.

### 4. Inline `role: "system"` turns were forwarded into the middle of the conversation

Reported after the sync above started working: every `claude-logos` request against Hetzner came back

```
400 {'error': {'message': 'System message must be at the beginning.', 'type': 'BadRequestError', ...}}
```

Claude Code injects `role: "system"` turns among the `messages` — six of them, at index 1, 12, 21, 28, 33 and 48 of the request that failed on prod (`log_entry` 583266) — a role the Messages API does not define for that field, which carries the system prompt in its own top-level `system`. `_translate_message` fell through to its generic branch and copied each one over verbatim, so the chat/completions body had system messages scattered through the conversation. OpenAI and Azure tolerate that, which is why this never showed up on the deployments #923 was tested against; a chat template does not, and an upstream rendering one rejects the request before the model sees it.

Their text now joins the system prompt, in the order it appeared:

- The instructions are kept — dropping them would silently change what the model was told.
- The remaining turns are left strictly alternating, which the templates that reject a stray system message also tend to require. Rewriting them as user turns would have produced two user turns in a row instead.
- `developer` is treated the same way, since some clients spell it that way.

Shared between both dialects via `system_and_messages`: chat/completions emits exactly one leading system (or `developer`, for a reasoning model) message, and the Responses API puts the text in `instructions` rather than in the input list.

Replaying the failing request's role sequence through the translation: 51 messages in, one leading system message out, all six reminders preserved.

## Testing

- **Orchestrator** — `1473 passed, 1 xfailed` (`main`: 1450). 23 new: nested-`/api/v1` URL construction, an untyped vendor listing not being mistaken for a Logos upstream, the refresh trigger, the disabled case, burst collapsing, pass serialisation, cancellation on stop, the three endpoint cases (plain refresh does not rescrape, provider change does, pre-startup call is not an error), 8 for the inline system turns across both dialects (including the exact role sequence that failed on prod), and 5 for the Azure mislabel diagnostic.
- **Webservice** — 5 new in `OrchestratorNotificationServiceTest`: immediate send without a transaction, no send before commit, send with the right body after commit, no send on rollback, unconfigured-orchestrator no-op.
- **UI** — `140 passed` (`main`: 127 passed + 1 failed). 10 new across `select.spec.ts` and `providers.spec.ts`.
- Every new test was confirmed to fail without its fix (lock and dedupe reverted; `select.html` and `providers.ts` reverted — 6 of 6 UI tests failed).
- `pre-commit` clean, `mvn compile` clean, `ng build` clean.

The pre-existing `shell.spec.ts` failure on `main` expected a `Dashboard` menu entry removed in #908; the expectation is dropped here.

## Database Changes

None.

## Notes

- Discovered models are still not granted to any team automatically — an admin assigns access per team.
- `sync_cloud_models` defaults to `false`, so an orchestrator running ahead of the webservice behaves exactly as before.


## Review follow-ups

Two findings from CodeRabbit, both confirmed before acting, fixed in `c3f6f620d`:

- **`urlsplit(...).hostname` raises on a malformed bracketed authority.** The mislabel diagnostic this PR adds reads it in a loop that runs before any provider is synced and outside the per-provider guard — and `AzureDeploymentSyncService.start()` awaits that first pass inline, right under a comment promising failures "never block startup". One malformed `base_url` would have taken orchestrator startup down. My regression.
- **The refresh notification went out before its transaction committed.** The orchestrator answers by reading the database back on its own connection, so an announcement that overtakes the commit finds a just-added provider missing and reports nothing to do — the empty model list this PR exists to prevent. Fixed in `OrchestratorNotificationService` rather than at the call sites, so all eight (`ProviderService` ×5, `ModelService` ×3) are covered. `@Async` moved off the entry point onto the send, since transaction synchronization is thread-bound and the deferral has to happen on the committing thread; the callback goes back through the bean's proxy so the HTTP round trip stays off it. A rolled-back change now announces nothing, which the immediate send got wrong in the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R33t8rhQKqMGy8urty3f4M



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Other (OpenAI-compatible)” cloud provider option.
  - Cloud provider model lists now refresh immediately after provider changes.
  - Added support for merging inline system and developer instructions consistently across compatible APIs.

- **Bug Fixes**
  - Cloud provider selections are preserved when creating or editing providers.
  - Fixed provider forms and dropdowns so the correct values display reliably.
  - Prevented duplicate API path segments during model discovery.
  - Added warnings for Azure providers using non-Azure endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
