### PR TITLE
`Logos`: Report failed manual lane loads to the UI

### DIFF
--- a/logos/docker-compose.dev.yaml
+++ b/logos/docker-compose.dev.yaml
@@ -228,7 +228,7 @@ services:
       # Exact paths in front of the orchestrator's logosnode catch-all (201), so
       # every action added to the UI has to be named here too — see the prod
       # compose for what happens when one is missed.
-      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
+      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/load_status`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
       - "traefik.http.routers.webservice-logosnode-admin.entrypoints=web8080"
       - "traefik.http.routers.webservice-logosnode-admin.service=logos-webservice-svc"
       - "traefik.http.routers.webservice-logosnode-admin.middlewares=strip-api"

--- a/logos/docker-compose.yaml
+++ b/logos/docker-compose.yaml
@@ -282,7 +282,7 @@ services:
       # and to both services but not to this line is still routed straight to the
       # orchestrator — which does not serve Spring's paths and answers 404. That
       # is what happened to lanes/add: present end to end, unreachable in prod.
-      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
+      - "traefik.http.routers.webservice-logosnode-admin.rule=Path(`/api/logosdb/providers/logosnode/calibrate_uncalibrated`) || Path(`/api/logosdb/providers/logosnode/lanes/delete`) || Path(`/api/logosdb/providers/logosnode/lanes/add`) || Path(`/api/logosdb/providers/logosnode/lanes/load_status`) || Path(`/api/logosdb/providers/logosnode/lanes/sleep`) || Path(`/api/logosdb/providers/logosnode/lanes/wake`)"
       - "traefik.http.routers.webservice-logosnode-admin.entrypoints=websecure"
       - "traefik.http.routers.webservice-logosnode-admin.tls=true"
       - "traefik.http.routers.webservice-logosnode-admin.tls.certresolver=letsencrypt"

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -6737,13 +6737,22 @@ class CapacityPlanner:
                                 provider_id,
                                 lane_id,
                             )
-                            # The model is loaded — the operator's goal is met.
-                            # Report it as success so the UI note resolves; but
-                            # not over a "running" entry: a concurrent attempt
-                            # for this same lane may still be executing and
-                            # owns the final state.
+                            # The model is loaded — the operator's goal is met,
+                            # so the UI note resolves as success. The hold-back
+                            # is a "running" entry that *names a lane*: it
+                            # belongs to a dispatch still executing, and that
+                            # dispatch's executor settles it. The exception is
+                            # the endpoint's lane-less "running" placeholder:
+                            # it is this attempt's own, and this attempt is
+                            # about to return without dispatching, so no
+                            # executor will ever settle it — leaving it would
+                            # pin the note at "Loading" for the outcome TTL
+                            # although the lane is already serving.
                             current = self.get_manual_load_outcome(provider_id, model_name)
-                            if not (current and current.get("status") == "running"):
+                            held_by_dispatch = (
+                                bool(current) and current.get("status") == "running" and "lane_id" in current
+                            )
+                            if not held_by_dispatch:
                                 self.record_manual_load_outcome(provider_id, model_name, "succeeded", lane_id=lane_id)
                             return False
                         logger.info(

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -169,9 +169,13 @@ class CapacityPlanner:
     LANE_LOAD_COMMAND_TIMEOUT_S = 1800
 
     # How long the outcome of a manual load stays queryable by the UI. Must
-    # outlive the whole attempt: the worker-command budget above plus the
-    # confirmation polling that follows it.
-    MANUAL_LOAD_OUTCOME_TTL_SECONDS = 3600.0
+    # outlive the whole attempt with margin: the _lane_lock wait, the
+    # LANE_LOAD_COMMAND_TIMEOUT_S command budget, the confirmation polling of
+    # the same length that follows it, plus polling/processing overhead. A
+    # TTL that only covered 1800 s + 1800 s could expire the "running" entry
+    # before the terminal outcome is written, and the UI would read an
+    # unknown (and keep polling) on a slow-but-healthy load.
+    MANUAL_LOAD_OUTCOME_TTL_SECONDS = 7200.0
 
     # Minimum tenure: after a model wakes/loads, give it at least this
     # long to serve its queue before it can be drained for another model.
@@ -1839,6 +1843,17 @@ class CapacityPlanner:
 
     def get_lane_action_failure(self, provider_id: int, lane_id: str) -> str | None:
         return self.__dict__.get("_lane_action_failure", {}).get(self._lane_key(provider_id, lane_id))
+
+    def clear_lane_action_failure(self, provider_id: int, lane_id: str) -> None:
+        """Drop a recorded reason before a new attempt starts.
+
+        The map is per lane id, and the planner reuses lane ids across
+        attempts of the same model — without this, a new attempt that fails
+        without recording a fresh reason would report the previous attempt's
+        failure to the operator. Every executor failure path records a new
+        reason, so clearing here cannot hide information.
+        """
+        self.__dict__.get("_lane_action_failure", {}).pop(self._lane_key(provider_id, lane_id), None)
 
     def _reconcile_load_failures(self, provider_id: int, lanes: List[LaneSchedulerSignals]) -> None:
         """Keep the load-failure state in step with the lanes a worker reports.
@@ -6689,6 +6704,7 @@ class CapacityPlanner:
                         params=self._build_load_params(model_name, lane_id, profile, capacity, provider_id),
                         reason="Manual load requested by an operator",
                     )
+                    self.clear_lane_action_failure(provider_id, lane_id)
                     self.record_manual_load_outcome(provider_id, model_name, "running", lane_id=lane_id)
                     confirmed = await self._execute_action_with_confirmation(
                         action, timeout_seconds=self.LANE_LOAD_COMMAND_TIMEOUT_S
@@ -8322,9 +8338,19 @@ class CapacityPlanner:
                         # did not (or no per-GPU data exists) — say which GPUs
                         # fell short, or this line reads as a bug: need <
                         # avail, yet the reservation was denied.
+                        # Report the gate's effective numbers (raw free minus
+                        # what in-flight operations already committed), not
+                        # the raw snapshot — raw free can look sufficient
+                        # while the reservation is correctly denied.
+                        _vram = self._vram_ledger
+                        effective_avail = _vram.get_effective_available_mb(action.provider_id, raw_avail)
                         gpu_free_parts: list[str] = []
                         if _per_gpu_free:
-                            gpu_free_parts = [f"GPU {dev}: {free:.0f}MB" for dev, free in sorted(_per_gpu_free.items())]
+                            gpu_free_parts = [
+                                f"GPU {dev}: "
+                                f"{_vram.get_gpu_effective_available_mb(action.provider_id, dev, free):.0f}MB"
+                                for dev, free in sorted(_per_gpu_free.items())
+                            ]
                         tp_size = len(self._parse_gpu_device_ids(_lane_gpus)) if _lane_gpus else 0
                         per_gpu_need = (
                             _estimated_load_vram / tp_size * self.VRAM_SAFETY_MARGIN
@@ -8337,22 +8363,24 @@ class CapacityPlanner:
                         )
                         if tp_size:
                             reason += f" (~{per_gpu_need / 1024.0:.1f} GB on each of {tp_size} GPUs)"
-                        reason += f", but the worker reports only {raw_avail / 1024.0:.1f} GB free"
+                        reason += f", but only {effective_avail / 1024.0:.1f} GB are effectively free on the worker"
                         if gpu_free_parts:
                             reason += " (" + ", ".join(gpu_free_parts) + ")"
                         reason += "."
                         self.record_lane_action_failure(action.provider_id, action.lane_id, reason)
                         _per_gpu_free_str = ", ".join(gpu_free_parts) or "unknown"
                         _per_gpu_detail = (
-                            f" need-per-GPU={per_gpu_need:.0f}MB per-GPU-free=[{_per_gpu_free_str}]"
+                            f" need-per-GPU={per_gpu_need:.0f}MB per-GPU-effective=[{_per_gpu_free_str}]"
                             if _per_gpu_free
                             else ""
                         )
                         logger.warning(
                             "VRAM reservation denied for load of %s: "
-                            "need=%.0fMB avail=%.0fMB committed=%.0fMB gpus=%s%s",
+                            "need=%.0fMB effective_avail=%.0fMB "
+                            "(raw=%.0fMB committed=%.0fMB) gpus=%s%s",
                             action.model_name,
                             _estimated_load_vram,
+                            effective_avail,
                             raw_avail,
                             self.get_pending_vram_mb(action.provider_id),
                             _lane_gpus or "unknown",

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -168,6 +168,11 @@ class CapacityPlanner:
     # workers and spurious load-failure cooldowns.
     LANE_LOAD_COMMAND_TIMEOUT_S = 1800
 
+    # How long the outcome of a manual load stays queryable by the UI. Must
+    # outlive the whole attempt: the worker-command budget above plus the
+    # confirmation polling that follows it.
+    MANUAL_LOAD_OUTCOME_TTL_SECONDS = 3600.0
+
     # Minimum tenure: after a model wakes/loads, give it at least this
     # long to serve its queue before it can be drained for another model.
     # Without this, a freshly-woken model has 0 active requests, making
@@ -436,6 +441,14 @@ class CapacityPlanner:
         # must keep blocking allocation until the lane serves or leaves the
         # worker. Reconciled every cycle in _reconcile_load_failures.
         self._load_failed_lane_ids: set[tuple[int, str]] = set()
+
+        # Outcome of the most recent manual load per (provider_id, model_name),
+        # for the statistics UI: the "Load lane" endpoint answers 202 and the
+        # load runs in the background, so without this the UI could never tell
+        # a slow load from a denied one. Entries expire after
+        # MANUAL_LOAD_OUTCOME_TTL_SECONDS (a load gets LANE_LOAD_COMMAND_TIMEOUT_S
+        # plus confirmation polling, so the window covers the whole attempt).
+        self._manual_load_outcomes: dict[tuple[int, str], Dict[str, Any]] = {}
 
         # Workers the cycle is currently skipping, and when the skipping began.
         # Backs the stuck-worker warning in _note_unplannable: a worker no
@@ -1746,6 +1759,84 @@ class CapacityPlanner:
             self._lane_load_failure_until.pop(key, None)
             return False
         return True
+
+    # ------------------------------------------------------------------
+    # Manual-load outcomes — the "Load lane" button answers 202 and the
+    # load runs in the background, so the UI can only learn the outcome by
+    # asking. Without this, a denied load (no room on the worker) looks
+    # identical to a slow one: the lane simply never appears, and the
+    # operator's only trace is a W line in the orchestrator log.
+    # ------------------------------------------------------------------
+
+    def record_manual_load_outcome(
+        self,
+        provider_id: int,
+        model_name: str,
+        status: str,
+        *,
+        lane_id: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Record the state of the most recent manual load of *model_name*.
+
+        *status* is one of ``"running"``, ``"succeeded"``, ``"failed"``;
+        *reason* is a human-readable explanation, meant for the operator who
+        clicked "Load lane" (e.g. which GPUs lacked how much VRAM). The entry
+        replaces any previous one for the (provider, model) pair — a retry
+        supersedes the attempt it retries.
+        """
+        entry: Dict[str, Any] = {"status": status, "updated_at": time.time()}
+        if lane_id is not None:
+            entry["lane_id"] = lane_id
+        if reason is not None:
+            entry["reason"] = reason
+        self._manual_load_outcome_store()[(provider_id, model_name)] = entry
+        self._purge_manual_load_outcomes()
+
+    def get_manual_load_outcome(self, provider_id: int, model_name: str) -> Dict[str, Any] | None:
+        """The most recent manual-load outcome for (provider, model), or None.
+
+        None means "no manual load of this model is known" — the caller must
+        not render it as a failure. Expired entries are dropped on read so
+        the store cannot grow unbounded.
+        """
+        store = self._manual_load_outcome_store()
+        entry = store.get((provider_id, model_name))
+        if entry is None:
+            return None
+        if time.time() - float(entry.get("updated_at") or 0.0) > self.MANUAL_LOAD_OUTCOME_TTL_SECONDS:
+            store.pop((provider_id, model_name), None)
+            return None
+        return dict(entry)
+
+    def _manual_load_outcome_store(self) -> Dict[tuple[int, str], Dict[str, Any]]:
+        """The outcome map, created on demand so harness planners that skip
+        __init__ work unchanged."""
+        store = self.__dict__.get("_manual_load_outcomes")
+        if store is None:
+            store = self._manual_load_outcomes = {}
+        return store
+
+    def _purge_manual_load_outcomes(self) -> None:
+        """Drop expired entries; bounded work, called on every record."""
+        now = time.time()
+        store = self._manual_load_outcome_store()
+        expired = [
+            key for key, entry in store.items() if now - float(entry.get("updated_at") or 0.0) > self.MANUAL_LOAD_OUTCOME_TTL_SECONDS
+        ]
+        for key in expired:
+            store.pop(key, None)
+
+    # The executor (_execute_action_with_confirmation) fails for reasons the
+    # manual-load path cannot know on its own — a denied VRAM reservation, a
+    # worker rejection, a confirmation timeout. It records a per-lane
+    # human-readable reason here; load_lane_manually picks it up for the
+    # outcome it records.
+    def record_lane_action_failure(self, provider_id: int, lane_id: str, reason: str) -> None:
+        self.__dict__.setdefault("_lane_action_failure", {})[self._lane_key(provider_id, lane_id)] = reason
+
+    def get_lane_action_failure(self, provider_id: int, lane_id: str) -> str | None:
+        return self.__dict__.get("_lane_action_failure", {}).get(self._lane_key(provider_id, lane_id))
 
     def _reconcile_load_failures(self, provider_id: int, lanes: List[LaneSchedulerSignals]) -> None:
         """Keep the load-failure state in step with the lanes a worker reports.
@@ -6488,6 +6579,10 @@ class CapacityPlanner:
         rejection = self.manual_load_rejection_reason(provider_id, model_name)
         if rejection is not None:
             logger.warning("Refusing manual load of %s on worker=%s: %s", model_name, provider_id, rejection)
+            # Normally the endpoint already answered 409 with this text before
+            # creating the task; record it anyway so a race between the two
+            # checks leaves the UI with a failure, not a hanging "Loading".
+            self.record_manual_load_outcome(provider_id, model_name, "failed", reason=rejection)
             return False
 
         # A load of this model already in flight on this worker: a second
@@ -6496,6 +6591,10 @@ class CapacityPlanner:
         # so the pick below would hand out the next free suffix and place a
         # second copy of the very model the operator is already waiting for.
         if any(model.lower() == model_name.lower() for model in self._inflight_load_models(provider_id).values()):
+            # Deliberately no outcome record: the in-flight load (this click's
+            # first copy, or a planner one) owns the entry and will write the
+            # final state. Overwriting "running" with a no-op here would make
+            # the UI drop its waiting note while the load is still going.
             logger.info(
                 "Manual load of %s on worker=%s is a no-op: a load of the model is already in flight",
                 model_name,
@@ -6533,6 +6632,16 @@ class CapacityPlanner:
                                 provider_id,
                                 lane_id,
                             )
+                            # The model is loaded — the operator's goal is met.
+                            # Report it as success so the UI note resolves; but
+                            # not over a "running" entry: a concurrent attempt
+                            # for this same lane may still be executing and
+                            # owns the final state.
+                            current = self.get_manual_load_outcome(provider_id, model_name)
+                            if not (current and current.get("status") == "running"):
+                                self.record_manual_load_outcome(
+                                    provider_id, model_name, "succeeded", lane_id=lane_id
+                                )
                             return False
                         logger.info(
                             "Manual load of %s on worker=%s: lane %s is held by %s; taking the next suffix",
@@ -6552,6 +6661,7 @@ class CapacityPlanner:
                             provider_id,
                             rejection,
                         )
+                        self.record_manual_load_outcome(provider_id, model_name, "failed", reason=rejection)
                         return False
 
                     capacity = self._safe_get_capacity(provider_id)
@@ -6560,6 +6670,13 @@ class CapacityPlanner:
                             "Refusing manual load of %s on worker=%s: capacity snapshot went away before dispatch",
                             model_name,
                             provider_id,
+                        )
+                        self.record_manual_load_outcome(
+                            provider_id,
+                            model_name,
+                            "failed",
+                            lane_id=lane_id,
+                            reason="the worker stopped reporting its capacity before the load could start",
                         )
                         return False
 
@@ -6572,13 +6689,33 @@ class CapacityPlanner:
                         params=self._build_load_params(model_name, lane_id, profile, capacity, provider_id),
                         reason="Manual load requested by an operator",
                     )
-                    return await self._execute_action_with_confirmation(
+                    self.record_manual_load_outcome(provider_id, model_name, "running", lane_id=lane_id)
+                    confirmed = await self._execute_action_with_confirmation(
                         action, timeout_seconds=self.LANE_LOAD_COMMAND_TIMEOUT_S
                     )
+                    if confirmed:
+                        self.record_manual_load_outcome(provider_id, model_name, "succeeded", lane_id=lane_id)
+                    else:
+                        # The executor recorded a human-readable reason for
+                        # every failure mode it knows; fall back to a generic
+                        # one if this one did not (a new branch that forgot it).
+                        reason = self.get_lane_action_failure(provider_id, lane_id)
+                        if reason is None:
+                            reason = "the load was not confirmed by the worker"
+                        self.record_manual_load_outcome(
+                            provider_id, model_name, "failed", lane_id=lane_id, reason=reason
+                        )
+                    return confirmed
             logger.warning(
                 "Manual load of %s on worker=%s: no free lane id after re-reading the runtime",
                 model_name,
                 provider_id,
+            )
+            self.record_manual_load_outcome(
+                provider_id,
+                model_name,
+                "failed",
+                reason="no free lane id was available on the worker",
             )
             return False
         finally:
@@ -8154,6 +8291,9 @@ class CapacityPlanner:
                         self._facade.get_provider_name(action.provider_id) or action.provider_id,
                         action.lane_id,
                     )
+                    self.record_lane_action_failure(
+                        action.provider_id, action.lane_id, "another load is already using this lane"
+                    )
                     return False
                 if self._lane_exists_in_runtime(action.provider_id, action.lane_id):
                     logger.warning(
@@ -8178,14 +8318,42 @@ class CapacityPlanner:
                         per_gpu_free=_per_gpu_free,
                     )
                     if _reservation_id is None:
+                        # The aggregate check above passed but the per-GPU one
+                        # did not (or no per-GPU data exists) — say which GPUs
+                        # fell short, or this line reads as a bug: need <
+                        # avail, yet the reservation was denied.
+                        gpu_free_parts: list[str] = []
+                        if _per_gpu_free:
+                            gpu_free_parts = [
+                                f"GPU {dev}: {free:.0f}MB"
+                                for dev, free in sorted(_per_gpu_free.items())
+                            ]
+                        tp_size = len(self._parse_gpu_device_ids(_lane_gpus)) if _lane_gpus else 0
+                        per_gpu_need = (
+                            _estimated_load_vram / tp_size * self.VRAM_SAFETY_MARGIN if tp_size else _estimated_load_vram * self.VRAM_SAFETY_MARGIN
+                        )
+                        reason = (
+                            f"not enough free VRAM for this model: it needs "
+                            f"~{_estimated_load_vram / 1024.0:.1f} GB in total"
+                        )
+                        if tp_size:
+                            reason += f" (~{per_gpu_need / 1024.0:.1f} GB on each of {tp_size} GPUs)"
+                        reason += f", but the worker reports only {raw_avail / 1024.0:.1f} GB free"
+                        if gpu_free_parts:
+                            reason += " (" + ", ".join(gpu_free_parts) + ")"
+                        reason += "."
+                        self.record_lane_action_failure(action.provider_id, action.lane_id, reason)
                         logger.warning(
                             "VRAM reservation denied for load of %s: "
-                            "need=%.0fMB avail=%.0fMB committed=%.0fMB gpus=%s",
+                            "need=%.0fMB avail=%.0fMB committed=%.0fMB gpus=%s%s",
                             action.model_name,
                             _estimated_load_vram,
                             raw_avail,
                             self.get_pending_vram_mb(action.provider_id),
                             _lane_gpus or "unknown",
+                            f" need-per-GPU={per_gpu_need:.0f}MB per-GPU-free=[{', '.join(gpu_free_parts) or 'unknown'}]"
+                            if _per_gpu_free
+                            else "",
                         )
                         return False
                 elif _reservation_id is None and _estimated_load_vram > 0:
@@ -8228,6 +8396,9 @@ class CapacityPlanner:
                             action.lane_id,
                             details=str(exc),
                         )
+                        self.record_lane_action_failure(
+                            action.provider_id, action.lane_id, f"the worker rejected the load: {exc}"
+                        )
                         return False
                     except Exception as exc:
                         logger.error(
@@ -8236,6 +8407,9 @@ class CapacityPlanner:
                             action.model_name,
                             action.lane_id,
                             exc,
+                        )
+                        self.record_lane_action_failure(
+                            action.provider_id, action.lane_id, f"the load command could not be sent: {exc}"
                         )
                         return False
                 else:
@@ -8266,6 +8440,11 @@ class CapacityPlanner:
                                 self._facade.get_provider_name(action.provider_id) or action.provider_id,
                             )
                             self._clear_inflight_add(action.provider_id, action.lane_id)
+                            self.record_lane_action_failure(
+                                action.provider_id,
+                                action.lane_id,
+                                "the worker accepted the load but rolled the lane change back",
+                            )
                             return False
                         self._registry.update_desired_lanes(action.provider_id, desired)
                         # Inflight entry now committed to registry — clear it
@@ -8279,6 +8458,9 @@ class CapacityPlanner:
                             exc,
                         )
                         self._clear_inflight_add(action.provider_id, action.lane_id)
+                        self.record_lane_action_failure(
+                            action.provider_id, action.lane_id, f"the load command could not be sent: {exc}"
+                        )
                         return False
 
             elif action.action == "stop":
@@ -8421,6 +8603,11 @@ class CapacityPlanner:
                     action.provider_id,
                     action.lane_id,
                     details="confirmation timeout",
+                )
+                self.record_lane_action_failure(
+                    action.provider_id,
+                    action.lane_id,
+                    f"the worker accepted the load but the lane did not reach the loaded state within {int(timeout_seconds)} s",
                 )
             # Sleep confirmation timeout: the command was sent, so the lane
             # is likely sleeping even though we couldn't verify.  Clear the

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -8338,19 +8338,20 @@ class CapacityPlanner:
                         # did not (or no per-GPU data exists) — say which GPUs
                         # fell short, or this line reads as a bug: need <
                         # avail, yet the reservation was denied.
-                        # Report the gate's effective numbers (raw free minus
-                        # what in-flight operations already committed), not
-                        # the raw snapshot — raw free can look sufficient
-                        # while the reservation is correctly denied.
+                        # Report the gate's effective numbers, not the raw
+                        # snapshot: at provider level the gate compares
+                        # needed against raw free minus what in-flight
+                        # operations already committed (raw free can look
+                        # sufficient while the reservation is correctly
+                        # denied). Per-GPU, _get_per_gpu_free already returns
+                        # the ledger-adjusted free the gate reads — use it
+                        # directly, subtracting commitments again would
+                        # under-report.
                         _vram = self._vram_ledger
                         effective_avail = _vram.get_effective_available_mb(action.provider_id, raw_avail)
                         gpu_free_parts: list[str] = []
                         if _per_gpu_free:
-                            gpu_free_parts = [
-                                f"GPU {dev}: "
-                                f"{_vram.get_gpu_effective_available_mb(action.provider_id, dev, free):.0f}MB"
-                                for dev, free in sorted(_per_gpu_free.items())
-                            ]
+                            gpu_free_parts = [f"GPU {dev}: {free:.0f}MB" for dev, free in sorted(_per_gpu_free.items())]
                         tp_size = len(self._parse_gpu_device_ids(_lane_gpus)) if _lane_gpus else 0
                         per_gpu_need = (
                             _estimated_load_vram / tp_size * self.VRAM_SAFETY_MARGIN

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -1822,7 +1822,9 @@ class CapacityPlanner:
         now = time.time()
         store = self._manual_load_outcome_store()
         expired = [
-            key for key, entry in store.items() if now - float(entry.get("updated_at") or 0.0) > self.MANUAL_LOAD_OUTCOME_TTL_SECONDS
+            key
+            for key, entry in store.items()
+            if now - float(entry.get("updated_at") or 0.0) > self.MANUAL_LOAD_OUTCOME_TTL_SECONDS
         ]
         for key in expired:
             store.pop(key, None)
@@ -6639,9 +6641,7 @@ class CapacityPlanner:
                             # owns the final state.
                             current = self.get_manual_load_outcome(provider_id, model_name)
                             if not (current and current.get("status") == "running"):
-                                self.record_manual_load_outcome(
-                                    provider_id, model_name, "succeeded", lane_id=lane_id
-                                )
+                                self.record_manual_load_outcome(provider_id, model_name, "succeeded", lane_id=lane_id)
                             return False
                         logger.info(
                             "Manual load of %s on worker=%s: lane %s is held by %s; taking the next suffix",
@@ -8324,13 +8324,12 @@ class CapacityPlanner:
                         # avail, yet the reservation was denied.
                         gpu_free_parts: list[str] = []
                         if _per_gpu_free:
-                            gpu_free_parts = [
-                                f"GPU {dev}: {free:.0f}MB"
-                                for dev, free in sorted(_per_gpu_free.items())
-                            ]
+                            gpu_free_parts = [f"GPU {dev}: {free:.0f}MB" for dev, free in sorted(_per_gpu_free.items())]
                         tp_size = len(self._parse_gpu_device_ids(_lane_gpus)) if _lane_gpus else 0
                         per_gpu_need = (
-                            _estimated_load_vram / tp_size * self.VRAM_SAFETY_MARGIN if tp_size else _estimated_load_vram * self.VRAM_SAFETY_MARGIN
+                            _estimated_load_vram / tp_size * self.VRAM_SAFETY_MARGIN
+                            if tp_size
+                            else _estimated_load_vram * self.VRAM_SAFETY_MARGIN
                         )
                         reason = (
                             f"not enough free VRAM for this model: it needs "
@@ -8343,6 +8342,12 @@ class CapacityPlanner:
                             reason += " (" + ", ".join(gpu_free_parts) + ")"
                         reason += "."
                         self.record_lane_action_failure(action.provider_id, action.lane_id, reason)
+                        _per_gpu_free_str = ", ".join(gpu_free_parts) or "unknown"
+                        _per_gpu_detail = (
+                            f" need-per-GPU={per_gpu_need:.0f}MB per-GPU-free=[{_per_gpu_free_str}]"
+                            if _per_gpu_free
+                            else ""
+                        )
                         logger.warning(
                             "VRAM reservation denied for load of %s: "
                             "need=%.0fMB avail=%.0fMB committed=%.0fMB gpus=%s%s",
@@ -8351,9 +8356,7 @@ class CapacityPlanner:
                             raw_avail,
                             self.get_pending_vram_mb(action.provider_id),
                             _lane_gpus or "unknown",
-                            f" need-per-GPU={per_gpu_need:.0f}MB per-GPU-free=[{', '.join(gpu_free_parts) or 'unknown'}]"
-                            if _per_gpu_free
-                            else "",
+                            _per_gpu_detail,
                         )
                         return False
                 elif _reservation_id is None and _estimated_load_vram > 0:
@@ -8607,7 +8610,8 @@ class CapacityPlanner:
                 self.record_lane_action_failure(
                     action.provider_id,
                     action.lane_id,
-                    f"the worker accepted the load but the lane did not reach the loaded state within {int(timeout_seconds)} s",
+                    f"the worker accepted the load but the lane did not reach the loaded state "
+                    f"within {int(timeout_seconds)} s",
                 )
             # Sleep confirmation timeout: the command was sent, so the lane
             # is likely sleeping even though we couldn't verify.  Clear the

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -1855,6 +1855,73 @@ class CapacityPlanner:
         """
         self.__dict__.get("_lane_action_failure", {}).pop(self._lane_key(provider_id, lane_id), None)
 
+    def manual_load_admission_rejection(self, provider_id: int, model_name: str) -> Optional[str]:
+        """Why a manual load must not be admitted now, or None if it may run.
+
+        The claim, not just the check, is what makes this atomic on the event
+        loop: the endpoint asks before it answers 202, and the marker it sets
+        when it answers None is what a second click for the same model meets —
+        a 409 the operator reads now, instead of a 202 whose background task
+        no-ops minutes later. ``load_lane_manually`` releases the marker when
+        the attempt settles, so a retry after a finished attempt is admitted
+        again.
+
+        A same-model load the planner is already bringing up is refused the
+        same way: the operator's click is redundant while it is minutes from
+        serving, and answering 202 for it would leave the operator's poll
+        waiting on an outcome the planner's run owns.
+        """
+        store = self.__dict__.setdefault("_manual_load_admission", {})
+        if (provider_id, model_name) in store:
+            return "A load of this model is already in flight on this worker"
+        if any(model.lower() == model_name.lower() for model in self._inflight_load_models(provider_id).values()):
+            return "A load of this model is already in flight on this worker"
+        store[(provider_id, model_name)] = True
+        return None
+
+    def _release_manual_load_admission(self, provider_id: int, model_name: str) -> None:
+        """Give up the admission marker when an attempt settles.
+
+        The marker blocks every other admission of the same model while it
+        lasts, so exactly one attempt runs per marker — a blind pop cannot
+        drop a newer attempt's marker. A release without an admission (a
+        direct call) is a no-op.
+        """
+        self.__dict__.get("_manual_load_admission", {}).pop((provider_id, model_name), None)
+
+    def _settle_manual_load_outcome(self, provider_id: int, model_name: str, lane_id: str, confirmed: bool) -> None:
+        """Publish the terminal state of a manual load whose outcome rides on
+        this lane.
+
+        The manual path records "running" before dispatch — against its own
+        lane, or against the lane of a same-model load already in flight when
+        the operator's click was a no-op (see ``_load_lane_manually``). The
+        entry belongs to the lane it names, so this only settles it when that
+        lane's outcome is in: a load of the same model on another lane must
+        not close it (the planner's failure must not pre-empt the operator's
+        own load, which may still be waiting for the lane lock). Only
+        lane-named entries are touched — the endpoint's lane-less "running"
+        placeholder is replaced with the attempt's own lane before dispatch —
+        and only "running" ones, so the manual path and the executor (which
+        settles every load outcome, planner's included) may both call this:
+        the second is a no-op.
+        """
+        entry = self.get_manual_load_outcome(provider_id, model_name)
+        if entry is None or entry.get("status") != "running":
+            return
+        if entry.get("lane_id") != lane_id:
+            return
+        if confirmed:
+            self.record_manual_load_outcome(provider_id, model_name, "succeeded", lane_id=lane_id)
+            return
+        # The executor recorded a human-readable reason for every failure mode
+        # it knows; fall back to a generic one if this one did not (a new
+        # branch that forgot it).
+        reason = self.get_lane_action_failure(provider_id, lane_id)
+        if reason is None:
+            reason = "the load was not confirmed by the worker"
+        self.record_manual_load_outcome(provider_id, model_name, "failed", lane_id=lane_id, reason=reason)
+
     def _reconcile_load_failures(self, provider_id: int, lanes: List[LaneSchedulerSignals]) -> None:
         """Keep the load-failure state in step with the lanes a worker reports.
 
@@ -6538,6 +6605,17 @@ class CapacityPlanner:
         return None
 
     async def load_lane_manually(self, provider_id: int, model_name: str) -> bool:
+        """The endpoint-facing wrapper: releases the admission marker when the
+        attempt settles, whatever its outcome, so a retry is admitted again.
+        The marker is what a second click for the same model meets while this
+        runs (see manual_load_admission_rejection).
+        """
+        try:
+            return await self._load_lane_manually(provider_id, model_name)
+        finally:
+            self._release_manual_load_admission(provider_id, model_name)
+
+    async def _load_lane_manually(self, provider_id: int, model_name: str) -> bool:
         """Operator-initiated load ("Load lane" in the statistics UI).
 
         Runs on the planner's own execution path rather than dispatching
@@ -6602,21 +6680,31 @@ class CapacityPlanner:
             self.record_manual_load_outcome(provider_id, model_name, "failed", reason=rejection)
             return False
 
-        # A load of this model already in flight on this worker: a second
-        # click, or the planner deciding the same model while the first copy
-        # is still minutes from serving. Its lane is not in the report yet,
-        # so the pick below would hand out the next free suffix and place a
-        # second copy of the very model the operator is already waiting for.
-        if any(model.lower() == model_name.lower() for model in self._inflight_load_models(provider_id).values()):
-            # Deliberately no outcome record: the in-flight load (this click's
-            # first copy, or a planner one) owns the entry and will write the
-            # final state. Overwriting "running" with a no-op here would make
-            # the UI drop its waiting note while the load is still going.
+        # A load of this model already in flight on this worker. The
+        # endpoint's admission check answers this case 409 before any task
+        # exists, so what reaches this backstop is the planner starting the
+        # same model between the admission and now. Its lane is not in the
+        # report yet, so the pick below would hand out the next free suffix
+        # and place a second copy of the very model the operator is already
+        # waiting for.
+        in_flight = self._inflight_load_models(provider_id)
+        same_model_lane = next(
+            (lane_id for lane_id, model in in_flight.items() if model.lower() == model_name.lower()), None
+        )
+        if same_model_lane is not None:
+            # Ride the in-flight load's lane: it owns the outcome, and the
+            # executor settles the "running" entry for whatever load of this
+            # model that lane is bringing up — a planner failure included,
+            # which otherwise never reached the operator's poll. Re-asserting
+            # the entry over an identical one (a manual first copy) changes
+            # nothing the UI sees; over a stale terminal it restarts the
+            # waiting note the new click belongs to.
             logger.info(
                 "Manual load of %s on worker=%s is a no-op: a load of the model is already in flight",
                 model_name,
                 provider_id,
             )
+            self.record_manual_load_outcome(provider_id, model_name, "running", lane_id=same_model_lane)
             return False
 
         excluded: set[str] = set()
@@ -6709,18 +6797,12 @@ class CapacityPlanner:
                     confirmed = await self._execute_action_with_confirmation(
                         action, timeout_seconds=self.LANE_LOAD_COMMAND_TIMEOUT_S
                     )
-                    if confirmed:
-                        self.record_manual_load_outcome(provider_id, model_name, "succeeded", lane_id=lane_id)
-                    else:
-                        # The executor recorded a human-readable reason for
-                        # every failure mode it knows; fall back to a generic
-                        # one if this one did not (a new branch that forgot it).
-                        reason = self.get_lane_action_failure(provider_id, lane_id)
-                        if reason is None:
-                            reason = "the load was not confirmed by the worker"
-                        self.record_manual_load_outcome(
-                            provider_id, model_name, "failed", lane_id=lane_id, reason=reason
-                        )
+                    # The executor's wrapper already settled the outcome for a
+                    # real run; this call is what settles it when the executor
+                    # was stood in for (the tests) and keeps the manual path
+                    # self-contained. Idempotent: settled entries are not
+                    # "running" anymore.
+                    self._settle_manual_load_outcome(provider_id, model_name, lane_id, confirmed)
                     return confirmed
             logger.warning(
                 "Manual load of %s on worker=%s: no free lane id after re-reading the runtime",
@@ -8025,7 +8107,20 @@ class CapacityPlanner:
         """Execute action and wait for worker status to confirm expected state.
 
         Returns True if confirmed, False if timeout.
+
+        Every load outcome — a manual one, a planned one, a cold load —
+        passes through this point, so this is also where a manual outcome
+        riding on the lane (see _settle_manual_load_outcome) learns its
+        terminal state: a failure of a planner-owned load of the model must
+        reach the operator's poll as well.
         """
+        confirmed = await self._execute_action_core(action, timeout_seconds=timeout_seconds)
+        if action.action == "load":
+            self._settle_manual_load_outcome(action.provider_id, action.model_name, action.lane_id, confirmed)
+        return confirmed
+
+    async def _execute_action_core(self, action: CapacityPlanAction, timeout_seconds: float = 60.0) -> bool:
+        """The executor proper; see _execute_action_with_confirmation."""
         logger.info(
             "Executing capacity action: %s on lane %s (model=%s, worker=%s) — %s",
             action.action,
@@ -8319,6 +8414,14 @@ class CapacityPlanner:
                         action.lane_id,
                     )
                     self._release_load_lane_id(action.provider_id, action.lane_id)
+                    # A load skipped because its lane already exists is a load
+                    # that already happened: for a manual outcome riding on
+                    # this lane, the operator's goal is met — the same reading
+                    # the manual path's own lane-exists no-op applies.
+                    if (self._runtime_lane_model(action.provider_id, action.lane_id) or "").lower() == (
+                        action.model_name or ""
+                    ).lower():
+                        self._settle_manual_load_outcome(action.provider_id, action.model_name, action.lane_id, True)
                     return False
                 # Estimate VRAM and atomically reserve
                 _estimated_load_vram = self._estimate_action_vram(action, _profile, _capacity) if _capacity else 0.0

--- a/logos/logos-orchestrator/src/logos/dbutils/dbrequest.py
+++ b/logos/logos-orchestrator/src/logos/dbutils/dbrequest.py
@@ -93,6 +93,11 @@ class InternalAddLaneRequest(BaseModel):
     lane: dict[str, Any]
 
 
+class InternalLaneLoadStatusRequest(BaseModel):
+    provider_id: int
+    model: str
+
+
 class InternalSleepLaneRequest(BaseModel):
     provider_id: int
     lane_id: str

--- a/logos/logos-orchestrator/src/logos/routers/internal.py
+++ b/logos/logos-orchestrator/src/logos/routers/internal.py
@@ -30,6 +30,7 @@ from logos.dbutils.dbrequest import (
     InternalBenchmarkRequest,
     InternalCalibrateRequest,
     InternalDeleteLaneRequest,
+    InternalLaneLoadStatusRequest,
     InternalSleepLaneRequest,
     InternalWakeLaneRequest,
     RefreshPipelineRequest,
@@ -705,6 +706,12 @@ async def internal_logosnode_add_lane(data: InternalAddLaneRequest, request: Req
     if rejection is not None:
         raise HTTPException(status_code=409, detail=rejection)
 
+    # Record "running" BEFORE answering, not only once the background task
+    # gets to it: the UI starts polling load_status as soon as it sees the 202,
+    # and a gap between the two would let it read the previous attempt's
+    # "failed" entry and show a stale failure for the fresh click.
+    _main._capacity_planner.record_manual_load_outcome(data.provider_id, model, "running")
+
     # Loading a model takes minutes (the planner budgets 1800 s for the command),
     # far beyond any caller's HTTP read timeout, and holding a servlet thread
     # open that long per load is its own problem. So kick it off and return: the
@@ -718,6 +725,41 @@ async def internal_logosnode_add_lane(data: InternalAddLaneRequest, request: Req
         status_code=202,
         content={"status": "accepted", "model": model, "provider_id": data.provider_id},
     )
+
+
+@router.post("/internal/logosnode/lanes/load_status", tags=["admin"])
+async def internal_logosnode_lane_load_status(data: InternalLaneLoadStatusRequest, request: Request):
+    """Outcome of the most recent manual load of a model, for the statistics UI.
+
+    The "Load lane" endpoint answers 202 and runs the load in the background,
+    where a refusal (no VRAM, worker rejection, ...) is currently only a log
+    line. The UI polls this endpoint while its "Loading …" note is up and
+    turns the note into the recorded error once the attempt is over.
+
+    ``status`` is ``"running" | "succeeded" | "failed" | "unknown"`` — unknown
+    means no manual load of this model is known to the planner (never clicked
+    here, the entry expired, or the orchestrator restarted in between), which
+    the UI must not render as a failure.
+    """
+    _require_internal_secret(request)
+
+    model = str(data.model or "").strip()
+    if not model:
+        raise HTTPException(status_code=400, detail="model is required")
+    if _main._capacity_planner is None:
+        raise HTTPException(status_code=503, detail="Capacity planner not ready")
+
+    # One shape for every answer — unknown included, with nulls — so the UI
+    # can read the fields without checking the status first.
+    outcome = _main._capacity_planner.get_manual_load_outcome(data.provider_id, model) or {}
+    return {
+        "status": outcome.get("status", "unknown"),
+        "model": model,
+        "provider_id": data.provider_id,
+        "lane_id": outcome.get("lane_id"),
+        "reason": outcome.get("reason"),
+        "updated_at": outcome.get("updated_at"),
+    }
 
 
 @router.post("/internal/logosnode/lanes/sleep", tags=["admin"])

--- a/logos/logos-orchestrator/src/logos/routers/internal.py
+++ b/logos/logos-orchestrator/src/logos/routers/internal.py
@@ -706,6 +706,17 @@ async def internal_logosnode_add_lane(data: InternalAddLaneRequest, request: Req
     if rejection is not None:
         raise HTTPException(status_code=409, detail=rejection)
 
+    # Admit before answering 202: the check-and-claim is atomic on the event
+    # loop, so a second click for the same model — or a load the planner is
+    # already bringing up — meets the marker now and gets a 409 the operator
+    # reads, instead of a 202 whose background task no-ops later and whose
+    # outcome the operator's poll would have to wait on. A refused click must
+    # not touch the recorded outcome either: it would reset a previous
+    # attempt's terminal state with no task left to settle it.
+    admission_rejection = _main._capacity_planner.manual_load_admission_rejection(data.provider_id, model)
+    if admission_rejection is not None:
+        raise HTTPException(status_code=409, detail=admission_rejection)
+
     # Record "running" BEFORE answering, not only once the background task
     # gets to it: the UI starts polling load_status as soon as it sees the 202,
     # and a gap between the two would let it read the previous attempt's

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
@@ -188,7 +188,8 @@ def test_denied_load_records_the_executors_reason():
     planner = _planner()
     planner._build_load_params = MagicMock(return_value={})
     reason = (
-        "not enough free VRAM for this model: it needs ~48.4 GB in total, but the " "worker reports only 63.4 GB free"
+        "not enough free VRAM for this model: it needs ~48.4 GB in total, "
+        "but only 0.8 GB are effectively free on the worker (GPU 0: 838MB, GPU 1: 838MB)."
     )
 
     async def deny(action, timeout_seconds=None):
@@ -216,6 +217,38 @@ def test_unconfirmed_load_without_a_recorded_reason_gets_the_fallback():
     outcome = planner.get_manual_load_outcome(1, "org/model-a")
     assert outcome["status"] == "failed"
     assert outcome["reason"] == "the load was not confirmed by the worker"
+
+
+def test_clear_lane_action_failure_drops_only_that_lane():
+    planner = _planner()
+    planner.record_lane_action_failure(1, "lane-a", "denied")
+    planner.record_lane_action_failure(1, "lane-b", "denied too")
+
+    planner.clear_lane_action_failure(1, "lane-a")
+
+    assert planner.get_lane_action_failure(1, "lane-a") is None
+    assert planner.get_lane_action_failure(1, "lane-b") == "denied too"
+
+
+def test_a_failed_attempt_cannot_inherit_the_previous_reason():
+    """A new attempt must not report a stale reason: the previous attempt
+    failed on this lane id, the new one enters "running" — which clears the
+    recorded failure — and it then fails without the executor recording a
+    fresh reason. The outcome must carry the fallback, not the old failure."""
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+    planner.record_lane_action_failure(1, "planner-org_model-a", "an older attempt's denial")
+
+    async def deny(action, timeout_seconds=None):
+        return False
+
+    planner._execute_action_with_confirmation = deny
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "the load was not confirmed by the worker"
+    assert planner.get_lane_action_failure(1, "planner-org_model-a") is None
 
 
 def test_lane_already_present_records_success_without_dispatch():

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
@@ -300,6 +300,27 @@ def test_lane_exists_no_op_does_not_overwrite_a_running_entry():
     assert outcome["status"] == "running"
 
 
+def test_lane_exists_no_op_settles_the_lane_less_endpoint_placeholder():
+    """The endpoint records a lane-less "running" when it answers 202, and the
+    attempt replaces it with its own lane only right before dispatch. When the
+    claimed id already holds the model, the attempt no-ops without dispatching
+    — no executor will ever settle the placeholder, so the no-op itself must
+    resolve it: the lane exists, the operator's goal is met, and leaving the
+    entry would pin the UI note at "Loading" for the outcome TTL."""
+    planner = _planner()
+    planner._execute_action_with_confirmation = MagicMock()
+    planner._lane_exists_in_runtime = MagicMock(return_value=True)
+    planner._runtime_lane_model = MagicMock(return_value="org/model-a")
+    planner.record_manual_load_outcome(1, "org/model-a", "running")
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+    planner._execute_action_with_confirmation.assert_not_called()
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "succeeded"
+    assert outcome["lane_id"] == "planner-org_model-a"
+
+
 # ── admission: atomic before the 202 ─────────────────────────────────────
 
 

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from logos.capacity.capacity_planner import CapacityPlanner
+from logos.sdi.models import CapacityPlanAction
 
 # logos/__init__ aliases itself to logos.main, which breaks the plain
 # `import logos.capacity...` attribute chain; the module object comes from
@@ -267,9 +268,10 @@ def test_lane_already_present_records_success_without_dispatch():
 
 
 def test_second_click_does_not_overwrite_the_inflight_outcome():
-    """While the first load is in flight, a second click is a no-op — and must
-    not stomp the "running" entry it waits on: overwriting it with a no-op
-    would make the UI drop its note while the load is still going."""
+    """While the first load is in flight, a second attempt is a no-op — it
+    re-asserts the "running" entry on the in-flight lane, which must come out
+    identical to the one it waits on: a different status or lane would make
+    the UI drop (or mis-attribute) its note while the load is still going."""
     planner = _planner()
     # A live claim of the first replica (owner None counts as live).
     planner._inflight_load_lane_ids = {1: {"planner-org_model-a": ("org/model-a", None)}}
@@ -296,3 +298,165 @@ def test_lane_exists_no_op_does_not_overwrite_a_running_entry():
 
     outcome = planner.get_manual_load_outcome(1, "org/model-a")
     assert outcome["status"] == "running"
+
+
+# ── admission: atomic before the 202 ─────────────────────────────────────
+
+
+def test_admission_is_atomic_a_second_click_meets_the_marker():
+    planner = _planner()
+
+    assert planner.manual_load_admission_rejection(1, "org/model-a") is None
+    # A different model is unaffected by the claim.
+    assert planner.manual_load_admission_rejection(1, "org/model-b") is None
+    # The second click for the same model is refused while the first is
+    # admitted — a 409 the operator reads, not a 202 whose task no-ops later.
+    assert planner.manual_load_admission_rejection(1, "org/model-a") == (
+        "A load of this model is already in flight on this worker"
+    )
+
+
+def test_admission_refuses_a_planner_inflight_load_of_the_same_model():
+    """A load the planner is already bringing up owns the operator's waiting
+    time: answering 202 would start a poll with no manual attempt behind it."""
+    planner = _planner()
+    # A live claim of the second replica by the planner's demand path.
+    planner._inflight_load_lane_ids = {1: {"planner-org_model-a-2": ("org/model-a", None)}}
+
+    assert planner.manual_load_admission_rejection(1, "org/model-a") == (
+        "A load of this model is already in flight on this worker"
+    )
+    assert planner.manual_load_admission_rejection(1, "org/model-b") is None
+
+
+def test_a_settled_attempt_releases_its_admission():
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+
+    async def execute(action, timeout_seconds=None):
+        return True
+
+    planner._execute_action_with_confirmation = execute
+
+    assert planner.manual_load_admission_rejection(1, "org/model-a") is None
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is True
+
+    # The attempt is over — a retry is admitted again.
+    assert planner.manual_load_admission_rejection(1, "org/model-a") is None
+
+
+# ── the planner-owned failure ────────────────────────────────────────────
+
+
+def test_a_planner_owned_inflight_failure_reaches_the_manual_outcome():
+    """The reported hole: the click is admitted, then the planner starts the
+    same model; the background task no-ops into the planner's load. When that
+    load fails, the executor's settlement must turn the manual outcome
+    terminal — otherwise the operator's poll waits on a failure only the
+    planner's log knows about, until the poll's cap.
+    """
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+
+    # The click is admitted while nothing is in flight ...
+    assert planner.manual_load_admission_rejection(1, "org/model-a") is None
+    # ... and the planner starts the same model in the meantime.
+    planner._inflight_load_lane_ids = {1: {"planner-org_model-a-2": ("org/model-a", None)}}
+
+    # The background task meets it: a no-op riding the planner's lane.
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"
+    assert outcome["lane_id"] == "planner-org_model-a-2"
+
+    # The planner's load fails; its executor run settles the entry.
+    reason = "not enough free VRAM for this model: it needs ~48.4 GB in total."
+    planner.record_lane_action_failure(1, "planner-org_model-a-2", reason)
+    planner._settle_manual_load_outcome(1, "org/model-a", "planner-org_model-a-2", False)
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == reason
+    assert outcome["lane_id"] == "planner-org_model-a-2"
+
+
+def _load_action(lane_id: str = "planner-org_model-a") -> CapacityPlanAction:
+    return CapacityPlanAction(
+        action="load",
+        provider_id=1,
+        lane_id=lane_id,
+        model_name="org/model-a",
+        reason="planner demand",
+    )
+
+
+def test_the_executor_settles_a_manual_outcome_riding_on_its_lane():
+    """The wrapper around the executor is what publishes the terminal state —
+    for a planner-owned load, nothing else ever calls the settlement."""
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "running", lane_id="planner-org_model-a")
+    reason = "the worker rejected the load: no feasible GPU subset"
+
+    async def core(action, timeout_seconds=60.0):
+        planner.record_lane_action_failure(action.provider_id, action.lane_id, reason)
+        return False
+
+    planner._execute_action_core = core
+    assert asyncio.run(planner._execute_action_with_confirmation(_load_action())) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == reason
+
+
+def test_the_executor_settles_a_confirmed_load_as_success():
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "running", lane_id="planner-org_model-a")
+
+    async def core(action, timeout_seconds=60.0):
+        return True
+
+    planner._execute_action_core = core
+    assert asyncio.run(planner._execute_action_with_confirmation(_load_action())) is True
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "succeeded"
+    assert outcome["lane_id"] == "planner-org_model-a"
+
+
+def test_a_load_of_the_same_model_on_another_lane_does_not_settle():
+    """The operator's own load may still be waiting for the lane lock while a
+    planner copy fails elsewhere: the outcome belongs to its own lane, and
+    the other one must not pre-empt it."""
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "running", lane_id="planner-org_model-a")
+
+    async def core(action, timeout_seconds=60.0):
+        return False
+
+    planner._execute_action_core = core
+    asyncio.run(planner._execute_action_with_confirmation(_load_action("planner-org_model-a-2")))
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"
+    assert outcome["lane_id"] == "planner-org_model-a"
+
+
+def test_the_lane_less_endpoint_placeholder_is_not_settled_by_any_load():
+    """The endpoint records "running" before the attempt knows its lane. That
+    placeholder is replaced with the attempt's own lane before dispatch, so a
+    load finishing in between must not settle it: the attempt may still be
+    on its way to its executor."""
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "running")
+
+    async def core(action, timeout_seconds=60.0):
+        return False
+
+    planner._execute_action_core = core
+    asyncio.run(planner._execute_action_with_confirmation(_load_action()))
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"
+    assert "lane_id" not in outcome

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
@@ -16,8 +16,6 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
-
 from logos.capacity.capacity_planner import CapacityPlanner
 
 # logos/__init__ aliases itself to logos.main, which breaks the plain
@@ -190,8 +188,7 @@ def test_denied_load_records_the_executors_reason():
     planner = _planner()
     planner._build_load_params = MagicMock(return_value={})
     reason = (
-        "not enough free VRAM for this model: it needs ~48.4 GB in total, but the "
-        "worker reports only 63.4 GB free"
+        "not enough free VRAM for this model: it needs ~48.4 GB in total, but the " "worker reports only 63.4 GB free"
     )
 
     async def deny(action, timeout_seconds=None):

--- a/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
+++ b/logos/logos-orchestrator/tests/unit/capacity/test_manual_load_outcome.py
@@ -1,0 +1,268 @@
+"""The recorded outcome of a manual load — what the statistics UI can ask for.
+
+``lanes/add`` answers 202 and runs the load in the background, so a refusal in
+there (no room on the worker, the worker rejected the command, the
+confirmation timed out) leaves the UI's "Loading …" note hanging forever —
+the refusal was a log line. The planner therefore records the outcome of the
+most recent manual load per (provider, model); the internal load_status
+endpoint hands it to Spring, and the UI polls it while the note is up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from logos.capacity.capacity_planner import CapacityPlanner
+
+# logos/__init__ aliases itself to logos.main, which breaks the plain
+# `import logos.capacity...` attribute chain; the module object comes from
+# the import above.
+planner_mod = sys.modules["logos.capacity.capacity_planner"]
+
+# Stands in for a real calibrated ModelProfile — load_lane_manually's own
+# calibration gate only ever reads .residency_source.
+_CALIBRATED_PROFILE = SimpleNamespace(residency_source="calibrated")
+
+
+def _planner(*, calibrating=False, has_status=True, capacity=object(), profiles=None) -> CapacityPlanner:
+    planner = CapacityPlanner.__new__(CapacityPlanner)
+    registry = MagicMock()
+    registry.is_calibrating.return_value = calibrating
+    registry.has_received_first_status.return_value = has_status
+    planner._registry = registry
+    facade = MagicMock()
+    facade.get_capacity_info.return_value = capacity
+    facade.get_provider_name.return_value = "worker-a"
+    facade.get_model_profiles.return_value = profiles if profiles is not None else {"org/model-a": _CALIBRATED_PROFILE}
+    planner._facade = facade
+    planner._lane_action_locks = {}
+    # A fresh worker: no lane to collide with, so loads reach the executor.
+    planner._lane_exists_in_runtime = MagicMock(return_value=False)
+    return planner
+
+
+# ── the outcome store ─────────────────────────────────────────────────────
+
+
+def test_record_and_read_back_the_outcome():
+    planner = _planner()
+    before = time.time()
+    planner.record_manual_load_outcome(
+        1, "org/model-a", "failed", lane_id="planner-org_model-a-2", reason="not enough free VRAM"
+    )
+    after = time.time()
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome is not None
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "not enough free VRAM"
+    assert outcome["lane_id"] == "planner-org_model-a-2"
+    assert before <= outcome["updated_at"] <= after
+
+
+def test_unknown_pair_reads_as_no_outcome():
+    """None must stay distinguishable from "failed": the UI must not render
+    "no manual load is known" as a refusal."""
+    planner = _planner()
+    assert planner.get_manual_load_outcome(1, "org/never-loaded") is None
+    planner.record_manual_load_outcome(1, "org/model-a", "running")
+    assert planner.get_manual_load_outcome(2, "org/model-a") is None
+    assert planner.get_manual_load_outcome(1, "org/model-b") is None
+
+
+def test_a_retry_supersedes_the_previous_outcome():
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "failed", reason="first try denied")
+    planner.record_manual_load_outcome(1, "org/model-a", "running")
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"
+    assert "reason" not in outcome
+    assert "lane_id" not in outcome
+
+
+def test_get_returns_a_copy_not_the_stored_entry():
+    planner = _planner()
+    planner.record_manual_load_outcome(1, "org/model-a", "running")
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    outcome["status"] = "tampered"
+    assert planner.get_manual_load_outcome(1, "org/model-a")["status"] == "running"
+
+
+def test_expired_outcome_reads_as_unknown_and_is_dropped(monkeypatch):
+    planner = _planner()
+    now = [1000.0]
+    monkeypatch.setattr(planner_mod.time, "time", lambda: now[0])
+    planner.record_manual_load_outcome(1, "org/model-a", "failed", reason="old attempt")
+
+    now[0] += CapacityPlanner.MANUAL_LOAD_OUTCOME_TTL_SECONDS + 1
+    assert planner.get_manual_load_outcome(1, "org/model-a") is None
+    assert planner._manual_load_outcomes == {}
+
+
+def test_recording_purges_other_expired_entries(monkeypatch):
+    planner = _planner()
+    now = [1000.0]
+    monkeypatch.setattr(planner_mod.time, "time", lambda: now[0])
+    planner.record_manual_load_outcome(1, "org/stale", "failed", reason="stale")
+
+    now[0] += CapacityPlanner.MANUAL_LOAD_OUTCOME_TTL_SECONDS + 1
+    planner.record_manual_load_outcome(2, "org/fresh", "running")
+
+    assert (1, "org/stale") not in planner._manual_load_outcomes
+    assert (2, "org/fresh") in planner._manual_load_outcomes
+
+
+# ── load_lane_manually records the outcome on every exit ─────────────────
+
+
+def test_pre_rejection_records_a_failed_outcome():
+    planner = _planner(calibrating=True)
+    planner._execute_action_with_confirmation = MagicMock()
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+    planner._execute_action_with_confirmation.assert_not_called()
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert "calibrating" in outcome["reason"]
+
+
+def test_capacity_gone_at_dispatch_records_a_failed_outcome():
+    """The snapshot can go away between the pre-check and the dispatch."""
+    planner = _planner()
+    planner._execute_action_with_confirmation = MagicMock()
+    planner._facade.get_capacity_info.side_effect = [object(), None]
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+    planner._execute_action_with_confirmation.assert_not_called()
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert "capacity" in outcome["reason"]
+
+
+def test_confirmed_load_records_succeeded_with_the_lane():
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+
+    async def confirm(action, timeout_seconds=None):
+        return True
+
+    planner._execute_action_with_confirmation = confirm
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is True
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "succeeded"
+    assert outcome["lane_id"] == "planner-org_model-a"
+
+
+def test_running_is_recorded_before_the_executor_runs():
+    """The endpoint records "running" when it answers 202, but a planner-initiated
+    path has no such caller — the planner itself must leave the UI something to
+    poll while the minutes-long load is in flight."""
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+    seen: dict = {}
+
+    async def execute(action, timeout_seconds=None):
+        seen["during"] = planner.get_manual_load_outcome(1, "org/model-a")
+        return True
+
+    planner._execute_action_with_confirmation = execute
+    asyncio.run(planner.load_lane_manually(1, "org/model-a"))
+
+    assert seen["during"]["status"] == "running"
+    assert seen["during"]["lane_id"] == "planner-org_model-a"
+
+
+def test_denied_load_records_the_executors_reason():
+    """The executor fails for reasons the manual path cannot know on its own;
+    it hands them over per lane and the outcome must carry them — this is the
+    "not enough VRAM" refusal the operator needs to see."""
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+    reason = (
+        "not enough free VRAM for this model: it needs ~48.4 GB in total, but the "
+        "worker reports only 63.4 GB free"
+    )
+
+    async def deny(action, timeout_seconds=None):
+        planner.record_lane_action_failure(action.provider_id, action.lane_id, reason)
+        return False
+
+    planner._execute_action_with_confirmation = deny
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == reason
+
+
+def test_unconfirmed_load_without_a_recorded_reason_gets_the_fallback():
+    planner = _planner()
+    planner._build_load_params = MagicMock(return_value={})
+
+    async def deny(action, timeout_seconds=None):
+        return False
+
+    planner._execute_action_with_confirmation = deny
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "the load was not confirmed by the worker"
+
+
+def test_lane_already_present_records_success_without_dispatch():
+    """The model is already loaded — the operator's goal is met, so the UI note
+    resolves as success; the executor must not be reached for it."""
+    planner = _planner()
+    planner._execute_action_with_confirmation = MagicMock()
+    planner._lane_exists_in_runtime = MagicMock(return_value=True)
+    planner._runtime_lane_model = MagicMock(return_value="org/model-a")
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+    planner._execute_action_with_confirmation.assert_not_called()
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "succeeded"
+
+
+def test_second_click_does_not_overwrite_the_inflight_outcome():
+    """While the first load is in flight, a second click is a no-op — and must
+    not stomp the "running" entry it waits on: overwriting it with a no-op
+    would make the UI drop its note while the load is still going."""
+    planner = _planner()
+    # A live claim of the first replica (owner None counts as live).
+    planner._inflight_load_lane_ids = {1: {"planner-org_model-a": ("org/model-a", None)}}
+    planner.record_manual_load_outcome(1, "org/model-a", "running", lane_id="planner-org_model-a")
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"
+    assert outcome["lane_id"] == "planner-org_model-a"
+
+
+def test_lane_exists_no_op_does_not_overwrite_a_running_entry():
+    """The report lagged the runtime: the claimed id already holds the model,
+    but a concurrent attempt for it may still be executing and owns the final
+    state — the no-op must not resolve the UI note early."""
+    planner = _planner()
+    planner._execute_action_with_confirmation = MagicMock()
+    planner._lane_exists_in_runtime = MagicMock(return_value=True)
+    planner._runtime_lane_model = MagicMock(return_value="org/model-a")
+    planner.record_manual_load_outcome(1, "org/model-a", "running", lane_id="planner-org_model-a")
+
+    assert asyncio.run(planner.load_lane_manually(1, "org/model-a")) is False
+
+    outcome = planner.get_manual_load_outcome(1, "org/model-a")
+    assert outcome["status"] == "running"

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_add_lane_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_add_lane_endpoint.py
@@ -24,9 +24,10 @@ def _payload(provider_id: int = 1, lane: dict | None = None):
     )
 
 
-def _planner(rejection: str | None = None) -> MagicMock:
+def _planner(rejection: str | None = None, admission: str | None = None) -> MagicMock:
     planner = MagicMock()
     planner.manual_load_rejection_reason.return_value = rejection
+    planner.manual_load_admission_rejection.return_value = admission
 
     async def _load(provider_id: int, model_name: str) -> bool:
         return True
@@ -89,6 +90,28 @@ async def test_returns_409_while_the_provider_is_calibrating(monkeypatch):
     assert exc_info.value.status_code == 409
     assert "calibrating" in exc_info.value.detail
     planner.load_lane_manually.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_409_when_a_load_of_the_model_is_already_in_flight(monkeypatch):
+    """Admission is atomic: the check-and-claim happens before the 202, so a
+    second click — or a load the planner is already bringing up — is refused
+    where the operator can read it, instead of becoming a 202 whose
+    background task no-ops later. The refused click must also leave the
+    recorded outcome untouched: resetting it to "running" would strand the
+    UI's poll with no task left to settle it.
+    """
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    planner = _planner(admission="A load of this model is already in flight on this worker")
+    monkeypatch.setattr(main_mod, "_capacity_planner", planner)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_mod.internal_logosnode_add_lane(_payload(provider_id=7), _make_request("Bearer correct-secret"))
+
+    assert exc_info.value.status_code == 409
+    assert "in flight" in exc_info.value.detail
+    planner.load_lane_manually.assert_not_called()
+    planner.record_manual_load_outcome.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
@@ -119,6 +119,7 @@ async def test_add_lane_records_running_before_answering(monkeypatch):
     monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
     planner = MagicMock()
     planner.manual_load_rejection_reason.return_value = None
+    planner.manual_load_admission_rejection.return_value = None
 
     async def _load(provider_id: int, model_name: str) -> bool:
         return True
@@ -133,6 +134,9 @@ async def test_add_lane_records_running_before_answering(monkeypatch):
         _make_request("Bearer correct-secret"),
     )
 
+    # Admitted before the "running" record: a refused click must not reset a
+    # previous attempt's terminal state with no task left to settle it.
+    planner.manual_load_admission_rejection.assert_called_once_with(7, "org/model-a")
     # Recorded synchronously, before the 202 goes out — not by the task.
     planner.record_manual_load_outcome.assert_called_once_with(7, "org/model-a", "running")
     planner.load_lane_manually.assert_called_once_with(7, "org/model-a")

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
@@ -16,8 +16,8 @@ import pytest
 from fastapi import HTTPException
 
 import logos as main_mod
-from logos.routers import internal as internal_mod
 from logos.dbutils.dbrequest import InternalLaneLoadStatusRequest
+from logos.routers import internal as internal_mod
 
 
 def _make_request(authorization: str = "") -> MagicMock:
@@ -51,7 +51,9 @@ async def test_rejects_payload_without_model(monkeypatch):
     monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
     monkeypatch.setattr(main_mod, "_capacity_planner", MagicMock())
     with pytest.raises(HTTPException) as exc_info:
-        await internal_mod.internal_logosnode_lane_load_status(_payload(model="  "), _make_request("Bearer correct-secret"))
+        await internal_mod.internal_logosnode_lane_load_status(
+            _payload(model="  "), _make_request("Bearer correct-secret")
+        )
     assert exc_info.value.status_code == 400
 
 

--- a/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
+++ b/logos/logos-orchestrator/tests/unit/main/test_internal_lane_load_status_endpoint.py
@@ -1,0 +1,138 @@
+"""The load_status endpoint: the UI's way of learning a background load failed.
+
+``lanes/add`` answers 202 and runs the load in the background, where a refusal
+is otherwise only a log line. The statistics UI polls this endpoint while its
+"Loading …" note is up and turns the note into the recorded reason once the
+attempt is over — so the answer must carry the reason, and "no outcome known"
+must stay distinguishable from "failed".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import logos as main_mod
+from logos.routers import internal as internal_mod
+from logos.dbutils.dbrequest import InternalLaneLoadStatusRequest
+
+
+def _make_request(authorization: str = "") -> MagicMock:
+    request = MagicMock()
+    request.headers.get = lambda key, default="": authorization if key == "authorization" else default
+    return request
+
+
+def _payload(provider_id: int = 1, model: str = "org/model-a") -> InternalLaneLoadStatusRequest:
+    return InternalLaneLoadStatusRequest(provider_id=provider_id, model=model)
+
+
+@pytest.mark.asyncio
+async def test_returns_403_when_secret_not_configured(monkeypatch):
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_mod.internal_logosnode_lane_load_status(_payload(), _make_request("Bearer secret"))
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_returns_401_when_secret_is_wrong(monkeypatch):
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_mod.internal_logosnode_lane_load_status(_payload(), _make_request("Bearer wrong-secret"))
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_rejects_payload_without_model(monkeypatch):
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    monkeypatch.setattr(main_mod, "_capacity_planner", MagicMock())
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_mod.internal_logosnode_lane_load_status(_payload(model="  "), _make_request("Bearer correct-secret"))
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_returns_503_when_planner_is_not_ready(monkeypatch):
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    monkeypatch.setattr(main_mod, "_capacity_planner", None)
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_mod.internal_logosnode_lane_load_status(_payload(), _make_request("Bearer correct-secret"))
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_returns_the_recorded_outcome(monkeypatch):
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    planner = MagicMock()
+    planner.get_manual_load_outcome.return_value = {
+        "status": "failed",
+        "updated_at": 123.0,
+        "lane_id": "planner-org_model-a-2",
+        "reason": "not enough free VRAM for this model",
+    }
+    monkeypatch.setattr(main_mod, "_capacity_planner", planner)
+
+    response = await internal_mod.internal_logosnode_lane_load_status(
+        _payload(provider_id=7), _make_request("Bearer correct-secret")
+    )
+
+    assert response == {
+        "status": "failed",
+        "model": "org/model-a",
+        "provider_id": 7,
+        "lane_id": "planner-org_model-a-2",
+        "reason": "not enough free VRAM for this model",
+        "updated_at": 123.0,
+    }
+    planner.get_manual_load_outcome.assert_called_once_with(7, "org/model-a")
+
+
+@pytest.mark.asyncio
+async def test_no_recorded_outcome_answers_unknown_not_failed(monkeypatch):
+    """The planner holds no entry (never loaded here, expired, orchestrator
+    restarted) — the UI must keep its note, not show a failure."""
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    planner = MagicMock()
+    planner.get_manual_load_outcome.return_value = None
+    monkeypatch.setattr(main_mod, "_capacity_planner", planner)
+
+    response = await internal_mod.internal_logosnode_lane_load_status(
+        _payload(provider_id=7), _make_request("Bearer correct-secret")
+    )
+
+    assert response["status"] == "unknown"
+    assert response["reason"] is None
+    assert response["lane_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_lane_records_running_before_answering(monkeypatch):
+    """The UI polls from the moment it sees the 202 — a gap between the answer
+    and the background task's first record would let it read the previous
+    attempt's "failed" entry and show a stale failure for the fresh click."""
+    monkeypatch.setattr(internal_mod, "_INTERNAL_SECRET", "correct-secret")
+    planner = MagicMock()
+    planner.manual_load_rejection_reason.return_value = None
+
+    async def _load(provider_id: int, model_name: str) -> bool:
+        return True
+
+    planner.load_lane_manually = MagicMock(side_effect=_load)
+    monkeypatch.setattr(main_mod, "_capacity_planner", planner)
+
+    from logos.dbutils.dbrequest import InternalAddLaneRequest
+
+    await internal_mod.internal_logosnode_add_lane(
+        InternalAddLaneRequest(provider_id=7, lane={"model": "org/model-a"}),
+        _make_request("Bearer correct-secret"),
+    )
+
+    # Recorded synchronously, before the 202 goes out — not by the task.
+    planner.record_manual_load_outcome.assert_called_once_with(7, "org/model-a", "running")
+    planner.load_lane_manually.assert_called_once_with(7, "org/model-a")
+    # Let the scheduled task run so it does not outlive the test.
+    await asyncio.sleep(0)

--- a/logos/logos-ui/src/app/features/ai-tools/ai-tools.spec.ts
+++ b/logos/logos-ui/src/app/features/ai-tools/ai-tools.spec.ts
@@ -45,6 +45,7 @@ const KEY: MyKey = {
   used_micro_cents: 0,
   settings: null,
   last_used_at: null,
+  rate_limit_usage: null,
   team: {
     id: 1,
     name: 'a team',

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -819,4 +819,35 @@ describe('LaneHealthPanel action feedback follows the worker', () => {
     await pendingB;
     expect(panel.unloadingLaneId()).toBeNull();
   });
+
+  it('does not let an A → B → A attempt settle the newer attempt on the same lane', async () => {
+    // Lane ids are per-worker, so the same id can exist on two workers: an
+    // A → B → A sequence re-uses both the provider and the lane name of the
+    // older attempt for a newer one, and matching on that pair would let the
+    // older attempt settle the newer one's signal and error.
+    const first = panel.handleUnload('planner-foo');
+    switchTo('gpu-02');
+    const onOther = panel.handleUnload('planner-foo');
+    unloadSettlers[1]();
+    await onOther;
+    expect(panel.unloadingLaneId()).toBeNull();
+
+    switchTo('gpu-01');
+    const second = panel.handleUnload('planner-foo');
+    expect(panel.unloadingLaneId()).toBe('planner-foo');
+
+    // The first attempt settles last — on the worker it started on, with the
+    // same lane name the newer attempt now holds.
+    unloadSettlers[0]();
+    await first;
+
+    // It must not have cleared the newer attempt's signal or written into
+    // its error.
+    expect(panel.unloadingLaneId()).toBe('planner-foo');
+    expect(panel.unloadError()).toBeNull();
+
+    unloadSettlers[2]();
+    await second;
+    expect(panel.unloadingLaneId()).toBeNull();
+  });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -713,10 +713,12 @@ describe('LaneHealthPanel action feedback follows the worker', () => {
   let panel: LaneHealthPanel;
   let unloadResult: { body?: unknown; error?: unknown };
   let settleUnload: (() => void) | null;
+  let unloadSettlers: Array<() => void>;
 
   beforeEach(async () => {
     unloadResult = {};
     settleUnload = null;
+    unloadSettlers = [];
     await TestBed.configureTestingModule({
       imports: [LaneHealthPanel],
       providers: [
@@ -725,8 +727,10 @@ describe('LaneHealthPanel action feedback follows the worker', () => {
           useValue: {
             unloadLane: () =>
               new Promise((resolve, reject) => {
-                settleUnload = () =>
+                const settle = () =>
                   unloadResult.error ? reject(unloadResult.error) : resolve(unloadResult.body ?? {});
+                unloadSettlers.push(settle);
+                settleUnload = settle;
               }),
             getLaneLoadStatus: () => Promise.resolve({ status: 'running' }),
           },
@@ -790,5 +794,29 @@ describe('LaneHealthPanel action feedback follows the worker', () => {
 
     // The refusal belongs to gpu-01; gpu-02's panel shows nothing.
     expect(panel.unloadError()).toBeNull();
+  });
+
+  it("does not clear the switched-to worker's in-flight signal when the older call settles", async () => {
+    // gpu-01's unload is in flight…
+    const pendingA = panel.handleUnload('planner-foo');
+    // …the operator switches, and fires gpu-02's own unload.
+    switchTo('gpu-02');
+    const pendingB = panel.handleUnload('planner-bar');
+    expect(panel.unloadingLaneId()).toBe('planner-bar');
+
+    // gpu-01's delayed answer must not release the signal: it belongs to
+    // gpu-02's attempt now, and clearing it while that call is still running
+    // would lift the in-flight guard — the next click would dispatch a
+    // duplicate unload to the same lane.
+    unloadSettlers[0]();
+    await pendingA;
+
+    expect(panel.unloadingLaneId()).toBe('planner-bar');
+    expect(panel.unloadError()).toBeNull();
+
+    // …and the signal stays fully functional for the attempt that owns it.
+    settleUnload?.();
+    await pendingB;
+    expect(panel.unloadingLaneId()).toBeNull();
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -627,6 +627,56 @@ describe('LaneHealthPanel load outcome poll', () => {
     await settle();
     expect(loadStatusCalls).toBe(calls);
   });
+
+  it('drops a delayed answer from a superseded session of the same model', async () => {
+    // The operator's retry starts a new polling session while the first
+    // session's request is still in flight: that delayed answer describes
+    // the old attempt and must not fail the new attempt's note. The
+    // provider/model guards cannot tell the two sessions apart — same
+    // provider, same model — only the session generation can.
+    await acceptLoad();
+    let firstCall = true;
+    let releaseFirst: (value: { status: string; reason?: string }) => void = () => {};
+    const delayed = new Promise<{ status: string; reason?: string }>((resolve) => {
+      releaseFirst = resolve;
+    });
+    loadStatusStub = () => {
+      if (firstCall) {
+        firstCall = false;
+        return delayed;
+      }
+      return Promise.resolve({ status: 'running' });
+    };
+
+    pollTick?.(); // session 1 asks; the answer is still on the wire
+    await settle();
+    expect(loadStatusCalls).toBe(1);
+
+    // The operator retries the same model — the 202 starts a new polling
+    // session. Reached directly, the way pickerProviderId is: what is under
+    // test is what a new session does to an in-flight answer, not the picker
+    // round-trip that leads here.
+    (panel as unknown as { startLoadStatusPoll(pid: number, model: string): void }).startLoadStatusPoll(
+      1,
+      'foo'
+    );
+
+    // Session 1's answer lands now — it belongs to the attempt the note
+    // replaced, not the one being polled.
+    releaseFirst({ status: 'failed', reason: 'old attempt denied' });
+    await settle();
+
+    expect(panel.addError()).toBeNull();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(panel.pickerOpen()).toBe(false);
+    // And the new session is untouched by it: it still polls and applies
+    // its own answers.
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(2);
+    expect(panel.addError()).toBeNull();
+    expect(panel.acceptedModel()).toBe('foo');
+  });
 });
 
 /**

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -628,3 +628,96 @@ describe('LaneHealthPanel load outcome poll', () => {
     expect(loadStatusCalls).toBe(calls);
   });
 });
+
+/**
+ * Action feedback follows the worker it was reported on.
+ *
+ * An unload refusal or a calibration note is the answer to an action on one
+ * specific worker: after the operator moves the dropdown, it means nothing
+ * under the new worker's panel — neither the message that was already up nor
+ * the answer of a call that is still in flight.
+ */
+describe('LaneHealthPanel action feedback follows the worker', () => {
+  let fixture: ComponentFixture<LaneHealthPanel>;
+  let panel: LaneHealthPanel;
+  let unloadResult: { body?: unknown; error?: unknown };
+  let settleUnload: (() => void) | null;
+
+  beforeEach(async () => {
+    unloadResult = {};
+    settleUnload = null;
+    await TestBed.configureTestingModule({
+      imports: [LaneHealthPanel],
+      providers: [
+        {
+          provide: StatisticsService,
+          useValue: {
+            unloadLane: () =>
+              new Promise((resolve, reject) => {
+                settleUnload = () =>
+                  unloadResult.error ? reject(unloadResult.error) : resolve(unloadResult.body ?? {});
+              }),
+            getLaneLoadStatus: () => Promise.resolve({ status: 'running' }),
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(LaneHealthPanel);
+    panel = fixture.componentInstance;
+    fixture.componentRef.setInput('lanesByProvider', {
+      'gpu-01': { 'planner-foo': lane({ model: 'foo', runtime_state: 'running' }) },
+      'gpu-02': { 'planner-bar': lane({ model: 'bar', runtime_state: 'running' }) },
+    });
+    fixture.componentRef.setInput('providerMeta', {
+      'gpu-01': { provider_id: 1 },
+      'gpu-02': { provider_id: 2 },
+    });
+    fixture.componentRef.setInput('selectedProvider', 'gpu-01');
+    fixture.detectChanges();
+  });
+
+  /** Move the provider dropdown, as the framework would. */
+  function switchTo(provider: string): void {
+    panel.selectedProvider = provider;
+    panel.ngOnChanges({ selectedProvider: new SimpleChange('gpu-01', provider, true) });
+  }
+
+  it('drops an unload error when the operator switches worker', async () => {
+    unloadResult.error = { status: 500, error: 'denied by worker-a' };
+    const pending = panel.handleUnload('planner-foo');
+    settleUnload?.();
+    await pending;
+    expect(panel.unloadError()).toBe('Unload of planner-foo failed: denied by worker-a');
+
+    switchTo('gpu-02');
+    expect(panel.unloadError()).toBeNull();
+  });
+
+  it('drops a sleep/wake error on the switch as well', async () => {
+    panel.sleepWakeError.set('Sleep of planner-foo failed: the worker said no');
+
+    switchTo('gpu-02');
+    expect(panel.sleepWakeError()).toBeNull();
+  });
+
+  it('clears the spinner of a call that is still in flight at the switch', async () => {
+    panel.handleUnload('planner-foo');
+    expect(panel.unloadingLaneId()).toBe('planner-foo');
+
+    switchTo('gpu-02');
+    expect(panel.unloadingLaneId()).toBeNull();
+  });
+
+  it('does not show a stale unload error under the switched-to worker', async () => {
+    const pending = panel.handleUnload('planner-foo');
+    // The call is still in flight when the operator switches.
+    switchTo('gpu-02');
+
+    unloadResult.error = { status: 500, error: 'denied by worker-a' };
+    settleUnload?.();
+    await pending;
+
+    // The refusal belongs to gpu-01; gpu-02's panel shows nothing.
+    expect(panel.unloadError()).toBeNull();
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import {
   LaneHealthPanel,
   acceptedModelIsResolved,
@@ -329,6 +330,10 @@ describe('LaneHealthPanel pending-note baseline', () => {
               new Promise<void>((resolve) => {
                 resolveAdd = resolve;
               }),
+            // The 202 starts the outcome poll, whose first tick lands 2.5 s
+            // later — beyond these tests' horizon, but a slow CI must not hit
+            // a stub without this method.
+            getLaneLoadStatus: () => Promise.resolve({ status: 'running' }),
           },
         },
       ],
@@ -390,5 +395,236 @@ describe('LaneHealthPanel pending-note baseline', () => {
 
     pushLanes({ 'planner-foo': lane({ model: 'foo', runtime_state: 'loaded' }) });
     expect(panel.acceptedModel()).toBe('foo');
+  });
+});
+
+/**
+ * The outcome poll behind the pending note.
+ *
+ * addLane's 202 only says "accepted"; the planner refuses some loads in the
+ * background (not enough VRAM for a second replica, the worker rejected the
+ * command, the confirmation timed out) and until this poll existed that
+ * refusal was a log line — the note stayed up forever. The poll asks the
+ * orchestrator for the recorded outcome of the (provider, model) load:
+ * "failed" turns the note into an error in the reopened picker, "succeeded"
+ * stops the poll but keeps the note until the lane actually shows up, and
+ * "running"/"unknown" leave everything exactly as it is.
+ */
+describe('LaneHealthPanel load outcome poll', () => {
+  // Private tuning constants, reached the same way pickerProviderId is.
+  const pollMs = (LaneHealthPanel as unknown as {
+    LOAD_STATUS_POLL_INTERVAL_MS: number;
+    LOAD_STATUS_POLL_CAP_MS: number;
+  });
+  let fixture: ComponentFixture<LaneHealthPanel>;
+  let panel: LaneHealthPanel;
+  let loadStatusCalls: number;
+  /** What the next poll gets — set per test. */
+  let loadStatusStub: () => Promise<{ status?: string; reason?: string }>;
+  /** The poll's interval callback, held instead of waiting 2.5 s real time. */
+  let pollTick: (() => void) | null = null;
+  let clearedIntervals: number;
+  let fakeNow: number;
+
+  beforeEach(async () => {
+    loadStatusCalls = 0;
+    loadStatusStub = () => Promise.resolve({ status: 'running' });
+    pollTick = null;
+    clearedIntervals = 0;
+    fakeNow = Date.now();
+    // The suite runs zoneless, so fakeAsync's tick() is not available: hold
+    // the poll's timer and fire it by hand, and advance Date.now for the cap.
+    vi.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(
+      ((callback: () => void) => {
+        pollTick = callback;
+        return 0;
+      }) as unknown as typeof setInterval
+    );
+    vi.spyOn(globalThis, 'clearInterval').mockImplementation(() => {
+      clearedIntervals += 1;
+    });
+    await TestBed.configureTestingModule({
+      imports: [LaneHealthPanel],
+      providers: [
+        {
+          provide: StatisticsService,
+          useValue: {
+            addLane: () => Promise.resolve(),
+            getLaneLoadStatus: () => {
+              loadStatusCalls += 1;
+              return loadStatusStub();
+            },
+            getProviderModels: () => Promise.resolve([{ model_id: 1, model_name: 'foo' }]),
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(LaneHealthPanel);
+    panel = fixture.componentInstance;
+    fixture.componentRef.setInput('lanesByProvider', {
+      'gpu-01': { 'planner-foo': lane({ model: 'foo', runtime_state: 'running' }) },
+    });
+    fixture.componentRef.setInput('providerMeta', { 'gpu-01': { provider_id: 1 } });
+    fixture.componentRef.setInput('selectedProvider', 'gpu-01');
+    panel.loadModels.set([{ model_id: 1, model_name: 'foo' }] satisfies ProviderModel[]);
+    (panel as unknown as { pickerProviderId: number | null }).pickerProviderId = 1;
+    panel.selectedModel.set('foo');
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Let the poll's promise chain (HTTP answer, then-handler) settle. */
+  async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  /** One status-stream push, as the baseline describe does. */
+  function pushLanes(next: Record<string, LaneSignalData>): void {
+    const prev = panel.lanesByProvider;
+    panel.lanesByProvider = { ...prev, 'gpu-01': next };
+    panel.ngOnChanges({ lanesByProvider: new SimpleChange(prev, panel.lanesByProvider, false) });
+  }
+
+  /** The 202 arrives: the note is up and the poll runs behind it. */
+  async function acceptLoad(): Promise<void> {
+    await panel.handleAddLane();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(panel.pickerOpen()).toBe(false);
+    expect(pollTick).not.toBeNull();
+  }
+
+  it('turns a background refusal into an error and re-offers the model', async () => {
+    await acceptLoad();
+    loadStatusStub = () =>
+      Promise.resolve({
+        status: 'failed',
+        reason:
+          'not enough free VRAM for this model: it needs ~48.4 GB in total, but the worker reports only 63.4 GB free',
+      });
+
+    pollTick?.(); // first poll fires
+    await settle();
+
+    // The note is gone, the picker came back with the recorded reason — where
+    // a synchronous refusal lands — and the model may be retried.
+    expect(panel.acceptedModel()).toBeNull();
+    expect(panel.pickerOpen()).toBe(true);
+    expect(panel.addError()).toBe(
+      'Loading foo failed: not enough free VRAM for this model: it needs ~48.4 GB in total, but the worker reports only 63.4 GB free'
+    );
+    expect(filterLoadableModels(panel.loadModels(), panel.acceptedModel())).toEqual([
+      { model_id: 1, model_name: 'foo' },
+    ]);
+    // And the poll is over with it — a stray later firing must not re-ask.
+    expect(clearedIntervals).toBeGreaterThan(0);
+    const calls = loadStatusCalls;
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(calls);
+  });
+
+  it('shows a reason-less refusal with a fallback instead of an empty message', async () => {
+    await acceptLoad();
+    loadStatusStub = () => Promise.resolve({ status: 'failed' });
+    pollTick?.();
+    await settle();
+    expect(panel.addError()).toBe('Loading foo failed: no reason was recorded');
+    expect(panel.acceptedModel()).toBeNull();
+  });
+
+  it('keeps the note after a recorded success until the lane shows up', async () => {
+    // Clearing the note on "succeeded" would re-offer the model in the gap
+    // between the planner's record and the next status push — the lane row
+    // owns the note from here, not the outcome poll.
+    await acceptLoad();
+    loadStatusStub = () => Promise.resolve({ status: 'succeeded' });
+    pollTick?.();
+    await settle();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(panel.addError()).toBeNull();
+    expect(clearedIntervals).toBeGreaterThan(0); // a terminal answer stops the poll
+
+    // The lane arrives in the stream: the note goes.
+    pushLanes({
+      'planner-foo': lane({ model: 'foo', runtime_state: 'running' }),
+      'planner-foo-2': lane({ model: 'foo', runtime_state: 'loaded' }),
+    });
+    expect(panel.acceptedModel()).toBeNull();
+  });
+
+  it('keeps waiting while the load is running or its outcome unrecorded', async () => {
+    // "unknown" is what the orchestrator answers after a restart — it must
+    // not read as a failure, the note just keeps saying what it says.
+    await acceptLoad();
+    pollTick?.();
+    await settle();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(panel.addError()).toBeNull();
+    expect(loadStatusCalls).toBe(1);
+
+    loadStatusStub = () => Promise.resolve({ status: 'unknown' });
+    pollTick?.();
+    await settle();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(panel.addError()).toBeNull();
+    expect(loadStatusCalls).toBe(2);
+  });
+
+  it('stops the poll when the operator switches provider', async () => {
+    await acceptLoad();
+    // The provider dropdown lives outside the panel: deliver the input change
+    // the way pushLanes does, as the framework would. The second provider has
+    // a provider_id like every real one — the switch guard compares the
+    // picker's provider against the current one.
+    panel.providerMeta = { 'gpu-01': { provider_id: 1 }, 'gpu-02': { provider_id: 2 } };
+    panel.selectedProvider = 'gpu-02';
+    panel.ngOnChanges({
+      selectedProvider: new SimpleChange('gpu-01', 'gpu-02', true),
+    });
+    expect(panel.acceptedModel()).toBeNull();
+    expect(clearedIntervals).toBeGreaterThan(0);
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(0);
+  });
+
+  it('stops the poll on a backend that predates the load_status route', async () => {
+    // A 404/501 is not a blip to retry: the deployed Spring has no route, so
+    // the poll would 404 until the cap. Stop and fall back to the
+    // lane-appearance check, which needs no backend support.
+    await acceptLoad();
+    loadStatusStub = () =>
+      Promise.reject(Object.assign(new Error('Not Found'), { status: 404 }));
+    pollTick?.();
+    await settle();
+    expect(panel.acceptedModel()).toBe('foo'); // note untouched
+    expect(clearedIntervals).toBeGreaterThan(0);
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(1);
+  });
+
+  it('gives up at the cap and leaves the note to the stream check', async () => {
+    // Past the orchestrator's load command timeout the live outcome is gone;
+    // re-asking for the same "running" is noise. The note stays — a lane that
+    // still arrives resolves it via the stream.
+    await acceptLoad();
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(1);
+
+    fakeNow += pollMs.LOAD_STATUS_POLL_CAP_MS + 1;
+    pollTick?.();
+    await settle();
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(clearedIntervals).toBeGreaterThan(0);
+    const calls = loadStatusCalls;
+    pollTick?.();
+    await settle();
+    expect(loadStatusCalls).toBe(calls);
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.spec.ts
@@ -609,9 +609,10 @@ describe('LaneHealthPanel load outcome poll', () => {
   });
 
   it('gives up at the cap and leaves the note to the stream check', async () => {
-    // Past the orchestrator's load command timeout the live outcome is gone;
-    // re-asking for the same "running" is noise. The note stays — a lane that
-    // still arrives resolves it via the stream.
+    // Past the full two-phase attempt (command + confirmation, ~60 min plus
+    // lock wait) the live outcome is gone; re-asking for the same "running"
+    // is noise. The note stays — a lane that still arrives resolves it via
+    // the stream.
     await acceptLoad();
     pollTick?.();
     await settle();
@@ -626,6 +627,26 @@ describe('LaneHealthPanel load outcome poll', () => {
     pollTick?.();
     await settle();
     expect(loadStatusCalls).toBe(calls);
+  });
+
+  it('keeps the outcome poll running when the operator merely closes the picker', async () => {
+    // The picker's Close button is not the end of an accepted load: the
+    // pending note stays up, and the poll must keep running — it is what
+    // will surface a background refusal minutes later. Stopping the poll on
+    // a plain close would leave such a refusal's "Loading …" note hanging
+    // indefinitely.
+    await acceptLoad();
+    panel.closePicker();
+
+    expect(panel.acceptedModel()).toBe('foo');
+    expect(pollTick).not.toBeNull(); // the close did not kill the poll
+
+    loadStatusStub = () => Promise.resolve({ status: 'failed', reason: 'denied late' });
+    pollTick?.();
+    await settle();
+
+    expect(panel.addError()).toBe('Loading foo failed: denied late');
+    expect(panel.acceptedModel()).toBeNull();
   });
 
   it('drops a delayed answer from a superseded session of the same model', async () => {

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Input,
   OnChanges,
+  OnDestroy,
   SimpleChanges,
   inject,
   signal,
@@ -194,7 +195,7 @@ export function laneSleepAction(lane: LaneSignalData): LaneSleepAction {
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './lane-health-panel.scss',
 })
-export class LaneHealthPanel implements OnChanges {
+export class LaneHealthPanel implements OnChanges, OnDestroy {
   @Input() lanesByProvider: Record<string, Record<string, LaneSignalData>> = {};
   @Input() providerMeta: Record<string, VramProviderMeta> = {};
   @Input() selectedProvider: string | null = null;
@@ -226,6 +227,29 @@ export class LaneHealthPanel implements OnChanges {
   private readonly modelsInFlight = new Set<number>();
   /** Provider the currently visible picker state belongs to. */
   private pickerProviderId: number | null = null;
+
+  // ── Accepted-load outcome polling ────────────────────────────────────────
+  /**
+   * How often to ask for the outcome of an accepted background load. The
+   * load itself takes minutes; the question here is cheap and only interesting
+   * because a refusal in the background is otherwise a log line.
+   */
+  private static readonly LOAD_STATUS_POLL_INTERVAL_MS = 2500;
+  /**
+   * Hard stop for the outcome poll. The orchestrator resolves every manual
+   * load within its load command timeout (30 min) — refusal, confirmed lane,
+   * or a recorded timeout — so well past that the live outcome is gone
+   * (planner restart, entry aged out) and the poll can only re-ask for the
+   * same "unknown". The lane-appearance check in ngOnChanges keeps owning the
+   * note from there on.
+   */
+  private static readonly LOAD_STATUS_POLL_CAP_MS = 31 * 60 * 1000;
+  /** Timer handle of the outcome poll; null while not polling. */
+  private loadStatusPoll: ReturnType<typeof setInterval> | null = null;
+  /** Provider the outcome poll belongs to — anything else is a stale poll. */
+  private loadStatusPollProviderId: number | null = null;
+  /** When the outcome poll must stop regardless of what it is told. */
+  private loadStatusPollDeadline = 0;
 
   get providerName(): string | null {
     return this.selectedProvider ?? Object.keys(this.lanesByProvider)[0] ?? null;
@@ -461,6 +485,7 @@ export class LaneHealthPanel implements OnChanges {
     this.selectedModel.set(null);
     this.addError.set(null);
     this.pickerProviderId = null;
+    this.stopLoadStatusPoll();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -488,6 +513,7 @@ export class LaneHealthPanel implements OnChanges {
       ) {
         this.acceptedModel.set(null);
         this.acceptedLaneIds = null;
+        this.stopLoadStatusPoll();
       }
     }
   }
@@ -495,6 +521,102 @@ export class LaneHealthPanel implements OnChanges {
   selectModel(event: Event): void {
     const value = (event.target as HTMLSelectElement).value;
     this.selectedModel.set(value || null);
+  }
+
+  /**
+   * Start asking for the outcome of an accepted background load.
+   *
+   * addLane's 202 only says "accepted", and the planner refuses some loads
+   * after the fact — not enough VRAM for a second replica, the worker
+   * rejected the command, the confirmation timed out. Until this poll existed,
+   * such a refusal was a log line and the pending note stayed up forever.
+   * While the note is up, the poll turns a recorded "failed" into an error
+   * (and re-offers the model) and a "succeeded" is noted as well; "running"
+   * and "unknown" leave everything as it is, because the lane-appearance
+   * check in ngOnChanges remains the primary exit for a load that arrives.
+   */
+  private startLoadStatusPoll(providerId: number, model: string): void {
+    this.stopLoadStatusPoll();
+    this.loadStatusPollProviderId = providerId;
+    this.loadStatusPollDeadline = Date.now() + LaneHealthPanel.LOAD_STATUS_POLL_CAP_MS;
+    this.loadStatusPoll = setInterval(
+      () => this.pollLoadStatus(providerId, model),
+      LaneHealthPanel.LOAD_STATUS_POLL_INTERVAL_MS
+    );
+  }
+
+  private stopLoadStatusPoll(): void {
+    if (this.loadStatusPoll != null) {
+      clearInterval(this.loadStatusPoll);
+      this.loadStatusPoll = null;
+    }
+    this.loadStatusPollProviderId = null;
+    this.loadStatusPollDeadline = 0;
+  }
+
+  private pollLoadStatus(providerId: number, model: string): void {
+    // The note went away (lane appeared, operator acted) or the operator moved
+    // to another provider — this poll is stale, whatever the next answer says.
+    if (
+      this.loadStatusPollProviderId !== providerId ||
+      this.providerId !== providerId ||
+      this.acceptedModel()?.trim().toLowerCase() !== model.trim().toLowerCase()
+    ) {
+      this.stopLoadStatusPoll();
+      return;
+    }
+    if (Date.now() > this.loadStatusPollDeadline) {
+      // The orchestrator has long since resolved this load; keep the note,
+      // stop re-asking for an outcome that no longer exists.
+      this.stopLoadStatusPoll();
+      return;
+    }
+    this.statisticsService
+      .getLaneLoadStatus(providerId, model)
+      .then((outcome) => this.applyLoadStatus(outcome, model))
+      .catch((err: unknown) => {
+        // A blip is fine — the next tick retries. 404/501 means the backend
+        // predates the load_status route, where the poll can never succeed:
+        // stop and fall back to the lane-appearance check.
+        const e = err as { status?: number };
+        if (e.status === 404 || e.status === 501) this.stopLoadStatusPoll();
+      });
+  }
+
+  /**
+   * Fold one load_status answer into the pending note.
+   *
+   * "failed" is the interesting one: the load is over, its reason is
+   * recorded, so the picker comes back with the error — exactly where a
+   * synchronous refusal lands — and the model is offered again. "succeeded"
+   * only stops the poll: the note stays until the lane actually shows up in
+   * the stream, so the model is not re-offered in the gap between the
+   * planner's record and the next status push. "running"/"unknown" change
+   * nothing.
+   */
+  private applyLoadStatus(
+    outcome: { status?: string; reason?: string },
+    model: string
+  ): void {
+    // The answer can land after the note already went away — apply nothing.
+    if (this.acceptedModel()?.trim().toLowerCase() !== model.trim().toLowerCase()) {
+      this.stopLoadStatusPoll();
+      return;
+    }
+    const status = (outcome.status ?? '').trim().toLowerCase();
+    if (status !== 'failed') {
+      if (status === 'succeeded') this.stopLoadStatusPoll();
+      return;
+    }
+    this.stopLoadStatusPoll();
+    this.acceptedModel.set(null);
+    this.acceptedLaneIds = null;
+    // The picker closed with the 202; reopen it so the reason sits next to
+    // the retry, like a synchronous refusal does.
+    this.openPicker();
+    this.addError.set(
+      `Loading ${model} failed: ${outcome.reason?.trim() || 'no reason was recorded'}`
+    );
   }
 
   async handleAddLane(): Promise<void> {
@@ -551,6 +673,10 @@ export class LaneHealthPanel implements OnChanges {
       ) {
         this.acceptedModel.set(null);
         this.acceptedLaneIds = null;
+      } else {
+        // The note stays up — put the outcome poll behind it, so a refusal in
+        // the background ends it with a reason instead of running away.
+        this.startLoadStatusPoll(pid, model);
       }
     } catch (err: unknown) {
       this.addingLane.set(false);
@@ -561,6 +687,10 @@ export class LaneHealthPanel implements OnChanges {
         this.addError.set(`Loading ${model} failed: ${this.failureDetail(err)}`);
       }
     }
+  }
+
+  ngOnDestroy(): void {
+    this.stopLoadStatusPoll();
   }
 }
 

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -380,25 +380,47 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     return messageIn(e?.error) ?? `HTTP ${e?.status ?? 0}`;
   }
 
+  /**
+   * Whether a lane action captured for provider `pid` may still touch the
+   * shared signal and error state on its completion.
+   *
+   * The signal is shared between attempts while `ngOnChanges` reassigns it on
+   * every provider switch: it only still belongs to the finishing attempt if
+   * the provider is unchanged AND the signal still names the attempt's lane.
+   * A finishing attempt that failed both must not clear the signal — after an
+   * A → B switch, B's own in-flight attempt holds it, and clearing it here
+   * would release the in-flight guard while B's call is still running, so the
+   * next click dispatches a duplicate action to the same lane. The provider
+   * half of the check matters even when the lane ids collide, because a lane
+   * id is per-worker and the same id can be in flight on two workers at once.
+   */
+  private actionStillOwned(pid: number | null, signal: () => string | null, laneId: string): boolean {
+    return this.providerId === pid && signal() === laneId;
+  }
+
   async handleUnload(laneId: string): Promise<void> {
     const pid = this.providerId;
     if (pid == null || this.unloadingLaneId() != null) return;
     this.unloadingLaneId.set(laneId);
     this.unloadError.set(null);
 
+    let failed: unknown = null;
     try {
       await this.statisticsService.unloadLane(pid, laneId);
-      this.unloadingLaneId.set(null);
     } catch (err: unknown) {
+      failed = err;
+    }
+    // The operator may have switched workers while the call was in flight;
+    // only the attempt that still owns its signal may settle it — see
+    // actionStillOwned.
+    if (this.actionStillOwned(pid, this.unloadingLaneId, laneId)) {
       this.unloadingLaneId.set(null);
-      // The operator may have switched workers while the call was in flight;
-      // the refusal belongs to the worker it was sent to, not the one now shown.
-      if (this.providerId !== pid) return;
-      const e = err as { status?: number };
+      if (failed === null) return;
+      const e = failed as { status?: number };
       if (e.status === 404 || e.status === 501 || e.status === 0) {
         this.unloadError.set('Action not available on this server yet.');
       } else {
-        this.unloadError.set(`Unload of ${laneId} failed: ${this.failureDetail(err)}`);
+        this.unloadError.set(`Unload of ${laneId} failed: ${this.failureDetail(failed)}`);
       }
     }
   }
@@ -409,15 +431,16 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     this.sleepingLaneId.set(laneId);
     this.sleepWakeError.set(null);
 
+    let failed: unknown = null;
     try {
       await this.statisticsService.sleepLane(pid, laneId);
-      this.sleepingLaneId.set(null);
     } catch (err: unknown) {
+      failed = err;
+    }
+    // Same ownership rule as handleUnload.
+    if (this.actionStillOwned(pid, this.sleepingLaneId, laneId)) {
       this.sleepingLaneId.set(null);
-      // The operator may have switched workers while the call was in flight;
-      // the refusal belongs to the worker it was sent to, not the one now shown.
-      if (this.providerId !== pid) return;
-      this.sleepWakeError.set(this.sleepWakeErrorText('Sleep', laneId, err));
+      if (failed !== null) this.sleepWakeError.set(this.sleepWakeErrorText('Sleep', laneId, failed));
     }
   }
 
@@ -427,15 +450,16 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     this.wakingLaneId.set(laneId);
     this.sleepWakeError.set(null);
 
+    let failed: unknown = null;
     try {
       await this.statisticsService.wakeLane(pid, laneId);
-      this.wakingLaneId.set(null);
     } catch (err: unknown) {
+      failed = err;
+    }
+    // Same ownership rule as handleUnload.
+    if (this.actionStillOwned(pid, this.wakingLaneId, laneId)) {
       this.wakingLaneId.set(null);
-      // The operator may have switched workers while the call was in flight;
-      // the refusal belongs to the worker it was sent to, not the one now shown.
-      if (this.providerId !== pid) return;
-      this.sleepWakeError.set(this.sleepWakeErrorText('Wake', laneId, err));
+      if (failed !== null) this.sleepWakeError.set(this.sleepWakeErrorText('Wake', laneId, failed));
     }
   }
 

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -250,6 +250,14 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
   private loadStatusPollProviderId: number | null = null;
   /** When the outcome poll must stop regardless of what it is told. */
   private loadStatusPollDeadline = 0;
+  /**
+   * Generation of the polling session: every start bumps it, and each request
+   * captures its own at dispatch time. A response that only resolves after a
+   * newer session started (a retry of the same model) belongs to the old
+   * attempt — the provider/model guards cannot tell the two apart, so it is
+   * dropped instead of being applied to the new attempt's note.
+   */
+  private loadStatusPollGeneration = 0;
 
   get providerName(): string | null {
     return this.selectedProvider ?? Object.keys(this.lanesByProvider)[0] ?? null;
@@ -556,8 +564,9 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     this.stopLoadStatusPoll();
     this.loadStatusPollProviderId = providerId;
     this.loadStatusPollDeadline = Date.now() + LaneHealthPanel.LOAD_STATUS_POLL_CAP_MS;
+    const generation = (this.loadStatusPollGeneration += 1);
     this.loadStatusPoll = setInterval(
-      () => this.pollLoadStatus(providerId, model),
+      () => this.pollLoadStatus(providerId, model, generation),
       LaneHealthPanel.LOAD_STATUS_POLL_INTERVAL_MS
     );
   }
@@ -571,7 +580,7 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     this.loadStatusPollDeadline = 0;
   }
 
-  private pollLoadStatus(providerId: number, model: string): void {
+  private pollLoadStatus(providerId: number, model: string, generation: number): void {
     // The note went away (lane appeared, operator acted) or the operator moved
     // to another provider — this poll is stale, whatever the next answer says.
     if (
@@ -590,8 +599,16 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     }
     this.statisticsService
       .getLaneLoadStatus(providerId, model)
-      .then((outcome) => this.applyLoadStatus(outcome, model))
+      .then((outcome) => {
+        // A newer session (a retry of the same model) started while this
+        // request was in flight: the answer describes the old attempt, not
+        // the one whose note is up now. Drop it — and keep this session's
+        // timer running, since it belongs to the newer session.
+        if (generation !== this.loadStatusPollGeneration) return;
+        this.applyLoadStatus(outcome, model);
+      })
       .catch((err: unknown) => {
+        if (generation !== this.loadStatusPollGeneration) return;
         // A blip is fine — the next tick retries. 404/501 means the backend
         // predates the load_status route, where the poll can never succeed:
         // stop and fall back to the lane-appearance check.

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -236,14 +236,17 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
    */
   private static readonly LOAD_STATUS_POLL_INTERVAL_MS = 2500;
   /**
-   * Hard stop for the outcome poll. The orchestrator resolves every manual
-   * load within its load command timeout (30 min) — refusal, confirmed lane,
-   * or a recorded timeout — so well past that the live outcome is gone
-   * (planner restart, entry aged out) and the poll can only re-ask for the
-   * same "unknown". The lane-appearance check in ngOnChanges keeps owning the
-   * note from there on.
+   * Hard stop for the outcome poll. A manual load gets the load command
+   * timeout (30 min) plus the confirmation polling of the same length that
+   * follows it, so the terminal outcome — a refusal, a confirmed lane, or a
+   * recorded timeout — is recorded no later than ~60 min plus lock wait
+   * after dispatch. The cap must outlive that, or it stops asking while a
+   * late failure is still in flight and the note hangs; well past it the
+   * live outcome is gone (planner restart, entry aged out) and the poll can
+   * only re-ask for the same "unknown". The lane-appearance check in
+   * ngOnChanges keeps owning the note from there on.
    */
-  private static readonly LOAD_STATUS_POLL_CAP_MS = 31 * 60 * 1000;
+  private static readonly LOAD_STATUS_POLL_CAP_MS = 65 * 60 * 1000;
   /** Timer handle of the outcome poll; null while not polling. */
   private loadStatusPoll: ReturnType<typeof setInterval> | null = null;
   /** Provider the outcome poll belongs to — anything else is a stale poll. */
@@ -502,7 +505,12 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     this.selectedModel.set(null);
     this.addError.set(null);
     this.pickerProviderId = null;
-    this.stopLoadStatusPoll();
+    // The outcome poll deliberately keeps running: the picker's Close button
+    // is not the end of an accepted load. The pending note stays up, and the
+    // poll is what will surface a background refusal minutes later — stopping
+    // it here would let such a refusal leave the note hanging indefinitely.
+    // It stops on its own when the attempt resolves, is superseded by a new
+    // one, the provider changes, it outlives the cap, or the panel is gone.
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -511,6 +519,10 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     // and submitting it would load a model onto a provider that never served it.
     if (changes['selectedProvider'] && this.pickerProviderId !== this.providerId) {
       this.closePicker();
+      // closePicker() no longer stops the outcome poll on its own (a plain
+      // Close must not kill it) — a provider change abandons the attempt, so
+      // stop it explicitly here.
+      this.stopLoadStatusPoll();
       this.loadModels.set([]);
       this.modelsLoading.set(false);
       this.acceptedModel.set(null);

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -381,26 +381,27 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
   }
 
   /**
-   * Whether a lane action captured for provider `pid` may still touch the
-   * shared signal and error state on its completion.
+   * Monotonic attempt counters, one per action kind.
    *
-   * The signal is shared between attempts while `ngOnChanges` reassigns it on
-   * every provider switch: it only still belongs to the finishing attempt if
-   * the provider is unchanged AND the signal still names the attempt's lane.
-   * A finishing attempt that failed both must not clear the signal — after an
-   * A → B switch, B's own in-flight attempt holds it, and clearing it here
-   * would release the in-flight guard while B's call is still running, so the
-   * next click dispatches a duplicate action to the same lane. The provider
-   * half of the check matters even when the lane ids collide, because a lane
-   * id is per-worker and the same id can be in flight on two workers at once.
+   * (provider, lane id) is not a unique attempt identity: a lane id is
+   * per-worker and can collide across workers, and an A → B → A switch
+   * re-uses both the provider and the lane name for a *newer* attempt while
+   * the older one is still in flight — matching a finishing attempt on that
+   * pair would let it settle the newer attempt's signal and error. Every new
+   * attempt and every provider switch (which abandons the in-flight attempts)
+   * bumps the counter of its kind, so a settling attempt may touch the shared
+   * signal and error only while its counter is still the current one: then no
+   * newer attempt of the kind has started and no switch has happened since it
+   * began.
    */
-  private actionStillOwned(pid: number | null, signal: () => string | null, laneId: string): boolean {
-    return this.providerId === pid && signal() === laneId;
-  }
+  private unloadAttempt = 0;
+  private sleepAttempt = 0;
+  private wakeAttempt = 0;
 
   async handleUnload(laneId: string): Promise<void> {
     const pid = this.providerId;
     if (pid == null || this.unloadingLaneId() != null) return;
+    const attempt = ++this.unloadAttempt;
     this.unloadingLaneId.set(laneId);
     this.unloadError.set(null);
 
@@ -410,10 +411,10 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
     } catch (err: unknown) {
       failed = err;
     }
-    // The operator may have switched workers while the call was in flight;
-    // only the attempt that still owns its signal may settle it — see
-    // actionStillOwned.
-    if (this.actionStillOwned(pid, this.unloadingLaneId, laneId)) {
+    // A newer attempt or a provider switch superseded this one while the call
+    // was in flight — see unloadAttempt. Only the latest attempt may settle
+    // the shared signal and error.
+    if (this.unloadAttempt === attempt) {
       this.unloadingLaneId.set(null);
       if (failed === null) return;
       const e = failed as { status?: number };
@@ -428,6 +429,7 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
   async handleSleep(laneId: string): Promise<void> {
     const pid = this.providerId;
     if (pid == null || this.sleepingLaneId() != null) return;
+    const attempt = ++this.sleepAttempt;
     this.sleepingLaneId.set(laneId);
     this.sleepWakeError.set(null);
 
@@ -438,7 +440,7 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       failed = err;
     }
     // Same ownership rule as handleUnload.
-    if (this.actionStillOwned(pid, this.sleepingLaneId, laneId)) {
+    if (this.sleepAttempt === attempt) {
       this.sleepingLaneId.set(null);
       if (failed !== null) this.sleepWakeError.set(this.sleepWakeErrorText('Sleep', laneId, failed));
     }
@@ -447,6 +449,7 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
   async handleWake(laneId: string): Promise<void> {
     const pid = this.providerId;
     if (pid == null || this.wakingLaneId() != null) return;
+    const attempt = ++this.wakeAttempt;
     this.wakingLaneId.set(laneId);
     this.sleepWakeError.set(null);
 
@@ -457,7 +460,7 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       failed = err;
     }
     // Same ownership rule as handleUnload.
-    if (this.actionStillOwned(pid, this.wakingLaneId, laneId)) {
+    if (this.wakeAttempt === attempt) {
       this.wakingLaneId.set(null);
       if (failed !== null) this.sleepWakeError.set(this.sleepWakeErrorText('Wake', laneId, failed));
     }
@@ -559,6 +562,12 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       this.sleepWakeError.set(null);
       this.sleepingLaneId.set(null);
       this.wakingLaneId.set(null);
+      // The in-flight calls are abandoned as well: when they settle later,
+      // their counters no longer match, so they cannot touch the shared
+      // signal or error of the worker the operator is on now.
+      this.unloadAttempt++;
+      this.sleepAttempt++;
+      this.wakeAttempt++;
     }
     // The lane the operator asked for has arrived in the status stream — the
     // row itself now reports its state, so the pending note has nothing to

--- a/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/lane-health-panel/lane-health-panel.ts
@@ -380,6 +380,9 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       this.unloadingLaneId.set(null);
     } catch (err: unknown) {
       this.unloadingLaneId.set(null);
+      // The operator may have switched workers while the call was in flight;
+      // the refusal belongs to the worker it was sent to, not the one now shown.
+      if (this.providerId !== pid) return;
       const e = err as { status?: number };
       if (e.status === 404 || e.status === 501 || e.status === 0) {
         this.unloadError.set('Action not available on this server yet.');
@@ -400,6 +403,9 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       this.sleepingLaneId.set(null);
     } catch (err: unknown) {
       this.sleepingLaneId.set(null);
+      // The operator may have switched workers while the call was in flight;
+      // the refusal belongs to the worker it was sent to, not the one now shown.
+      if (this.providerId !== pid) return;
       this.sleepWakeError.set(this.sleepWakeErrorText('Sleep', laneId, err));
     }
   }
@@ -415,6 +421,9 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       this.wakingLaneId.set(null);
     } catch (err: unknown) {
       this.wakingLaneId.set(null);
+      // The operator may have switched workers while the call was in flight;
+      // the refusal belongs to the worker it was sent to, not the one now shown.
+      if (this.providerId !== pid) return;
       this.sleepWakeError.set(this.sleepWakeErrorText('Wake', laneId, err));
     }
   }
@@ -498,6 +507,14 @@ export class LaneHealthPanel implements OnChanges, OnDestroy {
       this.modelsLoading.set(false);
       this.acceptedModel.set(null);
       this.acceptedLaneIds = null;
+      // Action feedback belongs to the worker it was reported on: an unload
+      // error or a still-spinning button from worker A must not sit under
+      // worker B's panel after the switch.
+      this.unloadError.set(null);
+      this.unloadingLaneId.set(null);
+      this.sleepWakeError.set(null);
+      this.sleepingLaneId.set(null);
+      this.wakingLaneId.set(null);
     }
     // The lane the operator asked for has arrived in the status stream — the
     // row itself now reports its state, so the pending note has nothing to

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
@@ -17,10 +17,13 @@ describe('WorkerGpuPanel calibration message', () => {
   let panel: WorkerGpuPanel;
   let calibrateResult: { body?: unknown; error?: unknown };
   let settleCalibrate: (() => void) | null;
+  /** Settlers of every call, in order — settleCalibrate is the newest one. */
+  let calibrateSettlers: Array<() => void>;
 
   beforeEach(async () => {
     calibrateResult = {};
     settleCalibrate = null;
+    calibrateSettlers = [];
     await TestBed.configureTestingModule({
       imports: [WorkerGpuPanel],
       providers: [
@@ -29,8 +32,10 @@ describe('WorkerGpuPanel calibration message', () => {
           useValue: {
             calibrateUncalibrated: () =>
               new Promise((resolve, reject) => {
-                settleCalibrate = () =>
+                const settle = () =>
                   calibrateResult.error ? reject(calibrateResult.error) : resolve(calibrateResult.body);
+                calibrateSettlers.push(settle);
+                settleCalibrate = settle;
               }),
           },
         },
@@ -150,5 +155,41 @@ describe('WorkerGpuPanel calibration message', () => {
 
     // The answer belongs to w-a; w-b's panel stays idle.
     expect(panel.calibrateState().kind).toBe('idle');
+  });
+
+  it('drops a stale answer from an earlier calibration of the same worker', async () => {
+    // A → B → A: two calibrations of worker A with a switch in between. The
+    // provider guard cannot tell the attempts apart — both captured A — so
+    // only the per-attempt token keeps the first answer from replacing the
+    // second request's loading state.
+    const first = panel.handleCalibrateUncalibrated();
+    expect(panel.calibrateState().kind).toBe('loading');
+
+    switchTo('w-b');
+    expect(panel.calibrateState().kind).toBe('idle');
+    switchTo('w-a');
+    expect(panel.calibrateState().kind).toBe('idle');
+
+    const second = panel.handleCalibrateUncalibrated();
+    expect(panel.calibrateState().kind).toBe('loading');
+    expect(calibrateSettlers).toHaveLength(2);
+
+    // The first (stale) answer lands first — it belongs to the earlier
+    // attempt and must not touch the newer one's state.
+    calibrateResult.body = { count: 1, models: ['org/a'] };
+    calibrateSettlers[0]();
+    await first;
+
+    expect(panel.calibrateState().kind).toBe('loading');
+
+    // The second answer resolves it.
+    calibrateResult.body = { count: 2, models: ['org/a', 'org/b'] };
+    settleCalibrate?.();
+    await second;
+
+    expect(panel.calibrateState()).toEqual({
+      kind: 'success',
+      message: 'Calibrating 2 model(s): org/a, org/b',
+    });
   });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
@@ -1,0 +1,125 @@
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WorkerGpuPanel } from './worker-gpu-panel';
+import { StatisticsService } from '../../services/statistics.service';
+
+/**
+ * The calibration message under the "Calibrate uncalibrated" button.
+ *
+ * It is the answer to an action on *one* worker: "Calibrating 2 model(s): …"
+ * said on worker A means nothing under worker B's panel. Switching workers
+ * must drop it — and an answer that arrives after the switch belongs to the
+ * worker it was asked for, so it is discarded rather than shown on the new
+ * one.
+ */
+describe('WorkerGpuPanel calibration message', () => {
+  let fixture: ComponentFixture<WorkerGpuPanel>;
+  let panel: WorkerGpuPanel;
+  let calibrateResult: { body?: unknown; error?: unknown };
+  let settleCalibrate: (() => void) | null;
+
+  beforeEach(async () => {
+    calibrateResult = {};
+    settleCalibrate = null;
+    await TestBed.configureTestingModule({
+      imports: [WorkerGpuPanel],
+      providers: [
+        {
+          provide: StatisticsService,
+          useValue: {
+            calibrateUncalibrated: () =>
+              new Promise((resolve, reject) => {
+                settleCalibrate = () =>
+                  calibrateResult.error ? reject(calibrateResult.error) : resolve(calibrateResult.body);
+              }),
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(WorkerGpuPanel);
+    panel = fixture.componentInstance;
+    fixture.componentRef.setInput('providerLatestSamples', { 'w-a': null, 'w-b': null });
+    fixture.componentRef.setInput('providerDevices', {});
+    fixture.componentRef.setInput('providerMeta', { 'w-a': { provider_id: 1 }, 'w-b': { provider_id: 2 } });
+    fixture.componentRef.setInput('lanesByProvider', {});
+    fixture.componentRef.setInput('activeProvider', 'w-a');
+    fixture.detectChanges();
+  });
+
+  /** Move the worker dropdown to another worker, as the framework would. */
+  function switchTo(provider: string): void {
+    const previous = panel.activeProvider;
+    panel.activeProvider = provider;
+    panel.ngOnChanges({ activeProvider: new SimpleChange(previous, provider, true) });
+  }
+
+  it('shows the success message for the worker it calibrated', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    expect(panel.calibrateState().kind).toBe('loading');
+
+    calibrateResult.body = { count: 2, models: ['org/a', 'org/b'] };
+    settleCalibrate?.();
+    await pending;
+
+    expect(panel.calibrateState()).toEqual({
+      kind: 'success',
+      message: 'Calibrating 2 model(s): org/a, org/b',
+    });
+  });
+
+  it('drops the message when the operator switches to another worker', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    calibrateResult.body = { count: 1, models: ['org/a'] };
+    settleCalibrate?.();
+    await pending;
+    expect(panel.calibrateState().kind).toBe('success');
+
+    switchTo('w-b');
+    expect(panel.calibrateState().kind).toBe('idle');
+  });
+
+  it('drops an error message on the switch as well', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    calibrateResult.error = { status: 500, error: { error: 'boom' } };
+    settleCalibrate?.();
+    await pending;
+    expect(panel.calibrateState().kind).toBe('error');
+
+    switchTo('w-b');
+    expect(panel.calibrateState().kind).toBe('idle');
+  });
+
+  it('does not show a stale success answer under the worker the operator moved to', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    // The call is still in flight when the operator switches.
+    switchTo('w-b');
+    expect(panel.calibrateState().kind).toBe('idle');
+
+    calibrateResult.body = { count: 1, models: ['org/a'] };
+    settleCalibrate?.();
+    await pending;
+
+    // The answer belongs to w-a; w-b's panel stays idle.
+    expect(panel.calibrateState().kind).toBe('idle');
+  });
+
+  it('does not show a stale error answer under the worker the operator moved to', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    switchTo('w-b');
+
+    calibrateResult.error = { status: 500, error: { error: 'boom' } };
+    settleCalibrate?.();
+    await pending;
+
+    expect(panel.calibrateState().kind).toBe('idle');
+  });
+
+  it('shows an error for the worker that is still active', async () => {
+    const pending = panel.handleCalibrateUncalibrated();
+    calibrateResult.error = { status: 500, error: { error: 'boom' } };
+    settleCalibrate?.();
+    await pending;
+
+    expect(panel.calibrateState()).toEqual({ kind: 'error', message: 'boom' });
+  });
+});

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.spec.ts
@@ -122,4 +122,33 @@ describe('WorkerGpuPanel calibration message', () => {
 
     expect(panel.calibrateState()).toEqual({ kind: 'error', message: 'boom' });
   });
+
+  it('drops a stale answer when the fallback worker changes under a null selection', async () => {
+    // No explicit selection: the panel shows providers[0]. The calibrate
+    // call goes out to that worker; while it is in flight the worker leaves
+    // the sample list, so the fallback flips to the next worker — without
+    // activeProvider ever changing. The answer must not land under the new
+    // panel.
+    panel.activeProvider = null;
+    panel.ngOnChanges({ activeProvider: new SimpleChange('w-a', null, true) });
+    expect(panel.resolvedActiveProvider).toBe('w-a');
+
+    const pending = panel.handleCalibrateUncalibrated();
+    expect(panel.calibrateState().kind).toBe('loading');
+
+    const previous = panel.providerLatestSamples;
+    panel.providerLatestSamples = { 'w-b': null };
+    panel.ngOnChanges({
+      providerLatestSamples: new SimpleChange(previous, panel.providerLatestSamples, true),
+    });
+    expect(panel.resolvedActiveProvider).toBe('w-b');
+    expect(panel.calibrateState().kind).toBe('idle'); // the flip already dropped the state
+
+    calibrateResult.body = { count: 1, models: ['org/a'] };
+    settleCalibrate?.();
+    await pending;
+
+    // The answer belongs to w-a; w-b's panel stays idle.
+    expect(panel.calibrateState().kind).toBe('idle');
+  });
 });

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
@@ -57,14 +57,22 @@ export class WorkerGpuPanel implements OnChanges {
   /** Worker the in-flight calibrate call was started on — its answer must not
    *  land under a worker the operator has moved on to. */
   private calibrateProvider: string | null = null;
+  /** The resolved worker the last input change settled on. */
+  private resolvedProvider: string | null = null;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (!changes['activeProvider']) return;
+  ngOnChanges(_changes: SimpleChanges): void {
+    const resolved = this.resolvedActiveProvider;
+    if (resolved === this.resolvedProvider) return;
     // The state is the answer to an action on *one* worker: "Calibrating 2
     // model(s): …" said on worker A means nothing under worker B's panel, so
-    // switching workers drops it instead of letting it hang around.
+    // a worker change drops it instead of letting it hang around. Compared
+    // against the *resolved* worker, not the raw selection: with no explicit
+    // selection the panel falls back to the first provider, and that fallback
+    // can change on its own — a worker leaves the list or goes offline — even
+    // though activeProvider itself never changed.
     this.calibrateState.set({ kind: 'idle' });
     this.calibrateProvider = null;
+    this.resolvedProvider = resolved;
   }
 
   // Sorted providers: online-first, then alphabetical
@@ -191,10 +199,11 @@ export class WorkerGpuPanel implements OnChanges {
 
     try {
       const body = await this.statisticsService.calibrateUncalibrated(pid);
-      // The operator can switch workers while the call is in flight; the
-      // answer belongs to the worker it was asked for, so a stale one is
-      // dropped — the switch has already reset the state to idle.
-      if (this.calibrateProvider !== active) return;
+      // The operator can switch workers while the call is in flight — or the
+      // fallback worker can change under a null selection — and the answer
+      // belongs to the worker it was asked for, so a stale one is dropped
+      // rather than shown under the panel the operator is looking at now.
+      if (this.calibrateProvider !== active || this.resolvedActiveProvider !== active) return;
       const count = typeof body?.count === 'number' ? body.count : 0;
       const models = Array.isArray(body?.models) ? (body.models as string[]) : [];
       const message =
@@ -203,7 +212,7 @@ export class WorkerGpuPanel implements OnChanges {
           : `Calibrating ${count} model(s): ${models.join(', ')}`;
       this.calibrateState.set({ kind: 'success', message });
     } catch (err: unknown) {
-      if (this.calibrateProvider !== active) return;
+      if (this.calibrateProvider !== active || this.resolvedActiveProvider !== active) return;
       const e = err as { status?: number; error?: { error?: string } };
       if (e.status === 404 || e.status === 501 || e.status === 0) {
         this.calibrateState.set({

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
@@ -1,4 +1,13 @@
-import { Component, Input, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  inject,
+  signal,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StatisticsService } from '../../services/statistics.service';
 import {
@@ -35,7 +44,7 @@ export function formatMb(mb: number): string {
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './worker-gpu-panel.scss',
 })
-export class WorkerGpuPanel {
+export class WorkerGpuPanel implements OnChanges {
   @Input() providerLatestSamples: Record<string, VramV2Sample | null> = {};
   @Input() providerDevices: Record<string, DeviceInfo[]> = {};
   @Input() providerMeta: Record<string, VramProviderMeta> = {};
@@ -45,6 +54,18 @@ export class WorkerGpuPanel {
   private statisticsService = inject(StatisticsService);
 
   calibrateState = signal<CalibrateState>({ kind: 'idle' });
+  /** Worker the in-flight calibrate call was started on — its answer must not
+   *  land under a worker the operator has moved on to. */
+  private calibrateProvider: string | null = null;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes['activeProvider']) return;
+    // The state is the answer to an action on *one* worker: "Calibrating 2
+    // model(s): …" said on worker A means nothing under worker B's panel, so
+    // switching workers drops it instead of letting it hang around.
+    this.calibrateState.set({ kind: 'idle' });
+    this.calibrateProvider = null;
+  }
 
   // Sorted providers: online-first, then alphabetical
   get providers(): string[] {
@@ -163,11 +184,17 @@ export class WorkerGpuPanel {
 
   async handleCalibrateUncalibrated(): Promise<void> {
     const pid = this.activeProviderId;
-    if (pid == null) return;
+    const active = this.resolvedActiveProvider;
+    if (pid == null || active == null) return;
+    this.calibrateProvider = active;
     this.calibrateState.set({ kind: 'loading' });
 
     try {
       const body = await this.statisticsService.calibrateUncalibrated(pid);
+      // The operator can switch workers while the call is in flight; the
+      // answer belongs to the worker it was asked for, so a stale one is
+      // dropped — the switch has already reset the state to idle.
+      if (this.calibrateProvider !== active) return;
       const count = typeof body?.count === 'number' ? body.count : 0;
       const models = Array.isArray(body?.models) ? (body.models as string[]) : [];
       const message =
@@ -176,6 +203,7 @@ export class WorkerGpuPanel {
           : `Calibrating ${count} model(s): ${models.join(', ')}`;
       this.calibrateState.set({ kind: 'success', message });
     } catch (err: unknown) {
+      if (this.calibrateProvider !== active) return;
       const e = err as { status?: number; error?: { error?: string } };
       if (e.status === 404 || e.status === 501 || e.status === 0) {
         this.calibrateState.set({

--- a/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
+++ b/logos/logos-ui/src/app/features/statistics/components/worker-gpu-panel/worker-gpu-panel.ts
@@ -59,6 +59,11 @@ export class WorkerGpuPanel implements OnChanges {
   private calibrateProvider: string | null = null;
   /** The resolved worker the last input change settled on. */
   private resolvedProvider: string | null = null;
+  /** Calibration attempt counter. Every start and every worker-change reset
+   *  advances it, so an answer only applies while its exact attempt is still
+   *  the current one — the worker name alone cannot tell two calibrations of
+   *  the same worker apart (A → B → A). */
+  private calibrateGeneration = 0;
 
   ngOnChanges(_changes: SimpleChanges): void {
     const resolved = this.resolvedActiveProvider;
@@ -72,6 +77,7 @@ export class WorkerGpuPanel implements OnChanges {
     // though activeProvider itself never changed.
     this.calibrateState.set({ kind: 'idle' });
     this.calibrateProvider = null;
+    this.calibrateGeneration += 1;
     this.resolvedProvider = resolved;
   }
 
@@ -194,16 +200,24 @@ export class WorkerGpuPanel implements OnChanges {
     const pid = this.activeProviderId;
     const active = this.resolvedActiveProvider;
     if (pid == null || active == null) return;
+    const generation = (this.calibrateGeneration += 1);
     this.calibrateProvider = active;
     this.calibrateState.set({ kind: 'loading' });
 
     try {
       const body = await this.statisticsService.calibrateUncalibrated(pid);
       // The operator can switch workers while the call is in flight — or the
-      // fallback worker can change under a null selection — and the answer
-      // belongs to the worker it was asked for, so a stale one is dropped
-      // rather than shown under the panel the operator is looking at now.
-      if (this.calibrateProvider !== active || this.resolvedActiveProvider !== active) return;
+      // fallback worker can change under a null selection, or a newer
+      // calibration of the very same worker can supersede this one (A → B →
+      // A) — and the answer belongs to the attempt it was made for, so a
+      // stale one is dropped rather than shown under the panel the operator
+      // is looking at now.
+      if (
+        generation !== this.calibrateGeneration ||
+        this.calibrateProvider !== active ||
+        this.resolvedActiveProvider !== active
+      )
+        return;
       const count = typeof body?.count === 'number' ? body.count : 0;
       const models = Array.isArray(body?.models) ? (body.models as string[]) : [];
       const message =
@@ -212,7 +226,12 @@ export class WorkerGpuPanel implements OnChanges {
           : `Calibrating ${count} model(s): ${models.join(', ')}`;
       this.calibrateState.set({ kind: 'success', message });
     } catch (err: unknown) {
-      if (this.calibrateProvider !== active || this.resolvedActiveProvider !== active) return;
+      if (
+        generation !== this.calibrateGeneration ||
+        this.calibrateProvider !== active ||
+        this.resolvedActiveProvider !== active
+      )
+        return;
       const e = err as { status?: number; error?: { error?: string } };
       if (e.status === 404 || e.status === 501 || e.status === 0) {
         this.calibrateState.set({

--- a/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
+++ b/logos/logos-ui/src/app/features/statistics/services/statistics.service.ts
@@ -126,6 +126,25 @@ export class StatisticsService {
     }));
   }
 
+  /**
+   * Recorded outcome of the most recent manual load of a model on a worker.
+   *
+   * `status` is `running | succeeded | failed | unknown`. `unknown` means the
+   * orchestrator holds no recorded outcome (it restarted, or the entry aged
+   * out) — callers must not render that as a failure.
+   */
+  getLaneLoadStatus(
+    providerId: number,
+    model: string,
+  ): Promise<{ status?: string; reason?: string; lane_id?: string }> {
+    return firstValueFrom(
+      this.http.post<{ status?: string; reason?: string; lane_id?: string }>(
+        '/api/logosdb/providers/logosnode/lanes/load_status',
+        { provider_id: providerId, model }
+      )
+    );
+  }
+
   unloadLane(providerId: number, laneId: string): Promise<unknown> {
     return firstValueFrom(this.http.post<unknown>('/api/logosdb/providers/logosnode/lanes/delete', {
       provider_id: providerId,

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
@@ -21,6 +21,7 @@ import de.tum.cit.aet.logos.logoswebservice.configuration.dto.ConnectModelProvid
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DeleteLaneRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DeleteProviderRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.DisconnectModelProviderRequestDTO;
+import de.tum.cit.aet.logos.logoswebservice.configuration.dto.LaneLoadStatusRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.GetProviderModelsRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.SleepLaneRequestDTO;
 import de.tum.cit.aet.logos.logoswebservice.configuration.dto.UpdateProviderRequestDTO;
@@ -143,6 +144,20 @@ public class ProviderController {
             return ResponseEntity.badRequest().body(Map.of("error", "provider_id and lane are required"));
         try {
             return workerAdminClient.addLane(req.providerId(), req.lane());
+        } catch (RestClientResponseException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
+        } catch (Exception e) {
+            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/providers/logosnode/lanes/load_status")
+    @PreAuthorize("hasAuthority('" + Role.Names.LOGOS_ADMIN + "')")
+    public ResponseEntity<?> laneLoadStatus(@RequestBody LaneLoadStatusRequestDTO req) {
+        if (req.providerId() == null || req.model() == null || req.model().isBlank())
+            return ResponseEntity.badRequest().body(Map.of("error", "provider_id and model are required"));
+        try {
+            return workerAdminClient.getLaneLoadStatus(req.providerId(), req.model());
         } catch (RestClientResponseException e) {
             return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
         } catch (Exception e) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/controller/ProviderController.java
@@ -161,7 +161,7 @@ public class ProviderController {
         } catch (RestClientResponseException e) {
             return ResponseEntity.status(e.getStatusCode()).body(parseOrWrap(e.getResponseBodyAsString()));
         } catch (Exception e) {
-            return ResponseEntity.status(503).body(Map.of("error", e.getMessage()));
+            return ResponseEntity.status(503).body(errorBody(e));
         }
     }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/LaneLoadStatusRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/LaneLoadStatusRequestDTO.java
@@ -1,0 +1,6 @@
+package de.tum.cit.aet.logos.logoswebservice.configuration.dto;
+
+public record LaneLoadStatusRequestDTO(
+        Integer providerId,
+        String model
+) {}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/LaneLoadStatusRequestDTO.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/configuration/dto/LaneLoadStatusRequestDTO.java
@@ -1,6 +1,15 @@
 package de.tum.cit.aet.logos.logoswebservice.configuration.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The field is pinned to the wire name it is sent with: the webservice mixes
+ * a plain ObjectMapper bean (which would not bind "provider_id" to a
+ * camelCase component) with snake_case request payloads, and the other lane
+ * DTOs only work because the deployed runtime applies the snake_case naming
+ * strategy. Explicit is safe in both worlds.
+ */
 public record LaneLoadStatusRequestDTO(
-        Integer providerId,
+        @JsonProperty("provider_id") Integer providerId,
         String model
 ) {}

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/orchestrator/OrchestratorWorkerAdminClient.java
@@ -56,6 +56,16 @@ public class OrchestratorWorkerAdminClient {
         return post("/internal/logosnode/lanes/add", Map.of("provider_id", providerId, "lane", lane));
     }
 
+    /**
+     * Asks the orchestrator for the outcome of the most recent manual load of a
+     * model. The load itself runs in the background after addLane's 202, and a
+     * refusal there (e.g. not enough VRAM) is otherwise only a log line — the
+     * statistics UI polls this while its "Loading" note is up.
+     */
+    public ResponseEntity<Map> getLaneLoadStatus(int providerId, String model) {
+        return post("/internal/logosnode/lanes/load_status", Map.of("provider_id", providerId, "model", model));
+    }
+
     public ResponseEntity<Map> startModelBenchmark(int modelProviderId, int sampleSize, int maxOutputTokens) {
         return post(
             "/internal/model_benchmarks/run",

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -370,8 +370,9 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     }
 
     private void pushVramInit(WebSocketSession session, SessionState state) {
+        VramWindow window = null;
         try {
-            VramWindow window = state.vramWindow.get();
+            window = state.vramWindow.get();
             // A baseline already went out for this window — the websocket
             // thread's init or an earlier tick's retry established it:
             // pushing the full day again would only restate what the viewer
@@ -390,7 +391,13 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             }
         } catch (Exception e) {
             log.warn("[ws/stats/v2] vram_init error: {}", e.getMessage());
-            send(session, Map.of("type", "vram_init", "payload", Map.of("error", "Failed to load VRAM data")));
+            // The error belongs to the window this init was captured for. If
+            // a day change swapped it out while the query was in flight, the
+            // newer window's init owns the viewer's baseline now — publishing
+            // this stale failure would overwrite a good day with an error.
+            if (window != null && isCurrentVramWindow(state, window)) {
+                send(session, Map.of("type", "vram_init", "payload", Map.of("error", "Failed to load VRAM data")));
+            }
         }
     }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -327,9 +327,14 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                         pushTimelineDelta(session, state);
                     }
                 }
-                if (t % 5 == 0) {
-                    pushVramDelta(session, state);
-                }
+                // VRAM deltas ride every tick: a lane the worker just loaded
+                // reaches the UI within one second of its status report
+                // instead of waiting up to five for the next vram cadence.
+                // The fetch is cursor-scoped (new snapshots only) and the
+                // provider-status hop is cached for 3 s, so the per-tick cost
+                // stays small; the push itself is still skipped when nothing
+                // moved (no new samples, cursor, or connection state).
+                pushVramDelta(session, state);
                 // Aggregates are the expensive push (findTotals alone scans the
                 // range twice more for tokens and cost), so they go out at a
                 // tenth of the request cadence and only when something in

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -41,16 +41,19 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private static final int LATEST_REQUESTS_PUSH_SIZE = RequestLogService.LATEST_REQUESTS_PAGE_SIZE;
 
 
-    private static class SessionState {
+    // Package-private, with its fields, so the unit test can pin the
+    // isCurrentVramWindow predicate on a real state instance.
+    static class SessionState {
         volatile boolean initialized = false;
         volatile String logosKey = "";
 
         volatile String vramDay = null;
         volatile int vramCursor = 0;
-        // Bumped on every vram window change (init, set_vram_day). A delta
-        // query that is in flight on the tick thread when the window changes
-        // on the websocket thread must not write the previous window's
-        // cursor and connection-state baseline back into the fresh state.
+        // Bumped on every vram window change (init, set_vram_day) BEFORE the
+        // new day and cursor are written: it is the commit point of the
+        // change. A delta captured before the change holds the old generation
+        // and is discarded when the bump lands; a delta that reads the new
+        // generation never pairs it with the old day.
         volatile int vramDayGeneration = 0;
 
         // The user-selected window. The live delta slide advances only the end
@@ -203,10 +206,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleInit(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         state.initialized = false;
 
+        // The generation bump precedes the window fields — see vramDayGeneration.
+        state.vramDayGeneration++;
         Object dayObj = msg.get("vram_day");
         state.vramDay = (dayObj instanceof String s && !s.isBlank()) ? s : null;
         state.vramCursor = 0;
-        state.vramDayGeneration++;
 
         Object tdObj = msg.get("timeline_deltas");
         state.deltaEnabled = tdObj == null || coerceBool(tdObj, true);
@@ -295,9 +299,10 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleSetVramDay(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         Object dayObj = msg.get("day");
         if (dayObj instanceof String s && !s.isBlank()) {
+            // The generation bump precedes the window fields — see vramDayGeneration.
+            state.vramDayGeneration++;
             state.vramDay = s;
             state.vramCursor = 0;
-            state.vramDayGeneration++;
             pushVramInit(session, state);
         }
     }
@@ -376,15 +381,19 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
     private void pushVramDelta(WebSocketSession session, SessionState state) {
         try {
-            String day = state.vramDay != null ? state.vramDay : LocalDate.now(ZoneOffset.UTC).toString();
+            // The generation is captured first, before the day and the
+            // cursor: a window change on the websocket thread (init,
+            // set_vram_day) bumps the generation before it writes the new
+            // day, so a stale day can never be paired with a fresh
+            // generation, and whatever the in-flight query fetched is
+            // checked against the window that is current when it returns —
+            // writing it back otherwise would send previous-day samples and
+            // overwrite the new day's cursor and connection-state baseline.
             int generation = state.vramDayGeneration;
-            Map<String, Object> payload = vramService.getVramStats(day, state.vramCursor);
-            // The window can change on the websocket thread (init, set_vram_day)
-            // while the query is in flight on the tick thread. The late result
-            // then describes the previous day and is dropped — writing it back
-            // would send previous-day samples and overwrite the new day's
-            // cursor and connection-state baseline.
-            if (generation != state.vramDayGeneration) return;
+            String day = state.vramDay != null ? state.vramDay : LocalDate.now(ZoneOffset.UTC).toString();
+            int cursor = state.vramCursor;
+            Map<String, Object> payload = vramService.getVramStats(day, cursor);
+            if (!isCurrentVramWindow(generation, day, state)) return;
             Object sid = payload.get("last_snapshot_id");
             int nextCursor = sid instanceof Number n ? n.intValue() : state.vramCursor;
             // Providers are always present (connection metadata is attached
@@ -403,6 +412,17 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         } catch (Exception e) {
             log.warn("[ws/stats/v2] vram_delta error: {}", e.getMessage());
         }
+    }
+
+    // Whether a vram window snapshot captured on the tick thread still
+    // describes the state's current window. The generation is the primary
+    // check; the day comparison is what makes the capture order matter —
+    // a stale day read before a window change can never be paired with the
+    // change's fresh generation and pass, so an in-flight query that spans
+    // the change is dropped whatever it fetched.
+    static boolean isCurrentVramWindow(int generation, String day, SessionState state) {
+        return generation == state.vramDayGeneration
+                && (state.vramDay == null || state.vramDay.equals(day));
     }
 
     private static boolean hasSamples(Map<String, Object> payload) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,20 +42,26 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private static final int LATEST_REQUESTS_PUSH_SIZE = RequestLogService.LATEST_REQUESTS_PAGE_SIZE;
 
 
+    // The vram window a session is looking at: the selected day (null =
+    // today), the cursor into it, and the provider connection-state baseline.
+    // One immutable reference so a transition (init, set_vram_day) is a single
+    // atomic swap and the tick thread's snapshot is a single atomic read —
+    // transition and snapshot can never disagree. Separate volatile fields
+    // (however ordered) cannot guarantee that: the writer can always pause
+    // between the generation bump and the day write, letting the tick capture
+    // a fresh generation with the stale day.
+    record VramWindow(String day, int cursor, String metaSig) {}
+
     // Package-private, with its fields, so the unit test can pin the
     // isCurrentVramWindow predicate on a real state instance.
     static class SessionState {
         volatile boolean initialized = false;
         volatile String logosKey = "";
 
-        volatile String vramDay = null;
-        volatile int vramCursor = 0;
-        // Bumped on every vram window change (init, set_vram_day) BEFORE the
-        // new day and cursor are written: it is the commit point of the
-        // change. A delta captured before the change holds the old generation
-        // and is discarded when the bump lands; a delta that reads the new
-        // generation never pairs it with the old day.
-        volatile int vramDayGeneration = 0;
+        // The current vram window; swapped atomically on every change. The
+        // reference identity is the generation: any earlier snapshot is stale
+        // the moment it is swapped out, whatever the writer paused on.
+        final AtomicReference<VramWindow> vramWindow = new AtomicReference<>(new VramWindow(null, 0, ""));
 
         // The user-selected window. The live delta slide advances only the end
         // to "now"; the start stays anchored where the preset put it.
@@ -96,7 +103,6 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         // a baseline and does not trigger a redundant stats push on top of
         // the one timeline_init already sent.
         volatile String prevScopeSig = "";
-        volatile String prevVramMetaSig = "";
 
         // Traffic moved since the last aggregate push, so the totals the
         // statistics page shows are out of date. Recomputing them is a scan of
@@ -206,11 +212,9 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleInit(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         state.initialized = false;
 
-        // The generation bump precedes the window fields — see vramDayGeneration.
-        state.vramDayGeneration++;
         Object dayObj = msg.get("vram_day");
-        state.vramDay = (dayObj instanceof String s && !s.isBlank()) ? s : null;
-        state.vramCursor = 0;
+        state.vramWindow.set(new VramWindow(
+            (dayObj instanceof String s && !s.isBlank()) ? s : null, 0, ""));
 
         Object tdObj = msg.get("timeline_deltas");
         state.deltaEnabled = tdObj == null || coerceBool(tdObj, true);
@@ -299,10 +303,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleSetVramDay(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         Object dayObj = msg.get("day");
         if (dayObj instanceof String s && !s.isBlank()) {
-            // The generation bump precedes the window fields — see vramDayGeneration.
-            state.vramDayGeneration++;
-            state.vramDay = s;
-            state.vramCursor = 0;
+            state.vramWindow.set(new VramWindow(s, 0, ""));
             pushVramInit(session, state);
         }
     }
@@ -368,12 +369,18 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
     private void pushVramInit(WebSocketSession session, SessionState state) {
         try {
-            String day = state.vramDay != null ? state.vramDay : LocalDate.now(ZoneOffset.UTC).toString();
+            VramWindow window = state.vramWindow.get();
+            String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
             Map<String, Object> payload = vramService.getVramStats(day, 0);
             Object sid = payload.get("last_snapshot_id");
-            state.vramCursor = sid instanceof Number n ? n.intValue() : 0;
-            state.prevVramMetaSig = vramMetaSig(payload);
-            send(session, Map.of("type", "vram_init", "payload", payload));
+            int cursor = sid instanceof Number n ? n.intValue() : 0;
+            // The payload belongs to the window it was captured for; if a
+            // window change swapped the reference meanwhile, that window's
+            // init is responsible for the push — the stale baseline is
+            // dropped together with the stale payload.
+            if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), cursor, vramMetaSig(payload)))) {
+                send(session, Map.of("type", "vram_init", "payload", payload));
+            }
         } catch (Exception e) {
             send(session, Map.of("type", "vram_init", "payload", Map.of("error", "Failed to load VRAM data")));
         }
@@ -381,21 +388,18 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
     private void pushVramDelta(WebSocketSession session, SessionState state) {
         try {
-            // The generation is captured first, before the day and the
-            // cursor: a window change on the websocket thread (init,
-            // set_vram_day) bumps the generation before it writes the new
-            // day, so a stale day can never be paired with a fresh
-            // generation, and whatever the in-flight query fetched is
-            // checked against the window that is current when it returns —
-            // writing it back otherwise would send previous-day samples and
-            // overwrite the new day's cursor and connection-state baseline.
-            int generation = state.vramDayGeneration;
-            String day = state.vramDay != null ? state.vramDay : LocalDate.now(ZoneOffset.UTC).toString();
-            int cursor = state.vramCursor;
-            Map<String, Object> payload = vramService.getVramStats(day, cursor);
-            if (!isCurrentVramWindow(generation, day, state)) return;
+            // The snapshot is one atomic read: whatever the in-flight query
+            // fetched is checked against the very reference it was captured
+            // from, and written back only by compareAndSet. A window change
+            // (init, set_vram_day) swaps the reference, so an in-flight delta
+            // spanning the change is dropped whatever it fetched — it can
+            // never send previous-day samples or overwrite the new day's
+            // cursor and connection-state baseline.
+            VramWindow window = state.vramWindow.get();
+            String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
+            Map<String, Object> payload = vramService.getVramStats(day, window.cursor());
             Object sid = payload.get("last_snapshot_id");
-            int nextCursor = sid instanceof Number n ? n.intValue() : state.vramCursor;
+            int nextCursor = sid instanceof Number n ? n.intValue() : window.cursor();
             // Providers are always present (connection metadata is attached
             // even without new snapshots), so deltas are pushed only when new
             // samples arrived, the cursor moved, or a provider's connection
@@ -403,26 +407,25 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             // no new snapshots arrive anymore).
             boolean hasNewSamples = hasSamples(payload);
             String metaSig = vramMetaSig(payload);
-            boolean metaChanged = !metaSig.equals(state.prevVramMetaSig);
-            if (hasNewSamples || nextCursor != state.vramCursor || metaChanged) {
-                state.vramCursor = nextCursor;
-                state.prevVramMetaSig = metaSig;
-                send(session, Map.of("type", "vram_delta", "payload", payload));
+            boolean metaChanged = !metaSig.equals(window.metaSig());
+            if (hasNewSamples || nextCursor != window.cursor() || metaChanged) {
+                if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), nextCursor, metaSig))) {
+                    send(session, Map.of("type", "vram_delta", "payload", payload));
+                }
             }
         } catch (Exception e) {
             log.warn("[ws/stats/v2] vram_delta error: {}", e.getMessage());
         }
     }
 
-    // Whether a vram window snapshot captured on the tick thread still
-    // describes the state's current window. The generation is the primary
-    // check; the day comparison is what makes the capture order matter —
-    // a stale day read before a window change can never be paired with the
-    // change's fresh generation and pass, so an in-flight query that spans
-    // the change is dropped whatever it fetched.
-    static boolean isCurrentVramWindow(int generation, String day, SessionState state) {
-        return generation == state.vramDayGeneration
-                && (state.vramDay == null || state.vramDay.equals(day));
+    // Whether a vram window snapshot captured on the tick thread is still the
+    // state's current window. The reference identity is the check: a
+    // transition is a single atomic swap, so a fresh-generation/stale-day
+    // pairing — what separate volatile fields allowed when the writer paused
+    // between the generation bump and the day write — is not expressible,
+    // and any snapshot swapped out is stale whatever it fetched.
+    static boolean isCurrentVramWindow(SessionState state, VramWindow snapshot) {
+        return state.vramWindow.get() == snapshot;
     }
 
     private static boolean hasSamples(Map<String, Object> payload) {

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -47,6 +47,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
         volatile String vramDay = null;
         volatile int vramCursor = 0;
+        // Bumped on every vram window change (init, set_vram_day). A delta
+        // query that is in flight on the tick thread when the window changes
+        // on the websocket thread must not write the previous window's
+        // cursor and connection-state baseline back into the fresh state.
+        volatile int vramDayGeneration = 0;
 
         // The user-selected window. The live delta slide advances only the end
         // to "now"; the start stays anchored where the preset put it.
@@ -201,6 +206,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         Object dayObj = msg.get("vram_day");
         state.vramDay = (dayObj instanceof String s && !s.isBlank()) ? s : null;
         state.vramCursor = 0;
+        state.vramDayGeneration++;
 
         Object tdObj = msg.get("timeline_deltas");
         state.deltaEnabled = tdObj == null || coerceBool(tdObj, true);
@@ -291,6 +297,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         if (dayObj instanceof String s && !s.isBlank()) {
             state.vramDay = s;
             state.vramCursor = 0;
+            state.vramDayGeneration++;
             pushVramInit(session, state);
         }
     }
@@ -370,7 +377,14 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void pushVramDelta(WebSocketSession session, SessionState state) {
         try {
             String day = state.vramDay != null ? state.vramDay : LocalDate.now(ZoneOffset.UTC).toString();
+            int generation = state.vramDayGeneration;
             Map<String, Object> payload = vramService.getVramStats(day, state.vramCursor);
+            // The window can change on the websocket thread (init, set_vram_day)
+            // while the query is in flight on the tick thread. The late result
+            // then describes the previous day and is dropped — writing it back
+            // would send previous-day samples and overwrite the new day's
+            // cursor and connection-state baseline.
+            if (generation != state.vramDayGeneration) return;
             Object sid = payload.get("last_snapshot_id");
             int nextCursor = sid instanceof Number n ? n.intValue() : state.vramCursor;
             // Providers are always present (connection metadata is attached

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -65,6 +65,14 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         // the moment it is swapped out, whatever the writer paused on.
         final AtomicReference<VramWindow> vramWindow = new AtomicReference<>(new VramWindow(null, 0, "", false));
 
+        // The one ordering mechanism between window transitions and
+        // publication. The tick's delta (capture to send) and every
+        // transition (the swap plus its init push) run under it, so a push
+        // for a superseded window always reaches the viewer before the newer
+        // window's init: the compareAndSet guards the state, this guard
+        // guards the order the messages arrive in.
+        final Object vramLock = new Object();
+
         // The user-selected window. The live delta slide advances only the end
         // to "now"; the start stays anchored where the preset put it.
         volatile String timelineStart;
@@ -215,8 +223,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         state.initialized = false;
 
         Object dayObj = msg.get("vram_day");
-        state.vramWindow.set(new VramWindow(
-            (dayObj instanceof String s && !s.isBlank()) ? s : null, 0, "", false));
+        String vramDay = (dayObj instanceof String s && !s.isBlank()) ? s : null;
 
         Object tdObj = msg.get("timeline_deltas");
         state.deltaEnabled = tdObj == null || coerceBool(tdObj, true);
@@ -245,7 +252,12 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         state.prevScopeSig = "";
 
         pushTimelineInit(session, state);
-        pushVramInit(session, state);
+        // The window swap and its init publication are one critical section
+        // on the vram lock — see vramLock.
+        synchronized (state.vramLock) {
+            state.vramWindow.set(new VramWindow(vramDay, 0, "", false));
+            pushVramInit(session, state);
+        }
         pushRequests(session, state, true);
         state.initialized = true;
     }
@@ -305,8 +317,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleSetVramDay(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         Object dayObj = msg.get("day");
         if (dayObj instanceof String s && !s.isBlank()) {
-            state.vramWindow.set(new VramWindow(s, 0, "", false));
-            pushVramInit(session, state);
+            // One critical section on the vram lock — see vramLock.
+            synchronized (state.vramLock) {
+                state.vramWindow.set(new VramWindow(s, 0, "", false));
+                pushVramInit(session, state);
+            }
         }
     }
 
@@ -402,46 +417,56 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     }
 
     private void pushVramDelta(WebSocketSession session, SessionState state) {
-        try {
-            // The snapshot is one atomic read: whatever the in-flight query
-            // fetched is checked against the very reference it was captured
-            // from, and written back only by compareAndSet. A window change
-            // (init, set_vram_day) swaps the reference, so an in-flight delta
-            // spanning the change is dropped whatever it fetched — it can
-            // never send previous-day samples or overwrite the new day's
-            // cursor and connection-state baseline.
-            VramWindow window = state.vramWindow.get();
-            // A window whose init has not gone out yet is not consumable by a
-            // delta: init and the first delta after a day change query the
-            // same (day, cursor 0) and race for the write-back — whichever
-            // loses the compareAndSet drops its push, and a delta winning
-            // that race would owe the viewer a full-day "init" that never
-            // comes. Instead the tick retries the owed init: one transient
-            // failure of the websocket thread's init must not wedge the
-            // session's vram feed behind a window no push will ever touch.
-            if (!window.baselineSent()) {
-                pushVramInit(session, state);
-                return;
-            }
-            String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
-            Map<String, Object> payload = vramService.getVramStats(day, window.cursor());
-            Object sid = payload.get("last_snapshot_id");
-            int nextCursor = sid instanceof Number n ? n.intValue() : window.cursor();
-            // Providers are always present (connection metadata is attached
-            // even without new snapshots), so deltas are pushed only when new
-            // samples arrived, the cursor moved, or a provider's connection
-            // state flipped (e.g. a worker went offline — exactly the moment
-            // no new snapshots arrive anymore).
-            boolean hasNewSamples = hasSamples(payload);
-            String metaSig = vramMetaSig(payload);
-            boolean metaChanged = !metaSig.equals(window.metaSig());
-            if (hasNewSamples || nextCursor != window.cursor() || metaChanged) {
-                if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), nextCursor, metaSig, window.baselineSent()))) {
-                    send(session, Map.of("type", "vram_delta", "payload", payload));
+        // The whole capture-to-send section runs on the vram lock (see
+        // vramLock): a window transition cannot land between this delta's
+        // capture and its publication, so a push for a superseded window
+        // always reaches the viewer before the newer window's init. The
+        // compareAndSet below stays as the state-level guard.
+        synchronized (state.vramLock) {
+            try {
+                // The snapshot is one atomic read: whatever the in-flight
+                // query fetched is checked against the very reference it was
+                // captured from, and written back only by compareAndSet. A
+                // window change (init, set_vram_day) swaps the reference, so
+                // an in-flight delta spanning the change is dropped whatever
+                // it fetched — it can never send previous-day samples or
+                // overwrite the new day's cursor and connection-state
+                // baseline.
+                VramWindow window = state.vramWindow.get();
+                // A window whose init has not gone out yet is not consumable
+                // by a delta: init and the first delta after a day change
+                // query the same (day, cursor 0) and race for the write-back
+                // — whichever loses the compareAndSet drops its push, and a
+                // delta winning that race would owe the viewer a full-day
+                // "init" that never comes. Instead the tick retries the owed
+                // init: one transient failure of the websocket thread's init
+                // must not wedge the session's vram feed behind a window no
+                // push will ever touch.
+                if (!window.baselineSent()) {
+                    pushVramInit(session, state);
+                    return;
                 }
+                String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
+                Map<String, Object> payload = vramService.getVramStats(day, window.cursor());
+                Object sid = payload.get("last_snapshot_id");
+                int nextCursor = sid instanceof Number n ? n.intValue() : window.cursor();
+                // Providers are always present (connection metadata is
+                // attached even without new snapshots), so deltas are pushed
+                // only when new samples arrived, the cursor moved, or a
+                // provider's connection state flipped (e.g. a worker went
+                // offline — exactly the moment no new snapshots arrive
+                // anymore).
+                boolean hasNewSamples = hasSamples(payload);
+                String metaSig = vramMetaSig(payload);
+                boolean metaChanged = !metaSig.equals(window.metaSig());
+                if (hasNewSamples || nextCursor != window.cursor() || metaChanged) {
+                    if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), nextCursor, metaSig, window.baselineSent()))) {
+                        send(session, Map.of("type", "vram_delta", "payload", payload));
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("[ws/stats/v2] vram_delta error: {}", e.getMessage());
             }
-        } catch (Exception e) {
-            log.warn("[ws/stats/v2] vram_delta error: {}", e.getMessage());
         }
     }
 

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -372,6 +372,11 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void pushVramInit(WebSocketSession session, SessionState state) {
         try {
             VramWindow window = state.vramWindow.get();
+            // A baseline already went out for this window — the websocket
+            // thread's init or an earlier tick's retry established it:
+            // pushing the full day again would only restate what the viewer
+            // has.
+            if (window.baselineSent()) return;
             String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
             Map<String, Object> payload = vramService.getVramStats(day, 0);
             Object sid = payload.get("last_snapshot_id");
@@ -384,6 +389,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
                 send(session, Map.of("type", "vram_init", "payload", payload));
             }
         } catch (Exception e) {
+            log.warn("[ws/stats/v2] vram_init error: {}", e.getMessage());
             send(session, Map.of("type", "vram_init", "payload", Map.of("error", "Failed to load VRAM data")));
         }
     }
@@ -398,14 +404,18 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             // never send previous-day samples or overwrite the new day's
             // cursor and connection-state baseline.
             VramWindow window = state.vramWindow.get();
-            // A window whose init has not gone out yet is not consumable:
-            // init and the first delta after a day change query the same
-            // (day, cursor 0) and race for the write-back — whichever loses
-            // the compareAndSet drops its push, and a delta winning that race
-            // would owe the viewer a full-day "init" that never comes. The
-            // init runs on the websocket thread the moment the window moves,
-            // so the next tick already sees the baseline.
-            if (!window.baselineSent()) return;
+            // A window whose init has not gone out yet is not consumable by a
+            // delta: init and the first delta after a day change query the
+            // same (day, cursor 0) and race for the write-back — whichever
+            // loses the compareAndSet drops its push, and a delta winning
+            // that race would owe the viewer a full-day "init" that never
+            // comes. Instead the tick retries the owed init: one transient
+            // failure of the websocket thread's init must not wedge the
+            // session's vram feed behind a window no push will ever touch.
+            if (!window.baselineSent()) {
+                pushVramInit(session, state);
+                return;
+            }
             String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
             Map<String, Object> payload = vramService.getVramStats(day, window.cursor());
             Object sid = payload.get("last_snapshot_id");

--- a/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
+++ b/logos/logos-webservice/src/main/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandler.java
@@ -43,14 +43,16 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
 
     // The vram window a session is looking at: the selected day (null =
-    // today), the cursor into it, and the provider connection-state baseline.
-    // One immutable reference so a transition (init, set_vram_day) is a single
-    // atomic swap and the tick thread's snapshot is a single atomic read —
-    // transition and snapshot can never disagree. Separate volatile fields
-    // (however ordered) cannot guarantee that: the writer can always pause
-    // between the generation bump and the day write, letting the tick capture
-    // a fresh generation with the stale day.
-    record VramWindow(String day, int cursor, String metaSig) {}
+    // today), the cursor into it, the provider connection-state baseline, and
+    // whether the window's init — the full-day payload that establishes the
+    // viewer's baseline — has gone out. One immutable reference so a
+    // transition (init, set_vram_day) is a single atomic swap and the tick
+    // thread's snapshot is a single atomic read — transition and snapshot can
+    // never disagree. Separate volatile fields (however ordered) cannot
+    // guarantee that: the writer can always pause between the generation bump
+    // and the day write, letting the tick capture a fresh generation with the
+    // stale day.
+    record VramWindow(String day, int cursor, String metaSig, boolean baselineSent) {}
 
     // Package-private, with its fields, so the unit test can pin the
     // isCurrentVramWindow predicate on a real state instance.
@@ -61,7 +63,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
         // The current vram window; swapped atomically on every change. The
         // reference identity is the generation: any earlier snapshot is stale
         // the moment it is swapped out, whatever the writer paused on.
-        final AtomicReference<VramWindow> vramWindow = new AtomicReference<>(new VramWindow(null, 0, ""));
+        final AtomicReference<VramWindow> vramWindow = new AtomicReference<>(new VramWindow(null, 0, "", false));
 
         // The user-selected window. The live delta slide advances only the end
         // to "now"; the start stays anchored where the preset put it.
@@ -214,7 +216,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
 
         Object dayObj = msg.get("vram_day");
         state.vramWindow.set(new VramWindow(
-            (dayObj instanceof String s && !s.isBlank()) ? s : null, 0, ""));
+            (dayObj instanceof String s && !s.isBlank()) ? s : null, 0, "", false));
 
         Object tdObj = msg.get("timeline_deltas");
         state.deltaEnabled = tdObj == null || coerceBool(tdObj, true);
@@ -303,7 +305,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
     private void handleSetVramDay(WebSocketSession session, SessionState state, Map<String, Object> msg) {
         Object dayObj = msg.get("day");
         if (dayObj instanceof String s && !s.isBlank()) {
-            state.vramWindow.set(new VramWindow(s, 0, ""));
+            state.vramWindow.set(new VramWindow(s, 0, "", false));
             pushVramInit(session, state);
         }
     }
@@ -378,7 +380,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             // window change swapped the reference meanwhile, that window's
             // init is responsible for the push — the stale baseline is
             // dropped together with the stale payload.
-            if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), cursor, vramMetaSig(payload)))) {
+            if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), cursor, vramMetaSig(payload), true))) {
                 send(session, Map.of("type", "vram_init", "payload", payload));
             }
         } catch (Exception e) {
@@ -396,6 +398,14 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             // never send previous-day samples or overwrite the new day's
             // cursor and connection-state baseline.
             VramWindow window = state.vramWindow.get();
+            // A window whose init has not gone out yet is not consumable:
+            // init and the first delta after a day change query the same
+            // (day, cursor 0) and race for the write-back — whichever loses
+            // the compareAndSet drops its push, and a delta winning that race
+            // would owe the viewer a full-day "init" that never comes. The
+            // init runs on the websocket thread the moment the window moves,
+            // so the next tick already sees the baseline.
+            if (!window.baselineSent()) return;
             String day = window.day() != null ? window.day() : LocalDate.now(ZoneOffset.UTC).toString();
             Map<String, Object> payload = vramService.getVramStats(day, window.cursor());
             Object sid = payload.get("last_snapshot_id");
@@ -409,7 +419,7 @@ public class StatsV2WebSocketHandler extends TextWebSocketHandler {
             String metaSig = vramMetaSig(payload);
             boolean metaChanged = !metaSig.equals(window.metaSig());
             if (hasNewSamples || nextCursor != window.cursor() || metaChanged) {
-                if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), nextCursor, metaSig))) {
+                if (state.vramWindow.compareAndSet(window, new VramWindow(window.day(), nextCursor, metaSig, window.baselineSent()))) {
                     send(session, Map.of("type", "vram_delta", "payload", payload));
                 }
             }

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -142,7 +142,7 @@ class StatsV2WebSocketHandlerLivePushTest {
 
         // The delta's day1 query (cursor 100) only returns after the
         // operator's set_vram_day has run to completion in the meantime —
-        // the exact interleaving the generation token guards against: the
+        // the exact interleaving the atomic window guards against: the
         // tick thread's in-flight query meets the websocket thread's window
         // change.
         when(vramService.getVramStats(day2, 0)).thenReturn(vramPayload(200, "offline"));
@@ -151,15 +151,15 @@ class StatsV2WebSocketHandlerLivePushTest {
             return vramPayload(100, "connected");
         });
 
-        Object state = ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
+        StatsV2WebSocketHandler.SessionState state = (StatsV2WebSocketHandler.SessionState)
+            ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
         ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
 
         // The late delta describes day1: it must not be sent, and it must
         // not write day1's cursor or connection-state baseline over the ones
         // day2's init just established.
-        assertThat(ReflectionTestUtils.getField(state, "vramCursor")).isEqualTo(200);
-        Object metaSig = ReflectionTestUtils.getField(state, "prevVramMetaSig");
-        assertThat(metaSig).asString().contains("offline").doesNotContain("connected");
+        assertThat(state.vramWindow.get().cursor()).isEqualTo(200);
+        assertThat(state.vramWindow.get().metaSig()).contains("offline").doesNotContain("connected");
 
         ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
         verify(session, atLeastOnce()).sendMessage(captor.capture());
@@ -169,23 +169,30 @@ class StatsV2WebSocketHandlerLivePushTest {
 
     @Test
     void a_stale_day_with_a_fresh_generation_is_not_a_current_window() {
-        // The interleaving the generation guard must survive: the delta reads
-        // the day before set_vram_day runs, the generation after it — the old
-        // day paired with the change's fresh generation. That snapshot must
-        // not pass the current-window check, whatever the query fetched for
-        // it; with the generation read first, it is the only pairing the
-        // capture order cannot produce.
+        // The interleaving the separate volatile fields had to survive — the
+        // delta reads the day before set_vram_day runs, the generation after
+        // it — is not expressible anymore: the window is one immutable
+        // reference, so a snapshot either is the current window or it is
+        // not, whatever the writer paused on and whatever the query fetched.
         StatsV2WebSocketHandler.SessionState state = new StatsV2WebSocketHandler.SessionState();
-        // The window has moved to day2 at generation 2.
-        state.vramDay = "2026-09-02";
-        state.vramCursor = 200;
-        state.vramDayGeneration = 2;
+        StatsV2WebSocketHandler.VramWindow stale = new StatsV2WebSocketHandler.VramWindow("2026-09-01", 100, "connected");
+        state.vramWindow.set(stale);
 
-        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(2, "2026-09-01", state)).isFalse();
+        // A snapshot of the window the state is in passes.
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(state, stale)).isTrue();
+
+        // The window moves to day2: the old snapshot is stale the moment it
+        // is swapped out, whatever the in-flight day1 query fetched for it.
+        StatsV2WebSocketHandler.VramWindow current = new StatsV2WebSocketHandler.VramWindow("2026-09-02", 200, "offline");
+        state.vramWindow.set(current);
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(state, stale)).isFalse();
         // A coherent snapshot of the window the state is in still passes.
-        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(2, "2026-09-02", state)).isTrue();
-        // And the fully stale snapshot of the moved-out window does not.
-        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(1, "2026-09-01", state)).isFalse();
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(state, current)).isTrue();
+        // And a superseded snapshot of the moved-in window does not: a delta
+        // paused between its capture and its write-back loses the
+        // compareAndSet against the writer's transition.
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(
+            state, new StatsV2WebSocketHandler.VramWindow("2026-09-02", 0, ""))).isFalse();
     }
 
     @Test

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -259,6 +259,50 @@ class StatsV2WebSocketHandlerLivePushTest {
     }
 
     @Test
+    void a_stale_failed_init_does_not_publish_an_error_over_a_newer_day() throws Exception {
+        // Stop the tick scheduler: the test drives the two threads' steps
+        // itself, in the interleaving order.
+        handler.shutdown();
+
+        String day1 = "2026-09-01";
+        String day2 = "2026-09-02";
+        when(vramService.getVramStats(day1, 0)).thenReturn(vramPayload(100, "connected"));
+        when(vramService.getVramStats(day2, 0)).thenReturn(vramPayload(200, "offline"));
+
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\",\"vram_day\":\"" + day1 + "\"}"));
+        clearInvocations(session);
+
+        StatsV2WebSocketHandler.SessionState state = (StatsV2WebSocketHandler.SessionState)
+            ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
+
+        // The init retry on the day1 window is in its query when the
+        // operator moves on to day2: day2's init establishes its baseline,
+        // and the stale day1 query then fails. Its error must not overwrite
+        // day2's fresh baseline — the success path drops a stale payload via
+        // the compareAndSet, and the error path must drop a stale failure the
+        // same way.
+        state.vramWindow.set(new StatsV2WebSocketHandler.VramWindow(day1, 0, "", false));
+        when(vramService.getVramStats(day1, 0)).thenAnswer(inv -> {
+            handler.handleMessage(session, new TextMessage("{\"action\":\"set_vram_day\",\"day\":\"" + day2 + "\"}"));
+            throw new RuntimeException("db blip");
+        });
+        ReflectionTestUtils.invokeMethod(handler, "pushVramInit", session, state);
+
+        // Day2's baseline is what the viewer is on now, and no stale error
+        // has gone out on top of it.
+        assertThat(state.vramWindow.get().day()).isEqualTo(day2);
+        assertThat(state.vramWindow.get().cursor()).isEqualTo(200);
+        assertThat(state.vramWindow.get().baselineSent()).isTrue();
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getAllValues())
+            .anyMatch(m -> m.getPayload().contains("\"type\":\"vram_init\"")
+                    && m.getPayload().contains("\"last_snapshot_id\":200"))
+            .noneMatch(m -> m.getPayload().contains("Failed to load VRAM data"));
+    }
+
+    @Test
     void a_stale_day_with_a_fresh_generation_is_not_a_current_window() {
         // The interleaving the separate volatile fields had to survive — the
         // delta reads the day before set_vram_day runs, the generation after

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -187,25 +187,74 @@ class StatsV2WebSocketHandlerLivePushTest {
         // set_vram_day has swapped in the fresh window, and its init captured
         // that window and is in its query. The tick thread's delta runs
         // against the very same window while that query is in flight: it must
-        // not consume the window's baseline — if it won the write-back, the
-        // init would lose its compareAndSet and the viewer would get a
-        // "delta" where the full-day "init" the day change owes it never
-        // comes.
+        // not consume the window's baseline as a delta — if it won the
+        // write-back, the viewer would get a "delta" where the full-day
+        // "init" the day change owes it never comes. The delta therefore
+        // retries the owed init; the two inits then race the write-back like
+        // any two pushes, and the loser drops.
         state.vramWindow.set(new StatsV2WebSocketHandler.VramWindow(day2, 0, "", false));
+        final boolean[] deltaRan = { false };
         when(vramService.getVramStats(day2, 0)).thenAnswer(inv -> {
-            ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
+            // Once only: the delta's init retry issues the very same query,
+            // and re-running the delta on its answer would recurse.
+            if (!deltaRan[0]) {
+                deltaRan[0] = true;
+                ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
+            }
             return vramPayload(200, "offline");
         });
         ReflectionTestUtils.invokeMethod(handler, "pushVramInit", session, state);
 
-        // The init went out as an init — not shadowed by a delta — and left
-        // the window baseline-established for the next tick's deltas.
+        // The baseline went out as an init — not shadowed by a delta — and
+        // the window is baseline-established for the next tick's deltas.
         assertThat(state.vramWindow.get().cursor()).isEqualTo(200);
         assertThat(state.vramWindow.get().baselineSent()).isTrue();
         ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
         verify(session, atLeastOnce()).sendMessage(captor.capture());
         assertThat(captor.getAllValues())
             .anyMatch(m -> m.getPayload().contains("\"type\":\"vram_init\""))
+            .noneMatch(m -> m.getPayload().contains("\"type\":\"vram_delta\""));
+    }
+
+    @Test
+    void a_transient_init_failure_recovers_on_the_next_tick() throws Exception {
+        // Stop the tick scheduler: the test drives the two threads' steps
+        // itself, in order.
+        handler.shutdown();
+
+        String day1 = "2026-09-01";
+        String day2 = "2026-09-02";
+        when(vramService.getVramStats(day1, 0)).thenReturn(vramPayload(100, "connected"));
+
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\",\"vram_day\":\"" + day1 + "\"}"));
+        clearInvocations(session);
+
+        StatsV2WebSocketHandler.SessionState state = (StatsV2WebSocketHandler.SessionState)
+            ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
+
+        // The day change's init hits a transient error: the error init goes
+        // out, but the window is still owed its baseline. A delta that only
+        // skipped uninitialised windows would leave the session's vram feed
+        // wedged behind this one failed query until a manual day change or a
+        // reconnect.
+        state.vramWindow.set(new StatsV2WebSocketHandler.VramWindow(day2, 0, "", false));
+        when(vramService.getVramStats(day2, 0)).thenThrow(new RuntimeException("db blip"))
+            .thenReturn(vramPayload(200, "offline"));
+        ReflectionTestUtils.invokeMethod(handler, "pushVramInit", session, state);
+        assertThat(state.vramWindow.get().baselineSent()).isFalse();
+
+        // The next tick's delta retries the owed init instead, and the
+        // recovered full-day payload reaches the viewer as a vram_init.
+        ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
+
+        assertThat(state.vramWindow.get().baselineSent()).isTrue();
+        assertThat(state.vramWindow.get().cursor()).isEqualTo(200);
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getAllValues())
+            .anyMatch(m -> m.getPayload().contains("\"type\":\"vram_init\"")
+                    && m.getPayload().contains("\"last_snapshot_id\":200"))
             .noneMatch(m -> m.getPayload().contains("\"type\":\"vram_delta\""));
     }
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -168,6 +168,27 @@ class StatsV2WebSocketHandlerLivePushTest {
     }
 
     @Test
+    void a_stale_day_with_a_fresh_generation_is_not_a_current_window() {
+        // The interleaving the generation guard must survive: the delta reads
+        // the day before set_vram_day runs, the generation after it — the old
+        // day paired with the change's fresh generation. That snapshot must
+        // not pass the current-window check, whatever the query fetched for
+        // it; with the generation read first, it is the only pairing the
+        // capture order cannot produce.
+        StatsV2WebSocketHandler.SessionState state = new StatsV2WebSocketHandler.SessionState();
+        // The window has moved to day2 at generation 2.
+        state.vramDay = "2026-09-02";
+        state.vramCursor = 200;
+        state.vramDayGeneration = 2;
+
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(2, "2026-09-01", state)).isFalse();
+        // A coherent snapshot of the window the state is in still passes.
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(2, "2026-09-02", state)).isTrue();
+        // And the fully stale snapshot of the moved-out window does not.
+        assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(1, "2026-09-01", state)).isFalse();
+    }
+
+    @Test
     void a_live_update_reaches_the_viewer_as_a_requests_push() throws Exception {
         connectAndInit();
 

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -113,6 +113,60 @@ class StatsV2WebSocketHandlerLivePushTest {
         clearInvocations(session);
     }
 
+    private static Map<String, Object> vramPayload(int lastSnapshotId, String connectionState) {
+        Map<String, Object> provider = new HashMap<>();
+        provider.put("provider_id", 1);
+        provider.put("name", "worker-a");
+        provider.put("data", List.of());
+        provider.put("connection_state", connectionState);
+        provider.put("calibrating", null);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("providers", List.of(provider));
+        payload.put("last_snapshot_id", lastSnapshotId);
+        return payload;
+    }
+
+    @Test
+    void a_stale_vram_delta_is_dropped_after_a_day_change() throws Exception {
+        // Stop the tick scheduler: the test drives pushVramDelta itself, and
+        // a concurrent real tick would race for the stubs below.
+        handler.shutdown();
+
+        String day1 = "2026-09-01";
+        String day2 = "2026-09-02";
+        when(vramService.getVramStats(day1, 0)).thenReturn(vramPayload(100, "connected"));
+
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\",\"vram_day\":\"" + day1 + "\"}"));
+        clearInvocations(session);
+
+        // The delta's day1 query (cursor 100) only returns after the
+        // operator's set_vram_day has run to completion in the meantime —
+        // the exact interleaving the generation token guards against: the
+        // tick thread's in-flight query meets the websocket thread's window
+        // change.
+        when(vramService.getVramStats(day2, 0)).thenReturn(vramPayload(200, "offline"));
+        when(vramService.getVramStats(day1, 100)).thenAnswer(inv -> {
+            handler.handleMessage(session, new TextMessage("{\"action\":\"set_vram_day\",\"day\":\"" + day2 + "\"}"));
+            return vramPayload(100, "connected");
+        });
+
+        Object state = ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
+        ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
+
+        // The late delta describes day1: it must not be sent, and it must
+        // not write day1's cursor or connection-state baseline over the ones
+        // day2's init just established.
+        assertThat(ReflectionTestUtils.getField(state, "vramCursor")).isEqualTo(200);
+        Object metaSig = ReflectionTestUtils.getField(state, "prevVramMetaSig");
+        assertThat(metaSig).asString().contains("offline").doesNotContain("connected");
+
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getAllValues())
+            .noneMatch(m -> m.getPayload().contains("\"type\":\"vram_delta\""));
+    }
+
     @Test
     void a_live_update_reaches_the_viewer_as_a_requests_push() throws Exception {
         connectAndInit();

--- a/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
+++ b/logos/logos-webservice/src/test/java/de/tum/cit/aet/logos/logoswebservice/websocket/StatsV2WebSocketHandlerLivePushTest.java
@@ -168,6 +168,48 @@ class StatsV2WebSocketHandlerLivePushTest {
     }
 
     @Test
+    void a_delta_cannot_preempt_the_init_of_a_day_change() throws Exception {
+        // Stop the tick scheduler: the test drives the two threads' steps
+        // itself, in the interleaving order.
+        handler.shutdown();
+
+        String day1 = "2026-09-01";
+        String day2 = "2026-09-02";
+        when(vramService.getVramStats(day1, 0)).thenReturn(vramPayload(100, "connected"));
+
+        handler.afterConnectionEstablished(session);
+        handler.handleMessage(session, new TextMessage("{\"action\":\"init\",\"vram_day\":\"" + day1 + "\"}"));
+        clearInvocations(session);
+
+        StatsV2WebSocketHandler.SessionState state = (StatsV2WebSocketHandler.SessionState)
+            ((Map<?, ?>) ReflectionTestUtils.getField(handler, "states")).get(session.getId());
+
+        // set_vram_day has swapped in the fresh window, and its init captured
+        // that window and is in its query. The tick thread's delta runs
+        // against the very same window while that query is in flight: it must
+        // not consume the window's baseline — if it won the write-back, the
+        // init would lose its compareAndSet and the viewer would get a
+        // "delta" where the full-day "init" the day change owes it never
+        // comes.
+        state.vramWindow.set(new StatsV2WebSocketHandler.VramWindow(day2, 0, "", false));
+        when(vramService.getVramStats(day2, 0)).thenAnswer(inv -> {
+            ReflectionTestUtils.invokeMethod(handler, "pushVramDelta", session, state);
+            return vramPayload(200, "offline");
+        });
+        ReflectionTestUtils.invokeMethod(handler, "pushVramInit", session, state);
+
+        // The init went out as an init — not shadowed by a delta — and left
+        // the window baseline-established for the next tick's deltas.
+        assertThat(state.vramWindow.get().cursor()).isEqualTo(200);
+        assertThat(state.vramWindow.get().baselineSent()).isTrue();
+        ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getAllValues())
+            .anyMatch(m -> m.getPayload().contains("\"type\":\"vram_init\""))
+            .noneMatch(m -> m.getPayload().contains("\"type\":\"vram_delta\""));
+    }
+
+    @Test
     void a_stale_day_with_a_fresh_generation_is_not_a_current_window() {
         // The interleaving the separate volatile fields had to survive — the
         // delta reads the day before set_vram_day runs, the generation after
@@ -175,7 +217,7 @@ class StatsV2WebSocketHandlerLivePushTest {
         // reference, so a snapshot either is the current window or it is
         // not, whatever the writer paused on and whatever the query fetched.
         StatsV2WebSocketHandler.SessionState state = new StatsV2WebSocketHandler.SessionState();
-        StatsV2WebSocketHandler.VramWindow stale = new StatsV2WebSocketHandler.VramWindow("2026-09-01", 100, "connected");
+        StatsV2WebSocketHandler.VramWindow stale = new StatsV2WebSocketHandler.VramWindow("2026-09-01", 100, "connected", true);
         state.vramWindow.set(stale);
 
         // A snapshot of the window the state is in passes.
@@ -183,7 +225,7 @@ class StatsV2WebSocketHandlerLivePushTest {
 
         // The window moves to day2: the old snapshot is stale the moment it
         // is swapped out, whatever the in-flight day1 query fetched for it.
-        StatsV2WebSocketHandler.VramWindow current = new StatsV2WebSocketHandler.VramWindow("2026-09-02", 200, "offline");
+        StatsV2WebSocketHandler.VramWindow current = new StatsV2WebSocketHandler.VramWindow("2026-09-02", 200, "offline", true);
         state.vramWindow.set(current);
         assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(state, stale)).isFalse();
         // A coherent snapshot of the window the state is in still passes.
@@ -192,7 +234,7 @@ class StatsV2WebSocketHandlerLivePushTest {
         // paused between its capture and its write-back loses the
         // compareAndSet against the writer's transition.
         assertThat(StatsV2WebSocketHandler.isCurrentVramWindow(
-            state, new StatsV2WebSocketHandler.VramWindow("2026-09-02", 0, ""))).isFalse();
+            state, new StatsV2WebSocketHandler.VramWindow("2026-09-02", 0, "", false))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Problem

Testing "load a model twice on one worker node" on deioma (Qwen/Qwen3.8-27B ×2), the second load **silently failed**: the VRAM reservation was correctly denied (3 GPUs, first replica already holds GPU 1+2 with a pre-allocated KV pool → no pair fits a second TP=2 replica), but the only trace was one W line in the orchestrator log:

```
planner W VRAM reservation denied for load of Qwen/Qwen3.8-27B: need=94757MB avail=162463MB committed=0MB gpus=0,1
```

The UI's "Loading … this can take minutes" note never resolves, because it only goes away when the lane appears in the status stream — which never happens for a denied load. Three layers of silence:

1. the per-GPU denial details in `vram_ledger.try_reserve_atomic` are DEBUG-only, so the W line reads contradictory (need < avail);
2. `lanes/add` answers 202 and refuses only in the background;
3. nothing ever reports the refusal to the UI.

## What this PR does (fix options 1 + 3 from the analysis)

**Option 1 — the failure reaches the UI** (the important part):

- The planner records the outcome of the most recent manual load per `(provider_id, model)`: `running | succeeded | failed` plus a human-readable `reason`, TTL 1 h. Every exit of `load_lane_manually` records — pre-rejection, capacity gone, executor refusal (reason handed over per lane), confirmation timeout, no free lane id. An in-flight load's `running` entry is never stomped by a second click.
- New `POST /internal/logosnode/lanes/load_status` (internal-secret auth) serves the outcome; `lanes/add` records `running` *before* answering 202 so the UI can't read the previous attempt's `failed`. No outcome → `unknown`, which the UI must not render as a failure.
- Spring: `ProviderController.laneLoadStatus` pass-through with the usual JWT + `LOGOS_ADMIN` gate, plus the new `LaneLoadStatusRequestDTO` and `OrchestratorWorkerAdminClient.getLaneLoadStatus`.
- Traefik: `lanes/load_status` added to the `webservice-logosnode-admin` (priority 202) exact-path rule in both compose files — without this the call would 404 at the orchestrator, as documented in the prod compose comment.
- UI: while the pending note is up, the lane-health panel polls the outcome every 2.5 s (hard stop past the full two-phase attempt, 65 min; stops on provider switch / 404 / terminal answer). A recorded `failed` reopens the picker with `Loading <model> failed: <reason>` and re-offers the model — exactly where a synchronous refusal lands.

**Option 3 — the log line tells the whole story**:

- The denial reason is recorded per lane (`not enough free VRAM for this model: it needs ~48.4 GB in total (~24.2 GB on each of 2 GPUs), but the worker reports only 63.4 GB free (GPU 0: 96595MB, GPU 1: 31705MB, GPU 2: 31705MB)`).
- The W line is enriched with `need-per-GPU=…MB per-GPU-free=[…]`, so it no longer reads as a bug.

Option 2 (synchronous 409 pre-check) is deliberately not included — the pre-check can't see per-GPU feasibility anyway and the background refusal is now reported, keeping the PR focused.

## Follow-up fixes (from the review rounds)

- Stale action feedback on provider switch: the lane-health and GPU panels reset unload/sleep/wake/calibration state — including in-flight answers — when the worker changes.
- Outcome-poll hardening: per-session generation token (a delayed answer from a superseded retry of the same model is dropped), the poll survives a plain picker close, and the cap covers the full command + confirmation attempt.
- Denial diagnostics report the reservation gate's effective free VRAM (raw minus committed) instead of the raw snapshot.
- `StatsV2WebSocketHandler` pushes VRAM deltas on every 1 s tick instead of every fifth: a loaded lane reaches the UI ~1 s after the worker reports it, not up to 5 s later.
- `ai-tools.spec.ts` fixture carries the `rate_limit_usage` field `MyKey` gained in #847, so the UI test build on main is healed.

## Deploy note

The **live** `/opt/logos/docker-compose.yaml` on the host needs the same one-line addition to the `webservice-logosnode-admin` rule (`|| Path('/api/logosdb/providers/logosnode/lanes/load_status')`) when the new image goes out, or the UI's poll 404s (it degrades gracefully — the note just behaves as before until the route is there).

## Tests

- Orchestrator: 20 new planner-outcome tests (`test_manual_load_outcome.py`) + 7 endpoint tests (`test_internal_lane_load_status_endpoint.py`); full `tests/unit/capacity/` green (395 passed, 1 xfailed), related internal-endpoint tests green.
- UI: 7 new poll-behavior tests in `lane-health-panel.spec.ts` (zoneless timer-spy style, no fakeAsync); full suite green — **except a pre-existing break on main**: `ai-tools.spec.ts` is missing the `rate_limit_usage` field that `MyKey` gained in #847, so `ng test` fails at the build step on a clean checkout. That break is fixed in this PR: the spec's `KEY` literal now carries `rate_limit_usage`, so `ng test` builds green on the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added load-status tracking for background model loads, including running, succeeded, failed, and unknown states with operator-facing reasons.
  - The lane health panel now monitors load progress automatically and reports failures more clearly.
  - Added routing support for load-status information in development and production environments.
  - VRAM availability updates are now checked every second.

- **Bug Fixes**
  - Prevented stale feedback after switching providers or workers.
  - Improved handling of delayed, rejected, failed, and completed lane loads.
  - Added safeguards for unavailable status services and outdated responses.
  - Improved calibration-state handling when changing workers.
  - Capacity errors now provide more accurate provider and GPU availability details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

