### PR TITLE
`Logos`: Install vLLM with the audio extra so transcription can decode uploads

### DIFF
--- a/.github/workflows/logos_update-vllm.yml
+++ b/.github/workflows/logos_update-vllm.yml
@@ -62,7 +62,11 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           BRANCH: ${{ steps.version.outputs.branch }}
         run: |
-          CURRENT=$(sed -nE 's/^ARG VLLM_PIP_SPEC="vllm==v?([^"]+)"$/\1/p' "$DOCKERFILE")
+          # The pin may carry extras (vllm[audio]==vX.Y.Z). Capture only the
+          # version: matching the extras as part of it would make the pin never
+          # compare equal to the PyPI version, and this workflow would open the
+          # same "update" PR every hour.
+          CURRENT=$(sed -nE 's/^ARG VLLM_PIP_SPEC="vllm(\[[^]]*\])?==v?([0-9][0-9a-z.]*)"$/\2/p' "$DOCKERFILE")
           echo "Current pin: v$CURRENT"
           if [ "$CURRENT" = "$VERSION" ]; then
             echo "Dockerfile already pins vllm==v$VERSION — nothing to do."
@@ -81,8 +85,13 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          sed -i -E "s|^ARG VLLM_PIP_SPEC=.*$|ARG VLLM_PIP_SPEC=\"vllm==v$VERSION\"|" "$DOCKERFILE"
-          grep -F "vllm==v$VERSION" "$DOCKERFILE" >/dev/null || {
+          # Carry the current extras (e.g. [audio]) over to the new pin.
+          # Rewriting the line as a bare "vllm==v<version>" would silently
+          # uninstall the features that depend on them — the [audio] extra is
+          # what makes /v1/audio/transcriptions able to decode uploads at all.
+          EXTRA=$(sed -nE 's/^ARG VLLM_PIP_SPEC="vllm(\[[^]]*\])?==.*"$/\1/p' "$DOCKERFILE")
+          sed -i -E "s|^ARG VLLM_PIP_SPEC=.*$|ARG VLLM_PIP_SPEC=\"vllm${EXTRA}==v$VERSION\"|" "$DOCKERFILE"
+          grep -F "vllm${EXTRA}==v$VERSION" "$DOCKERFILE" >/dev/null || {
             echo "::error::Failed to update VLLM_PIP_SPEC in $DOCKERFILE"
             exit 1
           }
@@ -133,7 +142,7 @@ jobs:
 
           ## Description
 
-          Updates the \`VLLM_PIP_SPEC\` build arg default in \`$DOCKERFILE\` to \`vllm==v$VERSION\`, and the \`VLLM_REASONING_EFFORT_VALUES\` snapshot label in \`$EFFORT_MODULE\` alongside it. Torch and FlashInfer are resolved from vLLM's own dependency pins at build time, so no other changes are needed.
+          Bumps the version in the \`VLLM_PIP_SPEC\` build arg default in \`$DOCKERFILE\` to v$VERSION — extras carried by the pin (e.g. \`[audio]\`, which the speech-to-text endpoints need) are preserved — and the \`VLLM_REASONING_EFFORT_VALUES\` snapshot label in \`$EFFORT_MODULE\` alongside it. Torch and FlashInfer are resolved from vLLM's own dependency pins at build time, so no other changes are needed.
 
           Please check the release notes for new \`ChatCompletionRequest.reasoning_effort\` values: only the label is bumped automatically, the tuple is not. Runtime normalization is unaffected either way — unknown values fall back to the template family's default.
 

--- a/logos/logos-workernode/Dockerfile
+++ b/logos/logos-workernode/Dockerfile
@@ -61,7 +61,17 @@
 # =============================================================================
 
 ARG BASE_IMAGE=ubuntu:24.04
-ARG VLLM_PIP_SPEC="vllm==v0.29.0"
+# The [audio] extra is required, not cosmetic: the speech-to-text endpoints
+# (/v1/audio/transcriptions, /v1/audio/translations) decode uploads through
+# vllm.multimodal.media.audio.load_audio, whose only two backends are
+# soundfile (primary) and av/PyAV (fallback, and the resampler to Whisper's
+# 16 kHz for any input that isn't already at that rate). Both ship solely in
+# this extra; without them every upload fails with the same opaque 400,
+# "Invalid or unsupported audio file." (PyAV bundles FFmpeg, so no ffmpeg apt
+# package is needed.) Extras must precede the version specifier (PEP 508):
+# vllm[audio]==vX.Y.Z parses, vllm==vX.Y.Z[audio] does not. The hourly
+# "Logos - Update vLLM" workflow carries the extra over when it bumps the pin.
+ARG VLLM_PIP_SPEC="vllm[audio]==v0.29.0"
 # TORCH_INDEX_URL — leave empty (default) to use the PyPI torch that vLLM
 # installs, which already includes CUDA support matching its nvidia-* deps.
 # Only set this to override with a specific CUDA wheel index (e.g.

--- a/logos/logos-workernode/docker-compose.dev.yml
+++ b/logos/logos-workernode/docker-compose.dev.yml
@@ -9,7 +9,9 @@ services:
       context: .
       args:
         BASE_IMAGE: ${BASE_IMAGE:-ubuntu:24.04}
-        VLLM_PIP_SPEC: ${VLLM_PIP_SPEC:-vllm}
+        # [audio] mirrors the Dockerfile default: without it the speech-to-text
+        # endpoints cannot decode any upload (see the pin comment there).
+        VLLM_PIP_SPEC: ${VLLM_PIP_SPEC:-vllm[audio]}
         NCCL_PIP_SPEC: ${NCCL_PIP_SPEC:-}
     container_name: logos-workernode
     init: true

--- a/logos/logos-workernode/tests/test_vllm_audio_extra.py
+++ b/logos/logos-workernode/tests/test_vllm_audio_extra.py
@@ -1,0 +1,140 @@
+"""Static guards for the worker image's vLLM audio dependencies.
+
+The speech-to-text endpoints (/v1/audio/transcriptions, /v1/audio/translations)
+decode uploads through ``vllm.multimodal.media.audio.load_audio``, which has
+exactly two backends and both are optional: ``soundfile`` (primary) and
+``av``/PyAV (fallback, and the resampler to Whisper's 16 kHz). They ship solely
+in vLLM's ``[audio]`` extra, so a pin without it turns *every* transcription
+request into the same opaque 400, "Invalid or unsupported audio file." — the
+failure mode of issue #925, which stood from the day Whisper support landed
+because the pin never carried the extra.
+
+The pin is not only hand-edited: ``.github/workflows/logos_update-vllm.yml``
+rewrites it on every vLLM release. These tests therefore cover both halves of
+the regression — the pin itself, and the automation that would otherwise strip
+the extra on the next version bump (or, having read the extra as part of the
+version, open the same update PR every hour).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_WORKERNODE = Path(__file__).resolve().parent.parent
+_REPO = _WORKERNODE.parent.parent
+
+DOCKERFILE = _WORKERNODE / "Dockerfile"
+COMPOSE_DEV = _WORKERNODE / "docker-compose.dev.yml"
+WORKFLOW = _REPO / ".github" / "workflows" / "logos_update-vllm.yml"
+
+# PEP 508 puts extras before the version specifier: "vllm[audio]==v0.29.0"
+# parses, "vllm==v0.29.0[audio]" does not (pip rejects it as an invalid
+# specifier). Asserting the shape — not just that "audio" appears somewhere —
+# is what keeps the well-meant-but-unbuildable spelling out of the image.
+_PIN_RE = re.compile(
+    r'^ARG VLLM_PIP_SPEC="vllm(?P<extras>\[[^]]*\])?==(?P<version>v?[0-9][0-9a-z.]*)"$',
+    re.M,
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"expected file not found: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _extras_of_pin() -> str:
+    match = _PIN_RE.search(_read(DOCKERFILE))
+    assert match, (
+        "no parseable 'ARG VLLM_PIP_SPEC=\"vllm[extras]==<version>\"' default in the Dockerfile — "
+        "extras must precede the version specifier (PEP 508)"
+    )
+    return match.group("extras") or ""
+
+
+def test_worker_image_pins_vllm_with_the_audio_extra() -> None:
+    extras = _extras_of_pin()
+    assert "audio" in extras.strip("[]").split(","), (
+        f"VLLM_PIP_SPEC extras are {extras or '(none)'}: without [audio] neither soundfile nor av is "
+        "installed and every /v1/audio/transcriptions upload fails with 'Invalid or unsupported audio file.'"
+    )
+
+
+def test_dev_compose_default_pins_vllm_with_the_audio_extra() -> None:
+    match = re.search(r"^\s*VLLM_PIP_SPEC:\s*\$\{VLLM_PIP_SPEC:-(?P<spec>[^}]+)\}", _read(COMPOSE_DEV), re.M)
+    assert match, "docker-compose.dev.yml no longer defines a VLLM_PIP_SPEC default"
+    assert "[audio]" in match.group("spec"), (
+        f"dev compose default is {match.group('spec')!r} — a dev worker built from it cannot decode "
+        "audio, so transcription bugs stay invisible until production"
+    )
+
+
+def _sed_substitution(assignment: str) -> tuple[re.Pattern[str], int]:
+    """Return the ERE and capture group of a ``VAR=$(sed -nE 's/…/\\N/p' …)`` line.
+
+    The pattern is compiled from the workflow verbatim, so these tests exercise
+    the expression the workflow actually runs rather than a copy of it. ERE and
+    Python's syntax coincide for the constructs used here (groups, ``?``,
+    character classes, anchors).
+    """
+    match = re.search(
+        rf"{assignment}=\$\(sed -nE 's/(?P<ere>[^/]+)/\\(?P<group>\d+)/p'",
+        _read(WORKFLOW),
+    )
+    assert match, f"the update workflow no longer extracts {assignment} with a single sed substitution"
+    return re.compile(match.group("ere")), int(match.group("group"))
+
+
+def test_update_workflow_reads_the_version_past_any_extras() -> None:
+    """A pin carrying extras must still compare equal to the PyPI version.
+
+    Otherwise "Check whether an update is needed" reads the current pin as
+    e.g. "0.29.0[audio]", never matches the release it just looked up, and the
+    hourly schedule opens a fresh update PR on every single run.
+    """
+    pattern, group = _sed_substitution("CURRENT")
+    cases = {
+        'ARG VLLM_PIP_SPEC="vllm[audio]==v0.29.0"': "0.29.0",
+        'ARG VLLM_PIP_SPEC="vllm==v0.29.0"': "0.29.0",  # control: bare pin still works
+        'ARG VLLM_PIP_SPEC="vllm[audio]==v0.30.0rc1"': "0.30.0rc1",
+        'ARG VLLM_PIP_SPEC="vllm[audio,video]==0.29.0"': "0.29.0",  # optional "v", several extras
+    }
+    for line, expected in cases.items():
+        match = pattern.search(line)
+        assert match, f"version not recognised in {line!r}"
+        assert match.group(group) == expected, f"read {match.group(group)!r} instead of {expected!r} from {line!r}"
+
+    # The live Dockerfile must be readable by the same expression, or the
+    # workflow silently treats it as "no pin found" and bumps unconditionally.
+    live = _PIN_RE.search(_read(DOCKERFILE))
+    assert live is not None
+    match = pattern.search(live.group(0))
+    assert match and match.group(group) == live.group("version").lstrip("v")
+
+
+def test_update_workflow_preserves_extras_when_bumping_the_pin() -> None:
+    """The rewrite must re-attach the extras it found, not hardcode a bare pin."""
+    workflow = _read(WORKFLOW)
+    assert 'ARG VLLM_PIP_SPEC=\\"vllm==v$VERSION\\"' not in workflow, (
+        "the pin rewrite hardcodes a bare 'vllm==v$VERSION' and drops every extra — "
+        "the next vLLM release would silently undo the [audio] fix"
+    )
+    assert (
+        'ARG VLLM_PIP_SPEC=\\"vllm${EXTRA}==v$VERSION\\"' in workflow
+    ), "the pin rewrite no longer re-attaches ${EXTRA}"
+    assert 'grep -F "vllm${EXTRA}==v$VERSION"' in workflow, "the post-rewrite guard no longer accounts for extras"
+
+    pattern, group = _sed_substitution("EXTRA")
+    cases = {
+        'ARG VLLM_PIP_SPEC="vllm[audio]==v0.29.0"': "[audio]",
+        'ARG VLLM_PIP_SPEC="vllm[audio,video]==v0.29.0"': "[audio,video]",
+    }
+    for line, expected in cases.items():
+        match = pattern.search(line)
+        assert match, f"extras not recognised in {line!r}"
+        assert match.group(group) == expected, f"read {match.group(group)!r} instead of {expected!r} from {line!r}"
+
+    # A bare pin yields an empty EXTRA, so the rewrite stays "vllm==v<version>".
+    match = pattern.search('ARG VLLM_PIP_SPEC="vllm==v0.29.0"')
+    assert match, "a pin without extras is no longer matched at all"
+    assert (match.group(group) or "") == ""


### PR DESCRIPTION
## Motivation

Closes #925. Every request to `/v1/audio/transcriptions` (and `/v1/audio/translations`) against a local Whisper deployment fails with an identical 400, whatever the uploaded file:

```json
{"error": {"message": "Invalid or unsupported audio file."}}
```

I hit this while wiring a small tool against Logos and reproduced it against prod with six independently generated, valid files (WAV 16 kHz, WAV 44.1 kHz, MP3, M4A, OGG, WebM) plus a 16 KB pure-silence WAV — all rejected identically. A working decoder would distinguish those, so nothing is being decoded at all.

## Description

**Root cause.** The string `Invalid or unsupported audio file.` does not exist anywhere in Logos; it is raised by vLLM in `vllm/entrypoints/speech_to_text/base/serving.py`, which wraps *any* failure of `load_audio` into that one message. `vllm/multimodal/media/audio.py::load_audio` has exactly two backends and both are optional dependencies:

1. `soundfile` — primary
2. `av` / PyAV — fallback, and the resampler (`resample_audio_pyav`) for any input not already at Whisper's 16 kHz, i.e. most real files

Per PyPI, vLLM 0.29.0's `audio` extra is `av`, `scipy`, `soundfile`, `soxr`, `mistral_common[audio]`. The worker image installed plain `vllm==v0.29.0`, so neither backend was present and every upload failed before decoding began. PyAV bundles FFmpeg, so no `ffmpeg` apt package is needed.

**This was never a regression.** `git log --all -S` over the workernode tree finds `soundfile`, `av` and `[audio]` in no commit on any ref: #704 added the full orchestrator/worker multipart round-trip for Whisper but never touched the Dockerfile or `requirements.txt`, and no later commit did either. So the endpoint has been unusable since the day it shipped.

**Changes:**

1. **`logos/logos-workernode/Dockerfile`** — pin `vllm[audio]==v0.29.0`, with a comment recording why the extra is load-bearing. Note the spelling: extras precede the version specifier (PEP 508). The `vllm==v0.28.0[audio]` form suggested in the issue is **not a valid requirement** — `packaging.requirements.Requirement` and pip both reject it (`Expected comma (within version specifier)…`), so it would have broken the build rather than fixed the bug. I chose the extra over hand-listing `soundfile`+`av` in `requirements.txt` so the dependency tracks vLLM's own definition; the cost is `scipy`/`soxr`/`opencv` (via `mistral_common[audio]`, only Voxtral needs them).

2. **`.github/workflows/logos_update-vllm.yml`** — the reason this needs more than a one-line pin change. The workflow runs hourly and rewrites the pin on every vLLM release; as written it would revert this fix within the hour:
   - the *check* step's `sed` captured `vllm==v?([^"]+)`, which does not match a pin carrying extras at all → `CURRENT` empty → never equal to the PyPI version → a spurious "Update vLLM" PR **every run**;
   - the *update* step replaced the whole line with a hardcoded `vllm==v$VERSION`, silently dropping the extra.

   The check step now reads the version past any extras, and the update step captures the existing extras and re-attaches them to the bumped pin. Bare pins keep working unchanged. The PR-body text the workflow generates was adjusted to match.

3. **`logos/logos-workernode/docker-compose.dev.yml`** — the dev default (`${VLLM_PIP_SPEC:-vllm}`) now mirrors the image, so a dev worker can decode audio too and the bug can't hide until prod.

## Tests

New `logos/logos-workernode/tests/test_vllm_audio_extra.py` (stdlib only, in the style of `test_installer_pins.py`) guards both halves of the failure — the pin and the automation that would strip it:

- the Dockerfile pin carries `[audio]`, asserted on the parsed *shape* so the unbuildable `vllm==vX.Y.Z[audio]` spelling can't slip in;
- the dev-compose default carries it too;
- the workflow's two `sed` expressions are **compiled out of the YAML verbatim** and exercised against pins with one extra, several extras, an `rc` version, and no extra — so the tests check the expression the workflow really runs, plus the live Dockerfile line;
- the rewrite must re-attach `${EXTRA}` and must not contain the hardcoded bare form.

Verified as genuine regressions: on the unfixed tree all **4 fail**, with the fix all **4 pass**.

I also ran both `sed` expressions against the real files: the check step reads `0.29.0` from the new pin (so no hourly PR spam), the update step reads `[audio]`, and a simulated bump to `v9.9.9` yields `ARG VLLM_PIP_SPEC="vllm[audio]==v9.9.9"` — the extra survives. `pre-commit run --files` passes on all four files; the workflow YAML additionally `yaml.safe_load`s.

## What I could not verify here

The image build and a live transcription against a rebuilt worker — no Docker/GPU in this environment. The dependency argument is settled independently, though: the issue author verified on the prod worker that `pip install soundfile av` in the same container makes the identical file decode correctly (`DECODE OK: shape=(66256,) sr=16000`), and uninstalling reverts to the error. Remaining step is the CI image build + Whisper-lane rollout; `check-workernode-build` diffs the Dockerfile, so this triggers a rebuild automatically.

One deployment note for review: the transcription path is only exercisable once a Whisper lane is actually loaded on a worker — that is scheduling state, not part of this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ULn1EiP4Rn2GQLYVsfvee
