### PR TITLE
`Logos`: Expose scheduling and ETTFT metrics to Prometheus

### DIFF
--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -37,6 +37,8 @@ from logos.terminal_logging import (
     wrap_plain,
 )
 
+from logos.pipeline.latency_store import LatencyStore
+
 from .demand_tracker import DemandTracker
 from .host_ram_ledger import HostRamLedger
 from .lane_comparator import best_lane
@@ -271,6 +273,7 @@ class CapacityPlanner:
         cycle_seconds: float = 10.0,
         enabled: bool = True,
         on_state_change: Optional[Any] = None,
+        latency_store: Optional[LatencyStore] = None,
     ) -> None:
         self._facade = logosnode_facade
         self._registry = logosnode_registry
@@ -278,6 +281,7 @@ class CapacityPlanner:
         self._cycle_seconds = cycle_seconds
         self._enabled = enabled
         self._on_state_change = on_state_change
+        self._latency_store = latency_store
         self._lane_idle_since: dict[tuple[int, str], float] = {}
         self._lane_sleep_since: dict[tuple[int, str], float] = {}
         self._lane_sleep_level: dict[tuple[int, str], int] = {}
@@ -752,6 +756,7 @@ class CapacityPlanner:
             provider_ids.sort(key=_provider_pressure, reverse=True)
         self._log_cluster_summary(provider_ids)
         self._refresh_engine_cache_metrics(provider_ids)
+        self._refresh_latency_store_metrics()
 
         # Cross-provider best-first ranking: pre-score every (provider,
         # model) candidate so the cheapest worker for each model wins,
@@ -918,6 +923,18 @@ class CapacityPlanner:
                 mtp_rate = agg["mtp_accepted"] / agg["mtp_draft"] if agg["mtp_draft"] > 0 else None
                 entries.append((model, provider_name, prefix_rate, mtp_rate))
         prom.update_engine_cache_metrics(entries)
+
+    def _refresh_latency_store_metrics(self) -> None:
+        """Publish EWMA learned-latency gauges from the latency store."""
+        if self._latency_store is None:
+            return
+        try:
+            rows = self._latency_store.snapshot_metrics(
+                get_provider_name=lambda pid: self._facade.get_provider_name(pid)
+            )
+            prom.update_latency_store_metrics(rows)
+        except Exception:
+            logger.debug("Failed to refresh latency store metrics", exc_info=True)
 
     def _log_cluster_summary(self, provider_ids: List[int]) -> None:
         """Print a colored cluster overview for the current planner cycle."""

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 
 from logos.logosnode_registry import LogosNodeCommandError, LogosNodeRuntimeRegistry
 from logos.monitoring import prometheus_metrics as prom
+from logos.pipeline.latency_store import LatencyStore
 from logos.sdi.logosnode_facade import LogosNodeSchedulingDataFacade
 from logos.sdi.models import CapacityPlanAction, LaneSchedulerSignals, ModelProfile
 from logos.terminal_logging import (
@@ -36,8 +37,6 @@ from logos.terminal_logging import (
     render_section,
     wrap_plain,
 )
-
-from logos.pipeline.latency_store import LatencyStore
 
 from .demand_tracker import DemandTracker
 from .host_ram_ledger import HostRamLedger

--- a/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
+++ b/logos/logos-orchestrator/src/logos/capacity/capacity_planner.py
@@ -943,7 +943,7 @@ class CapacityPlanner:
 
     def _refresh_latency_store_metrics(self) -> None:
         """Publish EWMA learned-latency gauges from the latency store."""
-        if self._latency_store is None:
+        if getattr(self, "_latency_store", None) is None:
             return
         try:
             rows = self._latency_store.snapshot_metrics(

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -65,6 +65,7 @@ from logos.logosnode_snapshot import (
     _sample_snapshot_id,
 )
 from logos.middleware import APIPrefixStripperMiddleware
+from logos.monitoring import prometheus_metrics as prom
 from logos.pipeline.context_resolver import ContextResolver
 from logos.pipeline.correcting_scheduler import ClassificationCorrectingScheduler
 from logos.pipeline.executor import ExecutionResult, Executor, StreamingExecutionStatus
@@ -100,6 +101,7 @@ from logos.terminal_logging import (
     format_number,
     model_name_cache,
     paint,
+    provider_name_cache,
     style_duration,
     style_model,
     style_request_id,
@@ -1270,6 +1272,7 @@ async def start_pipeline():
         demand_tracker=_demand_tracker,
         enabled=planner_enabled,
         on_state_change=scheduler.reevaluate_model_queues,
+        latency_store=_latency_store,
     )
     # Every worker report restores the forwarding gate's budget, so it is
     # also the moment to reconsider requests being held for it.
@@ -1608,6 +1611,30 @@ def _log_request_completion(
     logger.info(" ".join(parts))
 
 
+def _record_ettft_accuracy(scheduling_stats: Optional[dict], req_start: float) -> None:
+    """Observe |ettft_estimate - actual_ttft| at the moment the first token arrives.
+
+    ``req_start`` is the ``time.perf_counter()`` timestamp recorded when the
+    request entered the streaming handler; ``actual_ttft_s`` is the elapsed
+    wall-clock time from that point to the first token, which matches the ETTFT
+    model's definition (reclaim → state_overhead → queue_wait → prefill → TTFT).
+    """
+    if not scheduling_stats:
+        return
+    ettft_ms = scheduling_stats.get("ettft_estimate_ms")
+    if not isinstance(ettft_ms, (int, float)) or not math.isfinite(ettft_ms):
+        return
+    tier = str(scheduling_stats.get("ettft_tier") or "unknown")
+    provider_id = scheduling_stats.get("provider_id")
+    provider = provider_name_cache.get(provider_id) if provider_id is not None else "unknown"
+    prom.record_ettft_outcome(
+        estimate_s=ettft_ms / 1000.0,
+        actual_ttft_s=time.perf_counter() - req_start,
+        provider=provider or str(provider_id),
+        tier=tier,
+    )
+
+
 def _decision_response_headers(request_id, scheduling_stats) -> Optional[dict]:
     """Response headers exposing the scheduling decision to the client.
 
@@ -1816,6 +1843,7 @@ async def _streaming_response(
                                     if log_id:
                                         with DBManager() as db:
                                             db.set_time_at_first_token(log_id)
+                                    _record_ettft_accuracy(scheduling_stats, _req_start)
                                     ttft_recorded = True
                                 _live_streams.update(request_id, stream_log.streamed_tokens())
                                 yield chunk
@@ -2011,6 +2039,7 @@ async def _streaming_response(
                     if log_id:
                         with DBManager() as db:
                             db.set_time_at_first_token(log_id)
+                    _record_ettft_accuracy(scheduling_stats, _req_start)
                     ttft_recorded = True
             if cost_enricher:
                 for outgoing_chunk in cost_enricher.finish():

--- a/logos/logos-orchestrator/src/logos/main.py
+++ b/logos/logos-orchestrator/src/logos/main.py
@@ -1611,25 +1611,29 @@ def _log_request_completion(
     logger.info(" ".join(parts))
 
 
-def _record_ettft_accuracy(scheduling_stats: Optional[dict], req_start: float) -> None:
+def _record_ettft_accuracy(scheduling_stats: Optional[dict]) -> None:
     """Observe |ettft_estimate - actual_ttft| at the moment the first token arrives.
 
-    ``req_start`` is the ``time.perf_counter()`` timestamp recorded when the
-    request entered the streaming handler; ``actual_ttft_s`` is the elapsed
-    wall-clock time from that point to the first token, which matches the ETTFT
-    model's definition (reclaim → state_overhead → queue_wait → prefill → TTFT).
+    Uses ``schedule_start_s`` from scheduling_stats (captured in pipeline.py
+    immediately before the scheduler is invoked) so that the measured interval
+    covers the same phases as the ETTFT model: reclaim → state_overhead →
+    queue_wait → prefill → TTFT.  Falls back to ``req_start`` only when the
+    field is absent (e.g. for timeout/error paths that never reach scheduling).
     """
     if not scheduling_stats:
         return
     ettft_ms = scheduling_stats.get("ettft_estimate_ms")
     if not isinstance(ettft_ms, (int, float)) or not math.isfinite(ettft_ms):
         return
+    schedule_start = scheduling_stats.get("schedule_start_s")
+    if not isinstance(schedule_start, float):
+        return
     tier = str(scheduling_stats.get("ettft_tier") or "unknown")
     provider_id = scheduling_stats.get("provider_id")
     provider = provider_name_cache.get(provider_id) if provider_id is not None else "unknown"
     prom.record_ettft_outcome(
         estimate_s=ettft_ms / 1000.0,
-        actual_ttft_s=time.perf_counter() - req_start,
+        actual_ttft_s=time.perf_counter() - schedule_start,
         provider=provider or str(provider_id),
         tier=tier,
     )
@@ -1843,7 +1847,7 @@ async def _streaming_response(
                                     if log_id:
                                         with DBManager() as db:
                                             db.set_time_at_first_token(log_id)
-                                    _record_ettft_accuracy(scheduling_stats, _req_start)
+                                    _record_ettft_accuracy(scheduling_stats)
                                     ttft_recorded = True
                                 _live_streams.update(request_id, stream_log.streamed_tokens())
                                 yield chunk
@@ -2039,7 +2043,7 @@ async def _streaming_response(
                     if log_id:
                         with DBManager() as db:
                             db.set_time_at_first_token(log_id)
-                    _record_ettft_accuracy(scheduling_stats, _req_start)
+                    _record_ettft_accuracy(scheduling_stats)
                     ttft_recorded = True
             if cost_enricher:
                 for outgoing_chunk in cost_enricher.finish():

--- a/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
@@ -406,9 +406,7 @@ def record_ettft_outcome(
 
     if not (math.isfinite(estimate_s) and math.isfinite(actual_ttft_s)):
         return
-    ETTFT_ACCURACY_SECONDS.labels(provider=provider, tier=tier).observe(
-        abs(estimate_s - actual_ttft_s)
-    )
+    ETTFT_ACCURACY_SECONDS.labels(provider=provider, tier=tier).observe(abs(estimate_s - actual_ttft_s))
 
 
 def record_ettft_components(

--- a/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
+++ b/logos/logos-orchestrator/src/logos/monitoring/prometheus_metrics.py
@@ -268,6 +268,70 @@ REQUEST_CONTEXT_TOKENS = Histogram(
     registry=registry,
 )
 
+# ---------------------------------------------------------------------------
+# Scheduling metrics — ETTFT accuracy, component decomposition, tier
+# ---------------------------------------------------------------------------
+
+ETTFT_ACCURACY_SECONDS = Histogram(
+    "logos_ettft_accuracy_seconds",
+    "Absolute error |ettft_estimate_s - actual_ttft_s| per provider and tier at first-token time",
+    ["provider", "tier"],
+    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
+    registry=registry,
+)
+
+ETTFT_COMPONENTS_SECONDS = Histogram(
+    "logos_ettft_components_seconds",
+    "Duration of each ETTFT phase for the selected scheduling candidate",
+    # component: state_overhead | queue_wait | prefill | learned_ttft | reclaim_overhead
+    ["component", "model", "provider", "tier"],
+    buckets=(0.001, 0.01, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0),
+    registry=registry,
+)
+
+SCHEDULING_TIER_TOTAL = Counter(
+    "logos_scheduling_tier_total",
+    "Scheduling decisions by readiness tier of the selected candidate",
+    ["model", "provider", "tier"],
+    registry=registry,
+)
+
+SCHEDULING_UNAVAILABLE_TOTAL = Counter(
+    "logos_scheduling_unavailable_total",
+    "Candidates scored UNAVAILABLE during a scheduling pass (reclaim-check returned inf)",
+    ["model", "provider"],
+    registry=registry,
+)
+
+ADMISSION_HOLD_DURATION_SECONDS = Histogram(
+    "logos_admission_hold_duration_seconds",
+    "Wall-clock time a request spent waiting in the scheduler queue before being dispatched",
+    buckets=(0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1200.0),
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Latency-store EWMA values — learned infrastructure parameters
+# ---------------------------------------------------------------------------
+
+LATENCY_STORE_LEARNED_SECONDS = Gauge(
+    "logos_latency_store_learned_seconds",
+    "Current EWMA value from the latency store per (model, provider, metric). "
+    "metric is one of: cold, cold_reclaim, sleeping, sleeping_reclaim, ttft, e2e, prefill_s_per_token",
+    ["model", "provider", "metric"],
+    registry=registry,
+)
+
+LATENCY_STORE_OBSERVATION_COUNT = Gauge(
+    "logos_latency_store_observation_count",
+    "Number of observations feeding the EWMA for a (model, provider, metric)",
+    ["model", "provider", "metric"],
+    registry=registry,
+)
+
+# Label sets published by update_latency_store_metrics(), retired when keys vanish.
+_PUBLISHED_LATENCY_STORE_KEYS: set[tuple[str, str, str]] = set()
+
 # Label sets published by update_engine_cache_metrics(), so pairs whose lanes
 # are gone can be removed instead of keeping their last value forever.
 _PUBLISHED_ENGINE_METRIC_KEYS: set[tuple[str, str]] = set()
@@ -324,6 +388,75 @@ def update_engine_cache_metrics(entries: list[tuple[str, str, float | None, floa
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def record_ettft_outcome(
+    estimate_s: float,
+    actual_ttft_s: float,
+    provider: str,
+    tier: str,
+) -> None:
+    """Observe ETTFT accuracy: |estimate_s - actual_ttft_s| for the given provider/tier.
+
+    Call this once per request when the first token arrives, passing the
+    ETTFT estimate from SchedulingResult.ettft_estimate_ms / 1000 and the
+    wall-clock duration from scheduling-start to first token.
+    """
+    import math
+
+    if not (math.isfinite(estimate_s) and math.isfinite(actual_ttft_s)):
+        return
+    ETTFT_ACCURACY_SECONDS.labels(provider=provider, tier=tier).observe(
+        abs(estimate_s - actual_ttft_s)
+    )
+
+
+def record_ettft_components(
+    model: str,
+    provider: str,
+    tier: str,
+    state_overhead_s: float,
+    queue_wait_s: float,
+    prefill_s: float,
+    learned_ttft_s: float,
+    reclaim_overhead_s: float,
+) -> None:
+    """Observe the five ETTFT phase durations for a scheduled candidate."""
+    labels_base = dict(model=model, provider=provider, tier=tier)
+    ETTFT_COMPONENTS_SECONDS.labels(component="state_overhead", **labels_base).observe(state_overhead_s)
+    ETTFT_COMPONENTS_SECONDS.labels(component="queue_wait", **labels_base).observe(queue_wait_s)
+    ETTFT_COMPONENTS_SECONDS.labels(component="prefill", **labels_base).observe(prefill_s)
+    ETTFT_COMPONENTS_SECONDS.labels(component="learned_ttft", **labels_base).observe(learned_ttft_s)
+    ETTFT_COMPONENTS_SECONDS.labels(component="reclaim_overhead", **labels_base).observe(reclaim_overhead_s)
+
+
+def update_latency_store_metrics(
+    rows: "list[tuple[str, str, str, float, int]]",
+) -> None:
+    """Publish per-(model, provider, metric) EWMA gauges from a latency-store snapshot.
+
+    Each row is ``(model_name, provider_label, metric_name, value_s, observation_count)``.
+    Retired keys are removed from both gauges so stale label sets don't linger.
+    Call this once per capacity-planner cycle (or any other periodic driver).
+    """
+    current: set[tuple[str, str, str]] = set()
+    try:
+        for model, provider, metric, value, n in rows:
+            current.add((model, provider, metric))
+            LATENCY_STORE_LEARNED_SECONDS.labels(model=model, provider=provider, metric=metric).set(value)
+            LATENCY_STORE_OBSERVATION_COUNT.labels(model=model, provider=provider, metric=metric).set(n)
+        for model, provider, metric in _PUBLISHED_LATENCY_STORE_KEYS - current:
+            try:
+                LATENCY_STORE_LEARNED_SECONDS.remove(model, provider, metric)
+            except KeyError:
+                pass
+            try:
+                LATENCY_STORE_OBSERVATION_COUNT.remove(model, provider, metric)
+            except KeyError:
+                pass
+    finally:
+        _PUBLISHED_LATENCY_STORE_KEYS.clear()
+        _PUBLISHED_LATENCY_STORE_KEYS.update(current)
 
 
 def metrics_response() -> tuple[bytes, str]:

--- a/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
@@ -456,9 +456,7 @@ class ClassificationCorrectingScheduler(BaseScheduler):
 
         return scored
 
-    def _record_scheduling_metrics(
-        self, model_id: int, provider_id: int, ettft: "EttftEstimate"
-    ) -> None:
+    def _record_scheduling_metrics(self, model_id: int, provider_id: int, ettft: "EttftEstimate") -> None:
         """Record per-decision scheduling metrics for the selected candidate."""
         model = self._logosnode.get_model_name(model_id, provider_id) or str(model_id)
         provider = self._logosnode.get_provider_name(provider_id) or str(provider_id)

--- a/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
@@ -184,6 +184,7 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             model_id, provider_id, provider_type, score, priority_int, ettft = best
             self._record_affinity(request, model_id, provider_id, provider_type, affinity)
             self._log_decision(request.request_id, scored, request.classified_models or [], best, False)
+            self._record_scheduling_metrics(model_id, provider_id, ettft)
             result = self._create_result(
                 model_id,
                 provider_id,
@@ -240,6 +241,8 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             logosnode_candidate,
             True,
         )
+        lc_model_id, lc_provider_id, _, _, _, lc_ettft = logosnode_candidate
+        self._record_scheduling_metrics(lc_model_id, lc_provider_id, lc_ettft)
         result = await self._queue_and_wait(logosnode_candidate, request)
         if result is not None:
             self._record_affinity(request, result.model_id, result.provider_id, result.provider_type, affinity)
@@ -366,6 +369,10 @@ class ClassificationCorrectingScheduler(BaseScheduler):
                         self._logosnode.get_provider_name(provider_id) or provider_id,
                         ettft.reasoning,
                     )
+                    prom.SCHEDULING_UNAVAILABLE_TOTAL.labels(
+                        model=self._logosnode.get_model_name(model_id, provider_id) or str(model_id),
+                        provider=self._logosnode.get_provider_name(provider_id) or str(provider_id),
+                    ).inc()
                     # Only logosnode gets fallback queueing — model may be
                     # transitioning (sleep→wake) and will become available.
                     # Cloud unavailable means truly rate-limited → skip.
@@ -448,6 +455,35 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             )
 
         return scored
+
+    def _record_scheduling_metrics(
+        self, model_id: int, provider_id: int, ettft: "EttftEstimate"
+    ) -> None:
+        """Record per-decision scheduling metrics for the selected candidate."""
+        model = self._logosnode.get_model_name(model_id, provider_id) or str(model_id)
+        provider = self._logosnode.get_provider_name(provider_id) or str(provider_id)
+        tier = ettft.tier.value
+        prom.SCHEDULING_TIER_TOTAL.labels(model=model, provider=provider, tier=tier).inc()
+        # learned_ttft is the residual after subtracting the four explicitly
+        # tracked components from the total estimate.
+        learned_ttft_s = max(
+            0.0,
+            ettft.expected_wait_s
+            - ettft.state_overhead_s
+            - ettft.queue_wait_s
+            - ettft.prefill_s
+            - ettft.reclaim_overhead_s,
+        )
+        prom.record_ettft_components(
+            model=model,
+            provider=provider,
+            tier=tier,
+            state_overhead_s=ettft.state_overhead_s,
+            queue_wait_s=ettft.queue_wait_s,
+            prefill_s=ettft.prefill_s,
+            learned_ttft_s=learned_ttft_s,
+            reclaim_overhead_s=ettft.reclaim_overhead_s,
+        )
 
     def _estimate_ettft(
         self, model_id: int, provider_id: int, provider_type: str, input_tokens: int = 0
@@ -919,7 +955,9 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             timeout = (
                 request.timeout_s if request.timeout_s else global_timeout_s(1200)
             )  # 20 min queue wait (or LOGOS_TIMEOUT_S)
+            _hold_start = time.monotonic()
             result = await asyncio.wait_for(future, timeout=timeout)
+            prom.ADMISSION_HOLD_DURATION_SECONDS.observe(time.monotonic() - _hold_start)
 
             # Attach ETTFT info to the dequeued result (decision-time values:
             # the estimate and warmth as seen when the request was enqueued)

--- a/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/correcting_scheduler.py
@@ -928,6 +928,10 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             is_cold_at_queue=is_cold_at_queue,
             provider_affinity=request.required_provider_id,
         )
+        # Start the hold timer immediately after enqueue so that logging,
+        # queue-depth reads, and the capacity-task setup are included in the
+        # reported duration — they are part of the request's queue residence.
+        _hold_start = time.monotonic()
         queue_depth = self._queue_mgr.get_total_depth_by_deployment(model_id, provider_id)
         logger.info(
             "Request %s queued for model=%s worker=%s " "(corrected_score=%.2f, tier=%s, depth=%s)",
@@ -955,7 +959,6 @@ class ClassificationCorrectingScheduler(BaseScheduler):
             timeout = (
                 request.timeout_s if request.timeout_s else global_timeout_s(1200)
             )  # 20 min queue wait (or LOGOS_TIMEOUT_S)
-            _hold_start = time.monotonic()
             result = await asyncio.wait_for(future, timeout=timeout)
             prom.ADMISSION_HOLD_DURATION_SECONDS.observe(time.monotonic() - _hold_start)
 

--- a/logos/logos-orchestrator/src/logos/pipeline/latency_store.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/latency_store.py
@@ -261,6 +261,34 @@ class LatencyStore:
             state = self._overhead.get(key)
         return state.n if state is not None else 0
 
+    def snapshot_metrics(
+        self, get_provider_name: Optional[Callable[[int], Optional[str]]] = None
+    ) -> list[tuple[str, str, str, float, int]]:
+        """Return a point-in-time snapshot of all EWMA entries for Prometheus publishing.
+
+        Each row is ``(model_name, provider_label, metric_name, value_s, n)``.
+        ``metric_name`` is the tier value string for overhead entries
+        (e.g. ``"cold"``, ``"sleeping"``), or one of ``"ttft"``, ``"e2e"``,
+        ``"prefill_s_per_token"`` for the model-level metrics.
+        ``provider_label`` is the provider name when ``get_provider_name`` resolves
+        it, otherwise the string representation of the provider id.
+        """
+        rows: list[tuple[str, str, str, float, int]] = []
+        with self._lock:
+            for (model_name, provider_id, tier), state in self._overhead.items():
+                label = (get_provider_name(provider_id) if get_provider_name else None) or str(provider_id)
+                rows.append((model_name, label, tier.value, state.value, state.n))
+            for (model_name, provider_id), state in self._ttft.items():
+                label = (get_provider_name(provider_id) if get_provider_name else None) or str(provider_id)
+                rows.append((model_name, label, _TIER_TTFT, state.value, state.n))
+            for (model_name, provider_id), state in self._e2e_latency.items():
+                label = (get_provider_name(provider_id) if get_provider_name else None) or str(provider_id)
+                rows.append((model_name, label, _TIER_E2E, state.value, state.n))
+            for (model_name, provider_id), state in self._prefill_s_per_token.items():
+                label = (get_provider_name(provider_id) if get_provider_name else None) or str(provider_id)
+                rows.append((model_name, label, _TIER_PREFILL_PER_TOKEN, state.value, state.n))
+        return rows
+
     # ------------------------------------------------------------------
     # Persistence helpers
     # ------------------------------------------------------------------

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -353,6 +353,7 @@ class RequestPipeline:
             classification_result=classification_result,
             request_path=request.request_path,
             request_id=request_id,
+            schedule_start_s=schedule_start_s,
         )
         if not ctx_result.success:
             return ctx_result
@@ -396,6 +397,7 @@ class RequestPipeline:
         classification_result: "_ClassificationResult",
         request_id: str,
         request_path: Optional[str] = None,
+        schedule_start_s: Optional[float] = None,
     ) -> "PipelineResult":
         """Resolve execution context, retrying for logosnode providers whose lane may still be starting."""
         deadline = time.monotonic() + self._CONTEXT_RESOLVE_TIMEOUT_S
@@ -479,7 +481,7 @@ class RequestPipeline:
         self,
         scheduling_result,
         request_id: str,
-        schedule_start_s: float | None = None,
+        schedule_start_s: Optional[float] = None,
     ) -> dict:
         stats = {
             "request_id": request_id,

--- a/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
+++ b/logos/logos-orchestrator/src/logos/pipeline/pipeline.py
@@ -250,6 +250,7 @@ class RequestPipeline:
             timeout_s=request.payload.get("timeout_s"),
         )
 
+        schedule_start_s = time.perf_counter()
         try:
             scheduling_result = await self._scheduler.schedule(scheduling_request)
         except QueueTimeoutError as exc:
@@ -430,7 +431,7 @@ class RequestPipeline:
                     provider_id=scheduling_result.provider_id,
                     execution_context=exec_context,
                     classification_stats=classification_result.stats,
-                    scheduling_stats=self._scheduling_stats(scheduling_result, request_id),
+                    scheduling_stats=self._scheduling_stats(scheduling_result, request_id, schedule_start_s),
                 )
 
             # For cloud providers or after timeout, fail immediately
@@ -474,8 +475,13 @@ class RequestPipeline:
                 scheduling_result.provider_id,
             )
 
-    def _scheduling_stats(self, scheduling_result, request_id: str) -> dict:
-        return {
+    def _scheduling_stats(
+        self,
+        scheduling_result,
+        request_id: str,
+        schedule_start_s: float | None = None,
+    ) -> dict:
+        stats = {
             "request_id": request_id,
             "model_id": scheduling_result.model_id,
             "provider_id": scheduling_result.provider_id,
@@ -488,6 +494,9 @@ class RequestPipeline:
             "ettft_tier": scheduling_result.ettft_tier,
             "warmth_state": scheduling_result.warmth_state,
         }
+        if schedule_start_s is not None:
+            stats["schedule_start_s"] = schedule_start_s
+        return stats
 
     def _context_failure(
         self,


### PR DESCRIPTION
Add seven new metrics covering the three most meaningful scheduling signal categories, wired to existing code paths with no changes to public interfaces.

## Summary

- **ETTFT accuracy** (`logos_ettft_accuracy_seconds`): Histogram of `|ettft_estimate_s - actual_ttft_s|` per `(provider, tier)`, observed at first-token time in both the logosnode and cloud streaming paths. Primary calibration signal.
- **ETTFT component decomposition** (`logos_ettft_components_seconds`): Histogram per phase (`state_overhead`, `queue_wait`, `prefill`, `learned_ttft`, `reclaim_overhead`) × `(model, provider, tier)`, recorded on every scheduling decision. Pinpoints which phase carries estimation error.
- **Tier distribution** (`logos_scheduling_tier_total`): Counter for the selected candidate's readiness tier per `(model, provider, tier)` — COLD/WARM/SLEEPING/SLEEPING_RECLAIM — quick system-state overview.
- **UNAVAILABLE rate** (`logos_scheduling_unavailable_total`): Counter per `(model, provider)` incremented whenever the reclaim-check returns `inf`. Direct capacity indicator.
- **Hold duration** (`logos_admission_hold_duration_seconds`): Histogram of actual queue-wait time per request (from enqueue to dispatch future resolution).
- **Learned EWMA values** (`logos_latency_store_learned_seconds`, `logos_latency_store_observation_count`): Gauge snapshot of every EWMA entry in the `LatencyStore` — overhead per tier, TTFT, e2e, prefill rate — refreshed once per capacity-planner cycle. Low observation count flags unreliable routing decisions for a given provider.

## Changes

| File | What changed |
|------|-------------|
| `monitoring/prometheus_metrics.py` | 7 new metrics, 3 helper functions (`record_ettft_outcome`, `record_ettft_components`, `update_latency_store_metrics`) with label-retirement logic matching the existing `update_engine_cache_metrics` pattern |
| `pipeline/latency_store.py` | `snapshot_metrics(get_provider_name?)` — thread-safe point-in-time dump of all EWMA state as `(model, provider_label, metric, value, n)` tuples |
| `pipeline/correcting_scheduler.py` | `_record_scheduling_metrics()` helper called on every selected candidate (immediate + queued paths); UNAVAILABLE counter in `_compute_candidate_scores`; hold-duration observation in `_queue_and_wait` |
| `capacity/capacity_planner.py` | Optional `latency_store` constructor param; `_refresh_latency_store_metrics()` called alongside `_refresh_engine_cache_metrics` each cycle |
| `main.py` | `_record_ettft_accuracy()` helper + calls at first-token in logosnode and cloud streaming paths; `provider_name_cache` import; `latency_store` wired to `CapacityPlanner` |

## Notes for reviewers

- All additions are pure `+` (245 lines, 0 deletions). No existing metric names or signatures changed.
- ETTFT accuracy is measured from `_req_start` (perf_counter at streaming-handler entry) to first-token — this includes queue wait, consistent with the ETTFT model's `expected_wait_s` definition.
- The UNAVAILABLE counter counts per *candidate scored*, not per request, so a request with multiple UNAVAILABLE candidates increments it multiple times — this is intentional.
- `logos_admission_hold_duration_seconds` measures the scheduler-queue hold (from `asyncio.wait_for` start to future resolution), complementing the existing per-attempt `logos_admission_holds_total` counter.
- EWMA gauge labels fall back to `str(provider_id)` when the facade name lookup returns `None` (e.g. during startup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced scheduling telemetry, including ETTFT accuracy, phase timing, decision tiers, unavailable candidates, and admission wait durations.
  - Added provider-level latency tracking with EWMA values, observation counts, and provider-named snapshots.
  - Added manual-load status tracking with success, failure, and actionable reasons, including duplicate-load prevention and lane-specific failure details.

- **Reliability**
  - Latency refresh failures no longer interrupt capacity-planning cycles.
  - Invalid ETTF​T measurements are safely ignored.
  - Scheduling captures timing from request initiation through first-token delivery for more accurate measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->